### PR TITLE
Fix mouse::leave for drawables (titlebar)

### DIFF
--- a/event.c
+++ b/event.c
@@ -454,6 +454,9 @@ event_handle_motionnotify(xcb_motion_notify_event_t *ev)
         luaA_object_emit_signal(L, -3, "mouse::move", 2);
         lua_pop(L, 2);
     }
+
+    globalconf.last_motion_x = ev->event_x;
+    globalconf.last_motion_y = ev->event_y;
 }
 
 /** The leave notify event handler.
@@ -475,7 +478,7 @@ event_handle_leavenotify(xcb_leave_notify_event_t *ev)
     {
         luaA_object_push(L, c);
         luaA_object_emit_signal(L, -1, "mouse::leave", 0);
-        drawable_t *d = client_get_drawable(c, ev->event_x, ev->event_y);
+        drawable_t *d = client_get_drawable(c, globalconf.last_motion_x, globalconf.last_motion_y);
         if (d)
         {
             luaA_object_push_item(L, -1, d);

--- a/globalconf.h
+++ b/globalconf.h
@@ -157,6 +157,10 @@ typedef struct
     struct xkb_context *xkb_ctx;
     /* xkb state of dead keys on keyboard */
     struct xkb_state *xkb_state;
+    /* X coordinate of last mouse motion event */
+    uint16_t last_motion_x;
+    /* Y coordinate of last mouse motion event */
+    uint16_t last_motion_y;
 } awesome_t;
 
 extern awesome_t globalconf;


### PR DESCRIPTION
Store X/Y of the last motion event in `globalconf`, to have it available
in `event_handle_leavenotify`, where only the current X/Y is available
on the event.  And since the titlebar has only a drawable, but no
drawin, it will not get handled through `drawin_getbywin(ev->event)`.

An alternative might be to use a `drawin` also for the titlebar.