### PR TITLE
ewmh.activate: raise a client always

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -162,9 +162,8 @@ end
 function ewmh.activate(c, context, hints)
     client.focus = c
     if hints and hints.raise then
-        if awesome.startup or c:isvisible() then
-            c:raise()
-        else
+        c:raise()
+        if not awesome.startup and not c:isvisible() then
             c.urgent = true
         end
     end


### PR DESCRIPTION
When a client is not visible, this would adjust its stacking order still.

This is a proposal from IRC discussion with @b80905, where a `request::activate` signal from `movetotag` would not raise the client if it's not visible anymore.

This is not tested, but just a quick idea.