### PR TITLE
Improve transient for

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1030,6 +1030,37 @@ function client.run_or_raise(cmd, matcher, merge)
     util.spawn(cmd)
 end
 
+--- Get a matching transient_for client (if any).
+-- @client c The client.
+-- @tparam function matcher A function that should return true, if
+--   a matching parent client is found.
+-- @treturn client.client|nil The matching parent client or nil.
+function client.get_transient_for_matching(c, matcher)
+    local tc = c.transient_for
+    while tc do
+        if matcher(tc) then
+            return tc
+        end
+        tc = tc.transient_for
+    end
+    return nil
+end
+
+--- Is a client transient for another one?
+-- @client c The child client (having transient_for).
+-- @client c2 The parent client to check.
+-- @treturn client.client|nil The parent client or nil.
+function client.is_transient_for(c, c2)
+    local tc = c
+    while tc.transient_for do
+        if tc.transient_for == c2 then
+            return tc
+        end
+        tc = tc.transient_for
+    end
+    return nil
+end
+
 -- Register standards signals
 capi.client.add_signal("property::floating_geometry")
 capi.client.add_signal("property::floating")

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -79,7 +79,17 @@ local function tasklist_label(c, args)
     else
         name = name .. (util.escape(c.name) or util.escape("<untitled>"))
     end
-    if capi.client.focus == c then
+    local focused = capi.client.focus == c
+    -- Handle transient_for: the first parent that does not skip the taskbar
+    -- is considered to be focused, if the real client has skip_taskbar.
+    if not focused and capi.client.focus and capi.client.focus.skip_taskbar
+        and client.get_transient_for_matching(capi.client.focus,
+                                              function(c)
+                                                  return not c.skip_taskbar
+                                              end) == c then
+        focused = true
+    end
+    if focused then
         bg = bg_focus
         text = text .. "<span color='"..fg_focus.."'>"..name.."</span>"
         bg_image = bg_image_focus


### PR DESCRIPTION
I've came across this old branch, which is meant to improve the behavior described in #182, and provides utility functions to get the `transient_for` root.

Looking at it, I think `is_transient_for` should also return true for any intermediate clients?!