### PR TITLE
manage signal handler: use awesome.startup

### DIFF
--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -572,12 +572,12 @@ function tag.attached_connect_signal(screen, ...)
     end
 end
 
--- Register standards signals
-capi.client.connect_signal("manage", function(c, startup)
+-- Register standard signals.
+capi.client.connect_signal("manage", function(c)
     -- If we are not managing this application at startup,
     -- move it to the screen where the mouse is.
     -- We only do it for "normal" windows (i.e. no dock, etc).
-    if not startup and c.type ~= "desktop" and c.type ~= "dock" then
+    if not awesome.startup and c.type ~= "desktop" and c.type ~= "dock" then
         if c.transient_for then
             c.screen = c.transient_for.screen
             if not c.sticky then


### PR DESCRIPTION
The `manage` arg is gone.
