### PR TITLE
Drawin: handle non-integer margins / geometry

### DIFF
--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -27,6 +27,7 @@ local capi =
     awesome = awesome,
     mouse = mouse
 }
+local floor = math.floor
 
 local util = {}
 util.table = {}
@@ -524,6 +525,13 @@ function util.query_to_pattern(q)
                                              string.upper(c))
                     end)
     return s
+end
+
+--- Round a number to an integer.
+-- @tparam number x
+-- @treturn integer
+function util.round(x)
+    return floor(x + 0.5)
 end
 
 return util

--- a/lib/awful/wibox.lua
+++ b/lib/awful/wibox.lua
@@ -23,6 +23,7 @@ local table = table
 local error = error
 local wibox = require("wibox")
 local beautiful = require("beautiful")
+local round = require("awful.util").round
 
 local awfulwibox = { mt = {} }
 
@@ -154,7 +155,7 @@ function awfulwibox.align(wibox, align, screen)
         elseif align == "left" then
             wibox.y = area.y + area.height - (wibox.height + 2 * wibox.border_width)
         elseif align == "center" then
-            wibox.y = area.y + (area.height - wibox.height) / 2
+            wibox.y = area.y + round((area.height - wibox.height) / 2)
         end
     elseif position == "left" then
         if align == "right" then
@@ -162,7 +163,7 @@ function awfulwibox.align(wibox, align, screen)
         elseif align == "left" then
             wibox.y = area.y
         elseif align == "center" then
-            wibox.y = area.y + (area.height - wibox.height) / 2
+            wibox.y = area.y + round((area.height - wibox.height) / 2)
         end
     elseif position == "bottom" then
         if align == "right" then
@@ -170,7 +171,7 @@ function awfulwibox.align(wibox, align, screen)
         elseif align == "left" then
             wibox.x = area.x
         elseif align == "center" then
-            wibox.x = area.x + (area.width - wibox.width) / 2
+            wibox.x = area.x + round((area.width - wibox.width) / 2)
         end
     elseif position == "top" then
         if align == "right" then
@@ -178,7 +179,7 @@ function awfulwibox.align(wibox, align, screen)
         elseif align == "left" then
             wibox.x = area.x
         elseif align == "center" then
-            wibox.x = area.x + (area.width - wibox.width) / 2
+            wibox.x = area.x + round((area.width - wibox.width) / 2)
         end
     end
 
@@ -227,24 +228,24 @@ function awfulwibox.new(arg)
 
     -- Set default size
     if position == "left" or position == "right" then
-        arg.width = arg.width or beautiful.get_font_height(arg.font) * 1.5
+        arg.width = arg.width or round(beautiful.get_font_height(arg.font) * 1.5)
         if arg.height then
             has_to_stretch = false
             if arg.screen then
                 local hp = tostring(arg.height):match("(%d+)%%")
                 if hp then
-                    arg.height = capi.screen[arg.screen].geometry.height * hp / 100
+                    arg.height = round(capi.screen[arg.screen].geometry.height * hp / 100)
                 end
             end
         end
     else
-        arg.height = arg.height or beautiful.get_font_height(arg.font) * 1.5
+        arg.height = arg.height or round(beautiful.get_font_height(arg.font) * 1.5)
         if arg.width then
             has_to_stretch = false
             if arg.screen then
                 local wp = tostring(arg.width):match("(%d+)%%")
                 if wp then
-                    arg.width = capi.screen[arg.screen].geometry.width * wp / 100
+                    arg.width = round(capi.screen[arg.screen].geometry.width * wp / 100)
                 end
             end
         end

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -10,7 +10,7 @@
 -- Grab environment
 local print = print
 local awesome = awesome
-local floor = math.floor
+local round = require("awful.util").round
 
 local xresources = {}
 
@@ -94,7 +94,7 @@ end
 -- @tparam[opt] integer s The screen.
 -- @treturn integer Resulting size (rounded to integer).
 function xresources.apply_dpi(size, s)
-    return floor(size/96*xresources.get_dpi(s) + 0.5)
+    return round(size / 96 * xresources.get_dpi(s))
 end
 
 return xresources

--- a/lib/wibox/layout/flex.lua
+++ b/lib/wibox/layout/flex.lua
@@ -10,12 +10,9 @@ local widget_base = require("wibox.widget.base")
 local table = table
 local pairs = pairs
 local floor = math.floor
+local round = require("awful.util").round
 
 local flex = {}
-
-local function round(x)
-    return floor(x + 0.5)
-end
 
 --- Draw a flex layout. Each widget gets an equal share of the available space.
 -- @param wibox The wibox that this widget is drawn to.

--- a/luaa.h
+++ b/luaa.h
@@ -141,6 +141,31 @@ luaA_getopt_number(lua_State *L, int idx, const char *name, lua_Number def)
     return def;
 }
 
