### PR TITLE
tag_view_only_byindex: only deselect tags from the same screen

### DIFF
--- a/objects/tag.c
+++ b/objects/tag.c
@@ -198,6 +198,9 @@ tag_view_only_byindex(int dindex)
         tag_view(globalconf.L, -1, *tag == globalconf.tags.tab[dindex]);
         lua_pop(globalconf.L, 1);
     }
+
+    if(tag_screen)
+        screen_emit_signal(globalconf.L, tag_screen, "tag::history::update", 0);
 }
 
 /** Create a new tag.


### PR DESCRIPTION
Use the tag's clients to get the relevant screen.

Fixes https://awesome.naquadah.org/bugs/index.php?do=details&task_id=1219

Cleaned up from https://github.com/awesomeWM/awesome/pull/1
