### PR TITLE
Travis: build and upload API doc on success for master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
     # Disable 5.1 for now: no need to test both 5.1 and 5.2 currently.
     # - LUA=5.1 LUAPKG=5.1 LUALIB=/usr/lib/x86_64-linux-gnu/liblua5.1.so
     - LUA=5.2 LUAPKG=5.2 LUALIB=/usr/lib/x86_64-linux-gnu/liblua5.2.so
+  global:
+    # Secure token to push to gh-pages.
+    - secure: "LZxt9559+V3qJMdVgmKW4RYTt8ZINooex/qsnoEJUtZloj/eFNG4COT2z6a2yeH2tKWzknCsmV9nLPJiNEA2KLcyqDhjFQvJwKmsBuhGUmLyeQgfenjweorRjO8NT18X1SAEUXAMnClPu+OeTDs4BAuVn5foGZ7xpcRg2E+j2mc="
+
 
 before_install:
   - cmake --version
@@ -93,3 +97,8 @@ install:
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIB} -DLUA_INCLUDE_DIR=/usr/include/lua${LUAPKG}"
   - make && sudo env PATH=$PATH make install && awesome --version && tests/run.sh
+
+# Push updated API docs.
+after_success:
+  # NOTE: stdout/stderr might/should be discarded to not leak sensitive information.
+  - '[ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = false ] && { echo "Uploading documentation..." && cd build/doc && git init && git config user.name "awesome-robot on Travis CI" && git config user.email "awesome-robot@users.noreply.github.com" && git add . && git commit -m "Deployed to Github Pages via Travis" && git push --force --quiet "https://${GH_TOKEN}@github.com/awesomeWM/apidoc" master:gh-pages || echo "Uploading docs failed!"; } || echo "Not uploading docs for $TRAVIS_BRANCH:$TRAVIS_PULL_REQUEST."'

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,13 +96,21 @@ install:
   - sudo apt-get install -qq dbus-x11 xterm xdotool xterm xvfb
 
   # Determine custom version.
-  - '[ "$TRAVIS_PULL_REQUEST" = false ] && version="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)-$(date -Iseconds)" || version="${TRAVIS_BRANCH}-PR${TRAVIS_PULL_REQUEST}-g$(git rev-parse --short HEAD)-$(date -Iseconds)"'
+  - '[ "$TRAVIS_PULL_REQUEST" = false ] && AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)-$(date -Iseconds)" || AWESOME_VERSION="${TRAVIS_BRANCH}-PR${TRAVIS_PULL_REQUEST}-g$(git rev-parse --short HEAD)-$(date -Iseconds)"'
 
 script:
-  - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIB} -DLUA_INCLUDE_DIR=/usr/include/lua${LUAPKG} -D OVERRIDE_VERSION=$version"
+  - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIB} -DLUA_INCLUDE_DIR=/usr/include/lua${LUAPKG} -D OVERRIDE_VERSION=$AWESOME_VERSION"
   - make && sudo env PATH=$PATH make install && awesome --version && tests/run.sh
 
 # Push updated API docs.
 after_success:
+  - REPO_APIDOC="https://${GH_TOKEN}@github.com/awesomeWM/apidoc"
+  # Export these to not add "git config" calls to the long command.
+  - export GIT_AUTHOR_NAME="awesome-robot on Travis CI"
+  - export GIT_AUTHOR_EMAIL="awesome-robot@users.noreply.github.com"
+  - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+  - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+  # For testing the PR itself:
+  - TRAVIS_PULL_REQUEST=false
   # NOTE: stdout/stderr might/should be discarded to not leak sensitive information.
