### PR TITLE
Remove urgent state for already focused client

### DIFF
--- a/objects/client.h
+++ b/objects/client.h
@@ -170,7 +170,7 @@ void client_set_icon(client_t *, cairo_surface_t *);
 void client_set_icon_from_pixmaps(client_t *, xcb_pixmap_t, xcb_pixmap_t);
 void client_set_skip_taskbar(lua_State *, int, bool);
 void client_focus(client_t *);
-void client_focus_update(client_t *);
+bool client_focus_update(client_t *);
 bool client_hasproto(client_t *, xcb_atom_t);
 void client_ignore_enterleave_events(void);
 void client_restore_enterleave_events(void);
@@ -222,7 +222,7 @@ client_isfixed(client_t *c)
             && c->size_hints_honor);
 }
 
-/** Returns true if a client is tagged with one of the tags of the 
+/** Returns true if a client is tagged with one of the tags of the
  * specified screen and is not hidden. Note that "banned" clients are included.
  * \param c The client to check.
  * \param screen Virtual screen number.


### PR DESCRIPTION
- Remove urgent state in `client_focus_update` always.
- Make `client_focus_update` indicate if focus changed and use this from
`client_focus` to update `globalconf.focus.need_update`.

Fixes: https://awesome.naquadah.org/bugs/index.php?do=details&task_id=1310