### PR TITLE
Give focus to restored clients

### DIFF
--- a/awesomerc.lua.in
+++ b/awesomerc.lua.in
@@ -262,7 +262,15 @@ globalkeys = awful.util.table.join(
     awful.key({ modkey,           }, "space", function () awful.layout.inc( 1) end),
     awful.key({ modkey, "Shift"   }, "space", function () awful.layout.inc(-1) end),
 
-    awful.key({ modkey, "Control" }, "n", awful.client.restore),
+    awful.key({ modkey, "Control" }, "n",
+              function ()
+                  c = awful.client.restore()
+                  -- Focus restored client
+                  if c then
+                      client.focus = c
+                      c:raise()
+                  end
+              end),
 
     -- Prompt
     awful.key({ modkey },            "r",     function () mypromptbox[mouse.screen]:run() end),


### PR DESCRIPTION
When you are restoring previously minimized windows, you definetely want
focus on them.

Signed-off-by: Rastislav Barlik <barlik@zoho.com>