### PR TITLE
Modify CFLAGS handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,30 @@ endif()
 add_executable(${PROJECT_AWE_NAME}
     ${AWE_SRCS})
 
+# CFLAGS
+set(AWESOME_C_FLAGS
+    -O1 -std=gnu99 -ggdb3 -fno-strict-aliasing -Wall -Wextra
+    -Wchar-subscripts -Wundef -Wshadow -Wcast-align -Wwrite-strings
+    -Wsign-compare -Wunused -Wno-unused-parameter -Wuninitialized -Winit-self
+    -Wpointer-arith -Wformat-nonliteral
+    -Wno-format-zero-length -Wmissing-format-attribute -Wmissing-prototypes
+    -Wstrict-prototypes
+    CACHE STRING "CFLAGS used to compile ${PROJECT_AWE_NAME}")
+mark_as_advanced(AWESOME_C_FLAGS)
+target_compile_options(${PROJECT_AWE_NAME} PRIVATE ${AWESOME_C_FLAGS})
+
+# Linux w/ GCC requires -rdynamic to get backtrace to fully work.
+#
+# For "historical reasons", CMake adds the option to the linker flags
+# unnoticeably for Linux w/ GCC through its modules Linux-GNU.cmake
+# and Linux-GNU-C.cmake.  Our build system has counted on that.  But
+# just in case CMake should do away with the convention suddenly...
+if(DEFINED CMAKE_SHARED_LIBRARY_LINK_C_FLAGS AND
+        NOT CMAKE_SHARED_LIBRARY_LINK_C_FLAGS MATCHES "-rdynamic")
+    target_link_libraries(${PROJECT_AWE_NAME}
+        $<$<AND:$<PLATFORM_ID:Linux>,$<C_COMPILER_ID:GNU>>:-rdynamic>)
+endif()
+
 # FreeBSD requires dynamic linking
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     set_target_properties(${PROJECT_AWE_NAME}

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -15,15 +15,6 @@ option(GENERATE_MANPAGES "generate manpages" ON)
 option(COMPRESS_MANPAGES "compress manpages" ON)
 option(GENERATE_DOC "generate API documentation" ON)
 
-# {{{ CFLAGS
-add_definitions(-O1 -std=gnu99 -ggdb3 -rdynamic -fno-strict-aliasing -Wall -Wextra
-    -Wchar-subscripts -Wundef -Wshadow -Wcast-align -Wwrite-strings
-    -Wsign-compare -Wunused -Wno-unused-parameter -Wuninitialized -Winit-self
-    -Wpointer-arith -Wformat-nonliteral
-    -Wno-format-zero-length -Wmissing-format-attribute -Wmissing-prototypes
-    -Wstrict-prototypes)
-# }}}
-
 # {{{ Endianness
 include(TestBigEndian)
 TEST_BIG_ENDIAN(AWESOME_IS_BIG_ENDIAN)


### PR DESCRIPTION
 - Remove `-rdynamic` from "CFLAGS" and count on CMake to pass it to
   the compiler at the link phase (Issue #450).
 - Move the definition of "CFLAGS" from `awesomeConfig.cmake` to
   `CMakeLists.txt` and give it a name, `AWESOME_C_FLAGS`, so that the
   relation between the target and the flags is made clearer and
   manageable.
 - Make `AWESOME_C_FLAGS` a cached variable so that the developers can
   tweak the flags promptly in accordance with their necessities without
   changing the prescribed value.
 - Add a logic to cope with the case where CMake fails to set
   `-rdynamic`.

----
The whole purpose of these modifications is to make Awesome's build system more friendly not only to Linux-GNU but to other various environments.

I'd appreciate it if someone who is on Linux-GNU would check if `-rdynamic` is still passed to the compiler at the link phase once (and only once) and nothing is broken after this patch is applied.