### PR TITLE
Tooltips: minor fixes / improvements

### DIFF
--- a/lib/awful/titlebar.lua
+++ b/lib/awful/titlebar.lua
@@ -11,6 +11,7 @@ local error = error
 local type = type
 local abutton = require("awful.button")
 local aclient = require("awful.client")
+local atooltip = require("awful.tooltip")
 local beautiful = require("beautiful")
 local object = require("gears.object")
 local drawable = require("wibox.drawable")
@@ -177,12 +178,17 @@ end
 -- then found in the theme as "titlebar_[name]_button_[normal/focus]_[state]".
 -- If that value does not exist, the focused state is ignored for the next try.
 -- @param c The client for which a button is created.
--- @param name Name of the button, used for accessing the theme.
+-- @tparam string name Name of the button, used for accessing the theme and
+--   in the tooltip.
 -- @param selector A function that selects the image that should be displayed.
 -- @param action Function that is called when the button is clicked.
 -- @return The widget
 function titlebar.widget.button(c, name, selector, action)
     local ret = imagebox()
+
+    ret.tooltip = atooltip({ objects = {ret}, delay_show = 1 })
+    ret.tooltip:set_text(name)
+
     local function update()
         local img = selector(c)
         if type(img) ~= "nil" then

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -270,9 +270,6 @@ tooltip.new = function(args)
     self.marginbox = wibox.layout.margin(self.background, m_lr, m_lr, m_tb, m_tb)
     self.wibox:set_widget(self.marginbox)
 
-    -- add some signals on both the tooltip and widget
-    self.wibox:connect_signal("mouse::enter", data[self].hide)
-
     -- Add tooltip to objects
     if args.objects then
         for _, object in ipairs(args.objects) do

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -218,7 +218,7 @@ tooltip.new = function(args)
                 end
             end,
             hide = function()
-                if delay_timeout and delay_timeout.started then
+                if delay_timeout.started then
                     delay_timeout:stop()
                 end
                 hide(self)

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -130,7 +130,9 @@ end
 --   `wibox.widget.textbox.set_text`.
 tooltip.set_text = function(self, text)
     self.textbox:set_text(text)
-    set_geometry(self)
+    if self.visible then
+        set_geometry(self)
+    end
 end
 
 --- Change displayed text.
@@ -140,7 +142,9 @@ end
 --   `wibox.widget.textbox.set_markup`.
 tooltip.set_markup = function(self, text)
     self.textbox:set_markup(text)
-    set_geometry(self)
+    if self.visible then
+        set_geometry(self)
+    end
 end
 
 --- Change the tooltip's update interval.

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -45,6 +45,7 @@ local screen = screen
 local timer = require("gears.timer")
 local wibox = require("wibox")
 local a_placement = require("awful.placement")
+local abutton = require("awful.button")
 local beautiful = require("beautiful")
 local textbox = require("wibox.widget.textbox")
 local background = require("wibox.widget.background")
@@ -269,6 +270,10 @@ tooltip.new = function(args)
     local m_tb = args.margin_topbottom or dpi(3)
     self.marginbox = wibox.layout.margin(self.background, m_lr, m_lr, m_tb, m_tb)
     self.wibox:set_widget(self.marginbox)
+
+    -- Close the tooltip when clicking it.  This gets done on release, to not
+    -- emit the release event on an underlying object, e.g. the titlebar icon.
+    self.wibox:buttons(abutton({}, 1, nil, function() data[self].hide() end))
 
     -- Add tooltip to objects
     if args.objects then

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -135,7 +135,7 @@ tooltip.set_text = function(self, text)
     end
 end
 
---- Change displayed text.
+--- Change displayed markup.
 --
 -- @tparam tooltip self The tooltip object.
 -- @tparam string  text New tooltip markup, passed to

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -202,21 +202,34 @@ tooltip.new = function(args)
     }
 
     -- private data
-    local delay_timeout
     if args.delay_show then
+        local delay_timeout
+
         delay_timeout = timer { timeout = args.delay_show }
-        delay_timeout:connect_signal("timeout", function () show(self) end)
+        delay_timeout:connect_signal("timeout", function ()
+            show(self)
+            delay_timeout:stop()
+        end)
+
+        data[self] = {
+            show = function()
+                if not delay_timeout.started then
+                    delay_timeout:start()
+                end
+            end,
+            hide = function()
+                if delay_timeout and delay_timeout.started then
+                    delay_timeout:stop()
+                end
+                hide(self)
+            end,
+        }
+    else
+        data[self] = {
+            show = function() show(self) end,
+            hide = function() hide(self) end,
+        }
     end
-    data[self] = {
-        show = function()
-            if delay_timeout then delay_timeout:start()
-            else show(self) end
-        end,
-        hide = function()
-            if delay_timeout then delay_timeout:stop() end
-            hide(self)
-        end,
-    }
 
     -- export functions
     self.set_text = tooltip.set_text


### PR DESCRIPTION
I'm not sure about "tooltip: add support for show/hide callbacks" (https://github.com/awesomeWM/awesome/commit/265bdafcd0c94eea20509b00a57cc77d777403ea).

For https://github.com/awesomeWM/awesome/commit/bb37cf6695bb29283d7e6ddd83212ddc6106fe4e, I've seen an error/warning that the timer has not been started yet.  This can happen if some `mouse::leave` event gets emitted before `mouse::enter`.  This happened when looking at tooltips to the titlebar imageboxes.