### PR TITLE
Add functional tests via Xephyr/Xvfb/xdotool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,16 @@ before_install:
 
 install:
  # Based on "apt-get build-depends awesome":
- - sudo apt-get install -qq libcairo2-dev xmlto cmake libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libgdk-pixbuf2.0-dev libglib2.0-dev libxcb-image0-dev
+ - sudo apt-get install -qq cmake imagemagick libcairo2-dev libdbus-1-dev libgdk-pixbuf2.0-dev libglib2.0-dev libstartup-notification0-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-util0-dev libxcb-xinerama0-dev libxcb-xtest0-dev libxcb1-dev libxdg-basedir-dev
+
+ # Test deps.
+ - sudo apt-get install -qq dbus-x11
 
  # Install Lua.
  - sudo apt-get install -qq lua$LUA liblua$LUA-dev
 
  # Not necessary for all, maybe when testing generating docs.
- #  - sudo apt-get install -qq asciidoc
+ #  - sudo apt-get install -qq asciidoc xmlto
  # Not available on default Travis image:
  # lua-ldoc
 
@@ -31,6 +34,7 @@ install:
  - git clone --recursive git://anongit.freedesktop.org/xcb/util-cursor
  - cd util-cursor
  - ./autogen.sh && sudo make install
+ - ldconfig
  - cd ..
 
  # lgi: too old on travis, install it via luarocks.
@@ -42,7 +46,6 @@ install:
  - tar xf luarocks-2.2.0.tar.gz
  - cd luarocks-2.2.0
  - ./configure --lua-version=$LUA
- - make
  - sudo make install
  - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,15 @@ before_install:
  - ./autogen.sh && sudo make install
  - cd ..
 
+ # Too old on travis.
+ #  - sudo apt-get install -qq lua-lgi
+ - sudo apt-get install -qq gir1.2-pango-1.0
+
+ - sudo apt-get install -qq luarocks libgirepository1.0-dev
+ - sudo luarocks install lgi
+ - sudo luarocks install busted
+
+ - make
+
  # Not available on default Travis image:
  # lua-ldoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,11 @@ install:
  - sudo mount -t proc proc /mnt/debian/proc
  - sudo mount -t sysfs sysfs /mnt/debian/sys
  - sudo cp /etc/hosts /mnt/debian/etc/hosts
+ # For xterm.
+ - sudo mount --bind /dev/pts /mnt/debian/dev/pts
 
  # Build awesome and install themes etc, e.g.
  # /usr/local/share/awesome/themes/default/theme.lua.
+ # Use the default target first to create the "build" symlink.
  - sudo chroot /mnt/debian make -C /awesome
  - sudo chroot /mnt/debian make -C /awesome install

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ install:
 
  - sudo apt-get install -qq libgirepository1.0-dev
  - sudo luarocks install lgi
- - sudo luarocks install busted
+
+ # HACK: skip "make check", which fails on Travis.
+ #  - sudo luarocks install busted
 
  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: c
+
+env:
+  - LUA=5.1
+  # - LUA=5.2
+  # - LUA=5.3
+
+compiler:
+  - gcc
+  # - clang
+
+script:
+  - make check
+  - t/run.sh
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq xserver-xephyr
+ - sudo apt-get install -qq libcairo2-dev xmlto asciidoc cmake libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libgdk-pixbuf2.0-dev libglib2.0-dev libxcb-image0-dev
+ - sudo apt-get install -qq lua$LUA liblua$LUA-dev
+
+ # Not available on default Travis image: libxcb-cursor-dev
+ - sudo apt-get install -qq xutils-dev libxcb-render-util0-dev gperf
+ - git clone --recursive git://anongit.freedesktop.org/xcb/util-cursor
+ - cd util-cursor
+ - ./autogen.sh && sudo make install
+ - cd ..
+
+ # Not available on default Travis image:
+ # lua-ldoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: c
 
 env:
-  - LUA=5.1
-  # - LUA=5.2
+  # - LUA=5.1
+  - LUA=5.2
   # - LUA=5.3
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
 
 before_install:
  - sudo apt-get update -qq
+
+install:
  - sudo apt-get install -qq xserver-xephyr
  - sudo apt-get install -qq libcairo2-dev xmlto asciidoc cmake libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libgdk-pixbuf2.0-dev libglib2.0-dev libxcb-image0-dev
  - sudo apt-get install -qq lua$LUA liblua$LUA-dev
@@ -30,7 +32,16 @@ before_install:
  #  - sudo apt-get install -qq lua-lgi
  - sudo apt-get install -qq gir1.2-pango-1.0
 
