### PR TITLE
Fix the definition of A_STRNEQ_CASE

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -237,7 +237,7 @@ static inline int a_strcasecmp(const char *a, const char *b)
 }
 
 #define  A_STREQ_CASE(a, b) (((a) == (b)) || a_strcasecmp(a, b) == 0)
-#define A_STRNEQ_CASE(a, b) (!A_STRCASEEQ(a, b))
+#define A_STRNEQ_CASE(a, b) (!A_STREQ_CASE(a, b))
 
 /** \brief \c NULL resistant strncmp.
  * \param[in]  a     the first string.


### PR DESCRIPTION
Replace A_STRCASEEQ whose definition is not given anywhere with A_STREQ_CASE.

--
I'm not sure if this fix deserves a PR, because it appears that definition has been overlooked for years (dated back to 2011?).  I'm reporting that to you only for the sake of correctness. :-)