### PR TITLE
WIP: Persistent tag properties

### DIFF
--- a/lib/awful/layout/init.lua.in
+++ b/lib/awful/layout/init.lua.in
@@ -58,6 +58,16 @@ function layout.get(screen)
     return tag.getproperty(t, "layout") or layout.suit.floating
 end
 
+--- Get a layout by name.
+-- @return The layout function.
+function layout.get_by_name(name)
+    for _,layout in ipairs(layout.layouts) do
+        if layout.name == name then
+            return layout
+        end
+    end
+end
+
 --- Change the layout of the current tag.
 -- @param i Relative index.
 -- @param s The screen number. 
@@ -92,7 +102,7 @@ function layout.inc(i, s, layouts)
 end
 
 --- Set the layout function of the current tag.
--- @param _layout Layout name.
+-- @param _layout Layout.
 -- @param t The tag to modify, if null tag.selected() is used.
 function layout.set(_layout, t)
     t = t or tag.selected()

--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -31,6 +31,12 @@ local data = {}
 data.history = {}
 data.tags = setmetatable({}, { __mode = 'k' })
 
+data.properties = setmetatable({}, { __mode = 'k' })
+data.persistent_properties_registered = {} -- keys are names of persistent properties, value is the type.
+data.persistent_properties_loaded = setmetatable({}, { __mode = 'k' }) -- keys are tags, value always true.
+
+tag.property = {}
+
 -- History functions
 tag.history = {}
 tag.history.limit = 20
@@ -86,10 +92,10 @@ end
 function tag.add(name, props)
     local properties = props or {}
 
-    -- Be sure to set the screen before the tag is activated to avoid function
+    -- Be sure to set the screen before the tag is activated to avoid functions
     -- connected to property::activated to be called without a valid tag.
-    -- set properies cannot be used as this has to be set before the first signal
-    -- is sent
+    -- "property.set" cannot be used as this has to be set before the first
+    -- signal is sent.
     properties.screen = properties.screen or capi.mouse.screen
 
     -- Index is also required
@@ -97,8 +103,12 @@ function tag.add(name, props)
 
     local newtag = capi.tag{ name = name }
 
-    -- Start with a fresh property table to avoid collisions with unsupported data
+    -- Start with a fresh property table to avoid collisions with unsupported data.
     data.tags[newtag] = {screen=properties.screen, index=properties.index}
+
+    for p, type in pairs(data.persistent_properties_registered) do
+        tag.property.persist_for_tag(newtag, p, type)
+    end
 
     newtag.activated = true
 
@@ -557,23 +567,101 @@ end
 -- @tparam string prop The property name.
 -- @return The property.
 function tag.getproperty(_tag, prop)
-    if data.tags[_tag] then
-        return data.tags[_tag][prop]
+    util.deprecate("awful.tag.property.get")
+    return tag.property.get(_tag, prop)
+end
+
+function tag.setproperty(_tag, prop, value)
+    util.deprecate("awful.tag.property.set")
+    return tag.property.set(_tag, prop, value)
+end
+
+
+function tag.get_id(t)
+    return data.tags[t].screen .. '_' .. t.name
+end
+
+--- Get a tag property.
+-- @param _tag The tag.
+-- @param prop The property name.
+-- @return The property value.
+function tag.property.get(t, prop)
+    if t and not data.persistent_properties_loaded[t] then
+        data.persistent_properties_loaded[t] = true
+        for p in pairs(data.persistent_properties_registered) do
+            local value = awesome.get_xproperty("awful.tag.property."
+                .. tag.get_id(t) .. '.' .. p)
+            if value ~= nil then
+                if p == "layout" then
+                    -- HACK
+                    local alayout = require("awful.layout")
+                    value = alayout.get_by_name(value)
+                end
+                if value ~= nil then
+                    tag.property.set(t, p, value)
+                end
+            end
+            print("GET: awful.tag.property."
+                            .. tag.get_id(t) .. '.' .. p .. ' => ' .. tostring(value))
+        end
+    end
+    if data.tags[t] then
+        return data.tags[t][prop]
     end
 end
 
 --- Set a tag property.
--- This properties are internal to awful. Some are used to draw taglist, or to
+-- These properties are internal to awful. Some are used to draw taglist, or to
 -- handle layout, etc.
--- @param _tag The tag.
+-- @param t The tag.
 -- @param prop The property name.
 -- @param value The value.
-function tag.setproperty(_tag, prop, value)
-    if not data.tags[_tag] then
-        data.tags[_tag] = {}
+function tag.property.set(t, prop, value)
+    if not data.tags[t] then
+        data.tags[t] = {}
     end
