### PR TITLE
Print debug.traceback() with imagebox:set_image, when reading image failed

### DIFF
--- a/lib/wibox/widget/imagebox.lua.in
+++ b/lib/wibox/widget/imagebox.lua.in
@@ -83,6 +83,7 @@ function imagebox:set_image(image)
         local success, result = pcall(surface.load, image)
         if not success then
             print("Error while reading '" .. image .. "': " .. result)
+            print(debug.traceback())
             return false
         end
         image = result


### PR DESCRIPTION
This made it easier to figure out where a file causing an error was
coming from, but I could imagine that this could become too noisy, and
that there is/should probably be a more streamlined way to enable more
verbose logging / error output.