### PR TITLE
Fallback to comparing layout names in awful.layout.inc

### DIFF
--- a/lib/awful/layout/init.lua.in
+++ b/lib/awful/layout/init.lua.in
@@ -43,11 +43,20 @@ function layout.inc(layouts, i, s)
     if t then
         local curlayout = layout.get(s)
         local curindex
-        local rev_layouts = {}
         for k, v in ipairs(layouts) do
             if v == curlayout then
                 curindex = k
                 break
+            end
+        end
+        if not curindex then
+            -- Safety net: handle cases where another reference of the layout
+            -- might be given (e.g. when (accidentally) cloning it).
+            for k, v in ipairs(layouts) do
+                if v.name == curlayout.name then
+                    curindex = k
+                    break
+                end
             end
         end
         if curindex then


### PR DESCRIPTION
This helps in cases where you have accidentally cloned an entry from
`layouts`.

Previously, no current index would be found and the function would
silently fail.
