### PR TITLE
layouts: Allow layouts to be invoked with fake data

### DIFF
--- a/lib/awful/layout/suit/magnifier.lua.in
+++ b/lib/awful/layout/suit/magnifier.lua.in
@@ -23,8 +23,9 @@ function magnifier.arrange(p)
     -- Fullscreen?
     local area = p.workarea
     local cls = p.clients
-    local focus = capi.client.focus
-    local mwfact = tag.getmwfact(tag.selected(p.screen))
+    local focus = p.focus or capi.client.focus
+    local t = p.tag or tag.selected(p.screen)
+    local mwfact = tag.getmwfact(t)
     local fidx
 
     -- Check that the focused window is on the right screen

--- a/lib/awful/layout/suit/tile.lua.in
+++ b/lib/awful/layout/suit/tile.lua.in
@@ -74,7 +74,7 @@ local function tile_group(cls, wa, orientation, fact, group)
 end
 
 local function do_tile(param, orientation)
-    local t = tag.selected(param.screen)
+    local t = param.tag or tag.selected(param.screen)
     orientation = orientation or "right"
 
     -- This handles all different orientations.


### PR DESCRIPTION
This patch allows 2 things to be done:
- Write unit test to validate layouts using fake clients and tags
- Query the current layout geometry from another tag

The advantages of the former are clear and simple. Those of the later include:
- Creating a screenshot of another layout
- Display the layout wireframe in the tag list (like KDE2-3, Gnome2)
- Having and 'ALT-tab' like visual popup for tags

Changes: Typo
