### PR TITLE
Use delayed calls for autofocus signal handlers

### DIFF
--- a/lib/awful/autofocus.lua.in
+++ b/lib/awful/autofocus.lua.in
@@ -8,6 +8,7 @@ local client = client
 local screen = screen
 local aclient = require("awful.client")
 local atag = require("awful.tag")
+local timer = require("gears.timer")
 
 --- When loaded, this module makes sure that there's always a client that will have focus
 -- on events such as tag switching, client unmanaging, etc.
@@ -23,6 +24,12 @@ local function check_focus(obj)
     end
 end
 
+-- Check client focus (delayed).
+-- @param obj An object that should have a .screen property.
+local function check_focus_delayed(obj)
+    timer.delayed_call(check_focus, {screen = obj.screen})
+end
+
 -- Give focus on tag selection change.
 -- @param tag A tag object
 local function check_focus_tag(t)
@@ -35,11 +42,13 @@ local function check_focus_tag(t)
     end
 end
 
-atag.attached_connect_signal(nil, "property::selected", check_focus_tag)
-client.connect_signal("unmanage", check_focus)
-client.connect_signal("tagged", check_focus)
-client.connect_signal("untagged", check_focus)
-client.connect_signal("property::hidden", check_focus)
-client.connect_signal("property::minimized", check_focus)
+tag.connect_signal("property::selected", function (t)
+    timer.delayed_call(check_focus_tag, t)
+end)
+client.connect_signal("unmanage",            check_focus_delayed)
+client.connect_signal("tagged",              check_focus_delayed)
+client.connect_signal("untagged",            check_focus_delayed)
+client.connect_signal("property::hidden",    check_focus_delayed)
+client.connect_signal("property::minimized", check_focus_delayed)
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This avoids awful.autofocus to kick in, focusing some other client in
between (where a focused signal would get emitted for, although the
intermediate client was never meant to have focus).

This is the traceback:

    stack traceback:
      /home/user/.config/awesome/cyclefocus/init.lua:199: in function 'add'
      /home/user/.config/awesome/cyclefocus/init.lua:309: in function </home/user/.config/awesome/cyclefocus/init.lua:304>
      [C]: ?
      /usr/local/share/awesome/lib/awful/autofocus.lua:22: in function 'check_focus'
      /usr/local/share/awesome/lib/awful/autofocus.lua:31: in function </usr/local/share/awesome/lib/awful/autofocus.lua:28>
      [C]: ?
      /usr/local/share/awesome/lib/awful/tag.lua:517: in function 'viewonly'
      /usr/local/share/awesome/lib/awful/client.lua:69: in function 'jumpto'
      /home/user/.config/awesome/rc.lua:1188: in function 'client_run_or_raise'
      /home/user/.config/awesome/rc.lua:1217: in function 'run_or_raise'
      /home/user/.config/awesome/rc.lua:1243: in function 'press'
      /usr/local/share/awesome/lib/awful/key.lua:42: in function </usr/local/share/awesome/lib/awful/key.lua:42>

Ref: https://github.com/awesomeWM/awesome/pull/19

This supersedes https://github.com/awesomeWM/awesome/pull/107.