### PR TITLE
Make stdout/stderr line buffered

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -325,6 +325,10 @@ main(int argc, char **argv)
         { NULL,      0, NULL, 0 }
     };
 
+    /* Make stdout/stderr line buffered. */
+    setlinebuf(stdout);
+    setlinebuf(stderr);
+
     /* clear the globalconf structure */
     p_clear(&globalconf, 1);
     globalconf.keygrabber = LUA_REFNIL;


### PR DESCRIPTION
This should improve the behaviour with print()ing for debugging.

I was using `setbuf(…, 0)` initially, but it makes sense to buffer it
per line.