### PR TITLE
Do not call `xcb_ungrab_key` twice (before `xwindow_grabkeys`)

### DIFF
--- a/event.c
+++ b/event.c
@@ -801,14 +801,11 @@ event_handle_mappingnotify(xcb_mapping_notify_event_t *ev)
 
         /* regrab everything */
         xcb_screen_t *s = globalconf.screen;
-        /* yes XCB_BUTTON_MASK_ANY is also for grab_key even if it's look weird */
-        xcb_ungrab_key(globalconf.connection, XCB_GRAB_ANY, s->root, XCB_BUTTON_MASK_ANY);
         xwindow_grabkeys(s->root, &globalconf.keys);
 
         foreach(_c, globalconf.clients)
         {
             client_t *c = *_c;
-            xcb_ungrab_key(globalconf.connection, XCB_GRAB_ANY, c->frame_window, XCB_BUTTON_MASK_ANY);
             xwindow_grabkeys(c->frame_window, &c->keys);
         }
     }

--- a/objects/client.c
+++ b/objects/client.c
@@ -2440,7 +2440,6 @@ luaA_client_keys(lua_State *L)
     {
         luaA_key_array_set(L, 1, 2, keys);
         luaA_object_emit_signal(L, 1, "property::keys", 0);
-        xcb_ungrab_key(globalconf.connection, XCB_GRAB_ANY, c->frame_window, XCB_BUTTON_MASK_ANY);
         xwindow_grabkeys(c->frame_window, keys);
     }
 

--- a/root.c
+++ b/root.c
@@ -238,7 +238,6 @@ luaA_root_keys(lua_State *L)
             key_array_append(&globalconf.keys, luaA_object_ref_class(L, -1, &key_class));
 
         xcb_screen_t *s = globalconf.screen;
-        xcb_ungrab_key(globalconf.connection, XCB_GRAB_ANY, s->root, XCB_BUTTON_MASK_ANY);
         xwindow_grabkeys(s->root, &globalconf.keys);
 
         return 1;


### PR DESCRIPTION
It gets called in `xwindow_grabkeys` always:

    xwindow_grabkeys(xcb_window_t win, key_array_t *keys)
    {
        /* Ungrab everything first */
        xcb_ungrab_key(globalconf.connection, XCB_GRAB_ANY, win, XCB_BUTTON_MASK_ANY);