### PR TITLE
Make sure "err" is a string in debug::error handler

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -30,7 +30,7 @@ do
 
         naughty.notify({ preset = naughty.config.presets.critical,
                          title = "Oops, an error happened!",
-                         text = err })
+                         text = tostring(err) })
         in_error = false
     end)
 end


### PR DESCRIPTION
I've noticed that `Pango.parse_markup` returns "userdata" instead of a
string in case of errors [1], which then causes the `debug::error`
handler to not handle it correctly:

    W: awesome: luaA_dofunction:77: error while running function
    stack traceback:
     [C]: in ?
     [C]: in function 'error'
     /usr/local/share/awesome/lib/wibox/widget/textbox.lua:63: in function 'set_markup'
     [string "require("wibox").widget.textbox():set_markup(..."]:1: in function 'f'
     /usr/local/share/awesome/lib/awful/remote.lua:25: in function </usr/local/share/awesome/lib/awful/remote.lua:21>
    error: attempt to concatenate a userdata value

This patch makes sure that `err` is a string when passing it to
naughty.notify in the default `debug::error` handler.

1: https://github.com/pavouk/lgi/issues/115