### PR TITLE
client_resize_do: prefer client's current screen

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -795,7 +795,10 @@ client_resize_do(client_t *c, area_t geometry, bool force_notice, bool honor_hin
     lua_State *L = globalconf_get_lua_State();
     bool send_notice = force_notice;
     bool hide_titlebars = c->fullscreen;
-    screen_t *new_screen = screen_getbycoord(geometry.x, geometry.y);
+
+    screen_t *new_screen = c->screen;
+    if(!screen_coord_in_screen(new_screen, geometry.x, geometry.y))
+        new_screen = screen_getbycoord(geometry.x, geometry.y);
 
     if (honor_hints)
         geometry = client_apply_size_hints(c, geometry);

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -35,6 +35,7 @@
 #include "objects/client.h"
 #include "objects/drawin.h"
 
+#include <math.h>
 #include <stdio.h>
 
 #include <xcb/xcb.h>
@@ -297,8 +298,19 @@ screen_getbycoord(int x, int y)
         if(screen_coord_in_screen(*s, x, y))
             return *s;
 
-    /* No screen found, let's be creative. */
-    return globalconf.screens.tab[0];
+    /* No screen found, find nearest screen. */
+    screen_t * nearest_screen = globalconf.screens.tab[0];
+    int nearest_dist = INT_MAX;
+    foreach(s, globalconf.screens)
+    {
+        int dist = sqrt(pow((*s)->geometry.x - x, 2) + pow((*s)->geometry.y - y, 2));
+        if( dist < nearest_dist )
+        {
+            nearest_dist = dist;
+            nearest_screen = (*s);
+        }
+    }
+    return nearest_screen;
 }
 
 /** Are the given coordinates in a given screen?
@@ -310,8 +322,8 @@ screen_getbycoord(int x, int y)
 bool
 screen_coord_in_screen(screen_t *s, int x, int y)
 {
-    return (x < 0 || (x >= s->geometry.x && x < s->geometry.x + s->geometry.width))
-           && (y < 0 || (y >= s->geometry.y && y < s->geometry.y + s->geometry.height));
+    return (x >= s->geometry.x && x < s->geometry.x + s->geometry.width)
+           && (y >= s->geometry.y && y < s->geometry.y + s->geometry.height);
 }
 
 /** Get screens info.

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -285,8 +285,7 @@ screen_scan(void)
         screen_scan_x11();
 }
 
-/** Return the Xinerama screen number where the coordinates belongs to.
- * \param screen The logical screen number.
+/** Return the first screen number where the coordinates belong to.
  * \param x X coordinate
  * \param y Y coordinate
  * \return Screen pointer or screen param if no match or no multi-head.
@@ -295,12 +294,24 @@ screen_t *
 screen_getbycoord(int x, int y)
 {
     foreach(s, globalconf.screens)
-        if((x < 0 || (x >= (*s)->geometry.x && x < (*s)->geometry.x + (*s)->geometry.width))
-           && (y < 0 || (y >= (*s)->geometry.y && y < (*s)->geometry.y + (*s)->geometry.height)))
+        if(screen_coord_in_screen(*s, x, y))
             return *s;
 
     /* No screen found, let's be creative. */
     return globalconf.screens.tab[0];
+}
+
+/** Are the given coordinates in a given screen?
+ * \param screen The logical screen number.
+ * \param x X coordinate
+ * \param y Y coordinate
+ * \return True if the X/Y coordinates are in the given screen.
+ */
+bool
+screen_coord_in_screen(screen_t *s, int x, int y)
+{
+    return (x < 0 || (x >= s->geometry.x && x < s->geometry.x + s->geometry.width))
+           && (y < 0 || (y >= s->geometry.y && y < s->geometry.y + s->geometry.height));
 }
 
 /** Get screens info.

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -43,6 +43,7 @@ ARRAY_FUNCS(screen_t *, screen, DO_NOTHING)
 void screen_class_setup(lua_State *L);
 void screen_scan(void);
 screen_t *screen_getbycoord(int, int);
+bool screen_coord_in_screen(screen_t *, int, int);
 int screen_get_index(screen_t *);
 area_t display_area_get(void);
 void screen_client_moveto(client_t *, screen_t *, bool);


### PR DESCRIPTION
In case of an overlapping screen configuration, prefer the client's
current screen.

Without this, clients would be moved to the first matching screen.

I've thought about adding a `screen_getbycoord_prefer_given` function to handle this, but using the factored out `screen_coord_in_screen` appears to be easy enough, and even clearer.

For reference, the xrandr setup:

    Screen 0: minimum 8 x 8, current 2948 x 1200, maximum 32767 x 32767
    LVDS1 connected primary 1366x768+0+0 (normal left inverted right x axis y axis) 277mm x 156mm
    HDMI2 connected 1920x1200+1028+0 (normal left inverted right x axis y axis) 519mm x 324mm

Note the offset of the HDMI2 output, which overlaps into LVDS1 (while I've
experimented with scaling etc).
