### PR TITLE
Only commit/configure client geometries once per main loop

### DIFF
--- a/event.h
+++ b/event.h
@@ -33,13 +33,13 @@ void luaA_emit_refresh(void);
 
 /* objects/client.c */
 void client_focus_refresh(void);
-void client_geometry_commit(void);
+void client_geometry_refresh(void);
 
 static inline int
 awesome_refresh(void)
 {
     luaA_emit_refresh();
-    client_geometry_commit();
+    client_geometry_refresh();
     banning_refresh();
     stack_refresh();
     client_focus_refresh();

--- a/event.h
+++ b/event.h
@@ -38,6 +38,9 @@ void client_properties_refresh(void);
 /* objects/drawable.c */
 void drawable_geometry_refresh(void);
 
+/* objects/drawin.c */
+void drawin_geometry_refresh(void);
+
 /* objects/window.c */
 void window_properties_refresh(void);
 
@@ -48,6 +51,7 @@ awesome_refresh(void)
     client_properties_refresh();
     window_properties_refresh();
     drawable_geometry_refresh();
+    drawin_geometry_refresh();
     banning_refresh();
     stack_refresh();
     client_focus_refresh();

--- a/event.h
+++ b/event.h
@@ -33,13 +33,17 @@ void luaA_emit_refresh(void);
 
 /* objects/client.c */
 void client_focus_refresh(void);
-void client_geometry_refresh(void);
+void client_properties_refresh(void);
+
+/* objects/window.c */
+void window_properties_refresh(void);
 
 static inline int
 awesome_refresh(void)
 {
     luaA_emit_refresh();
-    client_geometry_refresh();
+    client_properties_refresh();
+    window_properties_refresh();
     banning_refresh();
     stack_refresh();
     client_focus_refresh();

--- a/event.h
+++ b/event.h
@@ -35,6 +35,9 @@ void luaA_emit_refresh(void);
 void client_focus_refresh(void);
 void client_properties_refresh(void);
 
+/* objects/drawable.c */
+void drawable_geometry_refresh(void);
+
 /* objects/window.c */
 void window_properties_refresh(void);
 
@@ -44,6 +47,7 @@ awesome_refresh(void)
     luaA_emit_refresh();
     client_properties_refresh();
     window_properties_refresh();
+    drawable_geometry_refresh();
     banning_refresh();
     stack_refresh();
     client_focus_refresh();

--- a/event.h
+++ b/event.h
@@ -33,11 +33,13 @@ void luaA_emit_refresh(void);
 
 /* objects/client.c */
 void client_focus_refresh(void);
+void client_geometry_commit(void);
 
 static inline int
 awesome_refresh(void)
 {
     luaA_emit_refresh();
+    client_geometry_commit();
     banning_refresh();
     stack_refresh();
     client_focus_refresh();

--- a/globalconf.h
+++ b/globalconf.h
@@ -62,6 +62,7 @@ ARRAY_TYPE(tag_t *, tag)
 ARRAY_TYPE(screen_t *, screen)
 ARRAY_TYPE(client_t *, client)
 ARRAY_TYPE(drawin_t *, drawin)
+ARRAY_TYPE(drawable_t *, drawable)
 ARRAY_TYPE(window_t *, window)
 ARRAY_TYPE(xproperty_t, xproperty)
 
@@ -155,6 +156,8 @@ typedef struct
     window_array_t need_properties_refresh_windows;
     /** List of clients which need properties to be committed. */
     client_array_t need_properties_refresh_clients;
+    /** List of drawables which need their geometry to be committed. */
+    drawable_array_t need_geometry_refresh_drawable;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/globalconf.h
+++ b/globalconf.h
@@ -151,10 +151,10 @@ typedef struct
     xcb_colormap_t default_cmap;
     /** Do we have to reban clients? */
     bool need_lazy_banning;
-    /** Do we have to handle changed properties (e.g. geometry) for clients? */
-    bool need_client_properties_refresh;
-    /** List of clients and drawins which need properties to be committed. */
-    window_array_t need_properties_refresh;
+    /** List of windows which need properties to be committed. */
+    window_array_t need_properties_refresh_windows;
+    /** List of clients which need properties to be committed. */
+    client_array_t need_properties_refresh_clients;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/globalconf.h
+++ b/globalconf.h
@@ -55,12 +55,14 @@ typedef struct button_t button_t;
 typedef struct client_t client_t;
 typedef struct tag tag_t;
 typedef struct xproperty xproperty_t;
+typedef struct window_t window_t;
 
 ARRAY_TYPE(button_t *, button)
 ARRAY_TYPE(tag_t *, tag)
 ARRAY_TYPE(screen_t *, screen)
 ARRAY_TYPE(client_t *, client)
 ARRAY_TYPE(drawin_t *, drawin)
+ARRAY_TYPE(window_t *, window)
 ARRAY_TYPE(xproperty_t, xproperty)
 
 /** Main configuration structure */
@@ -149,8 +151,10 @@ typedef struct
     xcb_colormap_t default_cmap;
     /** Do we have to reban clients? */
     bool need_lazy_banning;
-    /** Do we have to handle new geometries for clients? */
-    bool need_geometry_refresh;
+    /** Do we have to handle changed properties (e.g. geometry) for clients? */
+    bool need_client_properties_refresh;
+    /** List of clients and drawins which need properties to be committed. */
+    window_array_t need_properties_refresh;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/globalconf.h
+++ b/globalconf.h
@@ -149,6 +149,8 @@ typedef struct
     xcb_colormap_t default_cmap;
     /** Do we have to reban clients? */
     bool need_lazy_banning;
+    /** Do we have to handle new geometries for clients? */
+    bool need_geometry_commit;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/globalconf.h
+++ b/globalconf.h
@@ -158,6 +158,8 @@ typedef struct
     client_array_t need_properties_refresh_clients;
     /** List of drawables which need their geometry to be committed. */
     drawable_array_t need_geometry_refresh_drawable;
+    /** List of drawins which need their geometry to be committed. */
+    drawin_array_t need_geometry_refresh_drawin;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/globalconf.h
+++ b/globalconf.h
@@ -150,7 +150,7 @@ typedef struct
     /** Do we have to reban clients? */
     bool need_lazy_banning;
     /** Do we have to handle new geometries for clients? */
-    bool need_geometry_commit;
+    bool need_geometry_refresh;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/objects/client.c
+++ b/objects/client.c
@@ -845,6 +845,9 @@ client_properties_refresh()
         }
     }
     client_restore_enterleave_events();
+
+    client_array_wipe(&globalconf.need_properties_refresh_clients);
+    client_array_init(&globalconf.need_properties_refresh_clients);
 }
 
 static void

