### PR TITLE
keyboardlayout: Extend allowable 'group_names' pattern range

### DIFF
--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -17,58 +17,261 @@ local widget_base = require("wibox.widget.base")
 -- awful.widget.keyboardlayout
 local keyboardlayout = { mt = {} }
 
+-- As to the country-code-like symbols below, refer to the names of XKB's
+-- data files in /.../xkb/symbols/*.
+keyboardlayout.xkeyboard_country_code = {
+   ["ad"] = true,    -- Andorra
+   ["af"] = true,    -- Afganistan
+   ["al"] = true,    -- Albania
+   ["am"] = true,    -- Armenia
+   ["ara"] = true,   -- Arabic
+   ["at"] = true,    -- Austria
+   ["az"] = true,    -- Azerbaijan
+   ["ba"] = true,    -- Bosnia and Herzegovina
+   ["bd"] = true,    -- Bangladesh
+   ["be"] = true,    -- Belgium
+   ["bg"] = true,    -- Bulgaria
+   ["br"] = true,    -- Brazil
+   ["bt"] = true,    -- Bhutan
+   ["bw"] = true,    -- Botswana
+   ["by"] = true,    -- Belarus
+   ["ca"] = true,    -- Canada
+   ["cd"] = true,    -- Congo
+   ["ch"] = true,    -- Switzerland
+   ["cm"] = true,    -- Cameroon
+   ["cn"] = true,    -- China
+   ["cz"] = true,    -- Czechia
+   ["de"] = true,    -- Germany
+   ["dk"] = true,    -- Denmark
+   ["ee"] = true,    -- Estonia
+   ["epo"] = true,   -- Esperanto
+   ["es"] = true,    -- Spain
+   ["et"] = true,    -- Ethiopia
+   ["fi"] = true,    -- Finland
+   ["fo"] = true,    -- Faroe Islands
+   ["fr"] = true,    -- France
+   ["gb"] = true,    -- United Kingdom
+   ["ge"] = true,    -- Georgia
+   ["gh"] = true,    -- Ghana
+   ["gn"] = true,    -- Guinea
+   ["gr"] = true,    -- Greece
+   ["hr"] = true,    -- Croatia
+   ["hu"] = true,    -- Hungary
+   ["ie"] = true,    -- Ireland
+   ["il"] = true,    -- Israel
+   ["in"] = true,    -- India
+   ["iq"] = true,    -- Iraq
+   ["ir"] = true,    -- Iran
+   ["is"] = true,    -- Iceland
+   ["it"] = true,    -- Italy
+   ["jp"] = true,    -- Japan
+   ["ke"] = true,    -- Kenya
+   ["kg"] = true,    -- Kyrgyzstan
+   ["kh"] = true,    -- Cambodia
+   ["kr"] = true,    -- Korea
+   ["kz"] = true,    -- Kazakhstan
+   ["la"] = true,    -- Laos
+   ["latam"] = true, -- Latin America
+   ["latin"] = true, -- Latin
+   ["lk"] = true,    -- Sri Lanka
+   ["lt"] = true,    -- Lithuania
+   ["lv"] = true,    -- Latvia
+   ["ma"] = true,    -- Morocco
+   ["mao"] = true,   -- Maori
+   ["me"] = true,    -- Montenegro
+   ["mk"] = true,    -- Macedonia
+   ["ml"] = true,    -- Mali
+   ["mm"] = true,    -- Myanmar
+   ["mn"] = true,    -- Mongolia
+   ["mt"] = true,    -- Malta
+   ["mv"] = true,    -- Maldives
+   ["ng"] = true,    -- Nigeria
+   ["nl"] = true,    -- Netherlands
+   ["no"] = true,    -- Norway
+   ["np"] = true,    -- Nepal
+   ["ph"] = true,    -- Philippines
+   ["pk"] = true,    -- Pakistan
+   ["pl"] = true,    -- Poland
+   ["pt"] = true,    -- Portugal
+   ["ro"] = true,    -- Romania
+   ["rs"] = true,    -- Serbia
+   ["ru"] = true,    -- Russia
+   ["se"] = true,    -- Sweden
+   ["si"] = true,    -- Slovenia
+   ["sk"] = true,    -- Slovakia
+   ["sn"] = true,    -- Senegal
+   ["sy"] = true,    -- Syria
+   ["th"] = true,    -- Thailand
+   ["tj"] = true,    -- Tajikistan
+   ["tm"] = true,    -- Turkmenistan
+   ["tr"] = true,    -- Turkey
+   ["tw"] = true,    -- Taiwan
+   ["tz"] = true,    -- Tanzania
+   ["ua"] = true,    -- Ukraine
+   ["us"] = true,    -- USA
+   ["uz"] = true,    -- Uzbekistan
+   ["vn"] = true,    -- Vietnam
+   ["za"] = true,    -- South Africa
+}
+
 -- Callback for updaing current layout
-local function update_status (keyboardlayout)
-   keyboardlayout._current = awesome.xkb_get_layout_group();
+local function update_status (self)
+   self._current = awesome.xkb_get_layout_group();
    local text = ""
-   if (#keyboardlayout._layout > 0) then
-      text = (" " .. keyboardlayout._layout[keyboardlayout._current] .. " ")
+   if (#self._layout > 0) then
+      text = (" " .. self._layout[self._current] .. " ")
    end
-   keyboardlayout.widget:set_text(text)
+   self.widget:set_text(text)
+end
+
+--- Auxiliary function for the local function update_layout().
+-- Create an array whose element is a table consisting of the four fields:
+-- vendor, file, section and group_idx, which all correspond to the
+-- xkb_symbols pattern "vendor/file(section):group_idx".
+-- @tparam string group_names The string awesome.xkb_get_group_names() returns.
+-- @treturn table An array of tables whose keys are vendor, file, section, and group_idx.
+function keyboardlayout.get_groups_from_group_names(group_names)
+   if group_names == nil then
+      return nil
+   end
+
+   -- Pattern elements to be captured.
+   local word_pat = "([%w_]+)"
+   local sec_pat = "(%b())"
+   local idx_pat = ":(%d)"
+   -- Pairs of a pattern and its callback.  In callbacks, set 'group_idx' to 1
+   -- and return it if there's no specification on 'group_idx' in the given
+   -- pattern.
+   local pattern_and_callback_pairs = {
+      -- vendor/file(section):group_idx
+      ["^" .. word_pat .. "/" .. word_pat .. sec_pat .. idx_pat .. "$"]
+         = function(token, pattern)
+            local vendor, file, section, group_idx = string.match(token, pattern)
+            return vendor, file, section, group_idx
+         end,
+      -- vendor/file(section)
+      ["^" .. word_pat .. "/" .. word_pat .. sec_pat .. "$"]
+         = function(token, pattern)
+            local vendor, file, section = string.match(token, pattern)
+            return vendor, file, section, 1
+         end,
+      -- vendor/file:group_idx
+      ["^" .. word_pat .. "/" .. word_pat .. idx_pat .. "$"]
+         = function(token, pattern)
+            local vendor, file, group_idx = string.match(token, pattern)
+            return vendor, file, nil, group_idx
+         end,
+      -- vendor/file
+      ["^" .. word_pat .. "/" .. word_pat .. "$"]
+         = function(token, pattern)
+            local vendor, file = string.match(token, pattern)
+            return vendor, file, nil, 1
+         end,
+      --  file(section):group_idx
+      ["^" .. word_pat .. sec_pat .. idx_pat .. "$"]
+         = function(token, pattern)
+            local file, section, group_idx = string.match(token, pattern)
+            return nil, file, section, group_idx
+         end,
+      -- file(section)
+      ["^" .. word_pat .. sec_pat .. "$"]
+         = function(token, pattern)
+            local file, section = string.match(token, pattern)
+            return nil, file, section, 1
+         end,
+      -- file:group_idx
+      ["^" .. word_pat .. idx_pat .. "$"]
+         = function(token, pattern)
+            local file, group_idx = string.match(token, pattern)
+            return nil, file, nil, group_idx
+         end,
+      -- file
+      ["^" .. word_pat .. "$"]
+         = function(token, pattern)
+            local file = string.match(token, pattern)
+            return nil, file, nil, 1
+         end
+      }
+
+   -- Split 'group_names' into 'tokens'.  The separator is "+".
+   local tokens = {}
+   string.gsub(group_names, "[^+]+", function(match)
+      table.insert(tokens, match)
+   end)
+
+   -- For each token in 'tokens', check if it matches one of the patterns in
+   -- the array 'pattern_and_callback_pairs', where the patterns are used as
+   -- key.  If a match is found, extract captured strings using the
+   -- corresponding callback function.  Check if those extracted is country
+   -- specific part of a layout.  If so, add it to 'layout_groups'; otherwise,
+   -- ignore it.
+   local layout_groups = {}
+   for i = 1, #tokens do
+      for pattern, callback in pairs(pattern_and_callback_pairs) do
+         local vendor, file, section, group_idx = callback(tokens[i], pattern)
+         if file then
+            if not keyboardlayout.xkeyboard_country_code[file] then
+               break
+            end
+
+            if section then
+               section = string.gsub(section, "%(([%w_]+)%)", "%1")
+            end
+
+            table.insert(layout_groups, { vendor = vendor,
+                                          file = file,
+                                          section = section,
+                                          group_idx = tonumber(group_idx) })
+            break
+         end
+      end
+   end
+
+   return layout_groups
 end
 
 -- Callback for updating list of layouts
-local function update_layout(keyboardlayout)
-   keyboardlayout._layout = {};
-   local group_names = awesome.xkb_get_group_names();
-
--- A typical layout string looks like "pc+us+ru:2+de:3+ba:4+inet",
--- and we want to get only three matches: "us", "ru:2", "de:3" "ba:4".
--- Please note that numbers of groups reported by xkb_get_group_names
--- is greater by one than the real group number.
-   local first_group = string.match(group_names, "+(%a+)");
-   if (not first_group) then
-      error ("Failed to get list of keyboard groups");
+local function update_layout(self)
+   self._layout = {};
+   local layouts = keyboardlayout.get_groups_from_group_names(awesome.xkb_get_group_names())
+   if layouts == nil or layouts[1] == nil then
+      error("Failed to get list of keyboard groups")
       return;
    end
-   keyboardlayout._layout[0] = first_group;
-
-   for name, number_str in string.gmatch(group_names, "+(%a+):(%d)") do
-      group = tonumber(number_str);
-      keyboardlayout._layout[group - 1] = name;
+   if #layouts == 1 then
+      layouts[1].group_idx = 0
    end
-   update_status(keyboardlayout)
+   for _, v in ipairs(layouts) do
+      local layout_name = v.file
+      if v.section ~= nil then
+         layout_name = layout_name .. "(" .. v.section .. ")"
+      end
+      -- Please note that numbers of groups reported by xkb_get_group_names
+      -- is greater by one than the real group number.
+      self._layout[v.group_idx - 1] = layout_name
+   end
+   update_status(self)
 end
 
 --- Create a keyboard layout widget. It shows current keyboard layout name in a textbox.
 -- @return A keyboard layout widget.
 function keyboardlayout.new()
    local widget = textbox()
-   local keyboardlayout = widget_base.make_widget(widget)
+   local self = widget_base.make_widget(widget)
 
-   keyboardlayout.widget = widget
+   self.widget = widget
 
-   update_layout(keyboardlayout);
+   update_layout(self);
 
-   keyboardlayout.next_layout = function()
-      new_layout = (keyboardlayout._current + 1) % (#keyboardlayout._layout + 1)
-      keyboardlayout.set_layout(new_layout)
+   self.next_layout = function()
+      new_layout = (self._current + 1) % (#self._layout + 1)
+      self.set_layout(new_layout)
    end
 
-   keyboardlayout.set_layout = function(group_number)
-      if (0 > group_number) or (group_number > #keyboardlayout._layout) then
+   self.set_layout = function(group_number)
+      if (0 > group_number) or (group_number > #self._layout) then
          error("Invalid group number: " .. group_number ..
-                  "expected number from 0 to " .. #keyboardlayout._layout)
+                  "expected number from 0 to " .. #self._layout)
          return;
       end
       awesome.xkb_set_layout_group(group_number);
@@ -76,16 +279,16 @@ function keyboardlayout.new()
 
    -- callback for processing layout changes
    capi.awesome.connect_signal("xkb::map_changed",
-                               function () update_layout(keyboardlayout) end)
+                               function () update_layout(self) end)
    capi.awesome.connect_signal("xkb::group_changed",
-                               function () update_status(keyboardlayout) end);
+                               function () update_status(self) end);
 
    -- Mouse bindings
-   keyboardlayout:buttons(
-      util.table.join(button({ }, 1, keyboardlayout.next_layout))
+   self:buttons(
+      util.table.join(button({ }, 1, self.next_layout))
    )
 
-   return keyboardlayout
+   return self
 end
 
 local _instance = nil;

--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -20,108 +20,108 @@ local keyboardlayout = { mt = {} }
 -- As to the country-code-like symbols below, refer to the names of XKB's
 -- data files in /.../xkb/symbols/*.
 keyboardlayout.xkeyboard_country_code = {
-   ["ad"] = true,    -- Andorra
-   ["af"] = true,    -- Afganistan
-   ["al"] = true,    -- Albania
-   ["am"] = true,    -- Armenia
-   ["ara"] = true,   -- Arabic
-   ["at"] = true,    -- Austria
-   ["az"] = true,    -- Azerbaijan
-   ["ba"] = true,    -- Bosnia and Herzegovina
-   ["bd"] = true,    -- Bangladesh
-   ["be"] = true,    -- Belgium
-   ["bg"] = true,    -- Bulgaria
-   ["br"] = true,    -- Brazil
-   ["bt"] = true,    -- Bhutan
-   ["bw"] = true,    -- Botswana
-   ["by"] = true,    -- Belarus
-   ["ca"] = true,    -- Canada
-   ["cd"] = true,    -- Congo
-   ["ch"] = true,    -- Switzerland
-   ["cm"] = true,    -- Cameroon
-   ["cn"] = true,    -- China
-   ["cz"] = true,    -- Czechia
-   ["de"] = true,    -- Germany
-   ["dk"] = true,    -- Denmark
-   ["ee"] = true,    -- Estonia
-   ["epo"] = true,   -- Esperanto
-   ["es"] = true,    -- Spain
-   ["et"] = true,    -- Ethiopia
-   ["fi"] = true,    -- Finland
-   ["fo"] = true,    -- Faroe Islands
-   ["fr"] = true,    -- France
-   ["gb"] = true,    -- United Kingdom
-   ["ge"] = true,    -- Georgia
-   ["gh"] = true,    -- Ghana
-   ["gn"] = true,    -- Guinea
-   ["gr"] = true,    -- Greece
-   ["hr"] = true,    -- Croatia
-   ["hu"] = true,    -- Hungary
-   ["ie"] = true,    -- Ireland
-   ["il"] = true,    -- Israel
-   ["in"] = true,    -- India
-   ["iq"] = true,    -- Iraq
-   ["ir"] = true,    -- Iran
-   ["is"] = true,    -- Iceland
-   ["it"] = true,    -- Italy
-   ["jp"] = true,    -- Japan
-   ["ke"] = true,    -- Kenya
-   ["kg"] = true,    -- Kyrgyzstan
-   ["kh"] = true,    -- Cambodia
-   ["kr"] = true,    -- Korea
-   ["kz"] = true,    -- Kazakhstan
-   ["la"] = true,    -- Laos
-   ["latam"] = true, -- Latin America
-   ["latin"] = true, -- Latin
-   ["lk"] = true,    -- Sri Lanka
-   ["lt"] = true,    -- Lithuania
-   ["lv"] = true,    -- Latvia
-   ["ma"] = true,    -- Morocco
-   ["mao"] = true,   -- Maori
-   ["me"] = true,    -- Montenegro
-   ["mk"] = true,    -- Macedonia
-   ["ml"] = true,    -- Mali
-   ["mm"] = true,    -- Myanmar
-   ["mn"] = true,    -- Mongolia
-   ["mt"] = true,    -- Malta
-   ["mv"] = true,    -- Maldives
-   ["ng"] = true,    -- Nigeria
-   ["nl"] = true,    -- Netherlands
-   ["no"] = true,    -- Norway
-   ["np"] = true,    -- Nepal
-   ["ph"] = true,    -- Philippines
-   ["pk"] = true,    -- Pakistan
-   ["pl"] = true,    -- Poland
-   ["pt"] = true,    -- Portugal
-   ["ro"] = true,    -- Romania
-   ["rs"] = true,    -- Serbia
-   ["ru"] = true,    -- Russia
-   ["se"] = true,    -- Sweden
-   ["si"] = true,    -- Slovenia
-   ["sk"] = true,    -- Slovakia
-   ["sn"] = true,    -- Senegal
-   ["sy"] = true,    -- Syria
-   ["th"] = true,    -- Thailand
-   ["tj"] = true,    -- Tajikistan
-   ["tm"] = true,    -- Turkmenistan
-   ["tr"] = true,    -- Turkey
-   ["tw"] = true,    -- Taiwan
-   ["tz"] = true,    -- Tanzania
-   ["ua"] = true,    -- Ukraine
-   ["us"] = true,    -- USA
-   ["uz"] = true,    -- Uzbekistan
-   ["vn"] = true,    -- Vietnam
-   ["za"] = true,    -- South Africa
+    ["ad"] = true,    -- Andorra
+    ["af"] = true,    -- Afganistan
+    ["al"] = true,    -- Albania
+    ["am"] = true,    -- Armenia
+    ["ara"] = true,   -- Arabic
+    ["at"] = true,    -- Austria
+    ["az"] = true,    -- Azerbaijan
+    ["ba"] = true,    -- Bosnia and Herzegovina
+    ["bd"] = true,    -- Bangladesh
+    ["be"] = true,    -- Belgium
+    ["bg"] = true,    -- Bulgaria
+    ["br"] = true,    -- Brazil
+    ["bt"] = true,    -- Bhutan
+    ["bw"] = true,    -- Botswana
+    ["by"] = true,    -- Belarus
+    ["ca"] = true,    -- Canada
+    ["cd"] = true,    -- Congo
+    ["ch"] = true,    -- Switzerland
+    ["cm"] = true,    -- Cameroon
+    ["cn"] = true,    -- China
+    ["cz"] = true,    -- Czechia
+    ["de"] = true,    -- Germany
+    ["dk"] = true,    -- Denmark
+    ["ee"] = true,    -- Estonia
+    ["epo"] = true,   -- Esperanto
+    ["es"] = true,    -- Spain
+    ["et"] = true,    -- Ethiopia
+    ["fi"] = true,    -- Finland
+    ["fo"] = true,    -- Faroe Islands
+    ["fr"] = true,    -- France
+    ["gb"] = true,    -- United Kingdom
+    ["ge"] = true,    -- Georgia
+    ["gh"] = true,    -- Ghana
+    ["gn"] = true,    -- Guinea
+    ["gr"] = true,    -- Greece
+    ["hr"] = true,    -- Croatia
+    ["hu"] = true,    -- Hungary
+    ["ie"] = true,    -- Ireland
+    ["il"] = true,    -- Israel
+    ["in"] = true,    -- India
+    ["iq"] = true,    -- Iraq
+    ["ir"] = true,    -- Iran
+    ["is"] = true,    -- Iceland
+    ["it"] = true,    -- Italy
+    ["jp"] = true,    -- Japan
+    ["ke"] = true,    -- Kenya
+    ["kg"] = true,    -- Kyrgyzstan
+    ["kh"] = true,    -- Cambodia
+    ["kr"] = true,    -- Korea
+    ["kz"] = true,    -- Kazakhstan
+    ["la"] = true,    -- Laos
+    ["latam"] = true, -- Latin America
+    ["latin"] = true, -- Latin
+    ["lk"] = true,    -- Sri Lanka
+    ["lt"] = true,    -- Lithuania
+    ["lv"] = true,    -- Latvia
+    ["ma"] = true,    -- Morocco
+    ["mao"] = true,   -- Maori
+    ["me"] = true,    -- Montenegro
+    ["mk"] = true,    -- Macedonia
+    ["ml"] = true,    -- Mali
+    ["mm"] = true,    -- Myanmar
+    ["mn"] = true,    -- Mongolia
+    ["mt"] = true,    -- Malta
+    ["mv"] = true,    -- Maldives
+    ["ng"] = true,    -- Nigeria
+    ["nl"] = true,    -- Netherlands
+    ["no"] = true,    -- Norway
+    ["np"] = true,    -- Nepal
+    ["ph"] = true,    -- Philippines
+    ["pk"] = true,    -- Pakistan
+    ["pl"] = true,    -- Poland
+    ["pt"] = true,    -- Portugal
+    ["ro"] = true,    -- Romania
+    ["rs"] = true,    -- Serbia
+    ["ru"] = true,    -- Russia
+    ["se"] = true,    -- Sweden
+    ["si"] = true,    -- Slovenia
+    ["sk"] = true,    -- Slovakia
+    ["sn"] = true,    -- Senegal
+    ["sy"] = true,    -- Syria
+    ["th"] = true,    -- Thailand
+    ["tj"] = true,    -- Tajikistan
+    ["tm"] = true,    -- Turkmenistan
+    ["tr"] = true,    -- Turkey
+    ["tw"] = true,    -- Taiwan
+    ["tz"] = true,    -- Tanzania
+    ["ua"] = true,    -- Ukraine
+    ["us"] = true,    -- USA
+    ["uz"] = true,    -- Uzbekistan
+    ["vn"] = true,    -- Vietnam
+    ["za"] = true,    -- South Africa
 }
 
 -- Callback for updaing current layout
 local function update_status (self)
-   self._current = awesome.xkb_get_layout_group();
-   local text = ""
-   if (#self._layout > 0) then
-      text = (" " .. self._layout[self._current] .. " ")
-   end
-   self.widget:set_text(text)
+    self._current = awesome.xkb_get_layout_group();
+    local text = ""
+    if (#self._layout > 0) then
+        text = (" " .. self._layout[self._current] .. " ")
+    end
+    self.widget:set_text(text)
 end
 
 --- Auxiliary function for the local function update_layout().
@@ -131,173 +131,173 @@ end
 -- @tparam string group_names The string awesome.xkb_get_group_names() returns.
 -- @treturn table An array of tables whose keys are vendor, file, section, and group_idx.
 function keyboardlayout.get_groups_from_group_names(group_names)
-   if group_names == nil then
-      return nil
-   end
+    if group_names == nil then
+        return nil
+    end
 
-   -- Pattern elements to be captured.
-   local word_pat = "([%w_]+)"
-   local sec_pat = "(%b())"
-   local idx_pat = ":(%d)"
-   -- Pairs of a pattern and its callback.  In callbacks, set 'group_idx' to 1
-   -- and return it if there's no specification on 'group_idx' in the given
-   -- pattern.
-   local pattern_and_callback_pairs = {
-      -- vendor/file(section):group_idx
-      ["^" .. word_pat .. "/" .. word_pat .. sec_pat .. idx_pat .. "$"]
-         = function(token, pattern)
-            local vendor, file, section, group_idx = string.match(token, pattern)
-            return vendor, file, section, group_idx
-         end,
-      -- vendor/file(section)
-      ["^" .. word_pat .. "/" .. word_pat .. sec_pat .. "$"]
-         = function(token, pattern)
-            local vendor, file, section = string.match(token, pattern)
-            return vendor, file, section, 1
-         end,
-      -- vendor/file:group_idx
-      ["^" .. word_pat .. "/" .. word_pat .. idx_pat .. "$"]
-         = function(token, pattern)
-            local vendor, file, group_idx = string.match(token, pattern)
-            return vendor, file, nil, group_idx
-         end,
-      -- vendor/file
-      ["^" .. word_pat .. "/" .. word_pat .. "$"]
-         = function(token, pattern)
-            local vendor, file = string.match(token, pattern)
-            return vendor, file, nil, 1
-         end,
-      --  file(section):group_idx
-      ["^" .. word_pat .. sec_pat .. idx_pat .. "$"]
-         = function(token, pattern)
-            local file, section, group_idx = string.match(token, pattern)
-            return nil, file, section, group_idx
-         end,
-      -- file(section)
-      ["^" .. word_pat .. sec_pat .. "$"]
-         = function(token, pattern)
-            local file, section = string.match(token, pattern)
-            return nil, file, section, 1
-         end,
-      -- file:group_idx
-      ["^" .. word_pat .. idx_pat .. "$"]
-         = function(token, pattern)
-            local file, group_idx = string.match(token, pattern)
-            return nil, file, nil, group_idx
-         end,
-      -- file
-      ["^" .. word_pat .. "$"]
-         = function(token, pattern)
-            local file = string.match(token, pattern)
-            return nil, file, nil, 1
-         end
-      }
-
-   -- Split 'group_names' into 'tokens'.  The separator is "+".
-   local tokens = {}
-   string.gsub(group_names, "[^+]+", function(match)
-      table.insert(tokens, match)
-   end)
-
-   -- For each token in 'tokens', check if it matches one of the patterns in
-   -- the array 'pattern_and_callback_pairs', where the patterns are used as
-   -- key.  If a match is found, extract captured strings using the
-   -- corresponding callback function.  Check if those extracted is country
-   -- specific part of a layout.  If so, add it to 'layout_groups'; otherwise,
-   -- ignore it.
-   local layout_groups = {}
-   for i = 1, #tokens do
-      for pattern, callback in pairs(pattern_and_callback_pairs) do
-         local vendor, file, section, group_idx = callback(tokens[i], pattern)
-         if file then
-            if not keyboardlayout.xkeyboard_country_code[file] then
-               break
+    -- Pattern elements to be captured.
+    local word_pat = "([%w_]+)"
+    local sec_pat = "(%b())"
+    local idx_pat = ":(%d)"
+    -- Pairs of a pattern and its callback.  In callbacks, set 'group_idx' to 1
+    -- and return it if there's no specification on 'group_idx' in the given
+    -- pattern.
+    local pattern_and_callback_pairs = {
+        -- vendor/file(section):group_idx
+        ["^" .. word_pat .. "/" .. word_pat .. sec_pat .. idx_pat .. "$"]
+            = function(token, pattern)
+                local vendor, file, section, group_idx = string.match(token, pattern)
+                return vendor, file, section, group_idx
+            end,
+        -- vendor/file(section)
+        ["^" .. word_pat .. "/" .. word_pat .. sec_pat .. "$"]
+            = function(token, pattern)
+                local vendor, file, section = string.match(token, pattern)
+                return vendor, file, section, 1
+            end,
+        -- vendor/file:group_idx
+        ["^" .. word_pat .. "/" .. word_pat .. idx_pat .. "$"]
+            = function(token, pattern)
+                local vendor, file, group_idx = string.match(token, pattern)
+                return vendor, file, nil, group_idx
+            end,
+        -- vendor/file
+        ["^" .. word_pat .. "/" .. word_pat .. "$"]
+            = function(token, pattern)
+                local vendor, file = string.match(token, pattern)
+                return vendor, file, nil, 1
+            end,
+        --  file(section):group_idx
+        ["^" .. word_pat .. sec_pat .. idx_pat .. "$"]
+            = function(token, pattern)
+                local file, section, group_idx = string.match(token, pattern)
+                return nil, file, section, group_idx
+            end,
+        -- file(section)
+        ["^" .. word_pat .. sec_pat .. "$"]
+            = function(token, pattern)
+                local file, section = string.match(token, pattern)
+                return nil, file, section, 1
+            end,
+        -- file:group_idx
+        ["^" .. word_pat .. idx_pat .. "$"]
+            = function(token, pattern)
+                local file, group_idx = string.match(token, pattern)
+                return nil, file, nil, group_idx
+            end,
+        -- file
+        ["^" .. word_pat .. "$"]
+            = function(token, pattern)
+                local file = string.match(token, pattern)
+                return nil, file, nil, 1
             end
+    }
 
-            if section then
-               section = string.gsub(section, "%(([%w_]+)%)", "%1")
+    -- Split 'group_names' into 'tokens'.  The separator is "+".
+    local tokens = {}
+    string.gsub(group_names, "[^+]+", function(match)
+        table.insert(tokens, match)
+    end)
+
+    -- For each token in 'tokens', check if it matches one of the patterns in
+    -- the array 'pattern_and_callback_pairs', where the patterns are used as
+    -- key.  If a match is found, extract captured strings using the
+    -- corresponding callback function.  Check if those extracted is country
+    -- specific part of a layout.  If so, add it to 'layout_groups'; otherwise,
+    -- ignore it.
+    local layout_groups = {}
+    for i = 1, #tokens do
+        for pattern, callback in pairs(pattern_and_callback_pairs) do
+            local vendor, file, section, group_idx = callback(tokens[i], pattern)
+            if file then
+                if not keyboardlayout.xkeyboard_country_code[file] then
+                    break
+                end
+
+                if section then
+                    section = string.gsub(section, "%(([%w_]+)%)", "%1")
+                end
+
+                table.insert(layout_groups, { vendor = vendor,
+                                              file = file,
+                                              section = section,
+                                              group_idx = tonumber(group_idx) })
+                break
             end
+        end
+    end
 
-            table.insert(layout_groups, { vendor = vendor,
-                                          file = file,
-                                          section = section,
-                                          group_idx = tonumber(group_idx) })
-            break
-         end
-      end
-   end
-
-   return layout_groups
+    return layout_groups
 end
 
 -- Callback for updating list of layouts
 local function update_layout(self)
-   self._layout = {};
-   local layouts = keyboardlayout.get_groups_from_group_names(awesome.xkb_get_group_names())
-   if layouts == nil or layouts[1] == nil then
-      error("Failed to get list of keyboard groups")
-      return;
-   end
-   if #layouts == 1 then
-      layouts[1].group_idx = 0
-   end
-   for _, v in ipairs(layouts) do
-      local layout_name = v.file
-      if v.section ~= nil then
-         layout_name = layout_name .. "(" .. v.section .. ")"
-      end
-      -- Please note that numbers of groups reported by xkb_get_group_names
-      -- is greater by one than the real group number.
-      self._layout[v.group_idx - 1] = layout_name
-   end
-   update_status(self)
+    self._layout = {};
+    local layouts = keyboardlayout.get_groups_from_group_names(awesome.xkb_get_group_names())
+    if layouts == nil or layouts[1] == nil then
+        error("Failed to get list of keyboard groups")
+        return;
+    end
+    if #layouts == 1 then
+        layouts[1].group_idx = 0
+    end
+    for _, v in ipairs(layouts) do
+        local layout_name = v.file
+        if v.section ~= nil then
+            layout_name = layout_name .. "(" .. v.section .. ")"
+        end
+        -- Please note that numbers of groups reported by xkb_get_group_names
+        -- is greater by one than the real group number.
+        self._layout[v.group_idx - 1] = layout_name
+    end
+    update_status(self)
 end
 
 --- Create a keyboard layout widget. It shows current keyboard layout name in a textbox.
 -- @return A keyboard layout widget.
 function keyboardlayout.new()
-   local widget = textbox()
-   local self = widget_base.make_widget(widget)
+    local widget = textbox()
+    local self = widget_base.make_widget(widget)
 
-   self.widget = widget
+    self.widget = widget
 
-   update_layout(self);
+    update_layout(self);
 
-   self.next_layout = function()
-      new_layout = (self._current + 1) % (#self._layout + 1)
-      self.set_layout(new_layout)
-   end
+    self.next_layout = function()
+        new_layout = (self._current + 1) % (#self._layout + 1)
+        self.set_layout(new_layout)
+    end
 
-   self.set_layout = function(group_number)
-      if (0 > group_number) or (group_number > #self._layout) then
-         error("Invalid group number: " .. group_number ..
-                  "expected number from 0 to " .. #self._layout)
-         return;
-      end
-      awesome.xkb_set_layout_group(group_number);
-   end
+    self.set_layout = function(group_number)
+        if (0 > group_number) or (group_number > #self._layout) then
+            error("Invalid group number: " .. group_number ..
+                    "expected number from 0 to " .. #self._layout)
+            return;
+        end
+        awesome.xkb_set_layout_group(group_number);
+    end
 
-   -- callback for processing layout changes
-   capi.awesome.connect_signal("xkb::map_changed",
-                               function () update_layout(self) end)
-   capi.awesome.connect_signal("xkb::group_changed",
-                               function () update_status(self) end);
+    -- callback for processing layout changes
+    capi.awesome.connect_signal("xkb::map_changed",
+                                function () update_layout(self) end)
+    capi.awesome.connect_signal("xkb::group_changed",
+                                function () update_status(self) end);
 
-   -- Mouse bindings
-   self:buttons(
-      util.table.join(button({ }, 1, self.next_layout))
-   )
+    -- Mouse bindings
+    self:buttons(
+        util.table.join(button({ }, 1, self.next_layout))
+    )
 
-   return self
+    return self
 end
 
 local _instance = nil;
 
 function keyboardlayout.mt:__call(...)
-   if _instance == nil then
-      _instance = keyboardlayout.new(...)
-   end
-   return _instance
+    if _instance == nil then
+        _instance = keyboardlayout.new(...)
+    end
+    return _instance
 end
 
 return setmetatable(keyboardlayout, keyboardlayout.mt)

--- a/spec/awful/keyboardlayout_spec.lua
+++ b/spec/awful/keyboardlayout_spec.lua
@@ -1,0 +1,97 @@
+---------------------------------------------------------------------------
+-- @author Uli Schlachter
+-- @copyright 2015 Uli Schlachter and Kazunobu Kuriyama
+---------------------------------------------------------------------------
+
+-- Hack so that beautiful can be loaded
+_G.awesome = {
+    xrdb_get_value = function() end
+}
+
+local kb = require("awful.widget.keyboardlayout")
+
+describe("awful.widget.keyboardlayout get_groups_from_group_names", function()
+    it("nil", function()
+        assert.is_nil(kb.get_groups_from_group_names(nil))
+    end)
+
+    local tests = {
+        -- possible worst cases
+        [""] = {
+        },
+        ["empty"] = {
+        },
+        ["empty(basic)"] = {
+        },
+        -- contrived cases for robustness test
+        ["pc()+de+jp+group()"] = {
+            { file = "de", group_idx = 1 },
+            { file = "jp", group_idx = 1 }
+        },
+        -- possible eight variations of a single term
+        ["de"] = {
+            { file = "de", group_idx = 1 }
+        },
+        ["de:2" ] = {
+            { file = "de", group_idx = 2 }
+        },
+        ["de(nodeadkeys)"] = {
+            { file = "de", group_idx = 1, section = "nodeadkeys" }
+        },
+        ["de(nodeadkeys):2"] = {
+            { file = "de", group_idx = 2, section = "nodeadkeys" }
+        },
+        ["macintosh_vndr/de"] = {
+            { file = "de", group_idx = 1, vendor = "macintosh_vndr" }
+        },
+        ["macintosh_vndr/de:2"] = {
+            { file = "de", group_idx = 2, vendor = "macintosh_vndr" }
+        },
+        ["macintosh_vndr/de(nodeadkeys)"] = {
+            { file = "de", group_idx = 1, vendor = "macintosh_vndr", section = "nodeadkeys" }
+        },
+        ["macintosh_vndr/de(nodeadkeys):2"] = {
+            { file = "de", group_idx = 2, vendor = "macintosh_vndr", section = "nodeadkeys" }
+        },
+        -- multiple terms
+        ["pc+de"] = {
+            { file = "de", group_idx = 1 }
+        },
+        ["pc+us+inet(evdev)+terminate(ctrl_alt_bksp)"] = {
+            { file = "us", group_idx = 1 }
+        },
+        ["pc(pc105)+us+group(caps_toggle)+group(ctrl_ac)"] = {
+            { file = "us", group_idx = 1 }
+        },
+        ["pc+us(intl)+inet(evdev)+group(win_switch)"] = {
+            { file = "us", group_idx = 1, section = "intl" }
+        },
+
+        ["macintosh_vndr/apple(alukbd)+macintosh_vndr/jp(usmac)"] = {
+            { file = "jp", group_idx = 1, vendor = "macintosh_vndr", section = "usmac" },
+        },
+        -- multiple layouts
+        ["pc+jp+us:2+inet(evdev)+capslock(hyper)"] = {
+            { file = "jp", group_idx = 1 },
+            { file = "us", group_idx = 2 }
+        },
+        ["pc+us+ru:2+de:3+ba:4+inet"] = {
+            { file = "us", group_idx = 1 },
+            { file = "ru", group_idx = 2 },
+            { file = "de", group_idx = 3 },
+            { file = "ba", group_idx = 4 },
+        },
+        ["macintosh_vndr/apple(alukbd)+macintosh_vndr/jp(usmac)+macintosh_vndr/jp(mac):2+group(shifts_toggle)"] = {
+            { file = "jp", group_idx = 1, vendor = "macintosh_vndr", section = "usmac" },
+            { file = "jp", group_idx = 2, vendor = "macintosh_vndr", section = "mac" },
+        },
+    }
+
+    for arg, expected in pairs(tests) do
+        it(arg, function()
+            assert.is.same(expected, kb.get_groups_from_group_names(arg))
+        end)
+    end
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Extend the range of the 'group_names' patterns which is currently
restricted to typical ones like

    pc+us+ru:2+de:3+ba:4+inet

to more general ones such as

    macintosh_vndr/apple(alukbd)+macintosh_vndr/jp(usmac)+macintosh_vndr/jp(mac):2

so that the keyboardlayout widget can handles all possible patterns
returned by awesome.xkb_get_layout_group().