### PR TITLE
config: sloppy focus: ignore mouse::enter if mouse was not moved

### DIFF
--- a/awesomerc.lua.in
+++ b/awesomerc.lua.in
@@ -435,20 +435,16 @@ client.connect_signal("manage", function (c)
 end)
 
 -- Enable sloppy focus.
-local sloppyfocus_last = {x=nil, y=nil, c=nil}
+local sloppyfocus_last = {c=nil}
 client.connect_signal("mouse::enter", function(c)
-    local mcoords = mouse.coords()
     if awful.layout.get(c.screen) ~= awful.layout.suit.magnifier
             and awful.client.focus.filter(c) then
         -- Skip focusing the client if the mouse wasn't moved.
-        if (mcoords.x ~= sloppyfocus_last.x or mcoords.y ~= sloppyfocus_last.y)
-            and c ~= sloppyfocus_last.c then
+        if c ~= sloppyfocus_last.c then
             client.focus = c
             sloppyfocus_last.c = c
         end
     end
-    sloppyfocus_last.x = mcoords.x
-    sloppyfocus_last.y = mcoords.y
 end)
 
 client.connect_signal("focus", function(c) c.border_color = beautiful.border_focus end)

--- a/awesomerc.lua.in
+++ b/awesomerc.lua.in
@@ -434,12 +434,18 @@ client.connect_signal("manage", function (c)
     end
 end)
 
--- Enable sloppy focus
+-- Enable sloppy focus.
+local sloppy_last_coords = {x=nil, y=nil}
 client.connect_signal("mouse::enter", function(c)
+    local mcoords = mouse.coords()
     if awful.layout.get(c.screen) ~= awful.layout.suit.magnifier
-        and awful.client.focus.filter(c) then
-        client.focus = c
+            and awful.client.focus.filter(c) then
+        -- Skip focusing the client if the mouse wasn't moved.
+        if mcoords.x ~= sloppy_last_coords.x or mcoords.y ~= sloppy_last_coords.y then
+            client.focus = c
+        end
     end
+    sloppy_last_coords = mcoords
 end)
 
 client.connect_signal("focus", function(c) c.border_color = beautiful.border_focus end)

--- a/awesomerc.lua.in
+++ b/awesomerc.lua.in
@@ -435,17 +435,20 @@ client.connect_signal("manage", function (c)
 end)
 
 -- Enable sloppy focus.
-local sloppy_last_coords = {x=nil, y=nil}
+local sloppyfocus_last = {x=nil, y=nil, c=nil}
 client.connect_signal("mouse::enter", function(c)
     local mcoords = mouse.coords()
     if awful.layout.get(c.screen) ~= awful.layout.suit.magnifier
             and awful.client.focus.filter(c) then
         -- Skip focusing the client if the mouse wasn't moved.
-        if mcoords.x ~= sloppy_last_coords.x or mcoords.y ~= sloppy_last_coords.y then
+        if (mcoords.x ~= sloppyfocus_last.x or mcoords.y ~= sloppyfocus_last.y)
+            and c ~= sloppyfocus_last.c then
             client.focus = c
+            sloppyfocus_last.c = c
         end
     end
-    sloppy_last_coords = mcoords
+    sloppyfocus_last.x = mcoords.x
+    sloppyfocus_last.y = mcoords.y
 end)
 
 client.connect_signal("focus", function(c) c.border_color = beautiful.border_focus end)


### PR DESCRIPTION
When raising a client's transient_for window, the parent window gets
also raised.  This might trigger a `mouse::enter` signal for the parent
window, if it was not visible at the mouse pointer's position before.

The sloppy focus handler in the default config now ignores any
`mouse::enter` events, when the mouse coordinates have not changed since
the last signal.