### PR TITLE
Replace color_strip_alpha with check_pango_color

### DIFF
--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -189,7 +189,12 @@ local function prompt_text_with_cursor(args)
         text_end = util.escape(text:sub(args.cursor_pos + 1))
     end
 
-    ret = _prompt .. text_start .. "<span background=\"" .. util.color_strip_alpha(args.cursor_color) .. "\" foreground=\"" .. util.color_strip_alpha(args.text_color) .. "\" underline=\"" .. underline .. "\">" .. char .. "</span>" .. text_end .. spacer
+    local cursor_color = util.ensure_pango_color(args.cursor_color)
+    local text_color = util.ensure_pango_color(args.text_color)
+
+    ret = _prompt .. text_start .. "<span background=\"" .. cursor_color ..
+        "\" foreground=\"" .. text_color .. "\" underline=\"" .. underline ..
+        "\">" .. char .. "</span>" .. text_end .. spacer
     return ret
 end
 

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -20,6 +20,8 @@ local type = type
 local rtable = table
 local pairs = pairs
 local string = string
+local lgi = require("lgi")
+local Pango = lgi.Pango
 local capi =
 {
     awesome = awesome,
@@ -47,14 +49,13 @@ function util.deprecate(see)
     io.stderr:write("\n" .. tb .. "\n")
 end
 
---- Strip alpha part of color.
+--- Get a valid color for Pango markup
 -- @param color The color.
--- @return The color without alpha channel.
-function util.color_strip_alpha(color)
-    if color:len() == 9 then
-        color = color:sub(1, 7)
-    end
-    return color
+-- @tparam string fallback The color to return if the first is invalid. (default: black)
+-- @treturn string color if it is valid, else fallback.
+function util.ensure_pango_color(color, fallback)
+    color = tostring(color)
+    return Pango.Color.parse(Pango.Color(), color) and color or fallback or "black"
 end
 
 --- Make i cycle.

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -99,8 +99,8 @@ function taglist.taglist_label(t, args)
     if not tag.getproperty(t, "icon_only") then
         text = "<span font_desc='"..font.."'>"
         if fg_color then
-            text = text .. "<span color='"..util.color_strip_alpha(fg_color).."'>" ..
-                (util.escape(t.name) or "") .. "</span>"
+            text = text .. "<span color='" .. util.ensure_pango_color(fg_color) ..
+                "'>" .. (util.escape(t.name) or "") .. "</span>"
         else
             text = text .. (util.escape(t.name) or "")
         end

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -29,14 +29,14 @@ tasklist.filter = {}
 local function tasklist_label(c, args)
     if not args then args = {} end
     local theme = beautiful.get()
-    local fg_normal = args.fg_normal or theme.tasklist_fg_normal or theme.fg_normal or "#ffffff"
+    local fg_normal = util.ensure_pango_color(args.fg_normal or theme.tasklist_fg_normal or theme.fg_normal, "white")
     local bg_normal = args.bg_normal or theme.tasklist_bg_normal or theme.bg_normal or "#000000"
-    local fg_focus = args.fg_focus or theme.tasklist_fg_focus or theme.fg_focus
-    local bg_focus = args.bg_focus or theme.tasklist_bg_focus or theme.bg_focus
-    local fg_urgent = args.fg_urgent or theme.tasklist_fg_urgent or theme.fg_urgent
-    local bg_urgent = args.bg_urgent or theme.tasklist_bg_urgent or theme.bg_urgent
-    local fg_minimize = args.fg_minimize or theme.tasklist_fg_minimize or theme.fg_minimize
-    local bg_minimize = args.bg_minimize or theme.tasklist_bg_minimize or theme.bg_minimize
+    local fg_focus = util.ensure_pango_color(args.fg_focus or theme.tasklist_fg_focus or theme.fg_focus, fg_normal)
+    local bg_focus = args.bg_focus or theme.tasklist_bg_focus or theme.bg_focus or bg_normal
+    local fg_urgent = util.ensure_pango_color(args.fg_urgent or theme.tasklist_fg_urgent or theme.fg_urgent, fg_normal)
+    local bg_urgent = args.bg_urgent or theme.tasklist_bg_urgent or theme.bg_urgent or bg_normal
+    local fg_minimize = util.ensure_pango_color(args.fg_minimize or theme.tasklist_fg_minimize or theme.fg_minimize, fg_normal)
+    local bg_minimize = args.bg_minimize or theme.tasklist_bg_minimize or theme.bg_minimize or bg_normal
     local bg_image_normal = args.bg_image_normal or theme.bg_image_normal
     local bg_image_focus = args.bg_image_focus or theme.bg_image_focus
     local bg_image_urgent = args.bg_image_urgent or theme.bg_image_urgent
@@ -75,23 +75,19 @@ local function tasklist_label(c, args)
     end
     if capi.client.focus == c then
         bg = bg_focus
+        text = text .. "<span color='"..fg_focus.."'>"..name.."</span>"
         bg_image = bg_image_focus
-        if fg_focus then
-            text = text .. "<span color='"..util.color_strip_alpha(fg_focus).."'>"..name.."</span>"
-        else
-            text = text .. "<span color='"..util.color_strip_alpha(fg_normal).."'>"..name.."</span>"
-        end
-    elseif c.urgent and fg_urgent then
+    elseif c.urgent then
         bg = bg_urgent
-        text = text .. "<span color='"..util.color_strip_alpha(fg_urgent).."'>"..name.."</span>"
+        text = text .. "<span color='"..fg_urgent.."'>"..name.."</span>"
         bg_image = bg_image_urgent
-    elseif c.minimized and fg_minimize and bg_minimize then
+    elseif c.minimized then
         bg = bg_minimize
-        text = text .. "<span color='"..util.color_strip_alpha(fg_minimize).."'>"..name.."</span>"
+        text = text .. "<span color='"..fg_minimize.."'>"..name.."</span>"
         bg_image = bg_image_minimize
     else
         bg = bg_normal
-        text = text .. "<span color='"..util.color_strip_alpha(fg_normal).."'>"..name.."</span>"
+        text = text .. "<span color='"..fg_normal.."'>"..name.."</span>"
         bg_image = bg_image_normal
     end
     text = text .. "</span>"

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -86,7 +86,7 @@ local common_args = { w = wibox.layout.fixed.horizontal(),
 -- @param c The desired text color.
 -- @return the text wrapped in a span tag.
 local function colortext(s, c)
-    return "<span color='" .. c .. "'>" .. s .. "</span>"
+    return "<span color='" .. awful.util.ensure_pango_color(c) .. "'>" .. s .. "</span>"
 end
 
 --- Get how the menu item should be displayed.
@@ -94,8 +94,7 @@ end
 -- @return item name, item background color, background image, item icon.
 local function label(o)
     if o.focused then
-        local color = awful.util.color_strip_alpha(theme.fg_focus)
-        return colortext(o.name, color), theme.bg_focus, nil, o.icon
+        return colortext(o.name, theme.fg_focus), theme.bg_focus, nil, o.icon
     else
         return o.name, theme.bg_normal, nil, o.icon
     end


### PR DESCRIPTION
Awesome uses `awful.util.color_strip_alpha` to fix colors before they are inserted into Pango markup. This is because Pango doesn't support hex colors with transparency and would return an error.

But colors in awesome are not always hex codes, for example:

 1. Sometimes background colors are inserted into Pango markup (e.g. for the menubar cursor #140). Background colors can be [Cairo patterns](http://awesome.naquadah.org/doc/api/modules/gears.color.html#create_pattern), which Pango does not support and which `color_strip_alpha` definitely won't fix.
 2. Pango also supports [X11 color names](http://en.wikipedia.org/wiki/X11_color_names), which is why `theme.fg_normal = "red"` works. Since `color_strip_alpha` assumes hex color codes it breaks any color name that happens to be 9 characters long. Try setting `theme.fg_normal = "chocolate"`, for example.

This PR replaces `color_strip_alpha` with a more robust `check_pango_color` function that returns `nil` if the color is not safe to use in Pango markup (thus allowing for replacement with fallback colors rather than showing error messages or `<Invalid text>`). This will cause a slight regression for any theme that relies on the alpha being stripped from hex colors (those colors will be replaced by the fallbacks).