### PR TITLE
Fix tag screen switching

### DIFF
--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -270,7 +270,22 @@ end
 -- @param t tag object
 -- @param s Screen number
 function tag.setscreen(t, s)
+    if not tag or type(t) ~= "tag" or not s then return end
+
+    -- Keeping the old index make very little sense when chaning screen
+    tag.setproperty(t, "index", nil)
+
+    local old_screen = tag.getproperty(t,"screen")
+
+    -- Change the screen
     tag.setproperty(t, "screen", s)
+
+    --Prevent some very strange side effects, does create some issue with multitag clients
+    for k,c in ipairs(t:clients()) do
+        c.screen = s --Move all clients
+        c:tags({t})
+    end
+    tag.history.restore(old_screen,1)
 end
 
 --- Get a tag's screen


### PR DESCRIPTION
The bugs this fix are:
- Invalid request using nil as screen
- Stop messing indexes in the old screen
- Prevent c.screen <-> t.screen mismatch
- Prevent no tags being selected in the old screen