+static inline int
+luaA_checkinteger(lua_State *L, int n)
+{
+    double d = lua_tonumber(L, n);
+    if (d != (int)d)
+        luaA_typerror(L, n, "integer");
+    return d;
+}
+
+static inline lua_Integer
+luaA_optinteger (lua_State *L, int narg, lua_Integer def)
+{
+    return luaL_opt(L, luaA_checkinteger, narg, def);
+}
+
+static inline int
+luaA_getopt_integer(lua_State *L, int idx, const char *name, lua_Integer def)
+{
+    lua_getfield(L, idx, name);
+    if (lua_isnil(L, -1) || lua_isnumber(L, -1))
+        def = luaA_optinteger(L, -1, def);
+    lua_pop(L, 1);
+    return def;
+}
+
 /** Push a area type to a table on stack.
  * \param L The Lua VM state.
  * \param geometry The area geometry to push.

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -380,10 +380,10 @@ luaA_drawin_geometry(lua_State *L)
         area_t wingeom;
 
         luaA_checktable(L, 2);
-        wingeom.x = luaA_getopt_number(L, 2, "x", drawin->geometry.x);
-        wingeom.y = luaA_getopt_number(L, 2, "y", drawin->geometry.y);
-        wingeom.width = luaA_getopt_number(L, 2, "width", drawin->geometry.width);
-        wingeom.height = luaA_getopt_number(L, 2, "height", drawin->geometry.height);
+        wingeom.x = luaA_getopt_integer(L, 2, "x", drawin->geometry.x);
+        wingeom.y = luaA_getopt_integer(L, 2, "y", drawin->geometry.y);
+        wingeom.width = luaA_getopt_integer(L, 2, "width", drawin->geometry.width);
+        wingeom.height = luaA_getopt_integer(L, 2, "height", drawin->geometry.height);
 
         if(wingeom.width > 0 && wingeom.height > 0)
             drawin_moveresize(L, 1, wingeom);
@@ -400,7 +400,7 @@ LUA_OBJECT_EXPORT_PROPERTY(drawin, drawin_t, visible, lua_pushboolean)
 static int
 luaA_drawin_set_x(lua_State *L, drawin_t *drawin)
 {
-    drawin_moveresize(L, -3, (area_t) { .x = luaL_checknumber(L, -1),
+    drawin_moveresize(L, -3, (area_t) { .x = luaA_checkinteger(L, -1),
                                         .y = drawin->geometry.y,
                                         .width = drawin->geometry.width,
                                         .height = drawin->geometry.height });
@@ -418,7 +418,7 @@ static int
 luaA_drawin_set_y(lua_State *L, drawin_t *drawin)
 {
     drawin_moveresize(L, -3, (area_t) { .x = drawin->geometry.x,
-                                        .y = luaL_checknumber(L, -1),
+                                        .y = luaA_checkinteger(L, -1),
                                         .width = drawin->geometry.width,
                                         .height = drawin->geometry.height });
     return 0;
@@ -434,7 +434,7 @@ luaA_drawin_get_y(lua_State *L, drawin_t *drawin)
 static int
 luaA_drawin_set_width(lua_State *L, drawin_t *drawin)
 {
-    int width = luaL_checknumber(L, -1);
+    int width = luaA_checkinteger(L, -1);
     if(width <= 0)
         luaL_error(L, "invalid width");
     drawin_moveresize(L, -3, (area_t) { .x = drawin->geometry.x,
@@ -454,7 +454,7 @@ luaA_drawin_get_width(lua_State *L, drawin_t *drawin)
 static int
 luaA_drawin_set_height(lua_State *L, drawin_t *drawin)
 {
-    int height = luaL_checknumber(L, -1);
+    int height = luaA_checkinteger(L, -1);
     if(height <= 0)
         luaL_error(L, "invalid height");
     drawin_moveresize(L, -3, (area_t) { .x = drawin->geometry.x,


### PR DESCRIPTION
This PR is meant for discussing how to address the issue described in the 2nd commit (https://github.com/awesomeWM/awesome/commit/c49165bf7d50bb30f12a673ebb3a62edb9fdc88b).

Setting a non-integer height of e.g. 1.42 will cast it to 1 (in `area_t`).

This is a problem when using a marginbox with a textbox widget and a
non-integer margin in a fixed layout: the fixed layout won't draw the
text.  This can be reproduced by using a non-integer margin with
`naughty.notify`.

It seems that it is problematic in general to have floats in Lua, but
integers in C for the drawin geometries.  An alternative might be to use
floats in `area_t`, too?

The first commit changes `margin:fit` to use `ceil`, while the second one does so in `drawin.c`.

Related comment about Cairo being fine about doubles everywhere from @psychon: https://github.com/awesomeWM/awesome/pull/250#issuecomment-107004468