-    data.tags[_tag][prop] = value
-    _tag:emit_signal("property::" .. prop)
+    if prop == "layout" then
+        if type(value) == "string" then
+            local alayout = require("awful.layout")
+            value = alayout.get_by_name(value)
+        end
+    end
+    if data.persistent_properties_registered[prop] then
+        local xprop = "awful.tag.property." .. tag.get_id(t) .. '.' .. prop
+        local xvalue = prop == "layout" and value and value.name or value
+        print("SET: " .. xprop .. " => " .. tostring(xvalue))
+        awesome.set_xproperty(xprop, xvalue)
+    end
+    data.tags[t][prop] = value
+    t:emit_signal("property::" .. prop)
+end
+
+function tag.property.persist_for_tag(t, prop, type)
+    xprop = "awful.tag.property." .. tag.get_id(t) .. "." .. prop
+    print("REGISTER: awful.tag.property." .. tag.get_id(t) .. "." .. prop)
+    awesome.register_xproperty(xprop, type)
+end
+
+--- Set a tag property to be persistent across restarts (via X properties).
+-- @param t The tag.
+-- @param prop The property name.
+-- @param type The type (used for register_xproperty).
+--             One of "string", "number" or "boolean".
+function tag.property.persist(prop, type)
+    local xprop
+    for _, t in ipairs(root.tags()) do
+        tag.property.persist_for_tag(t, prop, type)
+    end
+
+    -- Make already-set properties persistent
+    for t in pairs(data.properties) do
+        if data.properties[t] and data.properties[t][prop] ~= nil then
+            xprop = "awful.tag.property." .. tag.get_id(t) .. "." .. prop
+            awesome.set_xproperty(xprop, data.properties[t][prop])
+        end
+    end
+
+    data.persistent_properties_registered[prop] = type
 end
 
 --- Tag a client with the set of current tags.
@@ -685,6 +773,10 @@ capi.screen.add_signal("tag::history::update")
 for s = 1, capi.screen.count() do
     capi.screen[s]:connect_signal("tag::history::update", tag.history.update)
 end
+
+-- Register persistent properties.
+-- This uses the screen and index properties for the key/name.
+tag.property.persist("layout", "string")
 
 function tag.mt:__call(...)
     return tag.new(...)

--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -32,7 +32,7 @@ data.history = {}
 data.tags = setmetatable({}, { __mode = 'k' })
 
 data.properties = setmetatable({}, { __mode = 'k' })
-data.persistent_properties_registered = {} -- keys are names of persistent properties, value is the type.
+data.persistent_properties_registered = {} -- keys are names of persistent properties, value is a table of {type, conversion_function}.
 data.persistent_properties_loaded = setmetatable({}, { __mode = 'k' }) -- keys are tags, value always true.
 
 tag.property = {}
@@ -106,8 +106,8 @@ function tag.add(name, props)
     -- Start with a fresh property table to avoid collisions with unsupported data.
     data.tags[newtag] = {screen=properties.screen, index=properties.index}
 
-    for p, type in pairs(data.persistent_properties_registered) do
-        tag.property.persist_for_tag(newtag, p, type)
+    for p, pmeta in pairs(data.persistent_properties_registered) do
+        tag.property.persist_for_tag(newtag, p, pmeta.type)
     end
 
     newtag.activated = true
@@ -584,6 +584,9 @@ end
 
 
 function tag.get_id(t)
+    if not data.tags[t] then
+        return nil
+    end
     return data.tags[t].screen .. '_' .. t.name
 end
 
@@ -594,17 +597,17 @@ end
 function tag.property.get(t, prop)
     if t and not data.persistent_properties_loaded[t] then
         data.persistent_properties_loaded[t] = true
