### PR TITLE
Keep client order across restarts

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -79,7 +79,7 @@ awesome_atexit(bool restart)
     signal_object_emit(L, &global_signals, "exit", 1);
 
     /* Move clients where we want them to be */
-    foreach(c, globalconf.clients)
+    foreach_reverse(c, globalconf.clients)
     {
         xcb_reparent_window(globalconf.connection, (*c)->window, globalconf.screen->root,
                 (*c)->geometry.x, (*c)->geometry.y);
@@ -93,7 +93,7 @@ awesome_atexit(bool restart)
     lua_close(L);
 
     /* X11 is a great protocol. There is a save-set so that reparenting WMs
-     * don't kill clients when they shut down. However, when a focused windows
+     * don't kill clients when they shut down. However, when a focused window
      * is saved, the focus will move to its parent with revert-to none.
      * Immediately afterwards, this parent is destroyed and the focus is gone.
      * Work around this by placing the focus where we like it to be.

--- a/common/array.h
+++ b/common/array.h
@@ -50,6 +50,15 @@
             (var = &(array).tab[__foreach_index_##var]);                    \
             ++__foreach_index_##var)
 
+#define foreach_reverse(var, array) \
+    for(int __foreach_index_##var = (array).len-1; \
+        __foreach_index_##var > -1; \
+        __foreach_index_##var = -1) \
+        for(typeof((array).tab) var = &(array).tab[__foreach_index_##var];  \
+            (__foreach_index_##var > -1) &&                                 \
+            (var = &(array).tab[__foreach_index_##var]);                    \
+            --__foreach_index_##var)
+
 /** Common array functions */
 #define ARRAY_COMMON_FUNCS(type_t, pfx, dtor)                               \
     static inline pfx##_array_t * pfx##_array_new(void) {                   \


### PR DESCRIPTION
I've noticed that the internal order of clients gets reversed when
restarting awesome.

This patch fixes this by calling `xcb_reparent_window` in the reverse
order.