### PR TITLE
Raise client in awful.client.movetoscreen

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -549,7 +549,7 @@ function client.movetoscreen(c, s)
 
             if sel_is_focused then
                 sel:emit_signal("request::activate", "client.movetoscreen",
-                                {raise=false})
+                                {raise=true})
             end
         end
     end


### PR DESCRIPTION
The intention of [#98] / fbc72624 was to actually raise the client,
but that was never the case apparently, and got totally lost in
[#441] / 57755b3).

[#98]: https://github.com/awesomeWM/awesome/pull/98
[#441]: https://github.com/awesomeWM/awesome/pull/441