--- a/objects/client.c
+++ b/objects/client.c
@@ -799,15 +799,13 @@ client_apply_size_hints(client_t *c, area_t geometry)
 void
 client_properties_refresh()
 {
-    if (!globalconf.need_client_properties_refresh)
+    if (!globalconf.need_properties_refresh_clients.len)
         return;
-
-    globalconf.need_client_properties_refresh = false;
 
     /* Ignore all spurious enter/leave notify events */
     client_ignore_enterleave_events();
 
-    foreach(_c, globalconf.clients)
+    foreach(_c, globalconf.need_properties_refresh_clients)
     {
         client_t *c = *_c;
         if (c->property_refresh.geometry)
@@ -869,7 +867,7 @@ client_resize_do(client_t *c, area_t geometry, bool force_notice, bool honor_hin
     c->geometry = geometry;
 
     /* Mark geometry changes to be committed later. */
-    globalconf.need_client_properties_refresh = true;
+    client_array_push(&globalconf.need_properties_refresh_clients, c);
     c->property_refresh.geometry = true;
     c->property_refresh.send_notice = send_notice;
 

--- a/objects/client.h
+++ b/objects/client.h
@@ -131,10 +131,12 @@ struct client_t
     struct
     {
         /** Client's geometry needs to be committed. */
-        bool needed;
+        bool geometry;
         /** A notice has to be send (internally). */
         bool send_notice;
-    } geometry_refresh;
+        /** Client's opacity needs to be committed. */
+        bool opacity;
+    } property_refresh;
 };
 
 ARRAY_FUNCS(client_t *, client, DO_NOTHING)

--- a/objects/client.h
+++ b/objects/client.h
@@ -128,12 +128,11 @@ struct client_t
     } titlebar[CLIENT_TITLEBAR_COUNT];
     struct
     {
-        /** Client's geometry needs to be committed. */
+        WINDOW_OBJECT_PROPERTY_REFRESH
+        /** A client's geometry has to be committed. */
         bool geometry;
         /** A notice has to be send (internally). */
         bool send_notice;
-        /** Client's opacity needs to be committed. */
-        bool opacity;
     } property_refresh;
 };
 
