### PR TITLE
doc: remove references to Zaphod mode

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -265,7 +265,6 @@ screen_scan_xinerama(void)
 
 static void screen_scan_x11(void)
 {
-    /* One screen only / Zaphod mode */
     lua_State *L = globalconf_get_lua_State();
     xcb_screen_t *xcb_screen = globalconf.screen;
     screen_t *s = screen_new(L);

--- a/spawn.c
+++ b/spawn.c
@@ -336,8 +336,7 @@ parse_command(lua_State *L, int idx, GError **error)
 }
 
 /** Spawn a program.
- * This function is multi-head (Zaphod) aware and will set display to
- * the right screen according to mouse position.
+ * The program will be started on the default screen.
  *
  * @param cmd The command to launch.
  * @param use_sn Use startup-notification, true or false, default to true.


### PR DESCRIPTION
This has been removed a long time ago (in 32d9a5b).