### PR TITLE
Fix awful.rules.does_match

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -130,6 +130,16 @@ function rules.match_any(c, rule)
     return false
 end
 
+--- Does a given rule entry match a client?
+-- @client c The client.
+-- @tab entry Rule entry (with keys `rule`, `rule_any`, `except` and/or
+-- `except_any`).
+-- @treturn bool
+function rules.matches(c, entry)
+    return (rules.match(c, entry.rule) or rules.match_any(c, entry.rule_any)) and
+        (not rules.match(c, entry.except) and not rules.match_any(c, entry.except_any))
+end
+
 --- Get list of matching rules for a client.
 -- @client c The client.
 -- @tab _rules The rules to check. List with "rule", "rule_any", "except" and
@@ -138,8 +148,7 @@ end
 function rules.matching_rules(c, _rules)
     local result = {}
     for _, entry in ipairs(_rules) do
-        if (rules.match(c, entry.rule) or rules.match_any(c, entry.rule_any)) and
-            (not rules.match(c, entry.except) and not rules.match_any(c, entry.except_any)) then
+        if (rules.matches(c, entry)) then
             table.insert(result, entry)
         end
     end
@@ -148,12 +157,16 @@ end
 
 --- Check if a client matches a given set of rules.
 -- @client c The client.
--- @tab _rules The rules to check. List with "rule", "rule_any", "except" and
---            "except_any" keys.
+-- @tab _rules The rules to check. List of tables with `rule`, `rule_any`,
+--   `except` and `except_any` keys.
 -- @treturn bool True if at least one rule is matched, false otherwise.
-function rules.does_match(c, _rules)
-    local result = rules.matching_rules(c, _rules)
-    return #result == 0 and false or result
+function rules.matches_list(c, _rules)
+    for _, entry in ipairs(_rules) do
+        if (rules.matches(c, entry)) then
+            return true
+        end
+    end
+    return false
 end
 
 --- Apply awful.rules.rules to a client.

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -148,11 +148,11 @@ end
 
 --- Check if a client matches a given set of rules.
 -- @client c The client.
--- @tab rules The rules to check. List with "rule", "rule_any", "except" and
+-- @tab _rules The rules to check. List with "rule", "rule_any", "except" and
 --            "except_any" keys.
 -- @treturn bool True if at least one rule is matched, false otherwise.
-function rules.does_match(c, rules)
-    local result = rules.matching_rules(c, rules)
+function rules.does_match(c, _rules)
+    local result = rules.matching_rules(c, _rules)
     return #result == 0 and false or result
 end
 


### PR DESCRIPTION
This includes a fix (https://github.com/awesomeWM/awesome/commit/eb01e969f68ca577224bdf8693c5d13c5211be04) and some refactoring / improvement.

I am not sure about the new method name `entry_matches`.
There is `does_match` already for a list of rules, although it has never been working apparently (added in adbc7ac).

Maybe we could use `matches` and `list_matches`?