### PR TITLE
Change "Mod1" to "Mod4" in menubar/init.lua

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -275,7 +275,7 @@ local function prompt_keypressed_callback(mod, key, comm)
     elseif key == "Return" or key == "KP_Enter" then
         if mod.Control then
             current_item = #shownitems
-            if mod.Mod1 then
+            if mod.Mod4 then
                 -- add a terminal to the cmdline
                 shownitems[current_item].cmdline = menubar.utils.terminal
                         .. " -e " .. shownitems[current_item].cmdline


### PR DESCRIPTION
"Mod1" ususally stands for Alt, "Mod4" stands for Meta and "Mod4" is used in rc.lua. 
In menubar/init.lua it is said: ""C-M-Return"    execute the command in a terminal", but in code "Mod1" is used instead. It seems to me, it should be changed to "Mod4"