### PR TITLE
rc.lua: Prevent clients from being lost on RANRD changes (FS1155)

### DIFF
--- a/awesomerc.lua.in
+++ b/awesomerc.lua.in
@@ -383,6 +383,9 @@ client.connect_signal("manage", function (c)
             awful.placement.no_overlap(c)
             awful.placement.no_offscreen(c)
         end
+    elseif not c.size_hints.user_position and not c.size_hints.program_position then
+        -- Prevent clients from being unreachable after screen count change
+        awful.placement.no_offscreen(c)
     end
 
     local titlebars_enabled = false


### PR DESCRIPTION
Testing done:
- Using nvidia-settings

Why:
- Necessary to get Awesome 3.5 into Ubuntu and Debian unstable (Jessie + 1). Too late for Jessie.

I know it is less clean than the branch that support RANDR, but this is a short term fix for the 3.5 branch
