### PR TITLE
DRY off layout code

### DIFF
--- a/lib/awful/layout/init.lua.in
+++ b/lib/awful/layout/init.lua.in
@@ -112,7 +112,13 @@ function layout.arrange(screen)
         p.geometry = capi.screen[screen].geometry
         p.clients = client.tiled(screen)
         p.screen = screen
+        p.geometries = setmetatable({}, {__mode = "k"})
         layout.get(screen).arrange(p)
+        for c, g in pairs(p.geometries) do
+            g.width = g.width - c.border_width * 2
+            g.height = g.height - c.border_width * 2
+            c:geometry(g)
+        end
         capi.screen[screen]:emit_signal("arrange")
 
         arrange_lock = false

--- a/lib/awful/layout/suit/fair.lua.in
+++ b/lib/awful/layout/suit/fair.lua.in
@@ -64,8 +64,6 @@ local function do_fair(p, orientation)
                 g.x = g.width * col
             end
 
-            g.height = g.height - c.border_width * 2
-            g.width = g.width - c.border_width * 2
             g.y = g.y + wa.y
             g.x = g.x + wa.x
 
@@ -75,7 +73,7 @@ local function do_fair(p, orientation)
                 g.x, g.y = g.y, g.x
             end
 
-            c:geometry(g)
+            p.geometries[c] = g
         end
     end
 end

--- a/lib/awful/layout/suit/magnifier.lua.in
+++ b/lib/awful/layout/suit/magnifier.lua.in
@@ -88,10 +88,10 @@ function magnifier.arrange(p)
     local g = {
         x = geometry.x,
         y = geometry.y,
-        width = geometry.width - focus.border_width * 2,
-        height = geometry.height - focus.border_width * 2
+        width = geometry.width,
+        height = geometry.height
     }
-    focus:geometry(g)
+    p.geometries[focus] = g
 
     if #cls > 1 then
         geometry.x = area.x
@@ -111,7 +111,12 @@ function magnifier.arrange(p)
 
         -- First move clients that are before focused client.
         for k = fidx + 1, #cls do
-            cls[k]:geometry(geometry)
+            p.geometries[cls[k]] = {
+                x = geometry.x,
+                y = geometry.y,
+                width = geometry.width,
+                height = geometry.height
+            }
             geometry.y = geometry.y + geometry.height
         end
 
@@ -121,10 +126,10 @@ function magnifier.arrange(p)
             local g = {
                 x = geometry.x,
                 y = geometry.y,
-                width = geometry.width - cls[k].border_width * 2,
-                height = geometry.height - cls[k].border_width * 2
+                width = geometry.width,
+                height = geometry.height
             }
-            cls[k]:geometry(g)
+            p.geometries[cls[k]] = g
             geometry.y = geometry.y + geometry.height
         end
     end

--- a/lib/awful/layout/suit/max.lua.in
+++ b/lib/awful/layout/suit/max.lua.in
@@ -25,10 +25,10 @@ local function fmax(p, fs)
         local g = {
             x = area.x,
             y = area.y,
-            width = area.width - c.border_width * 2,
-            height = area.height - c.border_width * 2
+            width = area.width,
+            height = area.height
         }
-        c:geometry(g)
+        p.geometries[c] = g
     end
 end
 

--- a/lib/awful/layout/suit/spiral.lua.in
+++ b/lib/awful/layout/suit/spiral.lua.in
@@ -50,10 +50,10 @@ local function do_spiral(p, _spiral)
         local g = {
             x = wa.x,
             y = wa.y,
-            width = wa.width - 2 * c.border_width,
-            height = wa.height - 2 * c.border_width
+            width = wa.width,
+            height = wa.height
         }
-        c:geometry(g)
+        p.geometries[c] = g
     end
 end
 

