### PR TITLE
WIP: debugging signals

### DIFF
--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -224,6 +224,7 @@ signal_object_emit(lua_State *L, signal_array_t *arr, const char *name, int narg
         foreach(func, sigfound->sigfuncs)
             luaA_object_push(L, *func);
 
+        debug("Emitting class signal '%s' (%d funcs)", name, nbfunc);
         for(int i = 0; i < nbfunc; i++)
         {
             /* push all args */
@@ -269,6 +270,10 @@ luaA_object_emit_signal(lua_State *L, int oud,
     {
         int nbfunc = sigfound->sigfuncs.len;
         luaL_checkstack(L, lua_gettop(L) + nbfunc + nargs + 2, "too much signal");
+
+        const char *objname = lua_tostring(L, oud_abs);
+        debug("Emitting signal '%s' on %s (%d funcs)", name, objname, nbfunc);
+
         /* Push all functions and then execute, because this list can change
          * while executing funcs. */
         foreach(func, sigfound->sigfuncs)

--- a/common/util.c
+++ b/common/util.c
@@ -57,6 +57,19 @@ _warn(int line, const char *fct, const char *fmt, ...)
     fprintf(stderr, "\n");
 }
 
+/** Print debug message on stderr.
+ */
+void
+_debug(int line, const char *fct, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "D: awesome: %s:%d: ", fct, line);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, "\n");
+}
+
 /** \brief safe limited strcpy.
  *
  * Copies at most min(<tt>n-1</tt>, \c l) characters from \c src into \c dst,

--- a/common/util.h
+++ b/common/util.h
@@ -319,6 +319,12 @@ void _fatal(int, const char *, const char *, ...)
 void _warn(int, const char *, const char *, ...)
     __attribute__ ((format(printf, 3, 4)));
 
+#define debug(string, ...) _debug(__LINE__, \
+                                 __FUNCTION__, \
+                                 string, ## __VA_ARGS__)
+void _debug(int, const char *, const char *, ...)
+    __attribute__ ((format(printf, 3, 4)));
+
 void a_exec(const char *);
 
 #endif


### PR DESCRIPTION
This is a work-in-progress to help with debugging emitted signals.

For debugging purposes it would/might be useful to have an option for the awesome binary, which would dump/print all emitted signals.

From @psychon on IRC:

> there are two calls to signal_array_getbyid() in common/luaobject.c that are interesting for that
> and in lua there is gears.object which has its own :emit_signal() that would need to be changed

Edit: Uli would propose to use os.getenv() and C's getenv() for implementing this. An AWESOME_DEBUG env var that can be set to "signals"? Perhaps a comma-seperates list of things and gears.debug gets a function that gets called with an option and some strings and dumps them, if enabled?

Adding:

> if you really want to dump all emitted signals, I would suggest using an environment variable for that (because lua already has os.getenv())
> and for recursion reasons, it _might_ make sense to (optionally) print something at the beginning and the end of a signal
> so that one could figure out which signal causes which other ones to run...

Initially reported at: https://awesome.naquadah.org/bugs/index.php?do=details&task_id=1232