- - sudo apt-get install -qq luarocks libgirepository1.0-dev
+ # Install luarocks (for the selected Lua version).
+ - wget http://keplerproject.github.io/luarocks/releases/luarocks-2.2.0.tar.gz
+ - tar xf luarocks-2.2.0.tar.gz
+ - cd luarocks-2.2.0
+ - ./configure --lua-version=$LUA
+ - make
+ - sudo make install
+ - cd ..
+
+ - sudo apt-get install -qq libgirepository1.0-dev
  - sudo luarocks install lgi
  - sudo luarocks install busted
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - sudo chroot /mnt/debian /awesome/t/run.sh
 
 before_install:
- - sudo apt-get update -qq
+#  - sudo apt-get update -qq
 
 install:
  # NOTE: might not require sudo and could use container based environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
  - git clone --recursive git://anongit.freedesktop.org/xcb/util-cursor
  - cd util-cursor
  - ./autogen.sh && sudo make install
- - ldconfig
+ - sudo ldconfig
  - cd ..
 
  # lgi: too old on travis, install it via luarocks.

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,5 @@ install:
  #  - sudo luarocks install busted
 
  - make
+ # Install themes etc, e.g. /usr/local/share/awesome/themes/default/theme.lua.
+ - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: c
 
 env:
-  # - LUA=5.1
-  - LUA=5.2
-  # - LUA=5.3
+  - LUA=5.1
 
 compiler:
   - gcc
   # - clang
 
 script:
-  - make check
+  # - make check
   - t/run.sh
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,5 @@ install:
 
  # Build awesome and install themes etc, e.g.
  # /usr/local/share/awesome/themes/default/theme.lua.
+ - sudo chroot /mnt/debian make -C /awesome
  - sudo chroot /mnt/debian make -C /awesome install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,53 +8,28 @@ compiler:
   # - clang
 
 script:
-  # - make check
-  - t/run.sh
+  # Included in "make install".
+  # - chroot /debian make -C /awesome check
+  - chroot /mnt/debian /awesome/t/run.sh
 
 before_install:
  - sudo apt-get update -qq
 
 install:
- # Based on "apt-get build-depends awesome":
- - sudo apt-get install -qq cmake imagemagick libcairo2-dev libdbus-1-dev libgdk-pixbuf2.0-dev libglib2.0-dev libstartup-notification0-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-util0-dev libxcb-xinerama0-dev libxcb-xtest0-dev libxcb1-dev libxdg-basedir-dev
+ # NOTE: might not require sudo and could use container based environment
+ #       if debootstrap and fakechroot would be available.
 
- # Test deps.
- - sudo apt-get install -qq dbus-x11
+ # Install and setup Debian chroot.
+ - sudo apt-get install -qq debootstrap
+ - sudo debootstrap --variant=minbase testing /mnt/debian
+ - sudo mount -t proc proc /mnt/debian/proc
+ - sudo mount -t sysfs sysfs /mnt/debian/sys
+ - sudo cp /etc/hosts /mnt/debian/etc/hosts
 
- # Install Lua.
- - sudo apt-get install -qq lua$LUA liblua$LUA-dev
+ - sudo cp -a . /mnt/debian/awesome
 
- # Not necessary for all, maybe when testing generating docs.
- #  - sudo apt-get install -qq asciidoc xmlto
- # Not available on default Travis image:
- # lua-ldoc
+ - sudo chroot /mnt/debian /awesome/build-utils/setup-for-debian.sh $LUA
 
- # Not available on default Travis image: libxcb-cursor-dev
- - sudo apt-get install -qq xutils-dev libxcb-render-util0-dev gperf
- - git clone --recursive git://anongit.freedesktop.org/xcb/util-cursor
- - cd util-cursor
- - ./autogen.sh && sudo make install
- - sudo ldconfig
- - cd ..
-
- # lgi: too old on travis, install it via luarocks.
- #  - sudo apt-get install -qq lua-lgi
- - sudo apt-get install -qq gir1.2-pango-1.0
-
- # Install luarocks (for the selected Lua version).
- - wget http://keplerproject.github.io/luarocks/releases/luarocks-2.2.0.tar.gz
- - tar xf luarocks-2.2.0.tar.gz
- - cd luarocks-2.2.0
- - ./configure --lua-version=$LUA
- - sudo make install
- - cd ..
-
- - sudo apt-get install -qq libgirepository1.0-dev
- - sudo luarocks install lgi
-
- # HACK: skip "make check", which fails on Travis.
- #  - sudo luarocks install busted
-
- - make
- # Install themes etc, e.g. /usr/local/share/awesome/themes/default/theme.lua.
- - sudo make install
+ # Build awesome and install themes etc, e.g.
+ # /usr/local/share/awesome/themes/default/theme.lua.
+ - sudo chroot /mnt/debian make -C /awesome install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,16 @@ before_install:
  - sudo apt-get update -qq
 
 install:
