### PR TITLE
Get clients in stacking order (for awful.client.swap.bydirection)

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -215,10 +215,11 @@ end
 
 --- Get visible clients from a screen.
 --
--- @param screen The screen number, or nil for all screens.
--- @return A table with all visible clients.
-function client.visible(screen)
-    local cls = capi.client.get(screen)
+-- @tparam[opt] integer screen The screen number, or nil for all screens.
+-- @tparam[opt=false] boolean stacked Use stacking order?
+-- @treturn table A table with all visible clients.
+function client.visible(screen, stacked)
+    local cls = capi.client.get(screen, stacked)
     local vcls = {}
     for k, c in pairs(cls) do
         if c:isvisible() then
@@ -230,10 +231,11 @@ end
 
 --- Get visible and tiled clients
 --
--- @param screen The screen number, or nil for all screens.
--- @return A table with all visible and tiled clients.
-function client.tiled(screen)
-    local clients = client.visible(screen)
+-- @tparam integer screen The screen number, or nil for all screens.
+-- @tparam[opt=false] boolean stacked Use stacking order?
+-- @treturn table A table with all visible and tiled clients.
+function client.tiled(screen, stacked)
+    local clients = client.visible(screen, stacked)
     local tclients = {}
     -- Remove floating clients
     for k, c in pairs(clients) do
@@ -252,18 +254,19 @@ end
 --
 -- @tparam int i The index.  Use 1 to get the next, -1 to get the previous.
 -- @client[opt] c The client.
+-- @tparam[opt=false] boolean stacked Use stacking order?
 -- @return A client, or nil if no client is available.
 --
 -- @usage -- focus the next window in the index
 -- awful.client.next(1)
 -- -- focus the previous
 -- awful.client.next(-1)
-function client.next(i, c)
+function client.next(i, c, stacked)
     -- Get currently focused client
     local sel = c or capi.client.focus
     if sel then
         -- Get all visible clients
-        local cls = client.visible(sel.screen)
+        local cls = client.visible(sel.screen, stacked)
         local fcls = {}
         -- Remove all non-normal clients
         for idx, c in ipairs(cls) do
@@ -287,10 +290,11 @@ end
 -- @tparam string dir The direction, can be either
 --   `"up"`, `"down"`, `"left"` or `"right"`.
 -- @client[opt] c The client.
-function client.focus.bydirection(dir, c)
+-- @tparam[opt=false] boolean stacked Use stacking order?
+function client.focus.bydirection(dir, c, stacked)
     local sel = c or capi.client.focus
     if sel then
-        local cltbl = client.visible(sel.screen)
+        local cltbl = client.visible(sel.screen, stacked)
         local geomtbl = {}
         for i,cl in ipairs(cltbl) do
             geomtbl[i] = cl:geometry()
@@ -310,7 +314,8 @@ end
 --
 -- @param dir The direction, can be either "up", "down", "left" or "right".
 -- @client[opt] c The client.
-function client.focus.global_bydirection(dir, c)
+-- @tparam[opt=false] boolean stacked Use stacking order?
+function client.focus.global_bydirection(dir, c, stacked)
     screen = screen or require("awful.screen")
     local sel = c or capi.client.focus
     local scr = awful.screen.focused()
@@ -325,7 +330,7 @@ function client.focus.global_bydirection(dir, c)
     if sel == capi.client.focus then
         screen.focus_bydirection(dir, scr)
         if scr ~= awful.screen.focused() then
-            local cltbl = client.visible(awful.screen.focused())
+            local cltbl = client.visible(awful.screen.focused(), stacked)
             local geomtbl = {}
             for i,cl in ipairs(cltbl) do
                 geomtbl[i] = cl:geometry()
@@ -353,13 +358,14 @@ function client.focus.byidx(i, c)
     end
 end
 
---- Swap a client with another client in the given direction
--- @param dir The direction, can be either "up", "down", "left" or "right".
--- @client[opt] c The client.
-function client.swap.bydirection(dir, c)
+--- Swap a client with another client in the given direction.
+-- @tparam string dir The direction, can be either "up", "down", "left" or "right".
+-- @client[opt=focused] c The client.
+-- @tparam[opt=false] boolean stacked Use stacking order?
+function client.swap.bydirection(dir, c, stacked)
     local sel = c or capi.client.focus
     if sel then
-        local cltbl = client.visible(sel.screen)
+        local cltbl = client.visible(sel.screen, stacked)
         local geomtbl = {}
         for i,cl in ipairs(cltbl) do
             geomtbl[i] = cl:geometry()
@@ -424,9 +430,10 @@ end
 --
 -- @param clockwise True to cycle clients clockwise.
 -- @param[opt] screen The screen where to cycle clients.
-function client.cycle(clockwise, screen)
+-- @tparam[opt=false] boolean stacked Use stacking order?
+function client.cycle(clockwise, screen, stacked)
     local screen = screen or awful.screen.focused()
-    local cls = client.visible(screen)
+    local cls = client.visible(screen, stacked)
     -- We can't rotate without at least 2 clients, buddy.
     if #cls >= 2 then
         local c = table.remove(cls, 1)

--- a/objects/client.c
+++ b/objects/client.c
@@ -1391,8 +1391,10 @@ client_kill(client_t *c)
 
 /** Get all clients into a table.
  *
- * @param[opt] screen A screen number.
- * @return A table with all clients.
+ * @tparam[opt] integer screen A screen number to filter clients on.
+ * @tparam[opt] boolean stacked Return clients in stacking order? (ordered from
+ *   top to bottom).
+ * @treturn table A table with clients.
  * @function get
  */
 static int
@@ -1400,17 +1402,33 @@ luaA_client_get(lua_State *L)
 {
     int i = 1;
     screen_t *screen = NULL;
+    bool stacked = false;
 
     if(!lua_isnoneornil(L, 1))
         screen = luaA_checkscreen(L, 1);
 
+    if(!lua_isnoneornil(L, 2))
+        stacked = luaA_checkboolean(L, 2);
+
     lua_newtable(L);
-    foreach(c, globalconf.clients)
-        if(screen == NULL || (*c)->screen == screen)
-        {
-            luaA_object_push(L, *c);
-            lua_rawseti(L, -2, i++);
-        }
+    if(stacked)
+    {
+        foreach_reverse(c, globalconf.stack)
+            if(screen == NULL || (*c)->screen == screen)
+            {
+                luaA_object_push(L, *c);
+                lua_rawseti(L, -2, i++);
+            }
+    }
+    else
+    {
+        foreach(c, globalconf.clients)
+            if(screen == NULL || (*c)->screen == screen)
+            {
+                luaA_object_push(L, *c);
+                lua_rawseti(L, -2, i++);
+            }
+    }
 
     return 1;
 }


### PR DESCRIPTION
Fixes/for https://github.com/awesomeWM/awesome/issues/178.

Clients in stacked order are returned top-to-bottom, which is what you're usually interested in (done in the fixup-commit).