### PR TITLE
Select SubstructureRedirect on our systray window

### DIFF
--- a/event.c
+++ b/event.c
@@ -373,6 +373,12 @@ event_handle_configurerequest(xcb_configure_request_event_t *ev)
             /* ICCCM 4.1.5 / 4.2.3, if nothing was changed, send an event saying so */
             client_send_configure(c);
     }
+    else if (xembed_getbywin(&globalconf.embedded, ev->window))
+    {
+        /* Ignore this so that systray icons cannot resize themselves.
+         * We decide their size!
+         */
+    }
     else
         event_handle_configurerequest_configure_window(ev);
 }

--- a/systray.c
+++ b/systray.c
@@ -48,8 +48,8 @@ systray_init(void)
                       xscreen->root,
                       -1, -1, 1, 1, 0,
                       XCB_COPY_FROM_PARENT, xscreen->root_visual,
-                      XCB_CW_BACK_PIXEL, (const uint32_t [])
-                      { xscreen->black_pixel });
+                      XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK, (const uint32_t [])
+                      { xscreen->black_pixel, XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT });
 
     atom_name = xcb_atom_name_by_screen("_NET_SYSTEM_TRAY", globalconf.default_screen);
     if(!atom_name)


### PR DESCRIPTION
This ensures that systray icons cannot resize themselves. We assign them some
size and they have to deal with what they get!

Fixes: https://github.com/awesomeWM/awesome/issues/487

Signed-off-by: Uli Schlachter <psychon@znc.in>