### PR TITLE
implement basic DEB/RPM packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,4 +381,6 @@ else()
 endif()
 # }}}
 
+INCLUDE(${CMAKE_SOURCE_DIR}/Packaging.cmake)
+
 # vim: filetype=cmake:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80:foldmethod=marker

--- a/Packaging.cmake
+++ b/Packaging.cmake
@@ -1,0 +1,62 @@
+if(NOT VERSION)
+	set(VERSION "unknown")
+endif()
+
+string(REGEX REPLACE "^v?([0-9.]+)-?(.*)$"
+	"\\1;\\2" version_result ${VERSION})
+
+list(LENGTH version_result version_result_list_length)
+
+if(version_result_list_length EQUAL 2)
+	list(GET version_result 0 version_num)
+	list(GET version_result 1 version_gitstamp)
+else(version_result_list_length EQUAL 2)
+	message("Unable to deduce a meaningful version number. \
+Set OVERRIDE_VERSION when you run CMake (cmake .. -DOVERRIDE_VERSION=3.14.159), or \
+just build from a git repository.")
+	set(version_num "0.0.0")
+	set(version_gitstamp "")
+endif(version_result_list_length EQUAL 2)
+
+if(version_gitstamp)
+	set(version_gitsuffix "~git${version_gitstamp}")
+else(version_gitstamp)
+	set(version_gitsuffix "")
+endif(version_gitstamp)
+
+string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)"
+	"\\1;\\2;\\3" version_num_split ${version_num})
+
+list(APPEND version_num_split 0 0 0) #ensure the list(GET )) commands below never fail
+
+list(GET version_num_split 0 CPACK_PACKAGE_VERSION_MAJOR)
+list(GET version_num_split 1 CPACK_PACKAGE_VERSION_MINOR)
+list(GET version_num_split 2 CPACK_PACKAGE_VERSION_PATCH)
+
+set(version_num "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+
+message(STATUS "Package version will be set to ${version_num}${version_gitsuffix}.")
+
+set(CPACK_PACKAGE_VERSION "${version_num}${version_gitsuffix}")
+
+if(NOT CPACK_GENERATOR)
+	find_program(rpmbuild_path "rpmbuild")
+	if(rpmbuild_path)
+		message(STATUS "rpmbuild found, enabling RPM for the 'package' target")
+		list(APPEND CPACK_GENERATOR RPM)
+	endif(rpmbuild_path)
+
+	find_program(dpkg_path "dpkg")
+	if (dpkg_path)
+		message(STATUS "dpkg found, enabling DEB for the 'package' target")
+		list(APPEND CPACK_GENERATOR DEB)
+	endif(dpkg_path)
+endif(NOT CPACK_GENERATOR)
+
+set(CPACK_PACKAGE_NAME "awesome")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "devnull@example.com")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A tiling window manager")
+
+if(CPACK_GENERATOR)
+	include(CPack)
+endif()

--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -12,9 +12,17 @@ After extracting the dist tarball, run:
 
 This will create a build directory, run cmake in it and build awesome.
 
-After building is finished, you can install:
+After building is finished, you can either install via `make install`:
 
     make install  # you might need root permissions
+
+or by auto-generating a .deb or .rpm package, for easy removal later on:
+
+    make package
+    
+    sudo dpkg -i awesome-x.y.z.deb
+    # or
+    sudo rpm -Uvh awesome-x.y.z.rpm
 
 ## Running awesome
 


### PR DESCRIPTION
continuing on from https://github.com/awesomeWM/awesome/pull/68, which I messed up the history of.

implement basic DEB packaging with CMake. (I don't have an RPM system to test with, but it should be trivial top add that on top of this)
This is very useful for users running from git, as it still allows for easy installation while also having dpkg manage all of awesome's files.

further from that, cpack now knows about awesome's version, so the output files will be named awesome-v3.5.2~git999... instead of awesome-0.1.1.
