### PR TITLE
awful.util.file_readable: return false for dirs

### DIFF
--- a/lib/awful/util.lua.in
+++ b/lib/awful/util.lua.in
@@ -207,13 +207,18 @@ function util.geticonpath(iconname, exts, dirs, size)
     end
 end
 
---- Check if file exists and is readable.
--- @param filename The file path
--- @return True if file exists and readable.
+--- Check if a file exists, is not readable and not a directory.
+-- @param filename The file path.
+-- @return True if file exists and is readable.
 function util.file_readable(filename)
     local file = io.open(filename)
     if file then
+        local _, _, code = file:read(1)
         io.close(file)
+        if code == 21 then
+            -- "Is a directory".
+            return false
+        end
         return true
     end
     return false


### PR DESCRIPTION
This is currently only used for icon lookups / where files are expected.