### PR TITLE
Add integration tests checking for leaks and fix some results

### DIFF
--- a/lib/awful/widget/textclock.lua
+++ b/lib/awful/widget/textclock.lua
@@ -31,13 +31,14 @@ function textclock.new(format, timeout)
     local timeout = timeout or 60
 
     local w = textbox()
-    local t = timer { timeout = timeout }
-    t:connect_signal("timeout", function()
+    local t
+    function w._textclock_update_cb()
         w:set_markup(DateTime.new_now_local():format(format))
         t.timeout = calc_timeout(timeout)
         t:again()
-    end)
-    t:start()
+        return true -- Continue the timer
+    end
+    t = timer.weak_start_new(timeout, w._textclock_update_cb)
     t:emit_signal("timeout")
     return w
 end

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -18,7 +18,7 @@ local base = {}
 -- {{{ Caches
 
 -- Indexes are widgets, allow them to be garbage-collected
-local widget_dependencies = setmetatable({}, { __mode = "k" })
+local widget_dependencies = setmetatable({}, { __mode = "kv" })
 
 -- Get the cache of the given kind for this widget. This returns a gears.cache
 -- that calls the callback of kind `kind` on the widget.

--- a/tests/_wibox_helper.lua
+++ b/tests/_wibox_helper.lua
@@ -28,5 +28,5 @@ return { create_wibox = function()
     --wb.visible = true
     wb:set_widget(layout)
 
-    return wb, textclock
+    return wb, textclock, img, left_layout, right_layout, layout
 end }

--- a/tests/_wibox_helper.lua
+++ b/tests/_wibox_helper.lua
@@ -1,0 +1,32 @@
+local awful = require("awful")
+local cairo = require("lgi").cairo
+local wibox = require("wibox")
+
+return { create_wibox = function()
+    local img = cairo.ImageSurface(cairo.Format.ARGB32, 20, 20)
+
+    -- Widgets that are aligned to the left
+    local left_layout = wibox.layout.fixed.horizontal()
+    left_layout:add(awful.widget.launcher({ image = img, command = "bash" }))
+    left_layout:add(awful.widget.taglist(1, awful.widget.taglist.filter.all))
+    left_layout:add(awful.widget.prompt())
+
+    -- Widgets that are aligned to the right
+    local right_layout = wibox.layout.fixed.horizontal()
+    local textclock = awful.widget.textclock()
+    right_layout:add(textclock)
+    right_layout:add(awful.widget.layoutbox(1))
+
+    -- Now bring it all together (with the tasklist in the middle)
+    local layout = wibox.layout.align.horizontal()
+    layout:set_left(left_layout)
+    layout:set_middle(awful.widget.tasklist(1, awful.widget.tasklist.filter.currenttags))
+    layout:set_right(right_layout)
+
+    -- Create wibox
+    local wb = wibox({ width = 1024, height = 20, screen = 1 })
+    --wb.visible = true
+    wb:set_widget(layout)
+
+    return wb, textclock
+end }

--- a/tests/test-benchmark.lua
+++ b/tests/test-benchmark.lua
@@ -2,10 +2,8 @@
 -- that we notice if they break.
 
 local awful = require("awful")
-local wibox = require("wibox")
-local lgi = require("lgi")
-local GLib = lgi.GLib
-local cairo = lgi.cairo
+local GLib = require("lgi").GLib
+local create_wibox = require("_wibox_helper").create_wibox
 
 local not_under_travis = not os.getenv("CI")
 
@@ -39,35 +37,6 @@ end
 
 local function do_pending_repaint()
     awesome.emit_signal("refresh")
-end
-
-local function create_wibox()
-    local img = cairo.ImageSurface(cairo.Format.ARGB32, 20, 20)
-
-    -- Widgets that are aligned to the left
-    local left_layout = wibox.layout.fixed.horizontal()
-    left_layout:add(awful.widget.launcher({ image = img, command = "bash" }))
-    left_layout:add(awful.widget.taglist(1, awful.widget.taglist.filter.all))
-    left_layout:add(awful.widget.prompt())
-
-    -- Widgets that are aligned to the right
-    local right_layout = wibox.layout.fixed.horizontal()
-    local textclock = awful.widget.textclock()
-    right_layout:add(textclock)
-    right_layout:add(awful.widget.layoutbox(1))
-
-    -- Now bring it all together (with the tasklist in the middle)
-    local layout = wibox.layout.align.horizontal()
-    layout:set_left(left_layout)
-    layout:set_middle(awful.widget.tasklist(1, awful.widget.tasklist.filter.currenttags))
-    layout:set_right(right_layout)
-
-    -- Create wibox
-    local wb = wibox({ width = 1024, height = 20, screen = 1 })
-    wb.visible = true
-    wb:set_widget(layout)
-
-    return wb, textclock
 end
 
 local wb, textclock = create_wibox()

--- a/tests/test-benchmark.lua
+++ b/tests/test-benchmark.lua
@@ -39,6 +39,11 @@ local function do_pending_repaint()
     awesome.emit_signal("refresh")
 end
 
+local function create_and_draw_wibox()
+    create_wibox()
+    do_pending_repaint()
+end
+
 local wb, textclock = create_wibox()
 
 local function relayout_textclock()
@@ -61,7 +66,7 @@ local function e2e_tag_switch()
     do_pending_repaint()
 end
 
-benchmark(create_wibox, "create wibox")
+benchmark(create_and_draw_wibox, "create&draw wibox")
 benchmark(update_textclock, "update textclock")
 benchmark(relayout_textclock, "relayout textclock")
 benchmark(redraw_textclock, "redraw textclock")

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -11,7 +11,8 @@ local errors = {}
 local prepare_for_collect = nil
 
 -- Test if some objects can be garbage collected
-local function collectable(a, b, c, d, e, f, g, h)
+local function collectable(a, b, c, d, e, f, g, h, last)
+    assert(last == nil, "got more arguments than supported")
     local objs = setmetatable({ a, b, c, d, e, f, g, h }, { __mode = "v" })
     a, b, c, d, e, f, g, h = nil, nil, nil, nil, nil, nil, nil, nil
     if prepare_for_collect then
@@ -37,11 +38,18 @@ collectable(awful.widget.launcher({ image = cairo.ImageSurface(cairo.Format.ARGB
 collectable(awful.widget.prompt())
 collectable(awful.widget.textclock())
 collectable(awful.widget.layoutbox(1))
+
 function prepare_for_collect()
     -- Only after doing the pending update can a taglist be GC'd.
     awesome.emit_signal("refresh")
 end
 collectable(awful.widget.taglist(1, awful.widget.taglist.filter.all))
+
+function prepare_for_collect()
+    -- Only after doing the pending update can a taglist be GC'd.
+    awesome.emit_signal("refresh")
+end
+collectable(awful.widget.tasklist(1, awful.widget.tasklist.filter.currenttags))
 
 -- And finally a full wibox
 function prepare_for_collect()

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -9,12 +9,15 @@ local wibox = require("wibox")
 local errors = {}
 
 local prepare_for_collect = nil
+local function emit_refresh()
+    awesome.emit_signal("refresh")
+end
 
 -- Make the layoutbox in the default config GC'able
 mywibox[1].visible = false
 mywibox = nil
 mylayoutbox = nil
-awesome.emit_signal("refresh")
+emit_refresh()
 
 -- Test if some objects can be garbage collected
 local function collectable(a, b, c, d, e, f, g, h, last)
@@ -45,23 +48,14 @@ collectable(awful.widget.prompt())
 collectable(awful.widget.textclock())
 collectable(awful.widget.layoutbox(1))
 
-function prepare_for_collect()
-    -- Only after doing the pending update can a taglist be GC'd.
-    awesome.emit_signal("refresh")
-end
+-- Some widgets do things via timer.delayed_call
+prepare_for_collect = emit_refresh
 collectable(awful.widget.taglist(1, awful.widget.taglist.filter.all))
 
-function prepare_for_collect()
-    -- Only after doing the pending update can a taglist be GC'd.
-    awesome.emit_signal("refresh")
-end
+prepare_for_collect = emit_refresh
 collectable(awful.widget.tasklist(1, awful.widget.tasklist.filter.currenttags))
 
--- And finally a full wibox
-function prepare_for_collect()
-    -- Only after doing the pending repaint can a wibox be GC'd.
-    awesome.emit_signal("refresh")
-end
+prepare_for_collect = emit_refresh
 collectable(create_wibox())
 
 require("_runner").run_steps({ function() return true end })

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -29,6 +29,7 @@ local function collectable(a, b, c, d, e, f, g, h, last)
         prepare_for_collect = nil
     end
     collectgarbage("collect")
+    collectgarbage("collect")
     -- Check if the table is now empty
     for k, v in pairs(objs) do
         print("Some object was not garbage collected!")

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -36,6 +36,20 @@ local function collectable(a, b, c, d, e, f, g, h, last)
     end
 end
 
+-- Use the layoutbox for testing delayed tooltips
+local function tooltip_delayed()
+    local l = awful.widget.layoutbox(1)
+    local t = l._layoutbox_tooltip
+    assert(t)
+    return l, t
+end
+
+local function tooltip_now()
+    local w = wibox.widget.textbox("some textbox")
+    local t = awful.tooltip({ objects = {w} })
+    return w, t
+end
+
 -- First test some basic widgets
 collectable(wibox.widget.base.make_widget())
 collectable(wibox.widget.textbox("foo"))
@@ -49,6 +63,12 @@ collectable(awful.widget.textclock())
 collectable(awful.widget.layoutbox(1))
 
 -- Some widgets do things via timer.delayed_call
+prepare_for_collect = emit_refresh
+collectable(tooltip_delayed())
+
+prepare_for_collect = emit_refresh
+collectable(tooltip_now())
+
 prepare_for_collect = emit_refresh
 collectable(awful.widget.taglist(1, awful.widget.taglist.filter.all))
 

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -1,0 +1,49 @@
+-- Some memory leak checks as integration tests.
+
+local awful = require("awful")
+local cairo = require("lgi").cairo
+local create_wibox = require("_wibox_helper").create_wibox
+local gears = require("gears")
+local wibox = require("wibox")
+
+local errors = {}
+
+local prepare_for_collect = nil
+
+-- Test if some objects can be garbage collected
+local function collectable(a, b, c, d, e, f, g, h)
+    local objs = setmetatable({ a, b, c, d, e, f, g, h }, { __mode = "v" })
+    a, b, c, d, e, f, g, h = nil, nil, nil, nil, nil, nil, nil, nil
+    if prepare_for_collect then
+        prepare_for_collect()
+        prepare_for_collect = nil
+    end
+    collectgarbage("collect")
+    -- Check if the table is now empty
+    for k, v in pairs(objs) do
+        print("Some object was not garbage collected!")
+        error(v)
+    end
+end
+
+-- First test some basic widgets
+collectable(wibox.widget.base.make_widget())
+collectable(wibox.widget.textbox("foo"))
+collectable(wibox.layout.fixed.horizontal())
+collectable(wibox.layout.align.horizontal())
+
+-- Then some random widgets from awful
+collectable(awful.widget.launcher({ image = cairo.ImageSurface(cairo.Format.ARGB32, 20, 20), command = "bash" }))
+collectable(awful.widget.prompt())
+collectable(awful.widget.textclock())
+collectable(awful.widget.layoutbox(1))
+collectable(awful.widget.taglist(1, awful.widget.taglist.filter.all))
+
+-- And finally a full wibox
+function prepare_for_collect()
+    -- Only after doing the pending repaint can a wibox be GC'd.
+    awesome.emit_signal("refresh")
+end
+collectable(create_wibox())
+
+require("_runner").run_steps({ function() return true end })

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -10,6 +10,12 @@ local errors = {}
 
 local prepare_for_collect = nil
 
+-- Make the layoutbox in the default config GC'able
+mywibox[1].visible = false
+mywibox = nil
+mylayoutbox = nil
+awesome.emit_signal("refresh")
+
 -- Test if some objects can be garbage collected
 local function collectable(a, b, c, d, e, f, g, h, last)
     assert(last == nil, "got more arguments than supported")

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -37,6 +37,10 @@ collectable(awful.widget.launcher({ image = cairo.ImageSurface(cairo.Format.ARGB
 collectable(awful.widget.prompt())
 collectable(awful.widget.textclock())
 collectable(awful.widget.layoutbox(1))
+function prepare_for_collect()
+    -- Only after doing the pending update can a taglist be GC'd.
+    awesome.emit_signal("refresh")
+end
 collectable(awful.widget.taglist(1, awful.widget.taglist.filter.all))
 
 -- And finally a full wibox


### PR DESCRIPTION
This creates random widgets and then checks if they can be garbage collected. Turns out that lots of things actually cannot be garbage collected. This is my result from investigating #477.

If you have any ideas of what else should be checked, feel free to mention it here.

Side note: It's relatively useless for a taglist to be garbage-collectable. 99% of users create taglists during startup and keep them alive forever. Still, if we don't want any memory leaks, we should also take seriously the ones that are irrelevant in practice.