### PR TITLE
awesomeConfig.cmake: do not use GLOB_RECURSE with *.c/*.h

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -277,14 +277,14 @@ set(AWESOME_THEMES_PATH      ${AWESOME_DATA_PATH}/themes)
 # }}}
 
 # {{{ Configure files
-file(GLOB_RECURSE awesome_c_configure_files RELATIVE
-    ${SOURCE_DIR}
+file(GLOB awesome_c_configure_files RELATIVE ${SOURCE_DIR}
     ${SOURCE_DIR}/*.c
     ${SOURCE_DIR}/*.h
-    ${SOURCE_DIR}/*/*.c
-    ${SOURCE_DIR}/*/*.h)
-file(GLOB_RECURSE awesome_lua_configure_files RELATIVE
-    ${SOURCE_DIR}
+    ${SOURCE_DIR}/common/*.c
+    ${SOURCE_DIR}/common/*.h
+    ${SOURCE_DIR}/objects/*.c
+    ${SOURCE_DIR}/objects/*.h)
+file(GLOB_RECURSE awesome_lua_configure_files RELATIVE ${SOURCE_DIR}
     ${SOURCE_DIR}/lib/*.lua
     ${SOURCE_DIR}/themes/*/*.lua)
 set(AWESOME_CONFIGURE_FILES
@@ -304,8 +304,7 @@ endforeach()
 #}}}
 
 # {{{ Copy additional files
-file(GLOB_RECURSE awesome_md_docs RELATIVE
-    ${SOURCE_DIR}
+file(GLOB awesome_md_docs RELATIVE ${SOURCE_DIR}
     ${SOURCE_DIR}/docs/*.md)
 set(AWESOME_ADDITIONAL_FILES
     ${awesome_md_docs})


### PR DESCRIPTION
This fixes "make (cmake)" picking up the files from the build dir itself
(recursively), i.e. "make cmake" would also create
`.build-HOST-x86_64-linux-gnu-4.9.2/.build-HOST-x86_64-linux-gnu-4.9.2/`.

It could also use `${AWE_SRCS}` etc here probably.