### PR TITLE
layout: Fix delayed arrange regression

### DIFF
--- a/lib/awful/layout/init.lua.in
+++ b/lib/awful/layout/init.lua.in
@@ -97,7 +97,7 @@ end
 --- Arrange a screen using its current layout.
 -- @param screen The screen to arrange.
 function layout.arrange(screen)
-    if delayed_arrange[screen] then return end
+    if not screen or delayed_arrange[screen] then return end
     delayed_arrange[screen] = true
 
     timer.delayed_call(function()


### PR DESCRIPTION
```lua
stack traceback:
        /usr/share/awesome/lib/awful/layout/init.lua:102: in function 'arrange'
        /usr/share/awesome/lib/awful/layout/init.lua:164: in function </usr/share/awesome/lib/awful/layout/init.lua:163>
        [C]: ?
        /usr/share/awesome/lib/awful/tag.lua:191: in function 'delete'
        /home/lepagee/.config/awesome/tyrannical/init.lua:205: in function </home/lepagee/.config/awesome/tyrannical/init.lua:198>
error: /usr/share/awesome/lib/awful/layout/init.lua:102: table index is nil
```

Tags don't have a screen for their whole lifecycle, so this happen