### PR TITLE
TBD: Add luaA_object_tostring_idx

### DIFF
--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -313,10 +313,10 @@ luaA_object_emit_signal_simple(lua_State *L)
 }
 
 int
-luaA_object_tostring(lua_State *L)
+luaA_object_tostring_idx(lua_State *L, int oud)
 {
-    lua_class_t *lua_class = luaA_class_get(L, 1);
-    lua_object_t *object = luaA_checkudata(L, 1, lua_class);
+    lua_class_t *lua_class = luaA_class_get(L, oud);
+    lua_object_t *object = luaA_checkudata(L, oud, lua_class);
     int offset = 0;
 
     for(; lua_class; lua_class = lua_class->parent)
@@ -347,6 +347,12 @@ luaA_object_tostring(lua_State *L)
     lua_concat(L, offset + 1);
 
     return 1;
+}
+
+int
+luaA_object_tostring(lua_State *L)
+{
+    return luaA_object_tostring_idx(L, 1);
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/common/luaobject.h
+++ b/common/luaobject.h
@@ -196,6 +196,7 @@ int luaA_object_emit_signal_simple(lua_State *);
     }
 
 int luaA_object_tostring(lua_State *);
+int luaA_object_tostring_idx(lua_State *, int);
 
 #define LUA_OBJECT_META(prefix) \
     { "__tostring", luaA_object_tostring }, \


### PR DESCRIPTION
This is meant to be used when the object is not at the top of the stack.

I wanted to use the objects string representation for debugging (in
luaA_object_emit_signal), and did not manage to manipulate the stack to
make the original `luaA_object_tostring` work.

Feedback on improving / renaming etc this would be appreciated!

This is useful / needed for #129.