### PR TITLE
Set c.screen in ewmh.tag and before tags in rules.execute

### DIFF
--- a/lib/awful/ewmh.lua.in
+++ b/lib/awful/ewmh.lua.in
@@ -147,6 +147,7 @@ function ewmh.tag(c, t)
     if not t then
         c.sticky = true
     else
+        c.screen = awful.tag.getscreen(t)
         c:tags({ t })
     end
 end

--- a/lib/awful/rules.lua.in
+++ b/lib/awful/rules.lua.in
@@ -206,8 +206,8 @@ function rules.execute(c, props, callbacks)
         if property == "floating" then
             aclient.floating.set(c, value)
         elseif property == "tag" then
-            c:tags({ value })
             c.screen = atag.getscreen(value)
+            c:tags({ value })
         elseif property == "switchtotag" and value and props.tag then
             atag.viewonly(props.tag)
         elseif property == "height" or property == "width" or


### PR DESCRIPTION
The current premise is that c.screen should be the same as
awful.tag.getscreen(t).

The addition in `ewmh.tag` appears to be the important part here,
changing the order in awful.rules.execute is (maybe) only for
consistency across the codebase.
