### PR TITLE
Weak connect

### DIFF
--- a/lib/wibox/drawable.lua.in
+++ b/lib/wibox/drawable.lua.in
@@ -120,7 +120,7 @@ function drawable:set_widget(widget)
 
     self.widget = widget
     if widget then
-        widget:connect_signal("widget::updated", self.draw)
+        widget:weak_connect_signal("widget::updated", self.draw)
     end
 
     -- Make sure the widget gets drawn

--- a/lib/wibox/layout/align.lua.in
+++ b/lib/wibox/layout/align.lua.in
@@ -140,7 +140,7 @@ local function widget_changed(layout, old_w, new_w)
     end
     if new_w then
         widget_base.check_widget(new_w)
-        new_w:connect_signal("widget::updated", layout._emit_updated)
+        new_w:weak_connect_signal("widget::updated", layout._emit_updated)
     end
     layout._emit_updated()
 end

--- a/lib/wibox/layout/constraint.lua.in
+++ b/lib/wibox/layout/constraint.lua.in
@@ -48,7 +48,7 @@ function constraint:set_widget(widget)
     end
     if widget then
         widget_base.check_widget(widget)
-        widget:connect_signal("widget::updated", self._emit_updated)
+        widget:weak_connect_signal("widget::updated", self._emit_updated)
     end
     self.widget = widget
     self:emit_signal("widget::updated")

--- a/lib/wibox/layout/fixed.lua.in
+++ b/lib/wibox/layout/fixed.lua.in
@@ -54,7 +54,7 @@ end
 function fixed:add(widget)
     widget_base.check_widget(widget)
     table.insert(self.widgets, widget)
-    widget:connect_signal("widget::updated", self._emit_updated)
+    widget:weak_connect_signal("widget::updated", self._emit_updated)
     self._emit_updated()
 end
 

--- a/lib/wibox/layout/flex.lua.in
+++ b/lib/wibox/layout/flex.lua.in
@@ -62,7 +62,7 @@ end
 function flex:add(widget)
     widget_base.check_widget(widget)
     table.insert(self.widgets, widget)
-    widget:connect_signal("widget::updated", self._emit_updated)
+    widget:weak_connect_signal("widget::updated", self._emit_updated)
     self._emit_updated()
 end
 

--- a/lib/wibox/layout/margin.lua.in
+++ b/lib/wibox/layout/margin.lua.in
@@ -58,7 +58,7 @@ function margin:set_widget(widget)
     end
     if widget then
         widget_base.check_widget(widget)
-        widget:connect_signal("widget::updated", self._emit_updated)
+        widget:weak_connect_signal("widget::updated", self._emit_updated)
     end
     self.widget = widget
     self._emit_updated()

--- a/lib/wibox/layout/mirror.lua.in
+++ b/lib/wibox/layout/mirror.lua.in
@@ -60,7 +60,7 @@ function mirror:set_widget(widget)
     end
     if widget then
         widget_base.check_widget(widget)
-        widget:connect_signal("widget::updated", self._emit_updated)
+        widget:weak_connect_signal("widget::updated", self._emit_updated)
     end
     self.widget = widget
     self._emit_updated()

--- a/lib/wibox/layout/rotate.lua.in
+++ b/lib/wibox/layout/rotate.lua.in
@@ -61,7 +61,7 @@ function rotate:set_widget(widget)
     end
     if widget then
         widget_base.check_widget(widget)
-        widget:connect_signal("widget::updated", self._emit_updated)
+        widget:weak_connect_signal("widget::updated", self._emit_updated)
     end
     self.widget = widget
     self._emit_updated()

--- a/lib/wibox/widget/background.lua.in
+++ b/lib/wibox/widget/background.lua.in
@@ -62,7 +62,7 @@ function background:set_widget(widget)
     end
     if widget then
         base.check_widget(widget)
-        widget:connect_signal("widget::updated", self._emit_updated)
+        widget:weak_connect_signal("widget::updated", self._emit_updated)
     end
     self.widget = widget
     self._emit_updated()


### PR DESCRIPTION
This PR adds `:weak_connect_signal()` to `gears.object`. This allows the callback function to be garbage collected and automatically disconnects the signal when this happens.

I don't know if this fixes any memory leaks, but I came up with this when thinking about something else and how to prevent "reference leaks" there.