### PR TITLE
Send old_screen with "property::screen" client signal

### DIFF
--- a/lib/awful/layout/init.lua.in
+++ b/lib/awful/layout/init.lua.in
@@ -140,10 +140,12 @@ capi.client.connect_signal("property::border_width", arrange_prop)
 capi.client.connect_signal("property::hidden", arrange_prop)
 capi.client.connect_signal("property::floating", arrange_prop)
 capi.client.connect_signal("property::geometry", arrange_prop)
--- If prop is screen, we do not know what was the previous screen, so
--- let's arrange all screens :-(
-capi.client.connect_signal("property::screen", function(c)
-    for screen = 1, capi.screen.count() do layout.arrange(screen) end end)
+capi.client.connect_signal("property::screen", function(c, old_screen)
+    if old_screen then
+        layout.arrange(old_screen)
+    end
+    layout.arrange(c.screen)
+end)
 
 local function arrange_on_tagged(c, tag)
     if not tag.screen then return end

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -373,6 +373,7 @@ screen_client_moveto(client_t *c, screen_t *new_screen, bool doresize)
 {
     lua_State *L = globalconf_get_lua_State();
     screen_t *old_screen = c->screen;
+    int old_screen_idx = screen_get_index(old_screen);
     area_t from, to;
     bool had_focus = false;
 
@@ -387,7 +388,11 @@ screen_client_moveto(client_t *c, screen_t *new_screen, bool doresize)
     if(!doresize)
     {
         luaA_object_push(L, c);
-        luaA_object_emit_signal(L, -1, "property::screen", 0);
+        if(old_screen_idx != 0)
+            lua_pushinteger(L, old_screen_idx);
+        else
+            lua_pushnil(L);
+        luaA_object_emit_signal(L, -2, "property::screen", 1);
         lua_pop(L, 1);
         if(had_focus)
             client_focus(c);
@@ -417,7 +422,11 @@ screen_client_moveto(client_t *c, screen_t *new_screen, bool doresize)
     /* move / resize the client */
     client_resize(c, new_geometry, false);
     luaA_object_push(L, c);
-    luaA_object_emit_signal(L, -1, "property::screen", 0);
+    if(old_screen_idx != 0)
+        lua_pushinteger(L, old_screen_idx);
+    else
+        lua_pushnil(L);
+    luaA_object_emit_signal(L, -2, "property::screen", 1);
     lua_pop(L, 1);
     if(had_focus)
         client_focus(c);


### PR DESCRIPTION
This should improve layout re-arranging with 2+ screens.