### PR TITLE
test(benchmark): add for tag switch

### DIFF
--- a/tests/test-benchmark.lua
+++ b/tests/test-benchmark.lua
@@ -87,9 +87,15 @@ local function update_textclock()
     do_pending_repaint()
 end
 
+local function e2e_tag_switch()
+    awful.tag.viewnext()
+    do_pending_repaint()
+end
+
 benchmark(create_wibox, "create wibox")
 benchmark(update_textclock, "update textclock")
 benchmark(relayout_textclock, "relayout textclock")
 benchmark(redraw_textclock, "redraw textclock")
+benchmark(e2e_tag_switch, "tag switch")
 
 require("_runner").run_steps({ function() return true end })


### PR DESCRIPTION
it's more like e2e test -- it not helps to find out what exactly became slower/faster but can help to measure "overall" rapidity of interface, because speed of tag switching strongly affects an impression of how fast awesome works, ie latest performance issues were most of all noticeable during tag switch

i think it also can be reproduced by calling manual redraw of panel wibox, i am not sure how it will be better