### PR TITLE
Add and use wibox.hierarchy:update()

### DIFF
--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -74,19 +74,25 @@ local function do_redraw(self)
     -- Relayout
     if self._need_relayout or self._need_complete_repaint then
         self._need_relayout = false
-        local old_hierarchy = self._widget_hierarchy
-        self._widget_hierarchy_callback_arg = {}
-        self._widget_hierarchy = self.widget and
-            hierarchy.new(get_widget_context(self), self.widget, width, height,
-                self._redraw_callback, self._layout_callback, self._widget_hierarchy_callback_arg)
+        if self._widget_hierarchy and self.widget then
+            self._widget_hierarchy:update(get_widget_context(self),
+                self.widget, width, height, self._dirty_area)
+        else
+            self._need_complete_repaint = true
+            if self.widget then
+                self._widget_hierarchy_callback_arg = {}
+                self._widget_hierarchy = hierarchy.new(get_widget_context(self), self.widget, width, height,
+                        self._redraw_callback, self._layout_callback, self._widget_hierarchy_callback_arg)
+            else
+                self._widget_hierarchy = nil
+            end
+        end
 
-        if old_hierarchy == nil or self._widget_hierarchy == nil or self._need_complete_repaint then
+        if self._need_complete_repaint then
             self._need_complete_repaint = false
             self._dirty_area:union_rectangle(cairo.RectangleInt{
                 x = 0, y = 0, width = width, height = height
             })
-        else
-            self._dirty_area:union(self._widget_hierarchy:find_differences(old_hierarchy))
         end
     end
 

--- a/spec/wibox/hierarchy_spec.lua
+++ b/spec/wibox/hierarchy_spec.lua
@@ -188,7 +188,7 @@ describe("wibox.hierarchy", function()
         end)
     end)
 
-    describe("find_differences", function()
+    describe("update", function()
         local child, intermediate, parent
         local instance
         local function nop() end
@@ -205,24 +205,59 @@ describe("wibox.hierarchy", function()
             instance = hierarchy.new(context, parent, 15, 16, nop, nop)
         end)
 
-        it("No difference", function()
-            local context = {}
-            local instance2 = hierarchy.new(context, parent, 15, 16, nop, nop)
-            local region = instance:find_differences(instance2)
+        it("No difference 1", function()
+            local region = instance:update(context, parent, 15, 16)
             assert.is.equal(region:num_rectangles(), 0)
         end)
 
+        it("No difference 2", function()
+            local region1 = Region.create()
+            local region2 = instance:update(context, parent, 15, 16, region1)
+            assert.is.equal(region1, region2)
+            assert.is.equal(region2:num_rectangles(), 0)
+        end)
+
         it("child moved", function()
+            -- Clear caches and change result of intermediate
             intermediate.layout = function()
                 return { make_child(child, 10, 20, matrix.create_translate(0, 4)) }
             end
-            local context = {}
-            local instance2 = hierarchy.new(context, parent, 15, 16, nop, nop)
-            local region = instance:find_differences(instance2)
+            intermediate:emit_signal("widget::layout_changed")
+
+            local region = instance:update(context, parent, 15, 16)
             assert.is.equal(region:num_rectangles(), 1)
             local rect = region:get_rectangle(0)
             -- The widget drew to 4, 5, 10, 20 before and 4, 4, 10, 20 after
             assert.is.same({ rect.x, rect.y, rect.width, rect.height }, { 4, 4, 10, 21 })
+        end)
+
+        it("child disappears", function()
+            -- Clear caches and change result of intermediate
+            intermediate.layout = function() end
+            intermediate:emit_signal("widget::layout_changed")
+
+            local region = instance:update(context, parent, 15, 16)
+            assert.is.equal(region:num_rectangles(), 1)
+            local rect = region:get_rectangle(0)
+            -- The child was drawn to 4, 5, 10, 20
+            assert.is.same({ rect.x, rect.y, rect.width, rect.height }, { 4, 5, 10, 20 })
+        end)
+
+        it("widget changed", function()
+            -- Clear caches and change result of parent
+            local new_intermediate = make_widget({
+                make_child(child, 10, 20, matrix.create_translate(0, 5))
+            })
+            parent.layout = function()
+                return { make_child(new_intermediate, 5, 2, matrix.create_translate(4, 0)) }
+            end
+            parent:emit_signal("widget::layout_changed")
+
+            local region = instance:update(context, parent, 15, 16)
+            assert.is.equal(region:num_rectangles(), 1)
+            local rect = region:get_rectangle(0)
+            -- Intermediate drew to 4, 0, 5, 2 (and so does new_intermediate)
+            assert.is.same({ rect.x, rect.y, rect.width, rect.height }, { 4, 0, 5, 2 })
         end)
     end)
 end)


### PR DESCRIPTION
This function updates a hierarchy if the layout of some widgets changed. It does
nothing on the parts that did not change. This should be more efficient than
recomputing the whole hierarchy whenever something changes.

Once again, this has some positive results on the "benchmark test":
```
Before:
        create wibox: 0.083016   sec/iter ( 13 iters, 1.161 sec for benchmark)
    update textclock: 0.00391091 sec/iter (271 iters, 3.219 sec for benchmark)
  relayout textclock: 0.00273234 sec/iter (397 iters, 1.087 sec for benchmark)
    redraw textclock: 0.0010191  sec/iter (989 iters, 1.745 sec for benchmark)

After:
        create wibox: 0.083146   sec/iter ( 13 iters, 1.163 sec for benchmark)
    update textclock: 0.00170519 sec/iter (647 iters, 2.201 sec for benchmark)
  relayout textclock: 0.000581637 sec/iter (1880 iters, 1.094 sec for benchmark)
    redraw textclock: 0.0010167  sec/iter (997 iters, 1.773 sec for benchmark)
```
So again no difference for creating wiboxes (100.16% compared to before). This
time we also have no real difference for creating wiboxes (99.76%). Update (44%)
and relayout (21%) are improved a lot.