### PR TITLE
tests/run.sh: Start Xvfb with -noreset

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -41,7 +41,7 @@ D=:5
 SIZE=1024x768
 
 if [ $HEADLESS = 1 ]; then
-    "$XVFB" $D -screen 0 ${SIZE}x24 &
+    "$XVFB" $D -noreset -screen 0 ${SIZE}x24 &
     xserver_pid=$!
 else
     # export XEPHYR_PAUSE=1000


### PR DESCRIPTION
When using Xephyr, this already starts the server with -noreset, but for Xvfb we
also need this flag. Without this flag, the DPI value that is set via xrdb gets
lost at server reset.

This wasn't a problem before commit 6d4837a53abb. That commit moved the launch
of the dbus session after the setting of the DPI. So previously, waiting for
server startup was half broken (the dbus session already tried to connect to the
server to check for when it shuts down), but due to this no server reset
occurred and thus the DPI was correctly applied. After this commit, the server
immediately resets after xrdb is done setting the DPI and the value set is lost.

Signed-off-by: Uli Schlachter <psychon@znc.in>