### PR TITLE
awesome_atexit: keep client order always

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -85,18 +85,15 @@ awesome_atexit(bool restart)
                 (*c)->geometry.x, (*c)->geometry.y);
     }
 
-    if (restart)
-    {
-        /* Save the client order across restarts */
-        xcb_window_t *wins = p_alloca(xcb_window_t, globalconf.clients.len);
-        int n = 0;
-        foreach(client, globalconf.clients)
-            wins[n++] = (*client)->window;
+    /* Save the client order.  This is useful also for "hard" restarts. */
+    xcb_window_t *wins = p_alloca(xcb_window_t, globalconf.clients.len);
+    int n = 0;
+    foreach(client, globalconf.clients)
+        wins[n++] = (*client)->window;
 
-        xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
-                            globalconf.screen->root,
-                            AWESOME_CLIENT_ORDER, XCB_ATOM_WINDOW, 32, n, wins);
-    }
+    xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
+                        globalconf.screen->root,
+                        AWESOME_CLIENT_ORDER, XCB_ATOM_WINDOW, 32, n, wins);
 
     a_dbus_cleanup();
 


### PR DESCRIPTION
This is not only useful for soft restarts, but also when TERMinating
awesome during development/testing.

The drawback appears to be that it would leak a property on the root
window in case it is really meant to be quit.