### PR TITLE
Do not unset max/fullscreen when setting the other

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -1085,8 +1085,6 @@ client_set_fullscreen(lua_State *L, int cidx, bool s)
         /* become fullscreen! */
         if(s)
         {
-            /* remove any max state */
-            client_set_maximized(L, cidx, false);
             /* You can only be part of one of the special layers. */
             client_set_below(L, cidx, false);
             client_set_above(L, cidx, false);
@@ -1126,8 +1124,6 @@ client_get_maximized(client_t *c)
         if(c->maximized_##type != s) \
         { \
             int abs_cidx = luaA_absindex(L, cidx); \
-            if(s) \
-                client_set_fullscreen(L, abs_cidx, false); \
             lua_pushboolean(L, s); \
             int max_before = client_get_maximized(c); \
             c->maximized_##type = s; \


### PR DESCRIPTION
From http://standards.freedesktop.org/wm-spec/latest/ar01s05.html:

> _NET_WM_STATE_FULLSCREEN indicates that the window should fill the
> entire screen and have no window decorations. Additionally the Window
> Manager is responsible for restoring the original geometry after a
> switch from fullscreen back to normal window. For example, a
> presentation program would use this hint.

awesome prefers fullscreen internally already.  With this patch, the
previous maximized state will be restored after leaving fullscreen mode.

Fixes https://github.com/awesomeWM/awesome/issues/245.