### PR TITLE
c.startup_id should be nil when launched without startup notification support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - sudo apt-get install -y libcairo2-dev xmlto asciidoc libpango1.0-dev gperf luadoc libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libxcb-image0-dev libev-dev libimlib2-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libxcursor-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
 
   # Deps for functional tests.
-  - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb
+  - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb rxvt-unicode
 
   # Install Lua (per env).
   - sudo apt-get install -y lib${LUANAME}-dev ${LUANAME} ${INSTALL_PKGS}

--- a/spawn.c
+++ b/spawn.c
@@ -283,7 +283,14 @@ spawn_launchee_timeout(gpointer context)
 static void
 spawn_callback(gpointer user_data)
 {
+    SnLauncherContext *context = (SnLauncherContext *) user_data;
     setsid();
+
+    if (context)
+        sn_launcher_context_setup_child_process(context);
+    else
+        /* Unset in case awesome was already started with this variable set */
+        unsetenv("DESKTOP_STARTUP_ID");
 }
 
 /** Parse a command line.
@@ -400,11 +407,10 @@ luaA_spawn(lua_State *L)
         /* app will have AWESOME_SPAWN_TIMEOUT seconds to complete,
          * or the timeout function will terminate the launch sequence anyway */
         g_timeout_add_seconds(AWESOME_SPAWN_TIMEOUT, spawn_launchee_timeout, context);
-        sn_launcher_context_setup_child_process(context);
     }
 
     retval = g_spawn_async_with_pipes(NULL, argv, NULL, G_SPAWN_SEARCH_PATH,
-                                      spawn_callback, NULL, &pid,
+                                      spawn_callback, context, &pid,
                                       stdin_ptr, stdout_ptr, stderr_ptr, &error);
     g_strfreev(argv);
     if(!retval)

--- a/tests/test-spawn-snid.lua
+++ b/tests/test-spawn-snid.lua
@@ -1,0 +1,42 @@
+--- Tests for spawn's startup notifications.
+
+local spawn = require("awful.spawn")
+
+local manage_called, c_snid
+
+client.connect_signal("manage", function(c)
+  manage_called = true
+  c_snid = c.startup_id
+end)
+
+
+local ret, snid
+local steps = {
+  function(count)
+    if count == 1 then
+      ret, snid = spawn('urxvt', true)
+    elseif manage_called then
+      local c = client.get()[1]
+      assert(ret)
+      assert(snid)
+      assert(snid == c_snid)
+      return true
+    end
+  end,
+
+  -- Test that c.startup_id is nil for a client without startup notifications,
+  -- and especially not the one from the previous spawn.
+  function(count)
+    if count == 1 then
+      manage_called = false
+      ret, snid = spawn('urxvt', false)
+    elseif manage_called then
+      assert(ret)
+      assert(snid == nil)
+      assert(c_snid == nil, "c.startup_snid should be nil!")
+      return true
+    end
+  end
+}
+
+require("_runner").run_steps(steps)


### PR DESCRIPTION
It seems like internally with use_snid=false the machinery to request it is not triggered, and then the next one with use_snid=false will get the previous one again.

I've tried to bisect it, but stopped at about HEAD~200 - seems to be an issue for longer already.

I've noticed it because I use `tag = X, switchtotag = true` with some client, and then recently changed some other default launcher to not use sn anymore, and that would get moved to the tag also (through my custom snid handler, before `spawn` got improved recently).