### PR TITLE
Allow layouts to be incoked with fake data

### DIFF
--- a/lib/awful/layout/suit/magnifier.lua.in
+++ b/lib/awful/layout/suit/magnifier.lua.in
@@ -23,8 +23,9 @@ function magnifier.arrange(p)
     -- Fullscreen?
     local area = p.workarea
     local cls = p.clients
-    local focus = capi.client.focus
-    local mwfact = tag.getmwfact(tag.selected(p.screen))
+    local focus = p.focus or capi.client.focus
+    local t = p.tag or tag.selected(p.screen)
+    local mwfact = tag.getmwfact(t)
     local fidx
 
     -- Check that the focused window is on the right screen

--- a/lib/awful/layout/suit/tile.lua.in
+++ b/lib/awful/layout/suit/tile.lua.in
@@ -74,7 +74,7 @@ local function tile_group(cls, wa, orientation, fact, group)
 end
 
 local function do_tile(param, orientation)
-    local t = tag.selected(param.screen)
+    local t = param.tag or tag.selected(param.screen)
     orientation = orientation or "right"
 
     -- This handles all different orientations.


### PR DESCRIPTION
This patch allow 2 things to be done:
- Write unit test to validate layouts using fake clients and tags
- Query the current layout geometry from another tag

The advantages of the former are clear and simple. Those for the later
include:
- Creating screenshot of an other layout
- Display the layout wireframe in the taglist (like KDE2-3, Gnome2)
- Having and 'alt-tab' like visula popup for tags

Proof of concept:

![blender217](https://cloud.githubusercontent.com/assets/340384/4516506/2b41461c-4bfa-11e4-9c96-94f74b478fcf.png)
