### PR TITLE
Fix cmake config - typo

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -303,7 +303,7 @@ macro(a_configure_file file)
     message(STATUS "Configuring ${outfile}")
     configure_file(${SOURCE_DIR}/${file}
                    ${BUILD_DIR}/${outfile}
-                   ESCAPE_QUOTE
+                   ESCAPE_QUOTES
                    @ONLY)
 endmacro()
 


### PR DESCRIPTION
This was giving a lot of errors using `-Wdev`

> CMake Warning (dev) at awesomeConfig.cmake:304 (configure_file):
>   configure_file called with unknown argument(s):
> 
>    ESCAPE_QUOTE

Should be `ESCAPE_QUOTES`, see:

http://www.cmake.org/cmake/help/v3.3/command/configure_file.html