### PR TITLE
TBD: Use $DISPLAY variable for D-Bus request name, defaulting to :0

### DIFF
--- a/lib/awful/dbus.lua.in
+++ b/lib/awful/dbus.lua.in
@@ -8,12 +8,19 @@
 local dbus = dbus
 
 --- D-Bus module for awful.
--- This module simply request the org.naquadah.awesome.awful name on the D-Bus
--- for futur usage by other awful modules.
+-- This module simply requests the org.naquadah.awesome.awful name on the D-Bus
+-- for future usage by other awful modules.
 -- awful.dbus
 
+local adbus = {}
+
 if dbus then
-    dbus.request_name("session", "org.naquadah.awesome.awful")
+    -- Build D-Bus request name, based on $DISPLAY.
+    adbus.name = "org.naquadah.awesome.awful.d"
+        .. os.getenv("DISPLAY"):gsub('^:', ''):gsub('%.0$', ''):gsub('[:.]', '_') or "0"
+    dbus.request_name("session", adbus.name)
 end
+
+return adbus
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/remote.lua.in
+++ b/lib/awful/remote.lua.in
@@ -5,7 +5,7 @@
 ---------------------------------------------------------------------------
 
 -- Grab environment we need
-require("awful.dbus")
+local adbus = require("awful.dbus")
 local load = loadstring or load -- v5.1 - loadstring, v5.2 - load
 local tostring = tostring
 local ipairs = ipairs
@@ -18,7 +18,7 @@ local type = type
 -- awful.remote
 
 if dbus then
-    dbus.connect_signal("org.naquadah.awesome.awful.Remote", function(data, code)
+    dbus.connect_signal(adbus.name .. ".Remote", function(data, code)
         if data.member == "Eval" then
             local f, e = load(code)
             if f then

--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -38,7 +38,8 @@ then
 fi
 
 DBUS_PATH=/
-DBUS_DEST=org.naquadah.awesome.awful
+DBUS_DEST=org.naquadah.awesome.awful.d$(echo ${DISPLAY:-"0"} \
+    | sed -e 's/\.0$//' -e 's/^://' | tr ':.' '_')
 DBUS_METHOD=${DBUS_DEST}.Remote.Eval
 
 a_dbus_send()


### PR DESCRIPTION
Does this make sense?  Or should "path" or something else be used?

Anyway, awesome-client should probably accept / use vars from the environment, e.g. `DBUS_DEST`.

The use case is with multiple instances of awesome, e.g. in a Xephyr server.