### PR TITLE
Fix Mac OS X iconv library linking failure

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -155,6 +155,43 @@ if(NOT AWESOME_REQUIRED_FOUND OR NOT AWESOME_COMMON_REQUIRED_FOUND)
     message(FATAL_ERROR)
 endif()
 
+# On Mac OS X, the executable of Awesome has to be linked against libiconv
+# explicitly.  Unfortunately, libiconv doesn't have its pkg-config file,
+# and CMake doesn't provide a module for looking up the library.  Thus, we
+# have to do everything for ourselves...
+if(APPLE)
+    if(NOT DEFINED AWESOME_ICONV_SEARCH_PATHS)
+        set(AWESOME_ICONV_SEARCH_PATHS /opt/local /opt /usr/local /usr)
+    endif()
+
+    if(NOT DEFINED AWESOME_ICONV_INCLUDE_DIR)
+        find_path(AWESOME_ICONV_INCLUDE_DIR
+                  iconv.h
+                  PATHS ${AWESOME_ICONV_SEARCH_PATHS}
+                  PATH_SUFFIXES include
+                  NO_CMAKE_SYSTEM_PATH)
+    endif()
+
+    if(NOT DEFINED AWESOME_ICONV_LIBRARY_PATH)
+        get_filename_component(AWESOME_ICONV_BASE_DIRECTORY ${AWESOME_ICONV_INCLUDE_DIR} DIRECTORY)
+        find_library(AWESOME_ICONV_LIBRARY_PATH
+                     NAMES iconv
+                     HINTS ${AWESOME_ICONV_BASE_DIRECTORY}
+                     PATH_SUFFIXES lib)
+    endif()
+
+    if(NOT DEFINED AWESOME_ICONV_LIBRARY_PATH)
+        message(FATAL_ERROR "Looking for iconv library - not found.")
+    else()
+        message(STATUS "Looking for iconv library - found: ${AWESOME_ICONV_LIBRARY_PATH}")
+    endif()
+
+    set(AWESOME_REQUIRED_LDFLAGS
+        ${AWESOME_REQUIRED_LDFLAGS} ${AWESOME_ICONV_LIBRARY_PATH})
+    set(AWESOME_REQUIRED_INCLUDE_DIRS
+        ${AWESOME_REQUIRED_INCLUDE_DIRS} ${AWESOME_ICONV_INCLUDE_DIR})
+endif(APPLE)
+
 macro(a_find_library variable library)
     find_library(${variable} ${library})
     if(NOT ${variable})


### PR DESCRIPTION
Awesome’s current build system is not much friendly to Mac OS X.  Once `make` is issued at the top directory, the build fails at the linking phase with the message:

```
Undefined symbols for architecture x86_64:
  "_libiconv", referenced from:
      _draw_iso2utf8 in draw.c.o
  "_libiconv_open", referenced from:
      _draw_iso2utf8 in draw.c.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [awesome] Error 1
make[2]: *** [CMakeFiles/awesome.dir/all] Error 2
make[1]: *** [all] Error 2
```

*while Mac OS X actually has an iconv library in `/usr` together with the header.*

Obviously, in order to fix this problem, all needed to do is to pass `-liconv` to the linker.

Although there’re several ways to accomplish it, the best way would be to have CMake detect the library and header, and set up linker arguments accordingly.

This PR is for that.

With this PR’s patch, once all the library dependencies are resolved, Awesome should be successfully built on Mac OS X without any command line tweaking or tinkering with files.

The following are the explanations why the proposed patch is written like that.

As is often the case with Mac OS X users, in addition to the “native” iconv library in `/usr`, another iconv library may be installed through package managers such as MacPorts and Homebrew.  To cope with such a situation, I got the auto-detection search paths to contain `/opt/local` and `/usr/local` as well as the standard `/usr`.

In case the auto-detection should fail, two new CMake variables called

```
AWESOME_ICONV_INCLUDE_DIR
AWESOME_ICONV_LIBRARY_PATH

```

are introduced so that the user can do any adjustment, e.g., via `cmake` command line options or `ccmake build` after a preliminary `cmake` invocation is once done successfully (I hope the usage of these variables is obvious from their names).

Unfortunately, the iconv library doesn’t use `pkg-config`, and CMake doesn’t provide a module for looking up the library.  That's why the code of the proposed PR is a little bit lengthy in comparison with that for other required libraries.