### PR TITLE
widget.common.list_update: improve margins (dpi / imagebox)

### DIFF
--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -15,6 +15,7 @@ local util = require("awful.util")
 local tags = require("awful.tag")
 local keygrabber = require("awful.keygrabber")
 local beautiful = require("beautiful")
+local dpi = require("beautiful").xresources.apply_dpi
 local object = require("gears.object")
 local surface = require("gears.surface")
 local cairo = require("lgi").cairo
@@ -546,13 +547,13 @@ function menu.entry(parent, args)
         end
         iconbox = wibox.widget.imagebox()
         if iconbox:set_image(icon) then
-            margin:set_left(2)
+            margin:set_left(dpi(2))
         else
             iconbox = nil
         end
     end
     if not iconbox then
-        margin:set_left(args.theme.height + 2)
+        margin:set_left(args.theme.height + dpi(2))
     end
     -- Create the submenu icon widget
     local submenu

--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -17,6 +17,7 @@ local util = require("awful.util")
 local wibox = require("wibox")
 local imagebox = require("wibox.widget.imagebox")
 local textbox = require("wibox.widget.textbox")
+local dpi = require("beautiful").xresources.apply_dpi
 
 --- Common utilities for awful widgets
 local common = {}
@@ -56,23 +57,25 @@ function common.list_update(w, buttons, label, data, objects)
     w:reset()
     for i, o in ipairs(objects) do
         local cache = data[o]
-        local ib, tb, bgb, m, l
+        local ib, tb, bgb, tbm, ibm, l
         if cache then
             ib = cache.ib
             tb = cache.tb
             bgb = cache.bgb
-            m   = cache.m
+            tbm = cache.tbm
+            ibm = cache.ibm
         else
             ib = wibox.widget.imagebox()
             tb = wibox.widget.textbox()
             bgb = wibox.widget.background()
-            m = wibox.layout.margin(tb, 4, 4)
+            tbm = wibox.layout.margin(tb, dpi(4), dpi(4))
+            ibm = wibox.layout.margin(ib, dpi(4))
             l = wibox.layout.fixed.horizontal()
 
             -- All of this is added in a fixed widget
             l:fill_space(true)
-            l:add(ib)
-            l:add(m)
+            l:add(ibm)
+            l:add(tbm)
 
             -- And all of this gets a background
             bgb:set_widget(l)
@@ -80,17 +83,18 @@ function common.list_update(w, buttons, label, data, objects)
             bgb:buttons(common.create_buttons(buttons, o))
 
             data[o] = {
-                ib = ib,
-                tb = tb,
+                ib  = ib,
+                tb  = tb,
                 bgb = bgb,
-                m   = m
+                tbm = tbm,
+                ibm = ibm,
             }
         end
 
         local text, bg, bg_image, icon = label(o)
         -- The text might be invalid, so use pcall.
         if text == nil or text == "" then
-            m:set_margins(0)
+            tbm:set_margins(0)
         else
             if not pcall(tb.set_markup, tb, text) then
                 tb:set_markup("<i>&lt;Invalid text&gt;</i>")
@@ -101,7 +105,11 @@ function common.list_update(w, buttons, label, data, objects)
             bg_image = bg_image(tb,o,m,objects,i)
         end
         bgb:set_bgimage(bg_image)
-        ib:set_image(icon)
+        if icon then
+            ib:set_image(icon)
+        else
+            ibm:set_margins(0)
+        end
         w:add(bgb)
    end
 end

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -24,6 +24,7 @@ local bt = require("beautiful")
 local wibox = require("wibox")
 local surface = require("gears.surface")
 local cairo = require("lgi").cairo
+local dpi = require("beautiful").xresources.apply_dpi
 
 local schar = string.char
 local sbyte = string.byte
@@ -36,8 +37,9 @@ local naughty = {}
 Naughty configuration - a table containing common popup settings.
 
 @table naughty.config
-@tfield[opt=4] int padding Space between popups and edge of the workarea.
-@tfield[opt=1] int spacing Spacing between popups.
+@tfield[opt=apply_dpi(4)] int padding Space between popups and edge of the
+  workarea.
+@tfield[opt=apply_dpi(1)] int spacing Spacing between popups.
 @tfield[opt={"/usr/share/pixmaps/"}] table icon_dirs List of directories
   that will be checked by `getIcon()`.
 @tfield[opt={ "png", "gif" }] table icon_formats List of formats that will be
@@ -57,8 +59,8 @@ notifications, e.g.
 --]]
 --
 naughty.config = {
-    padding = 4,
-    spacing = 1,
+    padding = dpi(4),
+    spacing = dpi(1),
     icon_dirs = { "/usr/share/pixmaps/", },
     icon_formats = { "png", "gif" },
     notify_callback = nil,
@@ -104,16 +106,16 @@ naughty.config.presets = {
 -- @tfield[opt=""] string text
 -- @tfield[opt] int screen Defaults to `awful.screen.focused`.
 -- @tfield[opt=true] boolean ontop
--- @tfield[opt=5] int margin
--- @tfield[opt=1] int border_width
+-- @tfield[opt=apply_dpi(5)] int margin
+-- @tfield[opt=apply_dpi(1)] int border_width
 -- @tfield[opt="top_right"] string position
 naughty.config.defaults = {
     timeout = 5,
     text = "",
     screen = nil,
     ontop = true,
-    margin = 5,
-    border_width = 1,
+    margin = dpi(5),
+    border_width = dpi(1),
     position = "top_right"
 }
 


### PR DESCRIPTION
Use `beautiful.xresources.apply_dpi` for `common.list_update`'s textbox
margins, and add a left margin for the imagebox, too.

The latter is useful/nicer with the default behavior of an inverted
style for the focused tasklist entry.