- - sudo apt-get install -qq xserver-xephyr
- - sudo apt-get install -qq libcairo2-dev xmlto asciidoc cmake libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libgdk-pixbuf2.0-dev libglib2.0-dev libxcb-image0-dev
+ # Based on "apt-get build-depends awesome":
+ - sudo apt-get install -qq libcairo2-dev xmlto cmake libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libgdk-pixbuf2.0-dev libglib2.0-dev libxcb-image0-dev
+
+ # Install Lua.
  - sudo apt-get install -qq lua$LUA liblua$LUA-dev
+
+ # Not necessary for all, maybe when testing generating docs.
+ #  - sudo apt-get install -qq asciidoc
+ # Not available on default Travis image:
+ # lua-ldoc
 
  # Not available on default Travis image: libxcb-cursor-dev
  - sudo apt-get install -qq xutils-dev libxcb-render-util0-dev gperf
@@ -28,7 +35,7 @@ install:
  - ./autogen.sh && sudo make install
  - cd ..
 
- # Too old on travis.
+ # lgi: too old on travis, install it via luarocks.
  #  - sudo apt-get install -qq lua-lgi
  - sudo apt-get install -qq gir1.2-pango-1.0
 
@@ -46,6 +53,3 @@ install:
  - sudo luarocks install busted
 
  - make
-
- # Not available on default Travis image:
- # lua-ldoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ compiler:
 script:
   # Included in "make install".
   # - chroot /debian make -C /awesome check
-  - chroot /mnt/debian /awesome/t/run.sh
+  - sudo chroot /mnt/debian /awesome/t/run.sh
 
 before_install:
  - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,27 @@ install:
  #       if debootstrap and fakechroot would be available.
 
  # Install and setup Debian chroot.
- - sudo apt-get install -qq debootstrap
- - sudo debootstrap --variant=minbase testing /mnt/debian
- - sudo mount -t proc proc /mnt/debian/proc
- - sudo mount -t sysfs sysfs /mnt/debian/sys
- - sudo cp /etc/hosts /mnt/debian/etc/hosts
+ # NOTE: used via cache (below).
+ #  - sudo apt-get install -qq debootstrap
+ #  - sudo debootstrap --variant=minbase testing /mnt/debian
+
+ # Download and use cached Debian chroot.
+ # This is built using debootstrap and build-utils/setup-for-debian.sh.
+ - cd /mnt
+ - sudo wget --no-check-certificate http://codeprobe.de/tmp/debian-chroot-awesome-travis-lua$LUA.tar.xz
+ # Contains debian/ folder.
+ - sudo tar xf debian-chroot-awesome-travis-lua$LUA.tar.xz
+ - cd -
 
  - sudo cp -a . /mnt/debian/awesome
 
- - sudo chroot /mnt/debian /awesome/build-utils/setup-for-debian.sh $LUA
+ # Setup Debian chroot.
+ # NOTE: used via cache (above).
+ #  - sudo chroot /mnt/debian /awesome/build-utils/setup-for-debian.sh $LUA
+
+ - sudo mount -t proc proc /mnt/debian/proc
+ - sudo mount -t sysfs sysfs /mnt/debian/sys
+ - sudo cp /etc/hosts /mnt/debian/etc/hosts
 
  # Build awesome and install themes etc, e.g.
  # /usr/local/share/awesome/themes/default/theme.lua.

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -188,7 +188,7 @@ else()
 endif()
 
 # Error check
-if(NOT LUA51_FOUND AND NOT LUA50_FOUND) # This is a workaround to a cmake bug
+if(NOT LUA52_FOUND AND NOT LUA51_FOUND AND NOT LUA50_FOUND) # This is a workaround to a cmake bug
     message(FATAL_ERROR "lua library not found")
 endif()
 

--- a/build-utils/setup-for-debian.sh
+++ b/build-utils/setup-for-debian.sh
@@ -59,4 +59,6 @@ cd ..
 
 sudo apt-get install -qq libgirepository1.0-dev
 sudo luarocks install lgi
