### PR TITLE
rect_to_device_geometry: make sure to return numbers as ints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,9 @@ install:
   - sudo apt-get install -qq gir1.2-pango-1.0
 
   # Install luarocks (for the selected Lua version).
-  - wget http://keplerproject.github.io/luarocks/releases/luarocks-2.2.1.tar.gz
-  - tar xf luarocks-2.2.1.tar.gz
-  - cd luarocks-2.2.1
+  - wget http://keplerproject.github.io/luarocks/releases/luarocks-2.2.2.tar.gz
+  - tar xf luarocks-2.2.2.tar.gz
+  - cd luarocks-2.2.2
   - ./configure --lua-version=$LUA
   - sudo make install
   - cd ..

--- a/lib/wibox/layout/base.lua.in
+++ b/lib/wibox/layout/base.lua.in
@@ -10,6 +10,7 @@ local pcall = pcall
 local print = print
 local min = math.min
 local max = math.max
+local floor = math.floor
 
 local base = {}
 
@@ -20,10 +21,10 @@ function base.rect_to_device_geometry(cr, x, y, width, height)
     local x2, y2 = cr:user_to_device(x, y + height)
     local x3, y3 = cr:user_to_device(x + width, y + height)
     local x4, y4 = cr:user_to_device(x + width, y)
-    local x = min(x1, x2, x3, x4)
-    local y = min(y1, y2, y3, y4)
-    local width = max(x1, x2, x3, x4) - x
-    local height = max(y1, y2, y3, y4) - y
+    local x = floor(min(x1, x2, x3, x4))
+    local y = floor(min(y1, y2, y3, y4))
+    local width = floor(max(x1, x2, x3, x4) - x)
+    local height = floor(max(y1, y2, y3, y4) - y)
 
     return x, y, width, height
 end


### PR DESCRIPTION
The following error was reported (in #247):

    Error while drawing widget:
    /usr/share/awesome/lib/wibox/widget/systray.lua:48: bad argument #2 to
    'systray' (number has no integer representation)

Something like "948,88" might be returned for x, which cannot be
represented as integer by Lua.

Fixes https://github.com/awesomeWM/awesome/pull/247