### PR TITLE
Make client.movetotag() raise the client

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -499,6 +499,9 @@ function client.movetotag(target, c)
     local sel = c or capi.client.focus
     local s = tag.getscreen(target)
     if sel and s then
+        if sel == capi.client.focus then
+            sel:emit_signal("request::activate", "client.movetotag", {raise=true})
+        end
         -- Set client on the same screen as the tag.
         sel.screen = s
         sel:tags({ target })


### PR DESCRIPTION
if you move two windows from one tag to another one and switch to the other tag, it might be that the focus is not on the topmost window, which looks odd if the windows are maximized. This is a fix.