### PR TITLE
Add finish callback to awful.mouse.client.move

### DIFF
--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -155,7 +155,10 @@ end
 --- Move a client.
 -- @param c The client to move, or the focused one if nil.
 -- @param snap The pixel to snap clients.
-function mouse.client.move(c, snap)
+-- @param finished_cb An optional callback function, that will be called
+--                 when moving the client has been finished. The client
+--                 that has been moved will be passed to that function.
+function mouse.client.move(c, snap, finished_cb)
     local c = c or capi.client.focus
 
     if not c
@@ -205,6 +208,9 @@ function mouse.client.move(c, snap)
                                       end
                                       return true
                                   end
+                              end
+                              if finished_cb then
+                                  finished_cb(c)
                               end
                               return false
                           end, "fleur")


### PR DESCRIPTION
This kind of callback might come in handy for user configurations and won't break any backward compatibility.