### PR TITLE
Add "visible" property to widgets

### DIFF
--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -57,7 +57,7 @@ local function do_redraw(self)
 
     -- Draw the widget
     self._widget_geometries = {}
-    if self.widget then
+    if self.widget and self.widget.visible then
         cr:set_source(self.foreground_color)
         self.widget:draw(self.widget_arg, cr, width, height)
         self:widget_at(self.widget, 0, 0, width, height)

--- a/lib/wibox/layout/base.lua
+++ b/lib/wibox/layout/base.lua
@@ -34,6 +34,9 @@ end
 -- @param height The available height for the widget
 -- @return The width and height that the widget wants to use
 function base.fit_widget(widget, width, height)
+    if not widget.visible then
+        return 0, 0
+    end
     -- Sanitize the input. This also filters out e.g. NaN.
     local width = math.max(0, width)
     local height = math.max(0, height)
@@ -50,6 +53,9 @@ end
 -- @param width The widget's width
 -- @param height The widget's height
 function base.draw_widget(wibox, cr, widget, x, y, width, height)
+    if not widget.visible then
+        return
+    end
     -- Use save() / restore() so that our modifications aren't permanent
     cr:save()
 

--- a/lib/wibox/layout/mirror.lua
+++ b/lib/wibox/layout/mirror.lua
@@ -17,9 +17,11 @@ local mirror = { mt = {} }
 
 --- Draw this layout
 function mirror:draw(wibox, cr, width, height)
-    if not self.widget then return { width = 0, height = 0 } end
+    if not self.widget then
+        return { width = 0, height = 0 }
+    end
     if not self.horizontal and not self.vertical then
-        self.widget:draw(wibox, cr, width, height)
+        base.draw_widget(wibox, cr, self.widget, 0, 0, width, height)
         return -- nothing changed
     end
 

--- a/lib/wibox/layout/rotate.lua
+++ b/lib/wibox/layout/rotate.lua
@@ -26,7 +26,9 @@ end
 
 --- Draw this layout
 function rotate:draw(wibox, cr, width, height)
-    if not self.widget then return { width = 0, height = 0 } end
+    if not self.widget or not self.widget.visible then
+        return { width = 0, height = 0 }
+    end
 
     local dir = self:get_direction()
 

--- a/lib/wibox/widget/background.lua
+++ b/lib/wibox/widget/background.lua
@@ -18,7 +18,7 @@ local background = { mt = {} }
 
 --- Draw this widget
 function background:draw(wibox, cr, width, height)
-    if not self.widget then
+    if not self.widget or not self.widget.visible then
         return
     end
 

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -107,6 +107,15 @@ function base.make_widget(proxy, widget_name)
         ret._fit_geometry_cache = cache.new(cb)
     end)
 
+    -- Add visible property and setter.
+    ret.visible = true
+    function ret:set_visible(b)
+        if b ~= self.visible then
+            self.visible = b
+            self:emit_signal("widget::updated")
+        end
+    end
+
     -- Add __tostring method to metatable.
     ret.widget_name = widget_name or object.modulename(3)
     local mt = {}

--- a/spec/wibox/test_utils.lua
+++ b/spec/wibox/test_utils.lua
@@ -59,6 +59,7 @@ return {
 
     widget_stub = function(width, height)
         local w = object()
+        w.visible = true
         w:add_signal("widget::updated")
 
         w.fit = function()


### PR DESCRIPTION
With `visible = false`, widgets will not be drawn.

I've looked for a quick way to hide a particular widget, which has no outer wibox.

Do you think this makes sense, or should the widget just get wrapped in a wibox (assuming that this would be enough then)?