-sudo luarocks install busted
+
+# HACK: script "make check", ref: https://github.com/awesomeWM/awesome/pull/139
+# sudo luarocks install busted

--- a/build-utils/setup-for-debian.sh
+++ b/build-utils/setup-for-debian.sh
@@ -26,7 +26,7 @@ sudo apt-get install -qq xvfb
 sudo apt-get install -qq cmake imagemagick libcairo2-dev libdbus-1-dev libgdk-pixbuf2.0-dev libglib2.0-dev libstartup-notification0-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-util0-dev libxcb-xinerama0-dev libxcb-xtest0-dev libxcb1-dev libxdg-basedir-dev
 
 # Test deps.
-sudo apt-get install -qq dbus-x11
+sudo apt-get install -qq dbus-x11 xterm xdotool
 
 # Install Lua.
 sudo apt-get install -qq lua$LUA liblua$LUA-dev

--- a/build-utils/setup-for-debian.sh
+++ b/build-utils/setup-for-debian.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Install build and test environment on a Debian system.
+# This is used from .travis.yml for Travis CI, and is meant to be run
+# in a minimal Debian environment (`debootstrap --variant=minbase).
+
+set -e
+set -x
+
+# Setup sudo "wrapper" function for "root".
+# Especially useful when "sudo" is not installed.
+if [ "$(id -u)" = 0 ]; then
+  sudo() { "$@"; }
+fi
+
+LUA=${1:-5.1}
+
+sudo apt-get update -qq
+
+sudo apt-get install -qq wget
+# For luarocks.
+sudo apt-get install -qq unzip
+
+sudo apt-get install -qq xvfb
+
+# Based on "apt-get build-depends awesome":
+sudo apt-get install -qq cmake imagemagick libcairo2-dev libdbus-1-dev libgdk-pixbuf2.0-dev libglib2.0-dev libstartup-notification0-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-util0-dev libxcb-xinerama0-dev libxcb-xtest0-dev libxcb1-dev libxdg-basedir-dev
+
+# Test deps.
+sudo apt-get install -qq dbus-x11
+
+# Install Lua.
+sudo apt-get install -qq lua$LUA liblua$LUA-dev
+
+# Not necessary for all, maybe when testing generating docs.
+#  - sudo apt-get install -qq asciidoc xmlto
+# Not available on default Travis image:
+# lua-ldoc
+
+# # Not available on default Travis image: libxcb-cursor-dev
+# - sudo apt-get install -qq xutils-dev libxcb-render-util0-dev gperf
+# - git clone --recursive git://anongit.freedesktop.org/xcb/util-cursor
+# - cd util-cursor
+# - ./autogen.sh && sudo make install
+# - sudo ldconfig
+# - cd ..
+sudo apt-get install -qq libxcb-cursor-dev
+
+# lgi: too old on travis, install it via luarocks.
+#  - sudo apt-get install -qq lua-lgi
+sudo apt-get install -qq gir1.2-pango-1.0
+
+# Install luarocks (for the selected Lua version).
+wget http://keplerproject.github.io/luarocks/releases/luarocks-2.2.0.tar.gz
+tar xf luarocks-2.2.0.tar.gz
+cd luarocks-2.2.0
+./configure --lua-version=$LUA
+sudo make install
+cd ..
+
+sudo apt-get install -qq libgirepository1.0-dev
+sudo luarocks install lgi
+sudo luarocks install busted

--- a/t/_runner.lua
+++ b/t/_runner.lua
@@ -6,6 +6,17 @@ runner = {
   quit_awesome_on_timeout = false
 }
 
+
+-- Helpers.
+
+--- Add some rules to awful.rules.rules, after the defaults.
+local default_rules = awful.util.table.clone(awful.rules.rules)
+runner.add_to_default_rules = function(r)
+  awful.rules.rules = awful.util.table.clone(default_rules)
+  table.insert(awful.rules.rules, r)
+end
+
+
 runner.run_steps = function(steps)
   -- Setup timer/timeout to limit waiting for signal and quitting awesome.
   -- This would be common for all tests.
@@ -59,6 +70,10 @@ runner.run_steps = function(steps)
           return
         end
       end
+    end
+    -- Remove any clients.
+    for _,c in ipairs(client.get()) do
+      c:kill()
     end
     awesome.quit()
   end) end)