@@ -152,6 +151,7 @@ void client_ban(client_t *);
 void client_ban_unfocus(client_t *);
 void client_unban(client_t *);
 void client_manage(xcb_window_t, xcb_get_geometry_reply_t *, xcb_get_window_attributes_reply_t *);
+void client_properties_refresh(void);
 bool client_resize(client_t *, area_t, bool);
 void client_unmanage(client_t *, bool);
 void client_kill(client_t *);

--- a/objects/client.h
+++ b/objects/client.h
@@ -128,9 +128,13 @@ struct client_t
         /** The drawable for this bar. */
         drawable_t *drawable;
     } titlebar[CLIENT_TITLEBAR_COUNT];
-    /** Client's geometry needs to be committed. */
-    bool need_geometry_commit;
-    bool need_geometry_commit_send_notice;
+    struct
+    {
+        /** Client's geometry needs to be committed. */
+        bool needed;
+        /** A notice has to be send (internally). */
+        bool send_notice;
+    } geometry_refresh;
 };
 
 ARRAY_FUNCS(client_t *, client, DO_NOTHING)

--- a/objects/client.h
+++ b/objects/client.h
@@ -119,7 +119,7 @@ struct client_t
     uint32_t pid;
     /** Window it is transient for */
     client_t *transient_for;
-    /** Titelbar information */
+    /** Titlebar information */
     struct {
         /** The size of this bar. */
         uint16_t size;

--- a/objects/client.h
+++ b/objects/client.h
@@ -128,6 +128,9 @@ struct client_t
         /** The drawable for this bar. */
         drawable_t *drawable;
     } titlebar[CLIENT_TITLEBAR_COUNT];
+    /** Client's geometry needs to be committed. */
+    bool need_geometry_commit;
+    bool need_geometry_commit_send_notice;
 };
 
 ARRAY_FUNCS(client_t *, client, DO_NOTHING)

--- a/objects/client.h
+++ b/objects/client.h
@@ -57,8 +57,6 @@ struct client_t
     char *name, *alt_name, *icon_name, *alt_icon_name;
     /** WM_CLASS stuff */
     char *class, *instance;
-    /** Window geometry */
-    area_t geometry;
     /** Startup ID */
     char *startup_id;
     /** True if the client is sticky */

--- a/objects/drawable.h
+++ b/objects/drawable.h
@@ -49,6 +49,7 @@ typedef struct drawable_t drawable_t;
 
 drawable_t *drawable_allocator(lua_State *, drawable_refresh_callback *, void *);
 void drawable_set_geometry(lua_State *, int, area_t);
