### PR TITLE
Enhanced awesome-client

### DIFF
--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -1,13 +1,12 @@
-#!/bin/sh
-
-READ_OPTIONS="-r"
+#!/bin/bash
 
 tty 2>&1 > /dev/null
 ISATTY=$?
 
 if [ "$ISATTY" = 0 ]
 then
-    # rlwrap provides readline to stuff which doesn't know readline by itself
+    # rlwrap provides readline functionality for "read", which is more enhanced
+    # than bash's "read" itself.
     RLWRAP=$(which rlwrap 2>/dev/null)
     if [ "$RLWRAP" != "" ]
     then
@@ -15,16 +14,10 @@ then
         then
             A_RERUN="no" exec $RLWRAP $0
         fi
+        READ_CMD="read"
     else
-        if [ "$BASH" ]
-        then
-            READ_OPTIONS=" -e"
-        fi
-    fi
-
-    if [ $BASH ]
-    then
-        READ_OPTIONS="$READ_OPTIONS -p awesome# "
+        # No rlwrap: use bash's readline.
+        READ_CMD="read -e"
     fi
 fi
 
@@ -55,10 +48,10 @@ a_dbus_send()
 
 if [ "$ISATTY" = 0 ]
 then
-    while read ${READ_OPTIONS} line
+    while $READ_CMD -p "awesome# " -r line
     do
         a_dbus_send "$line"
     done
 else
-    a_dbus_send "`cat`"
+    a_dbus_send "$(cat)"
 fi

--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o pipefail
+
 tty 2>&1 > /dev/null
 ISATTY=$?
 
@@ -36,14 +38,13 @@ DBUS_METHOD=${DBUS_DEST}.Remote.Eval
 
 a_dbus_send()
 {
-    reply=$($DBUS_SEND --dest=$DBUS_DEST --type=method_call --print-reply \
-        $DBUS_PATH $DBUS_METHOD string:"$1")
+    $DBUS_SEND --dest=$DBUS_DEST --type=method_call --print-reply \
+        $DBUS_PATH $DBUS_METHOD string:"$1" | tail -n +2
     ret=$?
-    if [ "$ret" != 0 ]; then
+    if [ "$ret" != 0 ] && [ "$ISATTY" != 0 ]; then
         echo "E: $DBUS_SEND failed." >&2
         exit $ret
     fi
-    echo "$reply" | tail -n +2
 }
 
 if [ "$ISATTY" = 0 ]

--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Use bash's pipefail option to get errors during failure in a command
+# pipeline.  This is useful to get notified about an error from dbus-send
+# when used with "|tail".
 set -o pipefail
 
 tty 2>&1 > /dev/null

--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -43,8 +43,14 @@ DBUS_METHOD=${DBUS_DEST}.Remote.Eval
 
 a_dbus_send()
 {
-    $DBUS_SEND --dest=$DBUS_DEST --type=method_call --print-reply $DBUS_PATH \
-        $DBUS_METHOD string:"$1" | tail -n +2
+    reply=$($DBUS_SEND --dest=$DBUS_DEST --type=method_call --print-reply \
+        $DBUS_PATH $DBUS_METHOD string:"$1")
+    ret=$?
+    if [ "$ret" != 0 ]; then
+        echo "E: $DBUS_SEND failed." >&2
+        exit $ret
+    fi
+    echo "$reply" | tail -n +2
 }
 
 if [ "$ISATTY" = 0 ]


### PR DESCRIPTION
It now exits with a non-zero status code when `dbus-send` fails.

I've also changed the shebang to use `bash` directly, which simplifies the logic to detect/handle "bash as /bin/sh" and allows to use `set -o pipefail` (which makes handling the D-Bus error easier - without using a subshell).

It also fixes the prompt:
 - trailing whitespace
 - prompt is actually used (which wasn't the case with /bin/sh not pointing at bash)

The first and third commits will be squashed, but I've left them as-is for now, to see the difference - and in case `/bin/sh` should be kept - which I could understand when `awesome-client` is meant to be used often.