--- a/t/_runner.lua
+++ b/t/_runner.lua
@@ -1,0 +1,68 @@
+timer = require("gears.timer")
+
+runner = {
+  quit_awesome_on_error = true,
+  -- quit-on-timeout defaults to false: indicates some problem with the test itself.
+  quit_awesome_on_timeout = false
+}
+
+runner.run_steps = function(steps)
+  -- Setup timer/timeout to limit waiting for signal and quitting awesome.
+  -- This would be common for all tests.
+  local t = timer({timeout=0.1})
+  local wait=50
+  local step=1
+  local step_count=0
+  t:connect_signal("timeout", function() timer.delayed_call(function()
+    io.flush()  -- for "tail -f".
+    step_count = step_count + 1
+    local step_as_string = step..'/'..#steps..' (@'..step_count..')'
+
+    -- Call the current step's function.
+    local success, result = pcall(steps[step], step_count)
+
+    if not success then
+      io.stderr:write('Error: running function for step '
+        ..step_as_string..': '..tostring(result)..'!\n')
+      t:stop()
+      if not runner.quit_awesome_on_error then
+        return  -- keep awesome open on error.
+      end
+
+    elseif result then
+      -- true: test succeeded.
+      if step < #steps then
+        -- Next step.
+        step = step+1
+        step_count = 0
+        wait = 5
+        t:again()
+        return
+      end
+
+    elseif result == false then
+      io.stderr:write("Step "..step_as_string.." failed (returned false).")
+      if not runner.quit_awesome_on_error then
+        return
+      end
+
+    else
+      wait = wait-1
+      if wait > 0 then
+        t:again()
+        return
+      else
+        io.stderr:write("Error: timeout waiting for signal in step "
+          ..step_as_string..".\n")
+        t:stop()
+        if not runner.quit_awesome_on_timeout then
+          return
+        end
+      end
+    end
+    awesome.quit()
+  end) end)
+  t:start()
+end
+
+return runner

--- a/t/run.sh
+++ b/t/run.sh
@@ -28,6 +28,7 @@ SIZE=1024x768
 
 if [ $HEADLESS = 1 ]; then
     "$XVFB" $D &
+    sleep 1
     xserver_pid=$(pgrep -n Xvfb)
 else
     # export XEPHYR_PAUSE=1000

--- a/t/run.sh
+++ b/t/run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 # Change to current dir (POSIXly).
 cd -P -- "$(dirname -- "$0")"

