### PR TITLE
menubar: handle nil Name in .desktop files

### DIFF
--- a/lib/menubar/utils.lua.in
+++ b/lib/menubar/utils.lua.in
@@ -177,6 +177,9 @@ function utils.parse(file)
     if program.Exec then
         -- Substitute Exec special codes as specified in
         -- http://standards.freedesktop.org/desktop-entry-spec/1.1/ar01s06.html
+        if program.Name == nil then
+            program.Name = '['.. file:match("([^/]+)%.desktop$") ..']'
+        end
         local cmdline = program.Exec:gsub('%%c', program.Name)
         cmdline = cmdline:gsub('%%[fuFU]', '')
         cmdline = cmdline:gsub('%%k', program.file)


### PR DESCRIPTION
Fixes erroring out on gsub() call, which propagated to a nil result from menu_gen.generate()