### PR TITLE
_NET_ACTIVE_WINDOW: set client urgent, if not made visible

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -403,6 +403,13 @@ ewmh_process_client_message(xcb_client_message_event_t *ev)
         if((c = client_getbywin(ev->window))) {
             client_focus(c);
             client_raise(c);
+
+            /* If the client is not visible by now, set the urgent flag. */
+            if(!client_isvisible(c)) {
+                luaA_object_push(globalconf.L, c);
+                client_set_urgent(globalconf.L, -1, true);
+                lua_pop(globalconf.L, 1);
+            }
         }
     }
 


### PR DESCRIPTION
Set the client's urgent flag, if it could not be made visible via
client_focus and client_raise.

This is a good compromise: it does not steal focus, if the client is not
in the current tag set, but makes it easy to get to it.

Ref: https://awesome.naquadah.org/bugs/index.php?do=details&task_id=848
