### PR TITLE
autofocus: emit `request::activate` signal

### DIFF
--- a/lib/awful/autofocus.lua.in
+++ b/lib/awful/autofocus.lua.in
@@ -20,7 +20,9 @@ local function check_focus(obj)
     -- When no visible client has the focus...
     if not client.focus or not client.focus:isvisible() then
         local c = aclient.focus.history.get(obj.screen, 0)
-        if c then client.focus = c end
+        if c then
+            c:emit_signal('request::activate', "autofocus.check_focus")
+        end
     end
 end
 
@@ -38,7 +40,9 @@ local function check_focus_tag(t)
     check_focus({ screen = s })
     if client.focus and client.focus.screen ~= s then
         local c = aclient.focus.history.get(s, 0)
-        if c then client.focus = c end
+        if c then
+            c:emit_signal('request::activate', "autofocus.check_focus_tag")
+        end
     end
 end
 


### PR DESCRIPTION
After a client gets unmanaged, the newly focused client might not be
visible / raised above other windows.

Using the `request::activate` signal makes the autofocus handler more
flexible, and will raise the focused client by default.