### PR TITLE
wibox.widget.textbox: set_markup/set_text: skip unchanged

### DIFF
--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -58,10 +58,15 @@ end
 --   `<b>bold</b>`). You can use awful.util.escape to escape
 --   parts of it.
 function textbox:set_markup(text)
+    if self._markup == text then
+        return
+    end
+
     local attr, parsed = Pango.parse_markup(text, -1, 0)
     -- In case of error, attr is false and parsed is an error message
     if not attr then error(parsed) end
 
+    self._markup = text
     self._layout.text = parsed
     self._layout.attributes = attr
     self:emit_signal("widget::updated")
@@ -70,6 +75,10 @@ end
 --- Set a textbox' text.
 -- @param text The text to display. Pango markup is ignored and shown as-is.
 function textbox:set_text(text)
+    if self._layout.text == text and self._layout.attributes == nil then
+        return
+    end
+    self._markup = nil
     self._layout.text = text
     self._layout.attributes = nil
     self:emit_signal("widget::updated")
@@ -80,6 +89,9 @@ end
 function textbox:set_ellipsize(mode)
     local allowed = { none = "NONE", start = "START", middle = "MIDDLE", ["end"] = "END" }
     if allowed[mode] then
+        if self._layout:get_ellipsize() == allowed[mode] then
+            return
+        end
         self._layout:set_ellipsize(allowed[mode])
         self:emit_signal("widget::updated")
     end
@@ -90,6 +102,9 @@ end
 function textbox:set_wrap(mode)
     local allowed = { word = "WORD", char = "CHAR", word_char = "WORD_CHAR" }
     if allowed[mode] then
+        if self._layout:get_wrap() == allowed[mode] then
+            return
+        end
         self._layout:set_wrap(allowed[mode])
         self:emit_signal("widget::updated")
     end
@@ -100,6 +115,9 @@ end
 function textbox:set_valign(mode)
     local allowed = { top = true, center = true, bottom = true }
     if allowed[mode] then
+        if self._valign == mode then
+            return
+        end
         self._valign = mode
         self:emit_signal("widget::updated")
     end
@@ -110,6 +128,9 @@ end
 function textbox:set_align(mode)
     local allowed = { left = "LEFT", center = "CENTER", right = "RIGHT" }
     if allowed[mode] then
+        if self._layout:get_alignment() == allowed[mode] then
+            return
+        end
         self._layout:set_alignment(allowed[mode])
         self:emit_signal("widget::updated")
     end


### PR DESCRIPTION
In case the text or markup has not changed, there's no need to update
the widget.

Not too sure about it, but came across it while hacking on widgets in general.