### PR TITLE
client.swap.global_bydirection: use `request::activate` signal

### DIFF
--- a/lib/awful/client.lua.in
+++ b/lib/awful/client.lua.in
@@ -397,7 +397,9 @@ function client.swap.global_bydirection(dir, c)
         end
 
         screen.focus(sel.screen)
-        capi.client.focus = sel
+        if sel == capi.client.focus then
+            sel:emit_signal("request::activate", "client.swap.global_bydirection")
+        end
     end
 end
 


### PR DESCRIPTION
Do not set `capi.client.focus` unconditionally, but use the `request::activate` signal if the swapped client was focused currently.