### PR TITLE
tooltips: re-place them on width/height changes

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -275,6 +275,10 @@ tooltip.new = function(args)
     -- emit the release event on an underlying object, e.g. the titlebar icon.
     self.wibox:buttons(abutton({}, 1, nil, function() data[self].hide() end))
 
+    -- Re-place when the geometry of the wibox changes.
+    self.wibox:connect_signal("property::width",  function() place(self) end)
+    self.wibox:connect_signal("property::height", function() place(self) end)
+
     -- Add tooltip to objects
     if args.objects then
         for _, object in ipairs(args.objects) do


### PR DESCRIPTION
If the dimensions of a tooltip change, e.g. after the text has been
changed, they are now placed again.

Note that this only works properly with https://github.com/awesomeWM/awesome/pull/412.