### PR TITLE
Add the option to ignore _NET_WM_DESKTOP

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -317,6 +317,7 @@ main(int argc, char **argv)
     p_clear(&globalconf, 1);
     globalconf.keygrabber = LUA_REFNIL;
     globalconf.mousegrabber = LUA_REFNIL;
+    globalconf.honor_ewmh_desktop = true;
     buffer_init(&globalconf.startup_errors);
 
     /* save argv */

--- a/ewmh.c
+++ b/ewmh.c
@@ -385,7 +385,7 @@ ewmh_process_client_message(xcb_client_message_event_t *ev)
         {
             if(ev->data.data32[0] == 0xffffffff)
                 c->sticky = true;
-            else
+            else if (globalconf.honor_ewmh_desktop)
                 for(int i = 0; i < globalconf.tags.len; i++)
                     if((int)ev->data.data32[0] == i)
                     {

--- a/globalconf.h
+++ b/globalconf.h
@@ -144,6 +144,8 @@ typedef struct
     tag_array_t tags;
     /** List of registered xproperties */
     xproperty_array_t xproperties;
+    /** Honor/Ignore _NET_WM_DESKTOP desktop */
+    bool honor_ewmh_desktop;
 } awesome_t;
 
 extern awesome_t globalconf;

--- a/luaa.c
+++ b/luaa.c
@@ -478,6 +478,33 @@ luaA_awesome_index(lua_State *L)
         return 1;
     }
 
+    if(A_STREQ(buf, "honor_ewmh_desktop")) {
+        lua_pushboolean(L, globalconf.honor_ewmh_desktop);
+        return 1;
+    }
+
+    return 0;
+}
+
+/** awesome global table setter.
+ * \param L The Lua VM state.
+ * \return The number of elements pushed on stack.
+ * \luastack
+ * \lfield a variable from globalconf
+ */
+static int
+luaA_awesome_new_index(lua_State *L)
+{
+    if(luaA_usemetatable(L, 1, 2))
+        return 1;
+
+    const char *buf = luaL_checkstring(L, 2);
+
+    if(A_STREQ(buf, "honor_ewmh_desktop") && lua_isboolean(L,3))
+    {
+        const int honor = lua_toboolean(L, 3);
+        globalconf.honor_ewmh_desktop = honor;
+    }
     return 0;
 }
 
@@ -583,6 +610,7 @@ luaA_init(xdgHandle* xdg)
         { "load_image", luaA_load_image },
         { "register_xproperty", luaA_register_xproperty },
         { "__index", luaA_awesome_index },
+        { "__newindex", luaA_awesome_new_index },
         { NULL, NULL }
     };
 


### PR DESCRIPTION
This fix a longstanding issue where some rare clients would ignore
awful.rule / tyrannical would set a tag, only to have it overwritten
later by this request. One example of clients behaving this way is
"Kate" the KDE text editor. The "choose session" window would behave
normally, but the main window will display in the wrong tag. Some
prints show that it first behave normally, but then is moved to the
wrong tag. This configuration variable can be set to "false" after
the last "not startup" client is managed by awesome. As I want
my tag manager (in my case, Tyrannical) to be a tyran and ignore
external focus/desktop requests, being able to disable this code
path make sense.

As for the implementation, it is a little cheap to use metatables for
that. It is currently how awesome does it, so it is how I will do it
for now.

Note:
Doing that, I saw that something still try to do capi.awesome.fg and capi.awesome.bg. I am not sure if it is my config or some other leftover from 3.4

Note2:
Unless you have serious concerns about segfaults, please just merge this pull as is. I will replace the way it is done in a future pull (force all capi objects to have a lua metatable, sodoing c.foo = "bar" will finally work at long last). I am aware I did not update the documentation, this is on purpose, this is an hidden API for now. It fix a bug and don't break the API at all.

Thanks, have a good week!
