### PR TITLE
awful.client.jumpto: make client sticky with tab.viewonly()

### DIFF
--- a/lib/awful/client.lua.in
+++ b/lib/awful/client.lua.in
@@ -66,7 +66,12 @@ function client.jumpto(c, merge)
         if merge then
             t.selected = true
         else
+            -- Make client sticky temporarily, to prevent autofocus etc from
+            -- considering it to be not visible.
+            local c_sticky = c.sticky
+            c.sticky = true
             tag.viewonly(t)
+            c.sticky = c_sticky
         end
     end
 


### PR DESCRIPTION
This avoids awful.autofocus to kick in, focusing some other client in
between (where a focused signal would get emitted for, although the
intermediate client was never meant to have focus).

This is the traceback:

    stack traceback:
      /home/user/.config/awesome/cyclefocus/init.lua:199: in function 'add'
      /home/user/.config/awesome/cyclefocus/init.lua:309: in function </home/user/.config/awesome/cyclefocus/init.lua:304>
      [C]: ?
      /usr/local/share/awesome/lib/awful/autofocus.lua:22: in function 'check_focus'
      /usr/local/share/awesome/lib/awful/autofocus.lua:31: in function </usr/local/share/awesome/lib/awful/autofocus.lua:28>
      [C]: ?
      /usr/local/share/awesome/lib/awful/tag.lua:517: in function 'viewonly'
      /usr/local/share/awesome/lib/awful/client.lua:69: in function 'jumpto'
      /home/user/.config/awesome/rc.lua:1188: in function 'client_run_or_raise'
      /home/user/.config/awesome/rc.lua:1217: in function 'run_or_raise'
      /home/user/.config/awesome/rc.lua:1243: in function 'press'
      /usr/local/share/awesome/lib/awful/key.lua:42: in function </usr/local/share/awesome/lib/awful/key.lua:42>



Ref: https://github.com/awesomeWM/awesome/pull/19
