### PR TITLE
Mark the client as focused in client.jumpto first

### DIFF
--- a/lib/awful/client.lua.in
+++ b/lib/awful/client.lua.in
@@ -51,6 +51,9 @@ client.property = {}
 -- @param merge If true then merge tags when clients are not visible.
 function client.jumpto(c, merge)
     local s = capi.client.focus and capi.client.focus.screen or capi.mouse.screen
+    -- Mark the client as focused, so autofocus does no magic.
+    capi.client.focus = c
+
     -- focus the screen
     if s ~= c.screen then
         capi.mouse.screen = c.screen
@@ -66,7 +69,7 @@ function client.jumpto(c, merge)
         end
     end
 
-    -- focus the client
+    -- Focus the client again, after it has been made visible.
     capi.client.focus = c
     c:raise()
 end


### PR DESCRIPTION
This avoids awful.autofocus to kick in, focusing some other client in
between (where a focused signal would get emitted for, although the
intermediate client was never meant to have focus).
