### PR TITLE
beautiful.xresources: allow to set/get DPI per screen

### DIFF
--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -60,21 +60,40 @@ function xresources.get_current_theme()
 end
 
 
---- Get DPI value from xrdb.
+local dpi_per_screen = {}
+
+--- Get global or per-screen DPI value falling back to xrdb.
+-- @tparam[opt=focused] integer s The screen.
 -- @treturn number DPI value.
-function xresources.get_dpi()
-    if not xresources.dpi then
-        xresources.dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi") or 96)
+function xresources.get_dpi(s)
+    if not s or not dpi_per_screen[s] then
+        if not xresources.dpi then
+            xresources.dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi") or 96)
+        end
+        return xresources.dpi
     end
-    return xresources.dpi
+    return dpi_per_screen[s]
 end
 
 
---- Compute resulting size applying current DPI value.
+--- Set DPI for a given screen (defaults to global).
+-- @tparam number dpi DPI value.
+-- @tparam[opt] integer s Screen.
+function xresources.set_dpi(dpi, s)
+    if not s then
+        xresources.dpi = dpi
+    else
+        dpi_per_screen[s] = dpi
+    end
+end
+
+
+--- Compute resulting size applying current DPI value (optionally per screen).
 -- @tparam number size Size
+-- @tparam[opt] integer s The screen.
 -- @treturn number Resulting size
-function xresources.apply_dpi(size)
-    return size/96*xresources.get_dpi()
+function xresources.apply_dpi(size, s)
+    return size/96*xresources.get_dpi(s)
 end
 
 return xresources


### PR DESCRIPTION
This adds an optional screen argument to get_dpi/apply_dpi and set_dpi
to store DPI values per screen.

This can be used in your config to manage different DPI values for an
internal and external display:

    beautiful.xresources.set_dpi(125, 1)
    beautiful.xresources.set_dpi(94, 2)

This is meant to be the foundation for more evolved DPI handling in
awesome.