### PR TITLE
Make textbox widget respect the current theme

### DIFF
--- a/lib/wibox/widget/textbox.lua.in
+++ b/lib/wibox/widget/textbox.lua.in
@@ -136,7 +136,7 @@ local function new(text, ignore_markup)
     ret:set_wrap("word_char")
     ret:set_valign("center")
     ret:set_align("left")
-    ret:set_font(theme and theme.font)
+    ret:set_font(beautiful and beautiful.font)
 
     if text then
         if ignore_markup then

--- a/lib/wibox/widget/textbox.lua.in
+++ b/lib/wibox/widget/textbox.lua.in
@@ -7,7 +7,6 @@
 
 local base = require("wibox.widget.base")
 local beautiful = require("beautiful")
-local theme = beautiful.get()
 local lgi = require("lgi")
 local cairo = lgi.cairo
 local Pango = lgi.Pango

--- a/lib/wibox/widget/textbox.lua.in
+++ b/lib/wibox/widget/textbox.lua.in
@@ -7,6 +7,7 @@
 
 local base = require("wibox.widget.base")
 local beautiful = require("beautiful")
+local theme = beautiful.get()
 local lgi = require("lgi")
 local cairo = lgi.cairo
 local Pango = lgi.Pango
@@ -136,7 +137,7 @@ local function new(text, ignore_markup)
     ret:set_wrap("word_char")
     ret:set_valign("center")
     ret:set_align("left")
-    ret:set_font()
+    ret:set_font(theme and theme.font)
 
     if text then
         if ignore_markup then


### PR DESCRIPTION
Without this fix `wibox.widget.textbox` ignores current theme font setting and resets to the initial one.

It becomes handy when initial theme is tweaked during runtime, ie. in *rc.lua* . Other Awesome WM components like `awful` (taglist, tasklist, menu) are aware and do respect actual theme settings.