### PR TITLE
Add client.first_tag, as a shortcut for `c:tags()[1]`

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -141,7 +141,7 @@ mytasklist.buttons = awful.util.table.join(
                                                   -- :isvisible() makes no sense
                                                   c.minimized = false
                                                   if not c:isvisible() then
-                                                      awful.tag.viewonly(c:tags()[1])
+                                                      awful.tag.viewonly(c:first_tag())
                                                   end
                                                   -- This will also un-minimize
                                                   -- the client, if needed

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -141,7 +141,7 @@ mytasklist.buttons = awful.util.table.join(
                                                   -- :isvisible() makes no sense
                                                   c.minimized = false
                                                   if not c:isvisible() then
-                                                      awful.tag.viewonly(c:first_tag())
+                                                      awful.tag.viewonly(c.first_tag)
                                                   end
                                                   -- This will also un-minimize
                                                   -- the client, if needed

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -61,7 +61,7 @@ function client.jumpto(c, merge)
     end
 
     -- Try to make client visible, this also covers e.g. sticky
-    local t = c:tags()[1]
+    local t = c:first_tag()
     if t and not c:isvisible() then
         if merge then
             t.selected = true

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -61,7 +61,7 @@ function client.jumpto(c, merge)
     end
 
     -- Try to make client visible, this also covers e.g. sticky
-    local t = c:first_tag()
+    local t = c.first_tag
     if t and not c:isvisible() then
         if merge then
             t.selected = true

--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -613,7 +613,7 @@ end
 --       terms[i] =
 --         {c.name,
 --          function()
---            awful.tag.viewonly(c:tags()[1])
+--            awful.tag.viewonly(c:first_tag())
 --            client.focus = c
 --          end,
 --          c.icon

--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -613,7 +613,7 @@ end
 --       terms[i] =
 --         {c.name,
 --          function()
---            awful.tag.viewonly(c:first_tag())
+--            awful.tag.viewonly(c.first_tag)
 --            client.focus = c
 --          end,
 --          c.icon

--- a/objects/client.c
+++ b/objects/client.c
@@ -97,6 +97,7 @@
  * @field shape_client_clip The client's clip shape as set by the program as a (native) cairo surface.
  * @field startup_id The FreeDesktop StartId.
  * @field valid If the client that this object refers to is still managed by awesome.
+ * @field first_tag The first tag of the client.  Optimized form of `c:tags()[1]`.
  * @table client
  */
 
@@ -1612,12 +1613,9 @@ luaA_client_tags(lua_State *L)
 }
 
 /** Get the first tag of a client.
- *
- * @treturn tag
- * @function first_tag
  */
 static int
-luaA_client_first_tag(lua_State *L)
+luaA_client_get_first_tag(lua_State *L)
 {
     client_t *c = luaA_checkudata(L, 1, &client_class);
 
@@ -2500,7 +2498,6 @@ client_class_setup(lua_State *L)
         { "geometry", luaA_client_geometry },
         { "apply_size_hints", luaA_client_apply_size_hints },
         { "tags", luaA_client_tags },
-        { "first_tag", luaA_client_first_tag },
         { "kill", luaA_client_kill },
         { "swap", luaA_client_swap },
         { "raise", luaA_client_raise },
@@ -2659,6 +2656,10 @@ client_class_setup(lua_State *L)
     luaA_class_add_property(&client_class, "client_shape_clip",
                             NULL,
                             (lua_class_propfunc_t) luaA_client_get_client_shape_clip,
+                            NULL);
+    luaA_class_add_property(&client_class, "first_tag",
+                            NULL,
+                            (lua_class_propfunc_t) luaA_client_get_first_tag,
                             NULL);
 
     /** when a client gains focus

--- a/objects/client.c
+++ b/objects/client.c
@@ -1611,6 +1611,26 @@ luaA_client_tags(lua_State *L)
     return 1;
 }
 
+/** Get the first tag of a client.
+ *
+ * @treturn tag
+ * @function first_tag
+ */
+static int
+luaA_client_first_tag(lua_State *L)
+{
+    client_t *c = luaA_checkudata(L, 1, &client_class);
+
+    foreach(tag, globalconf.tags)
+        if(is_client_tagged(c, *tag))
+        {
+            luaA_object_push(L, *tag);
+            return 1;
+        }
+
+    return 0;
+}
+
 /** Raise a client on top of others which are on the same layer.
  *
  * @function raise
@@ -2480,6 +2500,7 @@ client_class_setup(lua_State *L)
         { "geometry", luaA_client_geometry },
         { "apply_size_hints", luaA_client_apply_size_hints },
         { "tags", luaA_client_tags },
+        { "first_tag", luaA_client_first_tag },
         { "kill", luaA_client_kill },
         { "swap", luaA_client_swap },
         { "raise", luaA_client_raise },


### PR DESCRIPTION
This is meant to be a faster alternative in case only the first tag is
relevant/used.

I've recognized this to be slowish in a plugin.
Maybe it (`c:tags()`) could (also or instead) be optimized in general, by using some internal data structures (instead of the `for` loops).