### PR TITLE
awful.rules.execute: use delayed_call for emitting request::activate

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -545,6 +545,10 @@ main(int argc, char **argv)
     g_main_context_set_poll_func(g_main_context_default(), &a_glib_poll);
     gettimeofday(&last_wakeup, NULL);
 
+    /* Do all deferred work now once outside of the loop to get awesome.startup
+     * right. */
+    awesome_refresh();
+
     /* main event loop */
     globalconf.loop = g_main_loop_new(NULL, FALSE);
     g_main_loop_run(globalconf.loop);

--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -253,9 +253,14 @@ luaA_object_emit_signal(lua_State *L, int oud,
                         const char *name, int nargs)
 {
     int oud_abs = luaA_absindex(L, oud);
-    lua_object_t *obj = lua_touserdata(L, oud);
+    lua_class_t *lua_class = luaA_class_get(L, oud);
+    lua_object_t *obj = luaA_toudata(L, oud, lua_class);
     if(!obj) {
         warn("Trying to emit signal '%s' on non-object", name);
+        return;
+    }
+    else if(lua_class->checker && !lua_class->checker(obj)) {
+        warn("Trying to emit signal '%s' on invalid object", name);
         return;
     }
     signal_t *sigfound = signal_array_getbyid(&obj->signals,

--- a/lib/awful/rules.lua.in
+++ b/lib/awful/rules.lua.in
@@ -12,6 +12,7 @@ local ipairs = ipairs
 local pairs = pairs
 local aclient = require("awful.client")
 local atag = require("awful.tag")
+local timer = require("gears.timer")
 
 --- Apply rules to clients at startup.
 -- awful.rules
@@ -234,7 +235,10 @@ function rules.execute(c, props, callbacks)
     -- Do this at last so we do not erase things done by the focus
     -- signal.
     if props.focus and (type(props.focus) ~= "function" or props.focus(c)) then
-        c:emit_signal('request::activate',"rules")
+        local cb = function(c)
+            c:emit_signal('request::activate', "rules")
+        end
+        timer.delayed_call(cb, c)
     end
 end
 

--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -630,7 +630,9 @@ capi.client.connect_signal("manage", function(c)
     c:connect_signal("property::screen", tag.withcurrent)
 end)
 
-capi.client.connect_signal("manage", tag.withcurrent)
+capi.client.connect_signal("manage", function(c)
+    timer.delayed_call(tag.withcurrent, c)
+end)
 capi.tag.connect_signal("request::select", tag.viewonly)
 
 capi.tag.add_signal("property::hide")


### PR DESCRIPTION
This is a followup to commit 90fde13, which caused the client not to be
visible during the request::activate callback.

This requires an initial call to `awesome_refresh` before the main loop
to get `awesome.startup` right.

Ref: https://github.com/awesomeWM/awesome/commit/90fde139#commitcomment-9308225