### PR TITLE
Fix tooltip.set_geometry: provide textbox context

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -82,8 +82,9 @@ end
 -- @tparam tooltip self A tooltip object.
 local function set_geometry(self)
     local my_geo = self.wibox:geometry()
+    local textbox_context = {dpi=beautiful.xresources.get_dpi(mouse.screen)}
     -- calculate width / height
-    local n_w, n_h = self.textbox:fit(nil, -1, -1) -- Hack! :(
+    local n_w, n_h = self.textbox:fit(textbox_context, -1, -1) -- Hack! :(
     n_w = n_w + self.marginbox.left + self.marginbox.right
     n_h = n_h + self.marginbox.top + self.marginbox.bottom
     if my_geo.width ~= n_w or my_geo.height ~= n_h then


### PR DESCRIPTION
This is another fix like https://github.com/awesomeWM/awesome/commit/f2e554de91d0c275292e418de59784141a9780e1.

1. I wonder if `nil` should be handled as an empty context maybe? (but it is also fine to use just `{}` then)
2. Could a missing `dpi` value in the context be handled better, e.g. by using the textbox' screen / its dpi automatically?

I've used `mouse.screen`, which is also used with `placement.no_offscreen`.