### PR TITLE
rules.execute: do not delay the signal, but make ewmh delay it

### DIFF
--- a/lib/awful/ewmh.lua.in
+++ b/lib/awful/ewmh.lua.in
@@ -10,6 +10,7 @@ local screen = screen
 local ipairs = ipairs
 local math = math
 local atag = require("awful.tag")
+local timer = require("gears.timer")
 
 --- Implements EWMH requests handling.
 -- awful.ewmh
@@ -148,6 +149,11 @@ function ewmh.activate(c)
     end
 end
 
+-- Call ewmh.activate, at the end of the event loop.
+function ewmh.activate_delayed(c)
+    timer.delayed_call(ewmh.activate, c)
+end
+
 -- Tag a window with its requested tag
 function ewmh.tag(c, t)
     if not t then
@@ -158,7 +164,7 @@ function ewmh.tag(c, t)
     end
 end
 
-client.connect_signal("request::activate", ewmh.activate)
+client.connect_signal("request::activate", ewmh.activate_delayed)
 client.connect_signal("request::tag", ewmh.tag)
 client.connect_signal("request::maximized_horizontal", maximized_horizontal)
 client.connect_signal("request::maximized_vertical", maximized_vertical)

--- a/lib/awful/rules.lua.in
+++ b/lib/awful/rules.lua.in
@@ -235,10 +235,7 @@ function rules.execute(c, props, callbacks)
     -- Do this at last so we do not erase things done by the focus
     -- signal.
     if props.focus and (type(props.focus) ~= "function" or props.focus(c)) then
-        local cb = function(c)
-            c:emit_signal('request::activate', "rules")
-        end
-        timer.delayed_call(cb, c)
+        c:emit_signal('request::activate', "rules")
     end
 end
 


### PR DESCRIPTION
NOTE: this is work-in-progress, especially with regard to changes being
required to configs where ewmh.activate is meant to be overwritten.

This hopefully addresses
https://github.com/awesomeWM/awesome/pull/87#issuecomment-74189735.