-        for p in pairs(data.persistent_properties_registered) do
-            local value = awesome.get_xproperty("awful.tag.property."
+        for p, pmeta in pairs(data.persistent_properties_registered) do
+            local xvalue = awesome.get_xproperty("awful.tag.property."
                 .. tag.get_id(t) .. '.' .. p)
-            if value ~= nil then
-                if p == "layout" then
-                    -- HACK
-                    local alayout = require("awful.layout")
-                    value = alayout.get_by_name(value)
+            local value
+
+            if xvalue ~= nil then
+                if pmeta and pmeta.convert_f then
+                    value = pmeta.convert_f.from_xproperty(xvalue)
                 end
                 if value ~= nil then
-                    tag.property.set(t, p, value)
+                    tag.property.set(t, p, value, true)  -- Skip setting xproperty again.
                 end
             end
             print("GET: awful.tag.property."
@@ -622,20 +625,22 @@ end
 -- @param t The tag.
 -- @param prop The property name.
 -- @param value The value.
-function tag.property.set(t, prop, value)
+-- @param skip_xprop Skip setting the X property (internal).
+function tag.property.set(t, prop, value, skip_xprop)
+    assert(type(t) == "tag", "tag.property.set: "..type(t).." given instead of tag.")
     if not data.tags[t] then
         data.tags[t] = {}
     end
-    if prop == "layout" then
-        if type(value) == "string" then
-            local alayout = require("awful.layout")
-            value = alayout.get_by_name(value)
-        end
-    end
-    if data.persistent_properties_registered[prop] then
+    if not skip_xprop and data.persistent_properties_registered[prop] then
         local xprop = "awful.tag.property." .. tag.get_id(t) .. '.' .. prop
-        local xvalue = prop == "layout" and value and value.name or value
-        print("SET: " .. xprop .. " => " .. tostring(xvalue))
+        local xvalue
+
+        local pmeta = data.persistent_properties_registered[prop]
+        if pmeta and pmeta.convert_f then
+            xvalue = pmeta.convert_f.to_xproperty(value)
+        else
+            xvalue = value
+        end
         awesome.set_xproperty(xprop, xvalue)
     end
     data.tags[t][prop] = value
@@ -644,16 +649,38 @@ end
 
 function tag.property.persist_for_tag(t, prop, type)
     xprop = "awful.tag.property." .. tag.get_id(t) .. "." .. prop
-    print("REGISTER: awful.tag.property." .. tag.get_id(t) .. "." .. prop)
     awesome.register_xproperty(xprop, type)
 end
+
+
+-- Helper methods for conversion from/to X properties.
+-- These need to get cleaned up / refactored.
+local convert_float = {}
+convert_float.to_xproperty = function (float)
+    return tostring(float)
+end
+convert_float.from_xproperty = function (s)
+    return tonumber(s)
+end
+
+local convert_layout = {}
+convert_layout.to_xproperty = function (layout)
+    return layout.name
+end
+convert_layout.from_xproperty = function (s)
+    local alayout = require("awful.layout")
+    return alayout.get_by_name(s)
+end
+
 
 --- Set a tag property to be persistent across restarts (via X properties).
 -- @param t The tag.
 -- @param prop The property name.
 -- @param type The type (used for register_xproperty).
 --             One of "string", "number" or "boolean".
-function tag.property.persist(prop, type)
+-- @param convert_f Table object with to_xproperty/from_xproperty
+--                  functions, for conversion.
+function tag.property.persist(prop, type, convert_f)
     local xprop
     for _, t in ipairs(root.tags()) do
         tag.property.persist_for_tag(t, prop, type)
@@ -667,7 +694,9 @@ function tag.property.persist(prop, type)
         end
     end
 
-    data.persistent_properties_registered[prop] = type
+    data.persistent_properties_registered[prop] = {
+        type=type, convert_f=convert_f
+    }
 end
 
 --- Tag a client with the set of current tags.
@@ -692,7 +721,7 @@ end
 
 local function attached_connect_signal_screen(screen, sig, func)
     capi.tag.connect_signal(sig, function(_tag, ...)
-        if tag.getscreen(_tag) == screen then
+        if _tag.activated and tag.getscreen(_tag) == screen then
             func(_tag)
         end
     end)
@@ -782,7 +811,13 @@ end
 
 -- Register persistent properties.
 -- This uses the screen and index properties for the key/name.
-tag.property.persist("layout", "string")
+tag.property.persist("hide",       "boolean")
+tag.property.persist("icon",       "string")
+tag.property.persist("layout",     "string", convert_layout)
+tag.property.persist("mwfact",     "string", convert_float)
+tag.property.persist("ncol",       "number")
+tag.property.persist("nmaster",    "number")
+tag.property.persist("windowfact", "string", convert_float)
 
 function tag.mt:__call(...)
     return tag.new(...)

--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -128,9 +128,15 @@ function tag.new(names, screen, layout)
     local screen = screen or 1
     local tags = {}
     for id, name in ipairs(names) do
-        table.insert(tags, id, tag.add(name, {screen = screen,
-                                            layout = (layout and layout[id]) or
-                                                        layout}))
+        local t = tag.add(name, {screen = screen})
+
+        -- Handle persistent layout: do not overwrite it.
+        if not tag.property.get(t, "layout") then
+            layout = (layout and layout[id]) or layout
+            tag.property.set(t, "layout", layout)
+        end
+
+        table.insert(tags, id, t)
         -- Select the first tag.
         if id == 1 then
             tags[id].selected = true


### PR DESCRIPTION
This brings persistent properties for tags, via X properties on the root window (via `awesome.set_xproperty` etc).

This has been discussed / sketched in https://github.com/awesomeWM/awesome/pull/29 before.