### PR TITLE
Fully revert  90fde1393f

### DIFF
--- a/lib/awful/rules.lua.in
+++ b/lib/awful/rules.lua.in
@@ -224,6 +224,11 @@ function rules.execute(c, props, callbacks)
         end
     end
 
+    -- If untagged, stick the client on the current one.
+    if #c:tags() == 0 then
+        atag.withcurrent(c)
+    end
+
     -- Apply all callbacks.
     if callbacks then
         for i, callback in pairs(callbacks) do
@@ -239,6 +244,7 @@ function rules.execute(c, props, callbacks)
 end
 
 client.connect_signal("manage", rules.apply)
+client.disconnect_signal("manage", atag.withcurrent)
 
 return rules
 

--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -6,7 +6,6 @@
 
 -- Grab environment we need
 local util = require("awful.util")
-local timer = require("gears.timer")
 local tostring = tostring
 local pairs = pairs
 local ipairs = ipairs
@@ -630,9 +629,7 @@ capi.client.connect_signal("manage", function(c)
     c:connect_signal("property::screen", tag.withcurrent)
 end)
 
-capi.client.connect_signal("manage", function(c)
-    timer.delayed_call(tag.withcurrent, c)
-end)
+capi.client.connect_signal("manage", tag.withcurrent)
 capi.tag.connect_signal("request::select", tag.viewonly)
 
 capi.tag.add_signal("property::hide")

--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -630,7 +630,9 @@ capi.client.connect_signal("manage", function(c)
     c:connect_signal("property::screen", tag.withcurrent)
 end)
 
-capi.client.connect_signal("manage", tag.withcurrent)
+capi.client.connect_signal("manage", function(c)
+    timer.delayed_call(tag.withcurrent, c)
+end)
 capi.tag.connect_signal("request::select", tag.viewonly)
 
 capi.tag.add_signal("property::hide")


### PR DESCRIPTION
The partial revert of  90fde1393f in commit 254e50d88c5f58 was not enough. It broke floating clients, since they get tiled for an instant, and the geometry gets messed up. The easiest solution is to fully revert 90fde1393f.