### PR TITLE
Properly fix activating an "invisible" client via rules

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -545,10 +545,6 @@ main(int argc, char **argv)
     g_main_context_set_poll_func(g_main_context_default(), &a_glib_poll);
     gettimeofday(&last_wakeup, NULL);
 
-    /* Do all deferred work now once outside of the loop to get awesome.startup
-     * right. */
-    awesome_refresh();
-
     /* main event loop */
     globalconf.loop = g_main_loop_new(NULL, FALSE);
     g_main_loop_run(globalconf.loop);

--- a/lib/awful/rules.lua.in
+++ b/lib/awful/rules.lua.in
@@ -12,7 +12,6 @@ local ipairs = ipairs
 local pairs = pairs
 local aclient = require("awful.client")
 local atag = require("awful.tag")
-local timer = require("gears.timer")
 
 --- Apply rules to clients at startup.
 -- awful.rules
@@ -235,10 +234,7 @@ function rules.execute(c, props, callbacks)
     -- Do this at last so we do not erase things done by the focus
     -- signal.
     if props.focus and (type(props.focus) ~= "function" or props.focus(c)) then
-        local cb = function(c)
-            c:emit_signal('request::activate', "rules")
-        end
-        timer.delayed_call(cb, c)
+        c:emit_signal('request::activate',"rules")
     end
 end
 

--- a/lib/awful/tag.lua.in
+++ b/lib/awful/tag.lua.in
@@ -630,9 +630,7 @@ capi.client.connect_signal("manage", function(c)
     c:connect_signal("property::screen", tag.withcurrent)
 end)
 
-capi.client.connect_signal("manage", function(c)
-    timer.delayed_call(tag.withcurrent, c)
-end)
+capi.client.connect_signal("manage", tag.withcurrent)
 capi.tag.connect_signal("request::select", tag.viewonly)
 
 capi.tag.add_signal("property::hide")

--- a/objects/client.c
+++ b/objects/client.c
@@ -301,9 +301,6 @@ client_focus_update(client_t *c)
 {
     lua_State *L = globalconf_get_lua_State();
 
-    if(!client_maybevisible(c))
-        return false;
-
     if(globalconf.focus.client && globalconf.focus.client != c)
     {
         /* When we are called due to a FocusIn event (=old focused client
@@ -354,7 +351,7 @@ client_focus_refresh(void)
         return;
     globalconf.focus.need_update = false;
 
-    if(c)
+    if(c && client_maybevisible(c))
     {
         /* Make sure this window is unbanned and e.g. not minimized */
         client_unban(c);
@@ -1135,6 +1132,9 @@ client_unban(client_t *c)
         client_set_minimized(L, -1, false);
         client_set_hidden(L, -1, false);
         lua_pop(L, 1);
+
+        if (globalconf.focus.client == c)
+            globalconf.focus.need_update = true;
     }
 }
 


### PR DESCRIPTION
This reverts PR #87, except for f562b4a ("luaA_object_emit_signal: check
for valid object"), and allows focusing "invisible" clients (not attached to a tag yet) instead.

This is meant to finally fix the results of delaying the call to `tag.withcurrent` (https://github.com/awesomeWM/awesome/commit/90fde1393f697ca0d7201e385293a5ac4778d136).