--- a/lib/awful/layout/suit/tile.lua.in
+++ b/lib/awful/layout/suit/tile.lua.in
@@ -117,7 +117,7 @@ local function mouse_resize_handler(c, corner, x, y, orientation)
                           end, cursor)
 end
 
-local function tile_group(cls, wa, orientation, fact, group)
+local function tile_group(gs, cls, wa, orientation, fact, group)
     -- get our orientation right
     local height = "height"
     local width = "width"
@@ -142,7 +142,6 @@ local function tile_group(cls, wa, orientation, fact, group)
         local i = c - group.first +1
         local size_hints = cls[c].size_hints
         local size_hint = size_hints["min_"..width] or size_hints["base_"..width] or 0
-        size_hint = size_hint + cls[c].border_width*2
         size = math.max(size_hint, size)
 
         -- calculate the height
@@ -156,20 +155,22 @@ local function tile_group(cls, wa, orientation, fact, group)
     size = math.min(size, available)
 
     local coord = wa[y]
-    local geom = {}
     local used_size = 0
     local unused = wa[height]
     for c = group.first,group.last do
+        local geom = {}
+        local hints = {}
         local i = c - group.first +1
-        geom[width] = size - cls[c].border_width * 2
-        geom[height] = math.floor(unused * fact[i] / total_fact) - cls[c].border_width * 2
+        geom[width] = size
+        geom[height] = math.floor(unused * fact[i] / total_fact)
         geom[x] = group.coord
         geom[y] = coord
-        geom = cls[c]:geometry(geom)
-        coord = coord + geom[height] + cls[c].border_width * 2
-        unused = unused - geom[height] - cls[c].border_width * 2
+        gs[cls[c]] = geom
+        hints.width, hints.height = cls[c]:apply_size_hints(geom.width, geom.height)
+        coord = coord + hints[height]
+        unused = unused - hints[height]
         total_fact = total_fact - fact[i]
-        used_size = math.max(used_size, geom[width] + cls[c].border_width * 2)
+        used_size = math.max(used_size, hints[width])
     end
 
     return used_size
@@ -191,6 +192,7 @@ local function do_tile(param, orientation)
         y = "x"
     end
 
+    local gs = param.geometries
     local cls = param.clients
     local nmaster = math.min(tag.getnmaster(t), #cls)
     local nother = math.max(#cls - nmaster,0)
@@ -223,7 +225,7 @@ local function do_tile(param, orientation)
             if not data[0] then
                 data[0] = {}
             end
-            coord = coord + tile_group(cls, wa, orientation, data[0], {first=1, last=nmaster, coord = coord, size = size})
+            coord = coord + tile_group(gs, cls, wa, orientation, data[0], {first=1, last=nmaster, coord = coord, size = size})
         end
 
         if not place_master and nother > 0 then
@@ -243,7 +245,7 @@ local function do_tile(param, orientation)
                 if not data[i] then
                     data[i] = {}
                 end
-                coord = coord + tile_group(cls, wa, orientation, data[i], { first = first, last = last, coord = coord, size = size })
+                coord = coord + tile_group(gs, cls, wa, orientation, data[i], { first = first, last = last, coord = coord, size = size })
             end
         end
         place_master = not place_master


### PR DESCRIPTION
I noticed that each layout has its own code for setting client geometry and handling border widths, which is repetitious and over-complicated.

This PR reorganize things a little, so that each layout returns an array of of {client, geometry} pairs and these are all handled centrally by `awful.layout.arrange`. This has many advantages:

 1. Border widths can be handled as a simple post-processing step once all the client geometries have been returned
 2. Layouts are a little easier to write since you don't have to think about border widths
 3. Previously if a client's geometry was not altered by a layout, there was no way to tell whether that was because the client happened to have the correct geometry already or if the layout didn't care about the client's geometry at all (e.g. the floating layout). Now this distinction is explicit (by the layout not returning a {client, geometry} pair).
 4. Useless gaps (#80) can be easily implemented as another post-processing step, like border widths