### PR TITLE
Do not raise clients in client_manage

### DIFF
--- a/lib/awful/rules.lua.in
+++ b/lib/awful/rules.lua.in
@@ -204,7 +204,7 @@ function rules.apply(c)
     -- Do this at last so we do not erase things done by the focus
     -- signal.
     if props.focus and (type(props.focus) ~= "function" or props.focus(c)) then
-        client.focus = c
+        client.emit_signal('request::activate', c)
     end
 end
 

--- a/objects/client.c
+++ b/objects/client.c
@@ -549,7 +549,7 @@ HANDLE_GEOM(height)
     ewmh_client_check_hints(c);
 
     /* Push client in stack */
-    client_raise(c);
+    stack_client_push(c);
 
     /* Always stay in NORMAL_STATE. Even though iconified seems more
      * appropriate sometimes. The only possible loss is that clients not using


### PR DESCRIPTION
Instead, use stack_client_push and emit the `request::activate` signal
from awful.rules.apply, if the client gets focus.
