### PR TITLE
Add c:apply_size_hints() to client objects

### DIFF
--- a/luadoc/client.lua
+++ b/luadoc/client.lua
@@ -67,6 +67,14 @@ module("client")
 -- @name geometry
 -- @class function
 
+--- Apply size hints to a size.
+-- @param width Desired width of client
+-- @param height Desired height of client
+-- @return Actual width of client
+-- @return Actual height of client
+-- @name apply_size_hints
+-- @class function
+
 --- Return client struts (reserved space at the edge of the screen).
 -- @param struts A table with new strut values, or none.
 -- @return A table with strut values.

--- a/objects/client.c
+++ b/objects/client.c
@@ -1775,6 +1775,34 @@ luaA_client_geometry(lua_State *L)
     return luaA_pusharea(L, c->geometry);
 }
 
+/** Apply size hints to a lua-specified geometry.
+ * \param L The Lua VM state.
+ * \return The number of elements pushed on stack.
+ * \luastack
+ * \lparam Desired width of client.
+ * \lparam Desired height of client.
+ * \lreturn Corrected width.
+ * \lreturn Corrected height.
+ */
+static int
+luaA_client_apply_size_hints(lua_State *L)
+{
+    client_t *c = luaA_checkudata(L, 1, &client_class);
+    area_t geometry = c->geometry;
+    if(!client_isfixed(c))
+    {
+        geometry.width = luaL_checknumber(L, 2);
+        geometry.height = luaL_checknumber(L, 3);
+    }
+
+    if (c->size_hints_honor)
+        geometry = client_apply_size_hints(c, geometry);
+
+    lua_pushnumber(L, geometry.width);
+    lua_pushnumber(L, geometry.height);
+    return 2;
+}
+
 static int
 luaA_client_set_screen(lua_State *L, client_t *c)
 {
@@ -2308,6 +2336,7 @@ client_class_setup(lua_State *L)
         { "keys", luaA_client_keys },
         { "isvisible", luaA_client_isvisible },
         { "geometry", luaA_client_geometry },
+        { "apply_size_hints", luaA_client_apply_size_hints },
         { "tags", luaA_client_tags },
         { "kill", luaA_client_kill },
         { "swap", luaA_client_swap },


### PR DESCRIPTION
This function gets a width and height of a client, applies the client's size
hints to these numbers and returns the result.

Signed-off-by: Uli Schlachter <psychon@znc.in>