### PR TITLE
Minor doc fixes

### DIFF
--- a/lib/awful/autofocus.lua.in
+++ b/lib/awful/autofocus.lua.in
@@ -10,7 +10,7 @@ local aclient = require("awful.client")
 local atag = require("awful.tag")
 
 --- When loaded, this module makes sure that there's always a client that will have focus
--- on event such as tag switching, client unmanaging, etc.
+-- on events such as tag switching, client unmanaging, etc.
 -- awful.autofocus
 
 -- Give focus when clients appear/disappear.

--- a/lib/awful/keygrabber.lua.in
+++ b/lib/awful/keygrabber.lua.in
@@ -55,23 +55,22 @@ end
 -- A callback can return false to pass the events to the next key grabber in the stack.
 -- @param g The key grabber callback that will get the key events until it will be deleted or a new grabber is added.
 -- @return the given callback `g`
--- @usage Following function can be bound to a key, and used to resize a client
+-- @usage The following function can be bound to a key, and used to resize a client
 -- using keyboard.
--- <p><code>
--- function resize(c) <br/>
---   local grabber = awful.keygrabber.run(function(mod, key, event) </br>
---     if event == "release" then return end </br></br>
 --
---     if     key == 'Up'   then awful.client.moveresize(0, 0, 0, 5, c) <br/>
---     elseif key == 'Down' then awful.client.moveresize(0, 0, 0, -5, c) <br/>
---     elseif key == 'Right' then awful.client.moveresize(0, 0, 5, 0, c) <br/>
---     elseif key == 'Left'  then awful.client.moveresize(0, 0, -5, 0, c) <br/>
---     else   awful.keygrabber.stop(grabber) <br/>
---     end <br/><br/>
+-- function resize(c)
+--   local grabber = awful.keygrabber.run(function(mod, key, event)
+--     if event == "release" then return end
 --
---   end) <br/>
--- end <br/>
--- </code></p>
+--     if     key == 'Up'   then awful.client.moveresize(0, 0, 0, 5, c)
+--     elseif key == 'Down' then awful.client.moveresize(0, 0, 0, -5, c)
+--     elseif key == 'Right' then awful.client.moveresize(0, 0, 5, 0, c)
+--     elseif key == 'Left'  then awful.client.moveresize(0, 0, -5, 0, c)
+--     else   awful.keygrabber.stop(grabber)
+--     end
+--
+--   end)
+-- end
 function keygrabber.run(g)
     -- Remove the grabber if its in stack
     keygrabber.stop(g)

--- a/lib/awful/layout/suit/tile.lua.in
+++ b/lib/awful/layout/suit/tile.lua.in
@@ -77,7 +77,7 @@ local function do_tile(param, orientation)
     local t = tag.selected(param.screen)
     orientation = orientation or "right"
 
-    -- this handles are different orientations
+    -- This handles all different orientations.
     local height = "height"
     local width = "width"
     local x = "x"

--- a/lib/awful/util.lua.in
+++ b/lib/awful/util.lua.in
@@ -453,7 +453,7 @@ end
 
 ---
 -- Returns an iterator to cycle through, starting from the first element or the
--- given index, all elments of a table that match a given criteria.
+-- given index, all elements of a table that match a given criteria.
 --
 -- @param t      the table to iterate
 -- @param filter a function that returns true to indicate a positive match

--- a/objects/client.c
+++ b/objects/client.c
@@ -1125,7 +1125,7 @@ client_unban(client_t *c)
 void
 client_unmanage(client_t *c, bool window_valid)
 {
-    /* Reset transient_for attributes of widows that maybe referring to us */
+    /* Reset transient_for attributes of windows that might be referring to us */
     foreach(_tc, globalconf.clients)
     {
         client_t *tc = *_tc;
@@ -1605,7 +1605,7 @@ HANDLE_TITLEBAR(right, CLIENT_TITLEBAR_RIGHT)
 HANDLE_TITLEBAR(bottom, CLIENT_TITLEBAR_BOTTOM)
 HANDLE_TITLEBAR(left, CLIENT_TITLEBAR_LEFT)
 
-/** Return client geometry.
+/** Return or set client geometry.
  * \param L The Lua VM state.
  * \return The number of elements pushed on stack.
  * \luastack


### PR DESCRIPTION
I am not sure about the HTML changes in  lib/awful/keygrabber.lua.in, but from http://awesome.naquadah.org/doc/api/modules/awful.keygrabber.html it looks like "Usage" is meant to be literal (and gets wrapped in a `<pre>` tag).
