### PR TITLE
Fix the call to tag.history.restore from tag.delete

### DIFF
--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -158,7 +158,7 @@ function tag.delete(target_tag, fallback_tag)
 
     -- If no tags are visible, try and view one.
     if tag.selected(target_scr) == nil and ntags > 0 then
-        tag.history.restore()
+        tag.history.restore(nil, 1)
         if tag.selected(target_scr) == nil then
             tag.gettags(target_scr)[1].selected = true
         end


### PR DESCRIPTION
By default, tag.history.restore switches between the previous history
states, which is not what should get done when deleting a tag.

Without this, deleting multiple tags in a row, will jump back to the
first/fallback tag, instead of the older history entries.
