### PR TITLE
doc: distinguish between client.object and client.class

### DIFF
--- a/docs/02-contributing.md
+++ b/docs/02-contributing.md
@@ -81,7 +81,7 @@ documentation](https://stevedonovan.github.io/ldoc/manual/doc.md.html).
 
 In addition to the regular tags provided by LDoc there are also some aliases
 for typed parameters defined in `docs/config.ld`, e.g. `@client` for
-`@tparam client.client`, `@tag` for `@tparam tag` and `@tab` for
+`@tparam client.object`, `@tag` for `@tparam tag` and `@tab` for
 `@tparam table`).
 
 ## Patches

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -21,8 +21,8 @@ topics={
     '02-contributing.md',
 }
 
--- Setup @client to be an alias for "@tparam client.client"
-tparam_alias('client', 'client.client')
+-- Setup @client to be an alias for "@tparam client.object"
+tparam_alias('client', 'client.object')
 tparam_alias('tag', 'tag')
 -- Should be default, but is not.  Sets up "@tab" => "@tparam table".
 tparam_alias('tab', 'table')

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -76,7 +76,7 @@ end
 
 --- Get the first client that got the urgent hint.
 --
--- @treturn client The first urgent client.
+-- @treturn client.object The first urgent client.
 function client.urgent.get()
     if #client.data.urgent > 0 then
         return client.data.urgent[1]
@@ -169,7 +169,7 @@ end
 -- @tparam function filter An optional filter.  If no client is found in the
 --         first iteration, client.focus.filter is used by default to get any
 --         client.
--- @treturn client A client.
+-- @treturn client.object A client.
 function client.focus.history.get(screen, idx, filter)
     -- When this counter is equal to idx, we return the client
     local counter = 0

--- a/mouse.c
+++ b/mouse.c
@@ -240,7 +240,7 @@ luaA_mouse_coords(lua_State *L)
 
 /** Get the client or any object which is under the pointer.
  *
- * @treturn client.client|nil A client or nil.
+ * @treturn client.object|nil A client or nil.
  * @function object_under_pointer
  */
 static int

--- a/objects/client.c
+++ b/objects/client.c
@@ -51,6 +51,12 @@
 #include <xcb/shape.h>
 #include <cairo-xcb.h>
 
+/** Client class.
+ *
+ * @table class
+ * @field focus The focused `client.object`.
+ */
+
 /** Client object.
  *
  * @field window The X window id.
@@ -74,7 +80,6 @@
  * @field border_color The client border color.
  * @field urgent The client urgent state.
  * @field content An image representing the client window content (screenshot).
- * @field focus The focused client.
  * @field opacity The client opacity between 0 and 1.
  * @field ontop The client is on top of every other windows.
  * @field above The client is above normal windows.
@@ -98,7 +103,7 @@
  * @field startup_id The FreeDesktop StartId.
  * @field valid If the client that this object refers to is still managed by awesome.
  * @field first_tag The first tag of the client.  Optimized form of `c:tags()[1]`.
- * @table client
+ * @table object
  */
 
 /** Return client struts (reserved space at the edge of the screen).


### PR DESCRIPTION
Instead of `client.client`, the client object is now referred to as
`client.object` and the client class as `client.class`.

This moves the documentation of `client.focus` to the class.