### PR TITLE
awful.placement.no_offscreen: no negative x/y

### DIFF
--- a/lib/awful/placement.lua.in
+++ b/lib/awful/placement.lua.in
@@ -113,13 +113,15 @@ function placement.no_offscreen(c)
 
     if geometry.x + geometry.width + 2*border > screen_geometry.x + screen_geometry.width then
         geometry.x = screen_geometry.x + screen_geometry.width - geometry.width - 2*border
-    elseif geometry.x < screen_geometry.x then
+    end
+    if geometry.x < screen_geometry.x then
         geometry.x = screen_geometry.x
     end
 
     if geometry.y + geometry.height + border > screen_geometry.y + screen_geometry.height then
         geometry.y = screen_geometry.y + screen_geometry.height - geometry.height - 2*border
-    elseif geometry.y < screen_geometry.y then
+    end
+    if geometry.y < screen_geometry.y then
         geometry.y = screen_geometry.y
     end
 


### PR DESCRIPTION
If a client's width/height is larger than the screen's geometry, align
it at the screen's x/y offset.

Test case with gvim, from a maximized terminal on a floating tag:

    % gvim -u NONE -N --cmd "set lines=$((LINES + 5))"

Without this patch the top of the window is off-screen, but the bottom
should be.  Fixing it using a number of lines that fit the screen should
display the window completely.