### PR TITLE
placement.no_offscreen: add optional screen argument

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -105,11 +105,12 @@ end
 
 --- Place the client so no part of it will be outside the screen (workarea).
 -- @client c The client.
+-- @tparam[opt=client's screen] integer screen The screen.
 -- @treturn table The new client geometry.
-function placement.no_offscreen(c)
+function placement.no_offscreen(c, screen)
     local c = c or capi.client.focus
     local geometry = c:geometry()
-    local screen   = c.screen or a_screen.getbycoord(geometry.x, geometry.y)
+    local screen   = screen or c.screen or a_screen.getbycoord(geometry.x, geometry.y)
     local border   = c.border_width
     local screen_geometry = capi.screen[screen].workarea
 

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -74,7 +74,7 @@ local data = setmetatable({}, { __mode = 'k' })
 -- @tparam tooltip self A tooltip object.
 local function place(self)
     a_placement.next_to_mouse(self.wibox)
-    a_placement.no_offscreen(self.wibox)
+    a_placement.no_offscreen(self.wibox, mouse.screen)
 end
 
 -- Place the tooltip under the mouse.


### PR DESCRIPTION
This is used by `tooltip.place` then to tie the tooltip to the screen of
the mouse.  Without this, a tooltip from the tasklist might get moved to
the screen above the tasklist, if it gets considered to be on that
screen given its coordinates.