### PR TITLE
Don't add margin when icon_only = true

### DIFF
--- a/lib/awful/widget/common.lua.in
+++ b/lib/awful/widget/common.lua.in
@@ -76,8 +76,12 @@ function common.list_update(w, buttons, label, data, objects)
 
         local text, bg, bg_image, icon = label(o)
         -- The text might be invalid, so use pcall
-        if not pcall(tb.set_markup, tb, text) then
-            tb:set_markup("<i>&lt;Invalid text&gt;</i>")
+        if text == nil or text == "" then
+            m:set_margins(0)
+        else
+            if not pcall(tb.set_markup, tb, text) then
+                tb:set_markup("<i>&lt;Invalid text&gt;</i>")
+            end
         end
         bgb:set_bg(bg)
         if type(bg_image) == "function" then

--- a/lib/awful/widget/taglist.lua.in
+++ b/lib/awful/widget/taglist.lua.in
@@ -43,7 +43,7 @@ function taglist.taglist_label(t, args)
     local taglist_squares_resize = theme.taglist_squares_resize or args.squares_resize or "true"
     local taglist_disable_icon = args.taglist_disable_icon or theme.taglist_disable_icon or false
     local font = args.font or theme.taglist_font or theme.font or ""
-    local text = "<span font_desc='"..font.."'>"
+    local text = nil
     local sel = capi.client.focus
     local bg_color = nil
     local fg_color = nil
@@ -98,14 +98,15 @@ function taglist.taglist_label(t, args)
         fg_color = fg_focus
     end
     if not tag.getproperty(t, "icon_only") then
+        text = "<span font_desc='"..font.."'>"
         if fg_color then
             text = text .. "<span color='"..util.color_strip_alpha(fg_color).."'>" ..
                 (util.escape(t.name) or "") .. "</span>"
         else
             text = text .. (util.escape(t.name) or "")
         end
+        text = text .. "</span>"
     end
-    text = text .. "</span>"
     if not taglist_disable_icon then
         if tag.geticon(t) and type(tag.geticon(t)) == "image" then
             icon = tag.geticon(t)


### PR DESCRIPTION
Avoid adding an unnecessary margit to the taglist if it has the
`icon_only` property.

Fixes FS#1199 - widgets add an unnecessary margin if icon_only= true
https://awesome.naquadah.org/bugs/index.php?do=details&task_id=1199