### PR TITLE
Apply left/top titlebars in event_handle_configurerequest

### DIFF
--- a/event.c
+++ b/event.c
@@ -317,12 +317,14 @@ event_handle_configurerequest(xcb_configure_request_event_t *ev)
         {
             geometry.x = ev->x;
             /* The ConfigureRequest specifies the position of the outer corner of the client window, we want the frame */
+            geometry.x -= c->titlebar[CLIENT_TITLEBAR_LEFT].size;
             geometry.x -= c->border_width;
         }
         if(ev->value_mask & XCB_CONFIG_WINDOW_Y)
         {
             geometry.y = ev->y;
             /* The ConfigureRequest specifies the position of the outer corner of the client window, we want the frame */
+            geometry.y -= c->titlebar[CLIENT_TITLEBAR_TOP].size;
             geometry.y -= c->border_width;
         }
         if(ev->value_mask & XCB_CONFIG_WINDOW_WIDTH)


### PR DESCRIPTION
I have noticed that the HeidiSQL session manager window/dialog will be
moved down by the height of the top titlebar when selecting an entry
from the server list.

While I am not sure if that is the correct way to fix this, and what it
might break, it fixes the issue described above.