### PR TITLE
Set an upper limit on nmaster/ncol based on number of tiled windows

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -253,12 +253,12 @@ globalkeys = awful.util.table.join(
     awful.key({ modkey, "Control" }, "r", awesome.restart),
     awful.key({ modkey, "Shift"   }, "q", awesome.quit),
 
-    awful.key({ modkey,           }, "l",     function () awful.tag.incmwfact( 0.05)    end),
-    awful.key({ modkey,           }, "h",     function () awful.tag.incmwfact(-0.05)    end),
-    awful.key({ modkey, "Shift"   }, "h",     function () awful.tag.incnmaster( 1)      end),
-    awful.key({ modkey, "Shift"   }, "l",     function () awful.tag.incnmaster(-1)      end),
-    awful.key({ modkey, "Control" }, "h",     function () awful.tag.incncol( 1)         end),
-    awful.key({ modkey, "Control" }, "l",     function () awful.tag.incncol(-1)         end),
+    awful.key({ modkey,           }, "l",     function () awful.tag.incmwfact( 0.05)          end),
+    awful.key({ modkey,           }, "h",     function () awful.tag.incmwfact(-0.05)          end),
+    awful.key({ modkey, "Shift"   }, "h",     function () awful.tag.incnmaster( 1, nil, true) end),
+    awful.key({ modkey, "Shift"   }, "l",     function () awful.tag.incnmaster(-1, nil, true) end),
+    awful.key({ modkey, "Control" }, "h",     function () awful.tag.incncol( 1, nil, true)    end),
+    awful.key({ modkey, "Control" }, "l",     function () awful.tag.incncol(-1, nil, true)    end),
     awful.key({ modkey,           }, "space", function () awful.layout.inc( 1) end),
     awful.key({ modkey, "Shift"   }, "space", function () awful.layout.inc(-1) end),
 

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -26,6 +26,9 @@ local capi =
     root = root
 }
 
+-- we use require("awful.client") inside functions to prevent circular dependencies.
+local client
+
 local tag = { mt = {} }
 
 -- Private data
@@ -335,9 +338,10 @@ function tag.setscreen(t, s)
 end
 
 --- Get a tag's screen
--- @param t tag object
+-- @param[opt] t tag object
 -- @return Screen number
 function tag.getscreen(t)
+    local t = t or tag.selected()
     return tag.getproperty(t, "screen")
 end
 
@@ -460,9 +464,27 @@ end
 
 --- Increase the number of master windows.
 -- @param add Value to add to number of master windows.
--- @param t The tag to modify, if null tag.selected() is used.
-function tag.incnmaster(add, t)
-    tag.setnmaster(tag.getnmaster(t) + add, t)
+-- @param[opt] t The tag to modify, if null tag.selected() is used.
+-- @tparam[opt=false] boolean sensible Limit nmaster based on the number of
+-- visible tiled windows?
+function tag.incnmaster(add, t, sensible)
+    if sensible then
+        client = client or require("awful.client")
+        local ntiled = #client.tiled(tag.getscreen(t))
+
+        local nmaster = tag.getnmaster(t)
+        if nmaster > ntiled then
+            nmaster = ntiled
+        end
+
+        local newnmaster = nmaster + add
+        if newnmaster > ntiled then
+            newnmaster = ntiled
+        end
+        tag.setnmaster(newnmaster, t)
+    else
+        tag.setnmaster(tag.getnmaster(t) + add, t)
+    end
 end
 
 
@@ -500,9 +522,29 @@ end
 
 --- Increase number of column windows.
 -- @param add Value to add to number of column windows.
--- @param t The tag to modify, if null tag.selected() is used.
-function tag.incncol(add, t)
-    tag.setncol(tag.getncol(t) + add, t)
+-- @param[opt] t The tag to modify, if null tag.selected() is used.
+-- @tparam[opt=false] boolean sensible Limit ncol based on the number of visible
+-- tiled windows?
+function tag.incncol(add, t, sensible)
+    if sensible then
+        client = client or require("awful.client")
+        local ntiled = #client.tiled(tag.getscreen(t))
+        local nmaster = tag.getnmaster(t)
+        local nsecondary = ntiled - nmaster
+
+        local ncol = tag.getncol(t)
+        if ncol > nsecondary then
+            ncol = nsecondary
+        end
+
+        local newncol = ncol + add
+        if newncol > nsecondary then
+            newncol = nsecondary
+        end
+        tag.setncol(newncol, t)
+    else
+        tag.setncol(tag.getncol(t) + add, t)
+    end
 end
 
 --- View no tag.


### PR DESCRIPTION
(with the default key-mappings) 

Pressing Mod+Shift+h repeatedly keeps on increasing the value of nmaster indefinitely, past the number of windows visible on the screen. This means it can take a lot of presses of Mod+Shift+l to get it back to a value where you can actually see your layout changing.

With this patch, pressing Mod+Shift+l will always reduce the number of visible master windows by 1.


Same again for ncol.