-  - '[ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = false ] && { echo "Uploading documentation..." && cd build/doc && git init && git config user.name "awesome-robot on Travis CI" && git config user.email "awesome-robot@users.noreply.github.com" && git add . && git commit -m "Deployed to Github Pages via Travis" && git push --force --quiet "https://${GH_TOKEN}@github.com/awesomeWM/apidoc" master:gh-pages || echo "Uploading docs failed!"; } || echo "Not uploading docs for $TRAVIS_BRANCH:$TRAVIS_PULL_REQUEST."'
+  - '[ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = false ] && { echo "Uploading documentation..." && cd build/doc && git clone --branch gh-pages --bare $REPO_APIDOC .git && git config core.bare false && git reset && git add --all . && git commit -m "Updated docs for $AWESOME_VERSION via Travis" && git push --quiet origin gh-pages || echo "Uploading docs failed!"; } || echo "Not uploading docs for $TRAVIS_BRANCH:$TRAVIS_PULL_REQUEST."'

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,8 +95,11 @@ install:
   # Deps for functional tests.
   - sudo apt-get install -qq dbus-x11 xterm xdotool xterm xvfb
 
+  # Determine custom version.
+  - '[ "$TRAVIS_PULL_REQUEST" = false ] && version="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)-$(date -Iseconds)" || version="${TRAVIS_BRANCH}-PR${TRAVIS_PULL_REQUEST}-g$(git rev-parse --short HEAD)-$(date -Iseconds)"'
+
 script:
-  - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIB} -DLUA_INCLUDE_DIR=/usr/include/lua${LUAPKG}"
+  - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIB} -DLUA_INCLUDE_DIR=/usr/include/lua${LUAPKG} -D OVERRIDE_VERSION=$version"
   - make && sudo env PATH=$PATH make install && awesome --version && tests/run.sh
 
 # Push updated API docs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ install:
 
   # Install ldoc for building docs.
   - sudo luarocks install ldoc
+  - sudo luarocks install lua-discount
 
   # Install CMake 3+, via http://www.cmake.org/download/#latest.
   - wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.Z

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,10 +106,8 @@ script:
 after_success:
   - REPO_APIDOC="https://${GH_TOKEN}@github.com/awesomeWM/apidoc"
   # Export these to not add "git config" calls to the long command.
-  - export GIT_AUTHOR_NAME="awesome-robot on Travis CI"
-  - export GIT_AUTHOR_EMAIL="awesome-robot@users.noreply.github.com"
-  - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
-  - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+  - export GIT_COMMITTER_NAME="awesome-robot on Travis CI"
+  - export GIT_COMMITTER_EMAIL="awesome-robot@users.noreply.github.com"
   # For testing the PR itself:
   - TRAVIS_PULL_REQUEST=false
   # NOTE: stdout/stderr might/should be discarded to not leak sensitive information.

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -89,14 +89,16 @@ endif()
 # }}}
 
 # {{{ Version stamp
-if(EXISTS ${SOURCE_DIR}/.git/HEAD AND GIT_EXECUTABLE)
+if(OVERRIDE_VERSION)
+    set(VERSION ${OVERRIDE_VERSION})
+elseif(EXISTS ${SOURCE_DIR}/.git/HEAD AND GIT_EXECUTABLE)
     # get current version
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --dirty
         WORKING_DIRECTORY ${SOURCE_DIR}
         OUTPUT_VARIABLE VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE)
-    # file the git-version-stamp.sh script will look into
+    # File the build-utils/git-version-stamp.sh script will look into.
     set(VERSION_STAMP_FILE ${BUILD_DIR}/.version_stamp)
     file(WRITE ${VERSION_STAMP_FILE} ${VERSION})
     # create a version_stamp target later


### PR DESCRIPTION
This is a test / proof-of-concept.

It uses Github pages, and the docs will be published at http://awesomewm.github.io/apidoc/.

Useful Travis config vars: http://docs.travis-ci.com/user/environment-variables/, e.g. `TRAVIS_TAG`.

This could also push the documentation to http://awesome.naquadah.org/doc/api/master.
For this, secret/encrypted environment variables can be configured (see http://docs.travis-ci.com/user/encryption-keys/).
I have created a separate Github user, which has only limited access for this purpose, and who's Github token is used for this.

An example build: https://travis-ci.org/awesomeWM/awesome/builds/72388323 (with an adjusted test, normally PRs will be skipped).