### PR TITLE
Test if cairo-xcb is usable during startup

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -437,6 +437,9 @@ main(int argc, char **argv)
     if (xcb_cursor_context_new(globalconf.connection, globalconf.screen, &globalconf.cursor_ctx) < 0)
         fatal("Failed to initialize xcb-cursor");
 
+    /* Did we get some usable data from the above X11 setup? */
+    draw_test_cairo_xcb();
+
     /* initialize dbus */
     a_dbus_init();
 

--- a/draw.c
+++ b/draw.c
@@ -21,6 +21,7 @@
 
 #include "config.h"
 #include "draw.h"
+#include "globalconf.h"
 
 #include <langinfo.h>
 #include <iconv.h>
@@ -297,6 +298,21 @@ uint8_t draw_visual_depth(const xcb_screen_t *s, xcb_visualid_t vis)
                     return depth_iter.data->depth;
 
     fatal("Could not find a visual's depth");
+}
+
+void draw_test_cairo_xcb(void)
+{
+    xcb_pixmap_t pixmap = xcb_generate_id(globalconf.connection);
+    xcb_create_pixmap(globalconf.connection, globalconf.default_depth, pixmap,
+                      globalconf.screen->root, 1, 1);
+    cairo_surface_t *surface = cairo_xcb_surface_create(globalconf.connection,
+                                          pixmap, globalconf.visual, 1, 1);
+    if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
+        fatal("Could not set up display: got cairo surface with status %s",
+                cairo_status_to_string(cairo_surface_status(surface)));
+    cairo_surface_finish(surface);
+    cairo_surface_destroy(surface);
+    xcb_free_pixmap(globalconf.connection, pixmap);
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/draw.h
+++ b/draw.h
@@ -75,5 +75,7 @@ xcb_visualtype_t *draw_default_visual(const xcb_screen_t *s);
 xcb_visualtype_t *draw_argb_visual(const xcb_screen_t *s);
 uint8_t draw_visual_depth(const xcb_screen_t *s, xcb_visualid_t vis);
 
+void draw_test_cairo_xcb(void);
+
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Create a pixmap of size 1x1 and a cairo-xcb surface for this pixmap. If the
surface ends up in an error state, awesome will refuse to start.

This turns a "awesome is unusable and prints lots of errors on X11 servers where
the root window has a depth of 8bpp and no one knows where exactly the problem
is" into "awesome refuses to start on such X11 servers and prints an error that
helps Uli to say immediately what the problem is".

Signed-off-by: Uli Schlachter <psychon@znc.in>