### PR TITLE
awful.tag.update: Fix identical tag set detection

### DIFF
--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -178,7 +178,8 @@ function tag.history.update(obj)
     else
         if data.history[s].current then
             -- Check that the list is not identical
-            local identical = true
+            local identical = (data.history[s].current ~= nil
+                and (#data.history[s].current > 0 or (#data.history[s].current == 0 and #curtags==0)))
             for idx, _tag in ipairs(data.history[s].current) do
                 if curtags[idx] ~= _tag then
                     identical = false


### PR DESCRIPTION
If the "current" table is empty, then identical always true.
There is a lot of case where this can happen. Mostly when using
dynamic tagging.
