### PR TITLE
gears.wallpaper: Center maximized if no offset set

### DIFF
--- a/lib/gears/wallpaper.lua.in
+++ b/lib/gears/wallpaper.lua.in
@@ -138,6 +138,8 @@ function wallpaper.maximized(surf, s, ignore_aspect, offset)
 
     if offset then
         cr:translate(offset.x, offset.y)
+    elseif not ignore_aspect then
+        cr:translate(((geom.width / aspect_w) - w) / 2, ((geom.height / aspect_h) - h) / 2)
     end
 
     cr:set_source_surface(surf, 0, 0)


### PR DESCRIPTION
maximized() used to align the image with (0,0) so that it is shifted to the right or bottom. Most wallpapers are designed from the center, so this behavior is not desired usually. With this commit the wallpaper is centered when no offset is set. To get the old behavior use {x=0, y=0} for the offset parameter.

WARNING: This pull request changes the default behavior for `gears.wallpaper.maximized()`, however it uses the parameters efficiently (other ways would be to use a table for the arguments (inconsistent with other wallpaper methods) or skipping the offset argument with `nil`).
