### PR TITLE
Add functions for querying a textbox's preferred size

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -71,9 +71,8 @@ end
 -- @tparam tooltip self A tooltip object.
 local function set_geometry(self)
     local my_geo = self.wibox:geometry()
-    local textbox_context = {dpi=beautiful.xresources.get_dpi(mouse.screen)}
     -- calculate width / height
-    local n_w, n_h = self.textbox:fit(textbox_context, -1, -1) -- Hack! :(
+    local n_w, n_h = self.textbox:get_preferred_size(mouse.screen)
     n_w = n_w + self.marginbox.left + self.marginbox.right
     n_h = n_h + self.marginbox.top + self.marginbox.bottom
     if my_geo.width ~= n_w or my_geo.height ~= n_h then

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -598,18 +598,6 @@ function naughty.notify(args)
 
     if hover_timeout then notification.box:connect_signal("mouse::enter", hover_destroy) end
 
-    -- calculate the height
-    if not height then
-        local w, h = textbox:get_preferred_size(s)
-        if iconbox and icon_h + 2 * margin > h + 2 * margin then
-            height = icon_h + 2 * margin
-        else
-            height = h + 2 * margin
-        end
-    end
-
-    height = height + actions_total_height
-
     -- calculate the width
     if not width then
         local w, h = textbox:get_preferred_size(s)
@@ -619,6 +607,19 @@ function naughty.notify(args)
     if width < actions_max_width then
         width = actions_max_width
     end
+
+    -- calculate the height
+    if not height then
+        local w = width - (iconbox and icon_w + 2 * margin or 0) - 2 * margin
+        local h = textbox:get_height_for_width(w, s)
+        if iconbox and icon_h + 2 * margin > h + 2 * margin then
+            height = icon_h + 2 * margin
+        else
+            height = h + 2 * margin
+        end
+    end
+
+    height = height + actions_total_height
 
     -- crop to workarea size if too big
     local workarea = capi.screen[screen].workarea

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -458,8 +458,6 @@ function naughty.notify(args)
     local border_color = args.border_color or preset.border_color or beautiful.bg_focus or '#535d6c'
     local notification = { screen = screen, destroy_cb = destroy_cb, timeout = timeout }
 
-    local textbox_context = {dpi=bt.xresources.get_dpi(s)}
-
     -- replace notification if needed
     if args.replaces_id then
         local obj = naughty.getById(args.replaces_id)
@@ -532,7 +530,7 @@ function naughty.notify(args)
             actiontextbox:set_font(font)
             actiontextbox:set_markup(string.format('<b>%s</b>', action))
             -- calculate the height and width
-            local w, h = actiontextbox:fit(textbox_context, -1, -1) -- Hack! :(
+            local w, h = actiontextbox:get_preferred_size(s)
             local height = h + 2 * margin
             local width = w + 2 * margin
 
@@ -602,7 +600,7 @@ function naughty.notify(args)
 
     -- calculate the height
     if not height then
-        local w, h = textbox:fit(textbox_context, -1, -1) -- Hack! :-(
+        local w, h = textbox:get_preferred_size(s)
         if iconbox and icon_h + 2 * margin > h + 2 * margin then
             height = icon_h + 2 * margin
         else
@@ -614,7 +612,7 @@ function naughty.notify(args)
 
     -- calculate the width
     if not width then
-        local w, h = textbox:fit(textbox_context, -1, -1) -- Hack! :-(
+        local w, h = textbox:get_preferred_size(s)
         width = w + (iconbox and icon_w + 2 * margin or 0) + 2 * margin
     end
 


### PR DESCRIPTION
This implements #466 and adds `:get_preferred_size()`, `:get_preferred_size_at_dpi()`, `:get_height_for_width()` and `:get_height_for_width_at_dpi()` to textboxes. The next commit uses these functions instead of the `:fit(-1, -1)` hack that was used before. Finally, the last commit actually makes use of `:get_height_for_width()` to improve naughty.