+void drawable_geometry_refresh(void);
 void drawable_class_setup(lua_State *);
 
 #endif

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -149,7 +149,8 @@ drawin_moveresize(lua_State *L, int udx, area_t geometry)
 {
     drawin_t *w = luaA_checkudata(L, udx, &drawin_class);
     int number_of_vals = 0;
-    uint32_t moveresize_win_vals[4], mask_vals = 0;
+    uint32_t moveresize_win_vals[4];
+    uint16_t mask_vals = 0;
 
     if(w->geometry.x != geometry.x)
     {
@@ -177,14 +178,14 @@ drawin_moveresize(lua_State *L, int udx, area_t geometry)
 
     drawin_update_drawing(L, udx);
 
-    /* Activate BMA */
-    client_ignore_enterleave_events();
-
     if(mask_vals)
-        xcb_configure_window(globalconf.connection, w->window, mask_vals, moveresize_win_vals);
-
-    /* Deactivate BMA */
-    client_restore_enterleave_events();
+    {
+        w->property_refresh.geom_mask_vals = mask_vals;
+        memcpy(w->property_refresh.geom_moveresize_win_vals,
+               moveresize_win_vals,
+               sizeof moveresize_win_vals);
+        drawin_array_push(&globalconf.need_geometry_refresh_drawin, w);
+    }
 
     if(mask_vals & XCB_CONFIG_WINDOW_X)
         luaA_object_emit_signal(L, udx, "property::x", 0);
@@ -195,6 +196,35 @@ drawin_moveresize(lua_State *L, int udx, area_t geometry)
     if(mask_vals & XCB_CONFIG_WINDOW_HEIGHT)
         luaA_object_emit_signal(L, udx, "property::height", 0);
 }
+
+/** Commit pending drawin geometry changes.
+ */
+void
+drawin_geometry_refresh()
+{
+    if (!globalconf.need_geometry_refresh_drawin.len)
+        return;
+
+    /* Activate BMA */
+    client_ignore_enterleave_events();
+
+    printf("masks: %d, %d, %d, %d\n", XCB_CONFIG_WINDOW_X, XCB_CONFIG_WINDOW_Y, XCB_CONFIG_WINDOW_WIDTH, XCB_CONFIG_WINDOW_HEIGHT);
+    foreach(_d, globalconf.need_geometry_refresh_drawin)
+    {
+        drawin_t *d = *_d;
+        xcb_configure_window(globalconf.connection,
+                             d->window,
+                             d->property_refresh.geom_mask_vals,
+                             d->property_refresh.geom_moveresize_win_vals);
+    }
+
+    /* Deactivate BMA */
+    client_restore_enterleave_events();
+
+    drawin_array_wipe(&globalconf.need_geometry_refresh_drawin);
+    drawin_array_init(&globalconf.need_geometry_refresh_drawin);
+}
+
 
 /** Refresh the window content by copying its pixmap data to its window.
  * \param drawin The drawin to refresh.

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -208,7 +208,6 @@ drawin_geometry_refresh()
     /* Activate BMA */
     client_ignore_enterleave_events();
 
-    printf("masks: %d, %d, %d, %d\n", XCB_CONFIG_WINDOW_X, XCB_CONFIG_WINDOW_Y, XCB_CONFIG_WINDOW_WIDTH, XCB_CONFIG_WINDOW_HEIGHT);
     foreach(_d, globalconf.need_geometry_refresh_drawin)
     {
         drawin_t *d = *_d;

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -41,6 +41,8 @@ struct drawin_t
     struct
     {
         WINDOW_OBJECT_PROPERTY_REFRESH
+        uint32_t geom_moveresize_win_vals[4];
+        uint16_t geom_mask_vals;
     } property_refresh;
 };
 
@@ -51,6 +53,7 @@ drawin_t * drawin_getbywin(xcb_window_t);
 void drawin_refresh_pixmap_partial(drawin_t *, int16_t, int16_t, uint16_t, uint16_t);
 
 void drawin_class_setup(lua_State *);
+void drawin_geometry_refresh(void);
 
 lua_class_t drawin_class;
 

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -40,8 +40,7 @@ struct drawin_t
     drawable_t *drawable;
     struct
     {
-        /** Drawin's opacity needs to be committed. */
-        bool opacity;
+        WINDOW_OBJECT_PROPERTY_REFRESH
     } property_refresh;
 };
 

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -40,6 +40,11 @@ struct drawin_t
     drawable_t *drawable;
     /** The window geometry. */
     area_t geometry;
+    struct
+    {
+        /** Drawin's opacity needs to be committed. */
+        bool opacity;
+    } property_refresh;
 };
 
 ARRAY_FUNCS(drawin_t *, drawin, DO_NOTHING)

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -38,8 +38,6 @@ struct drawin_t
     char *cursor;
     /** The drawable for this drawin. */
     drawable_t *drawable;
