### PR TITLE
(input/utf8) key handling in mappings

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -131,7 +131,6 @@ pkg_check_modules(AWESOME_REQUIRED REQUIRED
     glib-2.0
     gdk-pixbuf-2.0
     cairo
-    x11
     x11-xcb
     xcb-cursor
     xcb-randr

--- a/objects/key.c
+++ b/objects/key.c
@@ -39,8 +39,6 @@
 #include "common/xutil.h"
 #include "xkb.h"
 
-/* XStringToKeysym() and XKeysymToString */
-#include <X11/Xlib.h>
 #include <xkbcommon/xkbcommon.h>
 
 /** Key object.
@@ -82,7 +80,7 @@ luaA_keystore(lua_State *L, int ud, const char *str, ssize_t len)
     /* Then set up the new state */
     if(*str != '#' || len == 1)
     {
-        key->keysym = XStringToKeysym(str);
+        key->keysym = xkb_keysym_from_name(str, 0);
         if(!key->keysym)
         {
             if(len > 1)

--- a/objects/key.c
+++ b/objects/key.c
@@ -55,6 +55,12 @@
  * @table key
  */
 
+static void
+key_wipe(keyb_t *key)
+{
+    p_delete(&key->utf8);
+}
+
 /** Get the number of instances.
  *
  * @return The number of key objects alive.
@@ -64,28 +70,31 @@
 static void
 luaA_keystore(lua_State *L, int ud, const char *str, ssize_t len)
 {
+    if(!len)
+        return;
     keyb_t *key = luaA_checkudata(L, ud, &key_class);
-    if(len)
+
+    /* First, unset everything */
+    p_delete(&key->utf8);
+    key->keycode = 0;
+    key->keysym = 0;
+
+    /* Then set up the new state */
+    if(*str != '#' || len == 1)
     {
-        if(*str != '#')
+        key->keysym = XStringToKeysym(str);
+        if(!key->keysym)
         {
-            key->keysym = XStringToKeysym(str);
-            if(!key->keysym)
-            {
-                if(len == 1)
-                    key->keysym = *str;
-                else
-                    warn("there's no keysym named \"%s\"", str);
-            }
-            key->keycode = 0;
+            if(len > 1)
+                warn("There is no keysym named \"%s\". Will be handled as utf8 key.", str);
+            key->utf8 = a_strdup(str);
         }
-        else
-        {
-            key->keycode = atoi(str + 1);
-            key->keysym = 0;
-        }
-        luaA_object_emit_signal(L, ud, "property::key", 0);
     }
+    else
+    {
+        key->keycode = atoi(str + 1);
+    }
+    luaA_object_emit_signal(L, ud, "property::key", 0);
 }
 
 /** Create a new key object.
@@ -205,15 +214,17 @@ luaA_key_get_key(lua_State *L, keyb_t *k)
         int slen = snprintf(buf, sizeof(buf), "#%u", k->keycode);
         lua_pushlstring(L, buf, slen);
     }
-    else
+    else if(k->keysym)
     {
         char buf[MAX(MB_LEN_MAX, 32)];
 
-        if (xkb_keysym_get_name(k->keysym, buf, countof(buf)) < 0) {
+        if(xkb_keysym_get_name(k->keysym, buf, countof(buf)) < 0)
             return 0;
-        }
-
         lua_pushstring(L, buf);
+    }
+    else
+    {
+        lua_pushstring(L, k->utf8);
     }
     return 1;
 }
@@ -252,7 +263,9 @@ key_class_setup(lua_State *L)
     };
 
     luaA_class_setup(L, &key_class, "key", NULL,
-                     (lua_class_allocator_t) key_new, NULL, NULL,
+                     (lua_class_allocator_t) key_new,
+                     (lua_class_collector_t) key_wipe,
+                     NULL,
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      key_methods, key_meta);
     luaA_class_add_property(&key_class, "key",

--- a/objects/key.c
+++ b/objects/key.c
@@ -35,6 +35,7 @@
  * @classmod key
  */
 
+#include "globalconf.h"
 #include "objects/key.h"
 #include "common/xutil.h"
 #include "xkb.h"
@@ -230,7 +231,9 @@ luaA_key_get_key(lua_State *L, keyb_t *k)
 static int
 luaA_key_get_keysym(lua_State *L, keyb_t *k)
 {
-    lua_pushstring(L, XKeysymToString(k->keysym));
+    char buf[MAX(MB_LEN_MAX, 32)];
+    xkb_state_key_get_utf8(globalconf.xkb_state, k->keysym, buf, countof(buf));
+    lua_pushstring(L, buf);
     return 1;
 }
 

--- a/objects/key.h
+++ b/objects/key.h
@@ -33,10 +33,14 @@ typedef struct keyb_t
     xcb_keysym_t keysym;
     /** Keycode */
     xcb_keycode_t keycode;
+    /** Key as UTF8 (fallback) */
+    const char *utf8;
 } keyb_t;
 
 lua_class_t key_class;
 LUA_OBJECT_FUNCS(key_class, keyb_t, key)
+/* NOTE: This does *NOT* free the key instances saved in the array. This is safe
+ * because Lua owns all instances and will call key_wipe() when appropriate. */
 DO_ARRAY(keyb_t *, key, DO_NOTHING)
 
 void key_class_setup(lua_State *);

--- a/root.c
+++ b/root.c
@@ -33,6 +33,7 @@
 #include "objects/button.h"
 #include "xwindow.h"
 
+#include <xkbcommon/xkbcommon.h>
 #include <xcb/xtest.h>
 #include <xcb/xcb_aux.h>
 #include <cairo-xcb.h>
@@ -129,7 +130,7 @@ _string_to_key_code(const char *s)
     xcb_keysym_t keysym;
     xcb_keycode_t *keycodes;
 
-    keysym   = XStringToKeysym(s);
+    keysym   = xkb_keysym_from_name(s, 0);
     keycodes = xcb_key_symbols_get_keycode(globalconf.keysyms, keysym);
 
     if(keycodes) {


### PR DESCRIPTION
This patch uses `xkb_state_key_get_utf8` to lookup keys that could not
get translated to a keycode or keysym during setup/definition.

This allows for using the actual key also for non-ASCII mappings:

    awful.key({ modkey }, "ü",          function() print("ü") end),
    awful.key({ modkey }, "#34",        function() print("#34") end),
    awful.key({ modkey }, "udiaeresis", function() print("udiaeresis") end),