--- a/t/run.sh
+++ b/t/run.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -e
+
+# Change to current dir (POSIXly).
+cd -P -- "$(dirname -- "$0")"
+this_dir=$PWD
+
+# Use a separate D-Bus session.
+eval $(dbus-launch --sh-syntax)
+
+root_dir=$PWD/..
+
+XEPHYR=Xephyr
+AWESOME=$root_dir/build/awesome
+RC_FILE=$root_dir/build/awesomerc.lua
+D=:5
+SIZE=1024x768
+
+# export XEPHYR_PAUSE=1000
+"$XEPHYR" $D -ac -name xephyr_$D -noreset -screen "$SIZE" $XEPHYR_OPTIONS &
+sleep 1
+xephyr_pid=$(pgrep -n Xephyr)
+# Toggles debugging mode, using XEPHYR_PAUSE.
+# pkill -USR1 Xephyr
+
+
+cd $root_dir/build
+
+LUA_PATH="$(lua -e 'print(package.path)');lib/?.lua;lib/?/init.lua"
+XDG_CONFIG_HOME="./"
+export LUA_PATH
+export XDG_CONFIG_HOME
+
+# awesome_log=$(mktemp)
+awesome_log=/tmp/_awesome_test.log
+echo "awesome_log: $awesome_log"
+
+# Start awesome.
+DISPLAY=$D "$AWESOME" -c "$RC_FILE" $AWESOME_OPTIONS > $awesome_log 2>&1 &
+sleep 1
+awesome_pid=$(pgrep -n awesome)
+
+cd -
+
+# Cleanup on exit.
+trap "set +e; kill -TERM $awesome_pid 2>/dev/null ; kill -TERM $xephyr_pid 2>/dev/null" 0 2 3 15
+
+restart_awesome=0
+errors=0
+for f in $this_dir/*.lua; do
+    if [ $restart_awesome = 1 ]; then
+        kill -HUP $awesome_pid
+    fi
+
+    # Send the test file to awesome.
+    cat $f | DISPLAY=$D awesome-client 2>&1 || true
+
+    # Tail the log and quit, when awesome quits.
+    tail -f --pid $awesome_pid $awesome_log
+
+    if grep -q -E '^Error|assertion failed' $awesome_log; then
+        echo "===> ERROR running $f! <==="
+        grep --color -o --binary-files=text -E '^Error.*|.*assertion failed.*' $awesome_log
+        errors=$(expr $errors + 1)
+    fi
+
+    reload=1
+done
+
+kill $xephyr_pid
+
+[ $errors = 0 ] && exit 0 || exit 1

--- a/t/run.sh
+++ b/t/run.sh
@@ -7,7 +7,7 @@ set -x
 cd -P -- "$(dirname -- "$0")"
 this_dir=$PWD
 
-# Use a separate D-Bus session.
+# Use a separate D-Bus session; sets $DBUS_SESSION_BUS_PID.
 eval $(dbus-launch --sh-syntax)
 
 root_dir=$PWD/..
@@ -57,7 +57,7 @@ cd -
 
 
 kill_childs() {
-    for p in $awesome_pid $xserver_pid; do
+    for p in $awesome_pid $xserver_pid $DBUS_SESSION_BUS_PID; do
         kill -TERM $p 2>/dev/null || true
     done
 }

--- a/t/run.sh
+++ b/t/run.sh
@@ -27,7 +27,7 @@ D=:5
 SIZE=1024x768
 
 if [ $HEADLESS = 1 ]; then
-    "$XVFB" $D &
+    "$XVFB" $D -screen 0 1280x1024x24 &
     sleep 1
     xserver_pid=$(pgrep -n Xvfb)
 else

--- a/t/run.sh
+++ b/t/run.sh
@@ -69,9 +69,16 @@ set_trap
 # Start awesome.
 start_awesome() {
     (cd $root_dir/build; \
-        DISPLAY=$D "$AWESOME" -c "$RC_FILE" $AWESOME_OPTIONS > $awesome_log 2>&1 &)
+        DISPLAY=$D "$AWESOME" -c "$RC_FILE" $AWESOME_OPTIONS > $awesome_log 2>&1 || true &)
     sleep 1
-    awesome_pid=$(pgrep -nf "awesome -c $RC_FILE")
+    awesome_pid=$(pgrep -nf "awesome -c $RC_FILE" || true)
+
+    if [ -z $awesome_pid ]; then
+        echo "Error: Failed to start awesome (-c $RC_FILE)!"
+        echo "Log:"
+        cat "$awesome_log"
+        exit 1
+    fi
     set_trap
 }
 

--- a/t/run.sh
+++ b/t/run.sh
@@ -43,7 +43,7 @@ cd $root_dir/build
 
 LUA_PATH="$(lua -e 'print(package.path)');lib/?.lua;lib/?/init.lua"
 # Add test dir (for _runner.lua).
-LUA_PATH="$LUA_PATH;../t/?.lua"
+LUA_PATH="$LUA_PATH;$this_dir/?.lua"
 XDG_CONFIG_HOME="./"
 export LUA_PATH
 export XDG_CONFIG_HOME

--- a/t/run.sh
+++ b/t/run.sh
@@ -78,10 +78,7 @@ start_awesome() {
         echo "Error: Failed to start awesome (-c $RC_FILE)!"
         echo "Log:"
         cat "$awesome_log"
-        # TEST
-        pgrep awesome ||     echo "pgrep awesome failed."
-        pgrep -n awesome ||  echo "pgrep -n awesome failed."
-        pgrep -nf awesome || echo "pgrep -nf awesome failed."
+        kill_childs
         exit 1
     fi
     set_trap

--- a/t/run.sh
+++ b/t/run.sh
@@ -27,7 +27,7 @@ D=:5
 SIZE=1024x768
 
 if [ $HEADLESS = 1 ]; then
-    "$XVFB" $D -screen 0 1280x1024x24 &
+    "$XVFB" $D -screen 0 ${SIZE}x24 &
     sleep 1
     xserver_pid=$(pgrep -n Xvfb)
 else

--- a/t/run.sh
+++ b/t/run.sh
@@ -77,6 +77,10 @@ start_awesome() {
         echo "Error: Failed to start awesome (-c $RC_FILE)!"
         echo "Log:"
         cat "$awesome_log"
+        # TEST
+        pgrep awesome ||     echo "pgrep awesome failed."
+        pgrep -n awesome ||  echo "pgrep -n awesome failed."
+        pgrep -nf awesome || echo "pgrep -nf awesome failed."
         exit 1
     fi
     set_trap

--- a/t/test-focus.lua
+++ b/t/test-focus.lua
@@ -1,0 +1,48 @@
+--- Tests for focus signals / property.
+-- Test for https://github.com/awesomeWM/awesome/issues/134.
+
+awful = require("awful")
+timer = require("gears.timer")
+
+beautiful = require("beautiful")
+beautiful.border_normal = "#0000ff"
+beautiful.border_focus  = "#00ff00"
+
+client.connect_signal("focus", function(c)
+  c.border_color = "#ff0000"
+end)
+
+
+local steps = {
+  -- border_color should get applied via focus signal for first client on tag.
+  function(count)
+    if count == 1 then
+      awful.util.spawn("xterm")
+    else
+      local c = client.get()[1]
+      if c then
+        assert(c.border_color == "#ff0000")
+        return true
+      end
+    end
+  end,
+
+  -- border_color should get applied via focus signal for second client on tag.
+  function(count)
+    if count == 1 then
+      awful.util.spawn("xterm")
+    else
+      if #client.get() == 2 then
+        local c = client.get()[1]
+        assert(c == client.focus)
+        if c then
+          assert(c.border_color == "#ff0000")
+          return true
+        end
+
+      end
+    end
+  end
+}
+
+require("_runner").run_steps(steps)

--- a/t/test-urgent.lua
+++ b/t/test-urgent.lua
@@ -1,0 +1,132 @@
+--- Tests for urgent property.
+
+awful = require("awful")
+timer = require("gears.timer")
+
+-- Some basic assertion that the tag is not marked "urgent" already.
+assert(awful.tag.getproperty(tags[1][2], "urgent") == nil)
+
+
+-- Setup signal handler which should be called.
+local urgent_cb_done
+client.connect_signal("property::urgent", function (c)
+  urgent_cb_done = true
+  assert(c.class == "XTerm", "Client should be xterm!")
+end)
+
+
+-- Steps to do for this test.
+local steps = {
+  -- Step 1: tag 2 should become urgent, when a client gets tagged via rules.
+  function(count)
+    if count == 1 then  -- Setup.
+      urgent_cb_done = false
+      -- Select first tag.
+      awful.tag.viewonly(tags[1][1])
+
+      awful.rules.rules = {
+        { rule = { class = "XTerm" },
+        properties = { tag = tags[1][2], focus = true } },
+      }
+      awful.util.spawn("xterm")
+    end
+    if urgent_cb_done then
+      assert(awful.tag.getproperty(tags[1][2], "urgent") == true)
+      assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 1)
+      return true
+    end
+  end,
+
+  -- Step 2: when switching to tag 2, it should not be urgend anymore.
+  function(count)
+    if count == 1 then
+      -- Setup: switch to tag.
+      os.execute('xdotool key super+2')
+    else
+      assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
+      assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
+      return true
+    end
+  end,
+
+  -- Step 3: tag 2 should not be urgent, but switched to.
+  function(count)
+    if count == 1 then  -- Setup.
+      local urgent_cb_done = false
+
+      -- Select first tag.
+      os.execute('xdotool key super+1')
+
+      awful.rules.rules = {
+        { rule = { class = "XTerm" },
+        properties = { tag = tags[1][2], focus = true, switchtotag = true } },
+      }
+      awful.util.spawn("xterm")
+    else
+      if urgent_cb_done then
+        assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
+        assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
+        assert(awful.tag.selectedlist()[1] == tags[1][2])
+        assert(awful.tag.selectedlist()[2] == nil)
+        return true
+      else
+        assert(awful.tag.selectedlist()[1] == tags[1][1])
+        assert(awful.tag.selectedlist()[2] == nil)
+      end
+    end
+  end,
+
+}
+
+
+-- Setup timer/timeout to limit waiting for signal and quitting awesome.
+-- This would be common for all tests.
+local t = timer({timeout=0.1})
+local wait=50
+local step=1
+local step_count=0
+t:connect_signal("timeout", function() timer.delayed_call(function()
+  io.flush()  -- for "tail -f".
+  step_count = step_count + 1
+  local step_as_string = step..'/'..#steps..' (@'..step_count..')'
+
+  -- Call the current step's function.
+  local success, result = pcall(steps[step], step_count)
+
+  if not success then
+    io.stderr:write('Error: running function for step '
+      ..step_as_string..': '..tostring(result)..'!\n')
+    t:stop()
+    return  -- keep awesome open on error.
+
+  elseif result then
+    -- true: test succeeded.
+    if step < #steps then
+      -- Next step.
+      step = step+1
+      step_count = 0
+      wait = 5
+      t:again()
+      return
+    end
+
+  elseif result == false then
+    error("Step "..step_as_string.." failed.")
+    assert(false)
+
+  else
+    wait = wait-1
+    -- io.stderr:write('wait:'..wait.."\n")
+    if wait > 0 then
+      t:again()
+      return
+    else
+      io.stderr:write("Error: timeout waiting for signal in step "
+        ..step_as_string..".\n")
+      t:stop()
+      return  -- keep awesome open on error.
+    end
+  end
+  awesome.quit()
+end) end)
+t:start()

--- a/t/test-urgent.lua
+++ b/t/test-urgent.lua
@@ -7,9 +7,16 @@ assert(awful.tag.getproperty(tags[1][2], "urgent") == nil)
 
 
 -- Setup signal handler which should be called.
+-- TODO: generalize and move to runner.
 local urgent_cb_done
 client.connect_signal("property::urgent", function (c)
   urgent_cb_done = true
+  assert(c.class == "XTerm", "Client should be xterm!")
+end)
+
+local manage_cb_done
+client.connect_signal("manage", function (c)
+  manage_cb_done = true
   assert(c.class == "XTerm", "Client should be xterm!")
 end)
 
@@ -23,10 +30,9 @@ local steps = {
       -- Select first tag.
       awful.tag.viewonly(tags[1][1])
 
-      awful.rules.rules = {
-        { rule = { class = "XTerm" },
-        properties = { tag = tags[1][2], focus = true } },
-      }
+      runner.add_to_default_rules({ rule = { class = "XTerm" },
+        properties = { tag = tags[1][2], focus = true } })
+
       awful.util.spawn("xterm")
     end
     if urgent_cb_done then
@@ -36,12 +42,15 @@ local steps = {
     end
   end,
 
-  -- Step 2: when switching to tag 2, it should not be urgend anymore.
+  -- Step 2: when switching to tag 2, it should not be urgent anymore.
   function(count)
     if count == 1 then
       -- Setup: switch to tag.
       os.execute('xdotool key super+2')
-    else
+
+    elseif awful.tag.selectedlist()[1] == tags[1][2] then
+      assert(#client.get() == 1)
+      assert(client.get()[1] == client.focus)
       assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
       assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
       return true
@@ -56,10 +65,9 @@ local steps = {
       -- Select first tag.
       os.execute('xdotool key super+1')
 
-      awful.rules.rules = {
-        { rule = { class = "XTerm" },
-        properties = { tag = tags[1][2], focus = true, switchtotag = true } },
-      }
+      runner.add_to_default_rules({ rule = { class = "XTerm" },
+        properties = { tag = tags[1][2], focus = true, switchtotag = true }})
+
       awful.util.spawn("xterm")
     else
       if urgent_cb_done then
@@ -72,6 +80,27 @@ local steps = {
         assert(awful.tag.selectedlist()[1] == tags[1][1])
         assert(awful.tag.selectedlist()[2] == nil)
       end
+    end
+  end,
+
+
+  -- Step 4: tag 2 should not become urgent, when a client gets tagged via
+  -- rules with focus=false.
+  function(count)
+    if count == 1 then  -- Setup.
+      client.get()[1]:kill()
+      manage_cb_done = false
+
+      runner.add_to_default_rules({rule = { class = "XTerm" },
+        properties = { tag = tags[1][2], focus = false }})
+
+      awful.util.spawn("xterm")
+    end
+    if manage_cb_done then
+      assert(client.get()[1].urgent == false)
+      assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
+      assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
+      return true
     end
   end,
 }


### PR DESCRIPTION
Run it via `t/run.sh`.

Related issues: #136 (Travis integration in general).

Build status of this branch: [![Build Status](https://travis-ci.org/blueyed/awesome.svg?branch=add-functional-tests)](https://travis-ci.org/blueyed/awesome)

Last successful build: https://travis-ci.org/blueyed/awesome/builds/51381508 (before rebasing on master, where libxcb-xkb is now missing).

It currently uses a pre-built Debian chroot to run the tests in.  A lot of packages are too old on Travis and I've figured that it might be easier to use Debian testing right away.
Using the pre-built images makes the tests run much faster.  This could be achieved by using Travis' cache facilities, but these are only available for container based environments (where `sudo` would not be available).  `sudo` is required for `chroot` (as long as `fakechroot` or something similar is not installed).

TODO:

 - [ ] This might make use of `busted` (more), instead of only using the custom runner.  Needs to be investigated / refactored then.
 - [ ] `W: awesome: a_dbus_connect:607: D-Bus session bus system failed: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory`: this could be avoided by bind-mounting `/mnt/debian/var/run/dbus` and `/mnt/debian/var/lib/dbus` probably, but it's not an issue really, is it?