### PR TITLE
Never explicitly focus the root window

### DIFF
--- a/globalconf.h
+++ b/globalconf.h
@@ -117,6 +117,8 @@ typedef struct
         client_t *client;
         /** Is there a focus change pending? */
         bool need_update;
+        /** When nothing has the input focus, this window actually is focused */
+        xcb_window_t window_no_focus;
     } focus;
     /** Drawins */
     drawin_array_t drawins;

--- a/objects/client.c
+++ b/objects/client.c
@@ -435,7 +435,7 @@ void
 client_focus_refresh(void)
 {
     client_t *c = globalconf.focus.client;
-    xcb_window_t win = globalconf.screen->root;
+    xcb_window_t win = globalconf.focus.window_no_focus;
 
     if(!globalconf.focus.need_update)
         return;
@@ -449,10 +449,11 @@ client_focus_refresh(void)
         if(!c->nofocus)
             win = c->window;
         else
-            /* Focus the root window to make sure the previously focused client
-             * doesn't get any input in case WM_TAKE_FOCUS gets ignored.
+            /* Move the focus away from whatever has it to make sure the
+             * previously focused client doesn't get any input in case
+             * WM_TAKE_FOCUS gets ignored.
              */
-            win = globalconf.screen->root;
+            win = globalconf.focus.window_no_focus;
 
         if(client_hasproto(c, WM_TAKE_FOCUS))
             xwindow_takefocus(c->window);


### PR DESCRIPTION
Whenever client.focus == nil, we set the input focus to the root window to
express "nothing has the input focus". However, thanks to the way X11 input
works, this means that whatever is under the mouse cursor gets keyboard input
events. This can easily be reproduced with urxvt and some small addition to the
config to unfocus things.

This commit changes things. Instead of focusing the root window, we create a
special "no focus" window that gets focused if we want nothing to have the
focus.

Edit: Note that this will not cause any change in behaviour that would be visible to Lua code. This should only make a difference for users.