### PR TITLE
tasklist/taglist: call update method only once per main loop

### DIFF
--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -159,20 +159,18 @@ function taglist.new(screen, filter, buttons, style, update_function, base_widge
     local w = base_widget or fixed.horizontal()
 
     local data = setmetatable({}, { __mode = 'k' })
-    local delayed_update
+
+    local queued_update = {}
     local u = function (s)
         if s ~= screen then return end
 
         -- Add a delayed callback for the first update.
-        if not delayed_update then
+        if not queued_update[s] then
             timer.delayed_call(function()
-                delayed_update()
-                delayed_update = nil
+                taglist_update(s, w, buttons, filter, data, style, uf)
+                queued_update[s] = false
             end)
-        end
-        -- Change the function used in the delayed callback.
-        delayed_update = function()
-            taglist_update(s, w, buttons, filter, data, style, uf)
+            queued_update[s] = true
         end
     end
     local uc = function (c) return u(c.screen) end

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -22,6 +22,7 @@ local tag = require("awful.tag")
 local beautiful = require("beautiful")
 local fixed = require("wibox.layout.fixed")
 local surface = require("gears.surface")
+local timer = require("gears.timer")
 
 local taglist = { mt = {} }
 taglist.filter = {}
@@ -158,8 +159,19 @@ function taglist.new(screen, filter, buttons, style, update_function, base_widge
     local w = base_widget or fixed.horizontal()
 
     local data = setmetatable({}, { __mode = 'k' })
+    local delayed_update
     local u = function (s)
-        if s == screen then
+        if s ~= screen then return end
+
+        -- Add a delayed callback for the first update.
+        if not delayed_update then
+            timer.delayed_call(function()
+                delayed_update()
+                delayed_update = nil
+            end)
+        end
+        -- Change the function used in the delayed callback.
+        delayed_update = function()
             taglist_update(s, w, buttons, filter, data, style, uf)
         end
     end

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -148,18 +148,15 @@ function tasklist.new(screen, filter, buttons, style, update_function, base_widg
 
     local data = setmetatable({}, { __mode = 'k' })
 
-    local delayed_update
+    local queued_update = false
     local u = function ()
         -- Add a delayed callback for the first update.
-        if not delayed_update then
+        if not queued_update then
             timer.delayed_call(function()
-                delayed_update()
-                delayed_update = nil
+                tasklist_update(screen, w, buttons, filter, data, style, uf)
+                queued_update = nil
             end)
-        end
-        -- Change the function used in the delayed callback.
-        delayed_update = function()
-            tasklist_update(screen, w, buttons, filter, data, style, uf)
+            queued_update = true
         end
     end
     tag.attached_connect_signal(screen, "property::selected", u)


### PR DESCRIPTION
Currently `tasklist_update` gets triggered often, because it listens to
a lot of properties.
This patch makes it only call the last one through `timer.delayed_call`.