### PR TITLE
Correctly generate mouse::enter and mouse::leave events on drawins, titlebars and clients

### DIFF
--- a/globalconf.h
+++ b/globalconf.h
@@ -108,6 +108,8 @@ typedef struct
     int keygrabber;
     /** The mouse pointer grabber function */
     int mousegrabber;
+    /** The drawable that currently contains the pointer */
+    drawable_t *drawable_under_mouse;
     /** Input focus information */
     struct
     {


### PR DESCRIPTION
Hopefully the title is self-explanatory and all the rest is explained in the individual commit messages. All I have to add is: This took me some `printf`-debugging and reading X11 docs to figure out. These input events always turn out to be complicated...

I think that this supersedes #382.