-    /** The window geometry. */
-    area_t geometry;
     struct
     {
         /** Drawin's opacity needs to be committed. */

--- a/objects/window.c
+++ b/objects/window.c
@@ -54,16 +54,19 @@ window_wipe(window_t *window)
 void
 window_properties_refresh()
 {
-    foreach(_w, globalconf.need_properties_refresh)
+    foreach(_w, globalconf.need_properties_refresh_windows)
     {
         window_t *w = *_w;
 
-        if (w->property_refresh.opacity)
+        if (w->property_refresh.border_width)
         {
-            xwindow_set_opacity(w->window, w->opacity);
-            w->property_refresh.opacity = false;
+            xcb_configure_window(globalconf.connection, window_get(w),
+                    XCB_CONFIG_WINDOW_BORDER_WIDTH,
+                    (uint32_t[]) { w->border_width });
+            w->property_refresh.border_width = false;
         }
-        window_array_remove(&globalconf.need_properties_refresh, _w);
+
+        window_array_remove(&globalconf.need_properties_refresh_windows, _w);
     }
 }
 
@@ -127,10 +130,6 @@ window_set_opacity(lua_State *L, int idx, double opacity)
     {
         window->opacity = opacity;
         xwindow_set_opacity(window_get(window), opacity);
-
-        /* Mark this property change to be committed later */
-        window_array_push(&globalconf.need_properties_refresh, window);
-        window->property_refresh.opacity = true;
 
         luaA_object_emit_signal(L, idx, "property::opacity", 0);
     }
@@ -206,9 +205,11 @@ window_set_border_width(lua_State *L, int idx, int width)
         return;
 
     if(window->window)
-        xcb_configure_window(globalconf.connection, window_get(window),
-                             XCB_CONFIG_WINDOW_BORDER_WIDTH,
-                             (uint32_t[]) { width });
+    {
+        /* Mark this property change to be committed later */
+        window_array_push(&globalconf.need_properties_refresh_windows, window);
+        window->property_refresh.border_width = true;
+    }
 
     window->border_width = width;
 

--- a/objects/window.h
+++ b/objects/window.h
@@ -70,15 +70,25 @@ typedef enum
     window_type_t type;
 
 /** Window structure */
-typedef struct
+typedef struct window_t
 {
     WINDOW_OBJECT_HEADER
+    /** Properties needed to be committed/refreshed.
+     * Common to drawin and client. */
+    struct
+    {
+        /** Window's opacity needs to be committed. */
+        bool opacity;
+    } property_refresh;
 } window_t;
 
 lua_class_t window_class;
 
+ARRAY_FUNCS(window_t *, window, DO_NOTHING)
+
 void window_class_setup(lua_State *);
 
+void window_properties_refresh(void);
 void window_set_opacity(lua_State *, int, double);
 void window_set_border_width(lua_State *, int, int);
 int luaA_window_get_type(lua_State *, window_t *);

--- a/objects/window.h
+++ b/objects/window.h
@@ -71,16 +71,17 @@ typedef enum
     /** The window geometry. */ \
     area_t geometry;
 
+/** Common properties needed to be committed/refreshed. */ \
+#define WINDOW_OBJECT_PROPERTY_REFRESH \
+    bool border_width;
+
 /** Window structure */
 typedef struct window_t
 {
     WINDOW_OBJECT_HEADER
-    /** Properties needed to be committed/refreshed.
-     * Common to drawin and client. */
     struct
     {
-        /** Window's opacity needs to be committed. */
-        bool opacity;
+        WINDOW_OBJECT_PROPERTY_REFRESH
     } property_refresh;
 } window_t;
 

--- a/objects/window.h
+++ b/objects/window.h
@@ -67,7 +67,9 @@ typedef enum
     /** Border width */ \
     uint16_t border_width; \
     /** The window type */ \
-    window_type_t type;
+    window_type_t type; \
+    /** The window geometry. */ \
+    area_t geometry;
 
 /** Window structure */
 typedef struct window_t


### PR DESCRIPTION
This adds client_geometry_commit and call it from awesome_refresh.
client_geometry_commit is factored out of client_resize_do.

Two new entries in client_t are used for this: need_geometry_commit and
need_geometry_commit_send_notice.  Additionally the flag
globalconf.need_geometry_commit is used for performance reasons.

This fixes the issue where changing the geometry of a client via the
property::screen signal would draw the client twice (see issue #168).

(It will also result in only one SIGWINCH signal in Zsh when (un)maximizing a terminal, instead of two.)

Given this, the delayed calls to layout.arrange are probably not needed
anymore. Ref: https://github.com/awesomeWM/awesome/pull/153#issuecomment-76051092