### PR TITLE
FS#1278 - Menubar should check all standard directories

### DIFF
--- a/lib/menubar/menu_gen.lua.in
+++ b/lib/menubar/menu_gen.lua.in
@@ -17,9 +17,14 @@ local menu_gen = {}
 
 -- Options section
 
+local data_dir = os.getenv("XDG_DATA_HOME")
+if not data_dir then
+    data_dir = os.getenv("HOME") .. '/.local/share/'
+end
+
 --- Specifies all directories where menubar should look for .desktop
 -- files. The search is not recursive.
-menu_gen.all_menu_dirs = { '/usr/share/applications/', '/usr/local/share/applications/' }
+menu_gen.all_menu_dirs = { data_dir .. 'applications/', '/usr/share/applications/', '/usr/local/share/applications/' }
 
 --- Specify the mapping of .desktop Categories section to the
 -- categories in the menubar. If "use" flag is set to false then any of


### PR DESCRIPTION
Added local desktop directory to list of directories parsed by menubar
by using the XDG specification
