### PR TITLE
spec: fix "require" statements

### DIFF
--- a/spec/awful/util_spec.lua
+++ b/spec/awful/util_spec.lua
@@ -5,7 +5,6 @@
 
 local util = require("awful.util")
 local say = require("say")
-local assert_util = require("luassert.util")
 
 describe("awful.util", function()
     it("table.keys_filter", function()

--- a/spec/gears/color_spec.lua
+++ b/spec/gears/color_spec.lua
@@ -6,7 +6,6 @@
 local color = require("gears.color")
 local cairo = require("lgi").cairo
 local say = require("say")
-local assert_util = require("luassert.util")
 
 describe("gears.color", function()
     describe("parse_color", function()

--- a/spec/wibox/test_utils.lua
+++ b/spec/wibox/test_utils.lua
@@ -7,7 +7,9 @@ local object = require("gears.object")
 local wbase = require("wibox.widget.base")
 local lbase = require("wibox.layout.base")
 local say = require("say")
-local assert_util = require("luassert.util")
+local assert = require("luassert")
+local spy = require("luassert.spy")
+local stub = require("luassert.stub")
 
 local real_draw_widget = lbase.draw_widget
 local widgets_drawn = nil


### PR DESCRIPTION
I don't know why it works by default, but it does not on a minimal
system (Travis, Debian minbase).