### PR TITLE
Add client.maximized (a shortcut for maximized_horizontal and -_vertical)

### DIFF
--- a/luadoc/client.lua
+++ b/luadoc/client.lua
@@ -31,6 +31,7 @@ module("client")
 -- @field above The client is above normal windows.
 -- @field below The client is below normal windows.
 -- @field fullscreen The client is fullscreen or not.
+-- @field maximized The client is maximized (horizontally and vertically) or not.
 -- @field maximized_horizontal The client is maximized horizontally or not.
 -- @field maximized_vertical The client is maximized vertically or not.
 -- @field transient_for The client the window is transient for.

--- a/objects/client.h
+++ b/objects/client.h
@@ -150,6 +150,7 @@ void client_set_below(lua_State *, int, bool);
 void client_set_modal(lua_State *, int, bool);
 void client_set_ontop(lua_State *, int, bool);
 void client_set_fullscreen(lua_State *, int, bool);
+void client_set_maximized(lua_State *, int, bool);
 void client_set_maximized_horizontal(lua_State *, int, bool);
 void client_set_maximized_vertical(lua_State *, int, bool);
 void client_set_minimized(lua_State *, int, bool);


### PR DESCRIPTION
This also adds the signals `request::maximized` and
`property::maximized`.

I have just come up with this as a more convenient method than having to handle both `maximized_horizontal` and `maximized_vertical` together most of the time.

There might be logical flaws and bugs in here!
