### PR TITLE
awful.util.deprecate: display deprecations only once

### DIFF
--- a/lib/awful/util.lua.in
+++ b/lib/awful/util.lua.in
@@ -30,13 +30,21 @@ util.table = {}
 
 util.shell = os.getenv("SHELL") or "/bin/sh"
 
+local displayed_deprecations = {}
+--- Display a deprecation notice, but only once per traceback.
+-- @param see Optional message to a new method / function to use.
 function util.deprecate(see)
+    local tb = debug.traceback()
+    if util.table.hasitem(displayed_deprecations, tb) then
+        return
+    end
+    table.insert(displayed_deprecations, tb)
     io.stderr:write("W: awful: function is deprecated")
     if see then
         io.stderr:write(", see " .. see)
     end
     io.stderr:write("\n")
-    io.stderr:write(debug.traceback())
+    io.stderr:write(tb)
 end
 
 --- Strip alpha part of color.

--- a/lib/awful/util.lua.in
+++ b/lib/awful/util.lua.in
@@ -17,6 +17,7 @@ local type = type
 local rtable = table
 local pairs = pairs
 local string = string
+local glib = require("lgi").GLib
 local capi =
 {
     awesome = awesome,
@@ -35,16 +36,16 @@ local displayed_deprecations = {}
 -- @param see Optional message to a new method / function to use.
 function util.deprecate(see)
     local tb = debug.traceback()
-    if util.table.hasitem(displayed_deprecations, tb) then
+    local tbhash = glib.String():append(tb):hash()
+    if displayed_deprecations[tbhash] then
         return
     end
-    table.insert(displayed_deprecations, tb)
+    displayed_deprecations[tbhash] = true
     io.stderr:write("W: awful: function is deprecated")
     if see then
         io.stderr:write(", see " .. see)
     end
-    io.stderr:write("\n")
-    io.stderr:write(tb)
+    io.stderr:write("\n" .. tb .. "\n")
 end
 
 --- Strip alpha part of color.


### PR DESCRIPTION
This remembers displayed tracebacks and skips them if they were
displayed already.