### PR TITLE
awful.tag: emit property:: signals only on change

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -937,11 +937,13 @@ function client.property.set(c, prop, value)
     if not client.data.properties[c] then
         client.data.properties[c] = {}
     end
-    if client.data.persistent_properties_registered[prop] then
-        c:set_xproperty("awful.client.property." .. prop, value)
+    if client.data.properties[c][prop] ~= value then
+        if client.data.persistent_properties_registered[prop] then
+            c:set_xproperty("awful.client.property." .. prop, value)
+        end
+        client.data.properties[c][prop] = value
+        c:emit_signal("property::" .. prop)
     end
-    client.data.properties[c][prop] = value
-    c:emit_signal("property::" .. prop)
 end
 
 --- Set a client property to be persistent across restarts (via X properties).

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -597,8 +597,10 @@ function tag.setproperty(_tag, prop, value)
     if not data.tags[_tag] then
         data.tags[_tag] = {}
     end
-    data.tags[_tag][prop] = value
-    _tag:emit_signal("property::" .. prop)
+    if data.tags[_tag][prop] ~= value then
+        data.tags[_tag][prop] = value
+        _tag:emit_signal("property::" .. prop)
+    end
 end
 
 --- Tag a client with the set of current tags.


### PR DESCRIPTION
This can have a significant performance impact in case you listen to the
property::hide signal to auto-hide tags for example.