### PR TITLE
Fix Error while drawing widget

### DIFF
--- a/lib/wibox/widget/systray.lua.in
+++ b/lib/wibox/widget/systray.lua.in
@@ -41,7 +41,7 @@ function systray:draw(wibox, cr, width, height)
     else
         base = in_dir / num_entries
     end
-    capi.awesome.systray(wibox.drawin, x, y, base, is_rotated, bg, reverse, spacing)
+    capi.awesome.systray(wibox.drawin, math.ceil(x), math.ceil(y), base, is_rotated, bg, reverse, spacing)
 end
 
 function systray:fit(width, height)


### PR DESCRIPTION
I'm error :
```
Error while drawing widget: /usr/share/awesome/lib/wibox/widget/systray.lua:48: bad argument #2 to 'systray' (number has no integer representation)
```
I am looking : /usr/share/awesome/lib/wibox/widget/systray.lua:48 and i am printing x and y
```
function systray:draw(wibox, cr, width, height)
    local x, y, _, _ = lbase.rect_to_device_geometry(cr, 0, 0, width, height)
    local num_entries = capi.awesome.systray()
    local bg = beautiful.bg_systray or beautiful.bg_normal or "#000000"
    local spacing = beautiful.systray_icon_spacing or 0

    -- Figure out if the cairo context is rotated
    local dir_x, dir_y = cr:user_to_device_distance(1, 0)
    local is_rotated = abs(dir_x) < abs(dir_y)

    local in_dir, ortho, base
    if horizontal then
        in_dir, ortho = width, height
        is_rotated = not is_rotated
    else
        ortho, in_dir = width, height
    end
    if ortho * num_entries <= in_dir then
        base = ortho
    else
        base = in_dir / num_entries
    end
    print(x)
    print(y)
    capi.awesome.systray(wibox.drawin, x, y, base, is_rotated, bg, reverse, spacing)
end
```
Result :
```
948,88888888889
0.0
Error while drawing widget: /usr/share/awesome/lib/wibox/widget/systray.lua:48: bad argument #2 to 'systray' (number has no integer representation)
```
I am patching :
```
function systray:draw(wibox, cr, width, height)
    local x, y, _, _ = lbase.rect_to_device_geometry(cr, 0, 0, width, height)
    local num_entries = capi.awesome.systray()
    local bg = beautiful.bg_systray or beautiful.bg_normal or "#000000"
    local spacing = beautiful.systray_icon_spacing or 0

    -- Figure out if the cairo context is rotated
    local dir_x, dir_y = cr:user_to_device_distance(1,
    print()
    print(x)
    print(math.ceil(y))
    print(y)0)
    local is_rotated = abs(dir_x) < abs(dir_y)

    local in_dir, ortho, base
    if horizontal then
        in_dir, ortho = width, height
        is_rotated = not is_rotated
    else
        ortho, in_dir = width, height
    end
    if ortho * num_entries <= in_dir then
        base = ortho
    else
        base = in_dir / num_entries
    end
    capi.awesome.systray(wibox.drawin, math.ceil(x), math.ceil(y), base, is_rotated, bg, reverse, spacing)
end
```
