### PR TITLE
Add context to request::activate signal (FS#1264)

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -418,7 +418,8 @@ ewmh_process_client_message(xcb_client_message_event_t *ev)
     {
         if((c = client_getbywin(ev->window))) {
             luaA_object_push(globalconf.L, c);
-            luaA_object_emit_signal(globalconf.L, -1, "request::activate", 0);
+            lua_pushstring(globalconf.L,"ewmh");
+            luaA_object_emit_signal(globalconf.L, -2, "request::activate", 1);
             lua_pop(globalconf.L, 1);
         }
     }

--- a/lib/awful/rules.lua.in
+++ b/lib/awful/rules.lua.in
@@ -239,7 +239,7 @@ function rules.execute(c, props, callbacks)
     -- Do this at last so we do not erase things done by the focus
     -- signal.
     if props.focus and (type(props.focus) ~= "function" or props.focus(c)) then
-        c:emit_signal('request::activate')
+        c:emit_signal('request::activate',"rules")
     end
 end
 


### PR DESCRIPTION
Umm I kind of forgot that this one wasn't merged before until I got the "bug" again today. It was on flyspray but was never proposed on Github. So, here it is! An old patch that still work and still fix what it is supposed to fix (aka, an ambiguity between 2 sources)

@blueyed Still think it's a good idea? I still do.
