### PR TITLE
Fix sporadic test failure due to lgi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,8 @@ endif()
 find_program(BUSTED_EXECUTABLE busted)
 if(BUSTED_EXECUTABLE)
     add_custom_target(check-unit ALL
-        ${BUSTED_EXECUTABLE} "--lpath=${CMAKE_BINARY_DIR}/lib/?.lua;${CMAKE_BINARY_DIR}/lib/?/init.lua;spec/?.lua"
+        ${BUSTED_EXECUTABLE} "--helper=${CMAKE_SOURCE_DIR}/spec/preload.lua"
+        "--lpath=${CMAKE_BINARY_DIR}/lib/?.lua;${CMAKE_BINARY_DIR}/lib/?/init.lua;spec/?.lua"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Running unit tests"
         VERBATIM)

--- a/spec/preload.lua
+++ b/spec/preload.lua
@@ -1,4 +1,4 @@
 -- This script is given to Busted via the --helper argument. Modules loaded here
 -- won't be cleared and reloaded by Busted. This is needed for lgi because lgi
--- is not safe to reload and yet Busted makes us try to do this.
+-- is not safe to reload and yet Busted manages to do this.
 require("lgi")

--- a/spec/preload.lua
+++ b/spec/preload.lua
@@ -1,0 +1,4 @@
+-- This script is given to Busted via the --helper argument. Modules loaded here
+-- won't be cleared and reloaded by Busted. This is needed for lgi because lgi
+-- is not safe to reload and yet Busted makes us try to do this.
+require("lgi")


### PR DESCRIPTION
With version 2.0rc5, Busted started cleaning up between tests more thoroughly.
The result was that it managed to unload and reload lgi. However, the C part of
lgi is not safe to be reloaded. This caused sporadic errors in the test suite
runs.

Work around this via a helper script that is run before Busted starts running
tests. When we load lgi in this helper script, it is loaded before Busted starts
saving and restoring everything and thus lgi won't ever be unloaded.

Signed-off-by: Uli Schlachter <psychon@znc.in>

@blueyed Could you test this patch some hundred times and see if this really fixes our problems?