### PR TITLE
Add a "deep" option to awful.util.table.clone

### DIFF
--- a/lib/awful/util.lua.in
+++ b/lib/awful/util.lua.in
@@ -436,11 +436,13 @@ end
 
 --- Clone a table
 -- @param t the table to clone
+-- @param deep Create a deep clone? (default: true)
 -- @return a clone of t
-function util.table.clone(t)
+function util.table.clone(t, deep)
+    local deep = deep == nil and true or deep
     local c = { }
     for k, v in pairs(t) do
-        if type(v) == "table" then
+        if deep and type(v) == "table" then
             c[k] = util.table.clone(v)
         else
             c[k] = v


### PR DESCRIPTION
This allows for having clones of a table, where its entries are still
references to the original values.

This is useful for copying a "default props" table, where you want to
keep the reference to entries like `awful.layout.suit.tile`.
