### PR TITLE
Expose properties on awful.widget.graph

### DIFF
--- a/lib/awful/widget/graph.lua
+++ b/lib/awful/widget/graph.lua
@@ -225,6 +225,7 @@ for _, prop in ipairs(properties) do
     if not graph["set_" .. prop] then
         graph["set_" .. prop] = function(_graph, value)
             data[_graph][prop] = value
+            _graph[prop] = value
             _graph:emit_signal("widget::updated")
             return _graph
         end
@@ -254,6 +255,7 @@ function graph.new(args)
 
     for _, prop in ipairs(properties) do
         _graph["set_" .. prop] = graph["set_" .. prop]
+        _graph[prop] = data[_graph][prop]
     end
 
     return _graph

--- a/lib/awful/widget/graph.lua
+++ b/lib/awful/widget/graph.lua
@@ -226,10 +226,14 @@ for _, prop in ipairs(properties) do
         graph["set_" .. prop] = function(_graph, value)
             if data[_graph][prop] ~= value then
                 data[_graph][prop] = value
-                _graph[prop] = value
                 _graph:emit_signal("widget::updated")
             end
             return _graph
+        end
+    end
+    if not graph["get_" .. prop] then
+        graph["get_" .. prop] = function(_graph)
+            return data[_graph][prop]
         end
     end
 end
@@ -257,7 +261,7 @@ function graph.new(args)
 
     for _, prop in ipairs(properties) do
         _graph["set_" .. prop] = graph["set_" .. prop]
-        _graph[prop] = data[_graph][prop]
+        _graph["get_" .. prop] = graph["get_" .. prop]
     end
 
     return _graph

--- a/lib/awful/widget/graph.lua
+++ b/lib/awful/widget/graph.lua
@@ -224,9 +224,11 @@ end
 for _, prop in ipairs(properties) do
     if not graph["set_" .. prop] then
         graph["set_" .. prop] = function(_graph, value)
-            data[_graph][prop] = value
-            _graph[prop] = value
-            _graph:emit_signal("widget::updated")
+            if data[_graph][prop] ~= value then
+                data[_graph][prop] = value
+                _graph[prop] = value
+                _graph:emit_signal("widget::updated")
+            end
             return _graph
         end
     end


### PR DESCRIPTION
This allows to see if a widget is stacked for example.

Ref from IRC:

    blueyed | A widget does not know if it's stacked? (it's in the private data table).
    blueyed | Should graph.new maybe attach "_data", too?  Or provide getter methods for the properties, similar to the setters?
    blueyed | psychon: is this something your new-widgets branch addresses/conflicts with?
    Elv1313 | define "stacked". The psychon patches improve this in the sense it prevent full redraw of everything
    Elv1313 | blueyed: ^
    blueyed | I just want to know (for vivious) if a widget is stacked (w:set_stack(true)).
    blueyed | The property can only be set on a widget, but there appears to be no getter.
    Elv1313 | blueyed: The stack is only for the graph and allow multiple data to be shown in the same graph
    blueyed | btw: please consider using the "next" milestone for announcing something to be merged soonish.
    Elv1313 | ok
    blueyed | Elv1313: yeah, but the data format is different when stacking is used, and vicious needs to be aware of it.
    blueyed | (it calls "add_value", and needs to provide the group there, too)
    Elv1313 | right
    Elv1313 | I would favor a Radical like property system. It has a little overhead, but myobject.myproperty = true will call myobject:set_myproperty(true) and
            | local v = myobject.myproperty call :get_myproperty()
    Elv1313 | I have a branch somewhere to implement it for the capi objects based on one of psychon unmerged commit, but I really have 0 time for awesome/my pet
            | projets
    Elv1313 | projects*
    blueyed | I see.  I leave it then patched locally for now.  But the quick fix might be to just expose the "_data" entry with the widget.
    Elv1313 | wibox now does that for its widgets. Awful.widgets come from another age and was ported to the wibox.widget system
