### PR TITLE
Fix/handle focus history on startup

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1078,6 +1078,14 @@ capi.client.add_signal("marked")
 capi.client.add_signal("unmarked")
 
 capi.client.connect_signal("focus", client.focus.history.add)
+-- Add clients during startup to focus history.
+-- This used to happen through ewmh.activate, but that only handles visible
+-- clients now.
+capi.client.connect_signal("manage", function (c)
+    if awesome.startup then
+        client.focus.history.add(c)
+    end
+end)
 capi.client.connect_signal("unmanage", client.focus.history.delete)
 
 capi.client.connect_signal("property::urgent", client.urgent.add)

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -153,14 +153,17 @@ local function geometry_change(window)
     geometry_change_lock = false
 end
 
---- Activate a window
+--- Activate a window.
+--
+-- This sets the focus during startup (which adds it to
+-- `awful.client.focus.history`), and if the client is visible.
 --
 -- @client c A client to use
 -- @tparam string context The context where this signal was used.
 -- @tparam[opt] table hints A table with additional hints:
 -- @tparam[opt=false] boolean hints.raise should the client be raised?
 function ewmh.activate(c, context, hints)
-    if c:isvisible() then
+    if awesome.startup or c:isvisible() then
         client.focus = c
     end
     if hints and hints.raise then

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -155,15 +155,14 @@ end
 
 --- Activate a window.
 --
--- This sets the focus during startup (which adds it to
--- `awful.client.focus.history`), and if the client is visible.
+-- This sets the focus only if the client is visible.
 --
 -- @client c A client to use
 -- @tparam string context The context where this signal was used.
 -- @tparam[opt] table hints A table with additional hints:
 -- @tparam[opt=false] boolean hints.raise should the client be raised?
 function ewmh.activate(c, context, hints)
-    if awesome.startup or c:isvisible() then
+    if c:isvisible() then
         client.focus = c
     end
     if hints and hints.raise then


### PR DESCRIPTION
After fcccc77 the focus history is not handled correctly any more during restart.

This PR suggests two ways to address this.