### PR TITLE
Emit tag::history::update signal from tag.history.restore

### DIFF
--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -234,6 +234,8 @@ function tag.history.restore(screen, idx)
     data.history[s].previous = setmetatable(sel, { __mode = 'v' })
     -- remove the reverted history entry
     if i ~= "previous" then table.remove(data.history[s], i) end
+
+    capi.screen[s]:emit_signal("tag::history::update")
 end
 
 --- Get a list of all tags on a screen


### PR DESCRIPTION
Restoring a previous history entry changes the tag history (in the
meaning of currently selected tags), and therefore should also emit the
tag::history::update signal.

A use case might be to automatically hide tags with no clients on them.

Signed-off-by: Daniel Hahler <git@thequod.de>