### PR TITLE
keygrabber: ignore modifiers for name of control keys

### DIFF
--- a/keygrabber.c
+++ b/keygrabber.c
@@ -89,14 +89,13 @@ keygrabber_handlekpress(lua_State *L, xcb_key_press_event_t *e)
 
     if (is_control(buf))
     {
-        /* use text names for control characters */
-        xkb_keysym_t keysym = xkb_state_key_get_one_sym(globalconf.xkb_state, e->detail);
-        xkb_keysym_get_name(keysym, buf, countof(buf) );
+        /* Use text names for control characters, ignoring all modifiers. */
+        xcb_keysym_t keysym = xcb_key_symbols_get_keysym(globalconf.keysyms,
+                                                         e->detail, 0);
+        xkb_keysym_get_name(keysym, buf, countof(buf));
     }
 
-
     luaA_pushmodifiers(L, e->state);
-
     lua_pushstring(L, buf);
 
     switch(e->response_type)
@@ -108,8 +107,6 @@ keygrabber_handlekpress(lua_State *L, xcb_key_press_event_t *e)
         lua_pushliteral(L, "release");
         break;
     }
-
-
     return true;
 }
 


### PR DESCRIPTION
`xkb_state_key_get_one_sym` returns `Meta_L` for a (release) event of
`Alt_L` when Shift is pressed.

This patch changes it to use `xcb_key_symbols_get_keysym` in the same
way like normal key handling does it in `event_handle_key`.  This was
changed in 372d12e, but apparently forgotten for the keygrabber.