### PR TITLE
Make client.focusable writable from Lua

### DIFF
--- a/lib/awful/client.lua.in
+++ b/lib/awful/client.lua.in
@@ -156,10 +156,12 @@ end
 --
 -- @client c The client that has been focused.
 function client.focus.history.add(c)
-    -- Remove the client if its in stack
-    client.focus.history.delete(c)
-    -- Record the client has latest focused
-    table.insert(client.data.focus, 1, c)
+    if client.focus.filter(c) then
+        -- Remove the client if its in stack
+        client.focus.history.delete(c)
+        -- Record the client has latest focused
+        table.insert(client.data.focus, 1, c)
+    end
 end
 
 --- Get the latest focused client for a screen in history.

--- a/objects/client.c
+++ b/objects/client.c
@@ -956,10 +956,10 @@ client_set_focusable(lua_State *L, int cidx, bool s)
 {
     client_t *c = luaA_checkudata(L, cidx, &client_class);
 
-    if(c->focusable != s)
+    if(c->focusable != s || !c->focusable_set)
     {
         c->focusable = s;
-        banning_need_update();
+        c->focusable_set = true;
         luaA_object_emit_signal(L, cidx, "property::focusable", 0);
     }
 }
@@ -1901,10 +1901,8 @@ luaA_client_set_focusable(lua_State *L, client_t *c)
 {
     if(lua_isnil(L, -1))
         c->focusable_set = false;
-    else {
-        c->focusable_set = true;
+    else
         client_set_focusable(L, -3, luaA_checkboolean(L, -1));
-    }
     return 0;
 }
 
@@ -2567,6 +2565,7 @@ client_class_setup(lua_State *L)
     signal_add(&client_class.signals, "property::above");
     signal_add(&client_class.signals, "property::below");
     signal_add(&client_class.signals, "property::class");
+    signal_add(&client_class.signals, "property::focusable");
     signal_add(&client_class.signals, "property::fullscreen");
     signal_add(&client_class.signals, "property::geometry");
     signal_add(&client_class.signals, "property::group_window");

--- a/objects/client.c
+++ b/objects/client.c
@@ -946,6 +946,24 @@ client_set_sticky(lua_State *L, int cidx, bool s)
     }
 }
 
+/** Set a client focusable, or not.
+ * \param L The Lua VM state.
+ * \param cidx The client index.
+ * \param s Set or not the client's focusable property.
+ */
+static void
+client_set_focusable(lua_State *L, int cidx, bool s)
+{
+    client_t *c = luaA_checkudata(L, cidx, &client_class);
+
+    if(c->focusable != s)
+    {
+        c->focusable = s;
+        banning_need_update();
+        luaA_object_emit_signal(L, cidx, "property::focusable", 0);
+    }
+}
+
 /** Set a client fullscreen, or not.
  * \param L The Lua VM state.
  * \param cidx The client index.
@@ -1879,6 +1897,18 @@ luaA_client_set_icon(lua_State *L, client_t *c)
 }
 
 static int
+luaA_client_set_focusable(lua_State *L, client_t *c)
+{
+    if(lua_isnil(L, -1))
+        c->focusable_set = false;
+    else {
+        c->focusable_set = true;
+        client_set_focusable(L, -3, luaA_checkboolean(L, -1));
+    }
+    return 0;
+}
+
+static int
 luaA_client_set_sticky(lua_State *L, client_t *c)
 {
     client_set_sticky(L, -3, luaA_checkboolean(L, -1));
@@ -2028,8 +2058,11 @@ luaA_client_get_focusable(lua_State *L, client_t *c)
 {
     bool ret;
 
+    if (c->focusable_set)
+        ret = c->focusable;
+
     /* A client can be focused if it doesnt have the "nofocus" hint...*/
-    if (!c->nofocus)
+    else if (!c->nofocus)
         ret = true;
     else
         /* ...or if it knows the WM_TAKE_FOCUS protocol */
@@ -2499,9 +2532,9 @@ client_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_client_get_size_hints,
                             NULL);
     luaA_class_add_property(&client_class, "focusable",
-                            NULL,
+                            (lua_class_propfunc_t) luaA_client_set_focusable,
                             (lua_class_propfunc_t) luaA_client_get_focusable,
-                            NULL);
+                            (lua_class_propfunc_t) luaA_client_set_focusable);
     luaA_class_add_property(&client_class, "shape_bounding",
                             (lua_class_propfunc_t) luaA_client_set_shape_bounding,
                             (lua_class_propfunc_t) luaA_client_get_shape_bounding,

--- a/objects/client.h
+++ b/objects/client.h
@@ -91,6 +91,10 @@ struct client_t
     bool skip_taskbar;
     /** True if the client cannot have focus */
     bool nofocus;
+    /** True if the client is focusable.  Overrides nofocus, and can be set
+     * from Lua. */
+    bool focusable;
+    bool focusable_set;
     /** Window of the group leader */
     xcb_window_t group_window;
     /** Window holding command needed to start it (session management related) */


### PR DESCRIPTION
It uses an extra boolean to keep track of if `c.focusable` has been set.

It's possible to unset the overriding by setting it to `nil`, i.e.
`client.focus.focusable = nil`.

Fixes #237