### PR TITLE
Vim style menu navigation in addition to arrow keys

### DIFF
--- a/lib/awful/menu.lua.in
+++ b/lib/awful/menu.lua.in
@@ -56,11 +56,11 @@ end
 -- key to up action. This is common to all created menu.
 -- @class table
 -- @name menu_keys
-menu.menu_keys = { up = { "Up" },
-              down = { "Down" },
-              back = { "Left" },
+menu.menu_keys = { up = { "Up", "k" },
+              down = { "Down", "j" },
+              back = { "Left", "h" },
               exec = { "Return" },
-              enter = { "Right" },
+              enter = { "Right", "l" },
               close = { "Escape" } }
 
 


### PR DESCRIPTION
Is there a reason it shouldn't be on by default? I'm not familiar enough with the code-base to tell if it will clash with anything.