### PR TITLE
bugfix: raise focused client in magnifier.arrange

### DIFF
--- a/lib/awful/layout/suit/magnifier.lua.in
+++ b/lib/awful/layout/suit/magnifier.lua.in
@@ -64,7 +64,6 @@ function magnifier.arrange(p)
         height = geometry.height - focus.border_width * 2
     }
     focus:geometry(g)
-    focus:raise()
 
     if #cls > 1 then
         geometry.x = area.x
@@ -72,7 +71,7 @@ function magnifier.arrange(p)
         geometry.height = area.height / (#cls - 1)
         geometry.width = area.width
 
-        -- We don't know what the focus window index. Try to find it.
+        -- We don't know the focus window index. Try to find it.
         if not fidx then
             for k, c in ipairs(cls) do
                 if c == focus then


### PR DESCRIPTION
This is useful in general, but especially after commit 620732a (Remove
raise call from mouse.client.move).
