### PR TITLE
Only set client's urgent after startup

### DIFF
--- a/lib/awful/ewmh.lua.in
+++ b/lib/awful/ewmh.lua.in
@@ -137,7 +137,7 @@ function ewmh.activate(c)
     if c:isvisible() then
         client.focus = c
         c:raise()
-    else
+    elseif not awesome.startup then
         c.urgent = true
     end
 end


### PR DESCRIPTION
This looks at awesome.startup in the default 'request::activate' signal
handler.
