### PR TITLE
Provide deprecation wrapper for awful.spawn.pread / fix return values for awful.util.spawn*

### DIFF
--- a/lib/awful/init.lua
+++ b/lib/awful/init.lua
@@ -21,12 +21,12 @@ local spawn = require("awful.spawn")
 
 util.spawn = function(...)
    util.deprecate("awful.spawn")
-   spawn.spawn(...)
+   return spawn.spawn(...)
 end
 
 util.spawn_with_shell = function(...)
    util.deprecate("awful.spawn.with_shell")
-   spawn.spawn_with_shell(...)
+   return spawn.with_shell(...)
 end
 
 util.pread = function(...)

--- a/lib/awful/init.lua
+++ b/lib/awful/init.lua
@@ -16,7 +16,7 @@ function timer(...)
 end
 
 --TODO: This is a hack for backwards-compatibility with 3.5, remove!
--- Set awful.util.spawn*
+-- Set awful.util.spawn* and awful.util.pread.
 local spawn = require("awful.spawn")
 
 util.spawn = function(...)
@@ -27,6 +27,11 @@ end
 util.spawn_with_shell = function(...)
    util.deprecate("awful.spawn.with_shell")
    spawn.spawn_with_shell(...)
+end
+
+util.pread = function(...)
+   util.deprecate("awful.spawn.pread")
+   return spawn.pread(...)
 end
 
 return


### PR DESCRIPTION
`awful.util.pread` is at least used by awesome-pomodoro, see https://github.com/nikolavp/awesome-pomodoro/pull/23.