### PR TITLE
wibox.widget.base: add __tostring method to widgets

### DIFF
--- a/lib/gears/object.lua
+++ b/lib/gears/object.lua
@@ -112,6 +112,21 @@ function object.mt:__call(...)
     return new(...)
 end
 
+--- Helper function to get the module name out of `debug.getinfo`.
+-- @usage
+--  local mt = {}
+--  mt.__tostring = function(o)
+--      return require("gears.object").modulename(debug.getinfo(1, 'S'))
+--  end
+--  return setmetatable(ret, mt)
+--
+-- @tparam table info Result from `debug.getinfo(level, 'S')`, where level
+--   is typically 1 or 2.
+-- @treturn string The module name, e.g. "wibox.widget.background".
+function object.modulename(info)
+    return info.source:gsub('.*/lib/', ''):gsub("/", "."):gsub("%.lua", "")
+end
+
 return setmetatable(object, object.mt)
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/gears/object.lua
+++ b/lib/gears/object.lua
@@ -116,15 +116,15 @@ end
 -- @usage
 --  local mt = {}
 --  mt.__tostring = function(o)
---      return require("gears.object").modulename(debug.getinfo(1, 'S'))
+--      return require("gears.object").modulename(2)
 --  end
 --  return setmetatable(ret, mt)
 --
--- @tparam table info Result from `debug.getinfo(level, 'S')`, where level
---   is typically 1 or 2.
+-- @tparam[opt=2] integer level Level for `debug.getinfo(level, "S")`.
+--   Typically 2 or 3.
 -- @treturn string The module name, e.g. "wibox.widget.background".
-function object.modulename(info)
-    return info.source:gsub('.*/lib/', ''):gsub("/", "."):gsub("%.lua", "")
+function object.modulename(level)
+    return debug.getinfo(level, "S").source:gsub(".*/lib/", ""):gsub("/", "."):gsub("%.lua", "")
 end
 
 return setmetatable(object, object.mt)

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -5,7 +5,7 @@
 -- @classmod wibox.widget.base
 ---------------------------------------------------------------------------
 
-local gears_debug = require("gears.debug")
+local debug = require("gears.debug")
 local object = require("gears.object")
 local setmetatable = setmetatable
 local pairs = pairs
@@ -123,14 +123,14 @@ end
 --- Do some sanity checking on widget. This function raises a lua error if
 -- widget is not a valid widget.
 function base.check_widget(widget)
-    gears_debug.assert(type(widget) == "table")
+    debug.assert(type(widget) == "table")
     for k, func in pairs({ "draw", "fit", "add_signal", "connect_signal", "disconnect_signal" }) do
-        gears_debug.assert(type(widget[func]) == "function", func .. " is not a function")
+        debug.assert(type(widget[func]) == "function", func .. " is not a function")
     end
 
     local width, height = widget:fit(0, 0)
-    gears_debug.assert(type(width) == "number")
-    gears_debug.assert(type(height) == "number")
+    debug.assert(type(width) == "number")
+    debug.assert(type(height) == "number")
 end
 
 return base

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -64,9 +64,9 @@ end
 -- that the needed signals are added and mouse input handling is set up.
 -- @param proxy If this is set, the returned widget will be a proxy for this
 --              widget. It will be equivalent to this widget.
--- @tparam[opt] string name Name of the widget.  If not set, it will be set
---   automatically via `gears.object.modulename`.
-function base.make_widget(proxy, name)
+-- @tparam[opt] string widget_name Name of the widget.  If not set, it will be
+--   set automatically via `gears.object.modulename`.
+function base.make_widget(proxy, widget_name)
     local ret = object()
 
     -- This signal is used by layouts to find out when they have to update.
@@ -104,7 +104,7 @@ function base.make_widget(proxy, name)
     end)
 
     -- Add __tostring method to metatable.
-    ret.widget_name = name or object.modulename(3)
+    ret.widget_name = widget_name or object.modulename(3)
     local mt = {}
     mt.__tostring = function(o)
         return ret.widget_name

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -64,7 +64,9 @@ end
 -- that the needed signals are added and mouse input handling is set up.
 -- @param proxy If this is set, the returned widget will be a proxy for this
 --              widget. It will be equivalent to this widget.
-function base.make_widget(proxy)
+-- @tparam[opt] string name Name of the widget.  If not set, it will be set
+--   automatically via `gears.object.modulename`.
+function base.make_widget(proxy, name)
     local ret = object()
 
     -- This signal is used by layouts to find out when they have to update.
@@ -101,12 +103,11 @@ function base.make_widget(proxy)
         ret._fit_geometry_cache = setmetatable({}, { __mode = 'v' })
     end)
 
-    -- Add __tostring method to metatable.  This requires to get the current
-    -- call stack in advance.
-    local debug_info = debug.getinfo(2, 'S')
+    -- Add __tostring method to metatable.
+    ret.widget_name = name or object.modulename(3)
     local mt = {}
     mt.__tostring = function(o)
-        return object.modulename(debug_info)
+        return ret.widget_name
     end
     return setmetatable(ret, mt)
 end

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -5,7 +5,7 @@
 -- @classmod wibox.widget.base
 ---------------------------------------------------------------------------
 
-local debug = require("gears.debug")
+local gears_debug = require("gears.debug")
 local object = require("gears.object")
 local setmetatable = setmetatable
 local pairs = pairs
@@ -101,7 +101,14 @@ function base.make_widget(proxy)
         ret._fit_geometry_cache = setmetatable({}, { __mode = 'v' })
     end)
 
-    return ret
+    -- Add __tostring method to metatable.  This requires to get the current
+    -- call stack in advance.
+    local debug_info = debug.getinfo(2, 'S')
+    local mt = {}
+    mt.__tostring = function(o)
+        return object.modulename(debug_info)
+    end
+    return setmetatable(ret, mt)
 end
 
 --- Generate an empty widget which takes no space and displays nothing
@@ -115,14 +122,14 @@ end
 --- Do some sanity checking on widget. This function raises a lua error if
 -- widget is not a valid widget.
 function base.check_widget(widget)
-    debug.assert(type(widget) == "table")
+    gears_debug.assert(type(widget) == "table")
     for k, func in pairs({ "draw", "fit", "add_signal", "connect_signal", "disconnect_signal" }) do
-        debug.assert(type(widget[func]) == "function", func .. " is not a function")
+        gears_debug.assert(type(widget[func]) == "function", func .. " is not a function")
     end
 
     local width, height = widget:fit(0, 0)
-    debug.assert(type(width) == "number")
-    debug.assert(type(height) == "number")
+    gears_debug.assert(type(width) == "number")
+    gears_debug.assert(type(height) == "number")
 end
 
 return base


### PR DESCRIPTION
The drawback here appears to be that `debug.getinfo` is not very
efficient, and required to be run to get the call stack.

However, using "S" to limit the information being gathered helps, and it
is not that slow after all:

    % time lua -e "for i = 1, 1000000 do debug.getinfo(1) end"
    2,25s user 0,00s system 99% cpu 2,255 total
    % time lua -e "for i = 1, 1000000 do debug.getinfo(1, 'S') end"
    1,32s user 0,00s system 99% cpu 1,318 total

Fixes https://github.com/awesomeWM/awesome/issues/337.