### PR TITLE
added dbus.call_method

### DIFF
--- a/dbus.c
+++ b/dbus.c
@@ -821,7 +821,7 @@ luaA_dbus_emit_signal(lua_State *L)
 
     if(nargs % 2 != 0)
     {
-        luaA_warn(L, "your D-Bus signal emiting method has wrong number of arguments");
+        luaA_warn(L, "your D-Bus signal emitting method has wrong number of arguments");
         dbus_message_unref(msg);
         lua_pushboolean(L, 0);
         return 1;

--- a/dbus.c
+++ b/dbus.c
@@ -797,7 +797,7 @@ luaA_dbus_disconnect_signal(lua_State *L)
  * \lparam A string indicating if we are using system or session bus.
  * \lparam A string with the dbus path.
  * \lparam A string with the dbus interface.
- * \lparam A string with the dbus method name.
+ * \lparam A string with the dbus signal name.
  * \lparam type of 1st arg
  * \lparam 1st arg value
  * \lparam type of 2nd arg

--- a/dbus.c
+++ b/dbus.c
@@ -813,6 +813,10 @@ luaA_dbus_emit_signal(lua_State *L)
     const char *name = luaL_checkstring(L, 4);
     DBusConnection *dbus_connection = a_dbus_bus_getbyname(bus_name);
     DBusMessage* msg = dbus_message_new_signal(path, itface, name);
+    if (msg == NULL) {
+        luaA_warn(L, "your D-Bus signal emitting method error'd");
+        return 0;
+    }
 
     DBusMessageIter iter;
     dbus_message_iter_init_append(msg, &iter);

--- a/dbus.c
+++ b/dbus.c
@@ -841,6 +841,7 @@ luaA_dbus_emit_signal(lua_State *L)
     }
     dbus_connection_send(dbus_connection, msg, NULL);
     dbus_message_unref(msg);
+    dbus_connection_flush(dbus_connection);
     lua_pushboolean(L, 1);
     return 1;
 }

--- a/docs/capi/dbus.lua.in
+++ b/docs/capi/dbus.lua.in
@@ -55,3 +55,17 @@
 -- @param value_2nd_arg value of 2nd argument
 -- ... etc
 -- @function emit_signal
+
+--- Call a method on the D-Bus.
+--
+-- @param bus A string indicating if we are using system or session bus.
+-- @param destination A string with the dbus destination.
+-- @param path A string with the dbus path.
+-- @param interface A string with the dbus interface.
+-- @param method A string with the dbus method name.
+-- @param type_1st_arg type of 1st argument
+-- @param value_1st_arg value of 1st argument
+-- @param type_2nd_arg type of 2nd argument
+-- @param value_2nd_arg value of 2nd argument
+-- ... etc
+-- @function call_method

--- a/docs/capi/dbus.lua.in
+++ b/docs/capi/dbus.lua.in
@@ -43,11 +43,12 @@
 -- @param func The function to call.
 -- @function disconnect_signal
 
--- Emit a signal on the D-Bus.
+--- Emit a signal on the D-Bus.
+--
 -- @param bus A string indicating if we are using system or session bus.
 -- @param path A string with the dbus path.
 -- @param interface A string with the dbus interface.
--- @param method A string with the dbus method name.
+-- @param method A string with the dbus signal name.
 -- @param type_1st_arg type of 1st argument
 -- @param value_1st_arg value of 1st argument
 -- @param type_2nd_arg type of 2nd argument


### PR DESCRIPTION
Added the ability to call D-Bus methods.

Plus i fixed a bug with `dbus_message_new_signal` returning `NULL`.

To call a method you best do:
```lua
local name, on_method_return
on_method_return = function (method, ...)
    dbus.disconnect_signal(name, on_method_return)
    -- process method return result here
end
local serial = dbus.call_method('org.dbus.destination', '/org/dbus/path/', 'org.dbus.interface', 'Method', unpack(args))
name = string.format('reply %d', serial)
dbus.connect_signal(name, on_method_return)
```

What do you think?