### PR TITLE
ewmh.activate: only focus visible clients

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -160,7 +160,9 @@ end
 -- @tparam[opt] table hints A table with additional hints:
 -- @tparam[opt=false] boolean hints.raise should the client be raised?
 function ewmh.activate(c, context, hints)
-    client.focus = c
+    if c:isvisible() then
+        client.focus = c
+    end
     if hints and hints.raise then
         if awesome.startup or c:isvisible() then
             c:raise()


### PR DESCRIPTION
Since focus can be moved to non-visible clients nowadays, this needs to be
checked in the `request::activate` handler.

Fixes https://github.com/awesomeWM/awesome/issues/455.