### PR TITLE
Restore old mousegrabber behavior

### DIFF
--- a/lib/awful/layout/suit/floating.lua
+++ b/lib/awful/layout/suit/floating.lua
@@ -28,10 +28,12 @@ function floating.mouse_resize_handler(c, corner, x, y)
     -- Warp mouse pointer
     capi.mouse.coords({ x = x, y = y })
 
+    local prev_coords = {}
     capi.mousegrabber.run(function (_mouse)
                               for k, v in ipairs(_mouse.buttons) do
                                   if v then
                                       local ng
+                                      prev_coords = { x =_mouse.x, y = _mouse.y }
                                       if corner == "bottom_right" then
                                           ng = { width = _mouse.x - g.x,
                                                  height = _mouse.y - g.y }
@@ -74,7 +76,7 @@ function floating.mouse_resize_handler(c, corner, x, y)
                                       return true
                                   end
                               end
-                              return false
+                              return prev_coords.x == _mouse.x and prev_coords.y == _mouse.y
                           end, corner .. "_corner")
 end
 

--- a/lib/awful/layout/suit/magnifier.lua
+++ b/lib/awful/layout/suit/magnifier.lua
@@ -30,9 +30,11 @@ function magnifier.mouse_resize_handler(c, corner, x, y)
     local center_y = wa.y + wa.height / 2
     local maxdist_pow = (wa.width^2 + wa.height^2) / 4
 
+    local prev_coords = {}
     capi.mousegrabber.run(function (_mouse)
                               for k, v in ipairs(_mouse.buttons) do
                                   if v then
+                                      prev_coords = { x =_mouse.x, y = _mouse.y }
                                       local dx = center_x - _mouse.x
                                       local dy = center_y - _mouse.y
                                       local dist = dx^2 + dy^2
@@ -43,7 +45,7 @@ function magnifier.mouse_resize_handler(c, corner, x, y)
                                       return true
                                   end
                               end
-                              return false
+                              return prev_coords.x == _mouse.x and prev_coords.y == _mouse.y
                           end, corner .. "_corner")
 end
 

--- a/lib/awful/layout/suit/tile.lua
+++ b/lib/awful/layout/suit/tile.lua
@@ -69,9 +69,11 @@ local function mouse_resize_handler(c, corner, x, y, orientation)
         capi.mouse.coords({ y = wa.y + wa.height * (1 - mwfact), x= g.x + offset })
     end
 
+    local prev_coords = {}
     capi.mousegrabber.run(function (_mouse)
                               for k, v in ipairs(_mouse.buttons) do
                                   if v then
+                                      prev_coords = { x =_mouse.x, y = _mouse.y }
                                       local fact_x = (_mouse.x - wa.x) / wa.width
                                       local fact_y = (_mouse.y - wa.y) / wa.height
                                       local mwfact
@@ -114,7 +116,7 @@ local function mouse_resize_handler(c, corner, x, y, orientation)
                                       return true
                                   end
                               end
-                              return false
+                              return prev_coords.x == _mouse.x and prev_coords.y == _mouse.y
                           end, cursor)
 end
 


### PR DESCRIPTION
18f6ab1 changed the behavior when resizing floating clients using the
mouse (via modkey + RMB).

Previously, you could initiate the mousegrabber using e.g. "modkey +
RMB", release the key and button, and resize the window using the left
mouse button.

This restores this behavior by canceling the mousegrabbers only if the
cursor was moved, without any mouse buttong being pressed.

Fixes https://github.com/awesomeWM/awesome/issues/309