### PR TITLE
wibox.layout: Add fixed and flex layouts widget spacing property

### DIFF
--- a/lib/wibox/layout/fixed.lua.in
+++ b/lib/wibox/layout/fixed.lua.in
@@ -19,7 +19,7 @@ local fixed = {}
 -- @param height The available height.
 -- @return The total space needed by the layout.
 function fixed:draw(wibox, cr, width, height)
-    local pos = 0
+    local pos,spacing = 0,self._spacing or 0
 
     for k, v in pairs(self.widgets) do
         local x, y, w, h, _
@@ -30,7 +30,7 @@ function fixed:draw(wibox, cr, width, height)
             if k ~= #self.widgets or not self._fill_space then
                 _, h = base.fit_widget(v, w, h);
             end
-            pos = pos + h
+            pos = pos + h + spacing
             in_dir = h
         else
             x, y = pos, 0
@@ -38,12 +38,12 @@ function fixed:draw(wibox, cr, width, height)
             if k ~= #self.widgets or not self._fill_space then
                 w, _ = base.fit_widget(v, w, h);
             end
-            pos = pos + w
+            pos = pos + w + spacing
             in_dir = w
         end
 
-        if (self.dir == "y" and pos > height) or
-            (self.dir ~= "y" and pos > width) then
+        if (self.dir == "y" and pos-spacing > height) or
+            (self.dir ~= "y" and pos-spacing > width) then
             break
         end
         base.draw_widget(wibox, cr, v, x, y, w, h)
@@ -90,10 +90,12 @@ function fixed:fit(orig_width, orig_height)
         end
     end
 
+    local spacing = ((self._spacing or 0)*(#self.widgets-1))
+
     if self.dir == "y" then
-        return used_max, used_in_dir
+        return used_max, used_in_dir + spacing
     end
-    return used_in_dir, used_max
+    return used_in_dir + spacing, used_max
 end
 
 --- Reset a fixed layout. This removes all widgets from the layout.
@@ -143,6 +145,12 @@ end
 -- Widgets can be added via :add().
 function fixed.vertical()
     return get_layout("y")
+end
+
+-- Add spacing between each layout widgets
+function fixed:set_spacing(spacing)
+    self._spacing = spacing
+    self:emit_signal("widget::updated")
 end
 
 return fixed

--- a/lib/wibox/layout/flex.lua.in
+++ b/lib/wibox/layout/flex.lua.in
@@ -24,14 +24,15 @@ end
 -- @param height The available height.
 -- @return The total space needed by the layout.
 function flex:draw(wibox, cr, width, height)
-    local pos = 0
-
+    local pos,spacing = 0,self._spacing or 0
     local num = #self.widgets
+    local total_spacing = (spacing*(num-1))
+
     local space_per_item
     if self.dir == "y" then
-        space_per_item = height / num
+        space_per_item = height / num - total_spacing/num
     else
-        space_per_item = width / num
+        space_per_item = width / num - total_spacing/num
     end
 
     if self._max_widget_size then
@@ -49,10 +50,10 @@ function flex:draw(wibox, cr, width, height)
         end
         base.draw_widget(wibox, cr, v, x, y, w, h)
 
-        pos = pos + space_per_item
+        pos = pos + space_per_item + spacing
 
-        if (self.dir == "y" and pos >= height) or
-            (self.dir ~= "y" and pos >= width) then
+        if (self.dir == "y" and pos-spacing >= height) or
+            (self.dir ~= "y" and pos-spacing >= width) then
             break
         end
     end
@@ -100,10 +101,12 @@ function flex:fit(orig_width, orig_height)
             #self.widgets * self._max_widget_size)
     end
 
+    local spacing = ((self._spacing or 0)*(#self.widgets-1))
+
     if self.dir == "y" then
-        return used_in_other, used_in_dir
+        return used_in_other, used_in_dir + spacing
     end
-    return used_in_dir, used_in_other
+    return used_in_dir + spacing, used_in_other
 end
 
 function flex:reset()
@@ -143,6 +146,12 @@ end
 -- equally among all widgets. Widgets can be added via :add(widget).
 function flex.vertical()
     return get_layout("y")
+end
+
+-- Add spacing between each layout widgets
+function flex:set_spacing(spacing)
+    self._spacing = spacing
+    self:emit_signal("widget::updated")
 end
 
 return flex


### PR DESCRIPTION
*_Why: *_
Because it look nice and is better than adding 10000 million margin widgets. Other toolkit also have such option

**Testing done:**
- It does not crash with giant red popup
- Flex fit is the same with and without spacing
- The align is fit_0_spacing+(#widget-1)*spacing

**Screenshot:**
![blender219](https://cloud.githubusercontent.com/assets/340384/4688646/846db996-5686-11e4-9bde-9b257f6a5bae.png)
(see the tag and tasklist)
