### PR TITLE
objects: Add .valid property (Fixes #110)

### DIFF
--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -369,6 +369,19 @@ luaA_class_index(lua_State *L)
 
     lua_class_t *class = luaA_class_get(L, 1);
 
+    /* Is this the special 'valid' property? This is the only property
+     * accessible for invalid objects and thus needs special handling. */
+    const char *attr = luaL_checkstring(L, 2);
+    if (A_STREQ(attr, "valid"))
+    {
+        void *p = luaA_toudata(L, 1, class);
+        if (class->checker)
+            lua_pushboolean(L, p != NULL && class->checker(p));
+        else
+            lua_pushboolean(L, p != NULL);
+        return 1;
+    }
+
     lua_class_property_t *prop = luaA_class_property_get(L, class, 2);
 
     /* Property does exist and has an index callback */

--- a/luadoc/client.lua
+++ b/luadoc/client.lua
@@ -47,6 +47,7 @@ module("client")
 -- @field shape_client_bounding The client's bounding shape as set by the program as a (native) cairo surface.
 -- @field shape_client_clip The client's clip shape as set by the program as a (native) cairo surface.
 -- @field startup_id The FreeDesktop StartId.
+-- @field valid If the client that this object refers to is still managed by awesome.
 -- @class table
 -- @name client
 


### PR DESCRIPTION
This property is especially useful for client objects which are unusable after
unmanage. "Unusuable" here means that pretty much everything you do with the
client object results in a lua error.

Syntax is c.valid.

Signed-off-by: Uli Schlachter <psychon@znc.in>