### PR TITLE
Set WM_CLASS and WM_NAME on all our windows (#551)

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -238,6 +238,9 @@ acquire_WM_Sn(bool replace)
                       -1, -1, 1, 1, 0,
                       XCB_COPY_FROM_PARENT, globalconf.screen->root_visual,
                       0, NULL);
+    xwindow_set_class_instance(globalconf.selection_owner_window);
+    xwindow_set_name_static(globalconf.selection_owner_window,
+            "Awesome WM_Sn selection owner window");
 
     atom_name = xcb_atom_name_by_screen("WM_S", globalconf.default_screen);
     if(!atom_name)
@@ -666,6 +669,8 @@ main(int argc, char **argv)
                           1,
                           globalconf.default_cmap
                       });
+    xwindow_set_class_instance(globalconf.focus.window_no_focus);
+    xwindow_set_name_static(globalconf.focus.window_no_focus, "Awesome no input window");
     xcb_map_window(globalconf.connection, globalconf.focus.window_no_focus);
     xcb_create_gc(globalconf.connection, globalconf.gc, globalconf.focus.window_no_focus,
                   XCB_GC_FOREGROUND | XCB_GC_BACKGROUND,

--- a/ewmh.c
+++ b/ewmh.c
@@ -23,6 +23,7 @@
 #include "objects/client.h"
 #include "objects/tag.h"
 #include "common/atoms.h"
+#include "xwindow.h"
 
 #include <sys/types.h>
 #include <unistd.h>
@@ -197,6 +198,9 @@ ewmh_init(void)
     /* set the window manager name */
     xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
                         father, _NET_WM_NAME, UTF8_STRING, 8, 7, "awesome");
+
+    /* Set an instance, just because we can */
+    xwindow_set_class_instance(father);
 
     /* set the window manager PID */
     i = getpid();

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -353,6 +353,8 @@ drawin_allocator(lua_State *L)
                           globalconf.default_cmap,
                           xcursor_new(globalconf.cursor_ctx, xcursor_font_fromstr(w->cursor))
                       });
+    xwindow_set_class_instance(w->window);
+    xwindow_set_name_static(w->window, "Awesome drawin");
 
     /* Set the right properties */
     ewmh_update_window_type(w->window, window_translate_type(w->type));

--- a/selection.c
+++ b/selection.c
@@ -31,6 +31,7 @@
 #include "globalconf.h"
 #include "common/atoms.h"
 #include "event.h"
+#include "xwindow.h"
 
 #include <xcb/xcb_atom.h>
 #include <xcb/xcb_event.h>
@@ -63,6 +64,8 @@ luaA_selection_get(lua_State *L)
         xcb_create_window(globalconf.connection, screen->root_depth, selection_window, screen->root,
                           0, 0, 1, 1, 0, XCB_COPY_FROM_PARENT, screen->root_visual,
                           mask, values);
+        xwindow_set_class_instance(selection_window);
+        xwindow_set_name_static(selection_window, "Awesome selection window");
     }
 
     xcb_convert_selection(globalconf.connection, selection_window,

--- a/systray.c
+++ b/systray.c
@@ -50,6 +50,8 @@ systray_init(void)
                       XCB_COPY_FROM_PARENT, xscreen->root_visual,
                       XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK, (const uint32_t [])
                       { xscreen->black_pixel, XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT });
+    xwindow_set_class_instance(globalconf.systray.window);
+    xwindow_set_name_static(globalconf.systray.window, "Awesome systray window");
 
     atom_name = xcb_atom_name_by_screen("_NET_SYSTEM_TRAY", globalconf.default_screen);
     if(!atom_name)

--- a/xwindow.h
+++ b/xwindow.h
@@ -44,5 +44,14 @@ cairo_surface_t *xwindow_get_shape(xcb_window_t, enum xcb_shape_sk_t);
 void xwindow_set_shape(xcb_window_t, int, int, enum xcb_shape_sk_t, cairo_surface_t *, int);
 void xwindow_translate_for_gravity(xcb_gravity_t, int16_t, int16_t, int16_t, int16_t, int16_t *, int16_t *);
 
+#define xwindow_set_name_static(win, name) \
+    xcb_icccm_set_wm_name(globalconf.connection, win, XCB_ATOM_STRING, 8, sizeof(name) - 1, name)
+#define xwindow_set_class_instance(win) \
+    xwindow_set_class_instance_static(win, "awesome", "awesome")
+#define xwindow_set_class_instance_static(win, instance, class) \
+    _xwindow_set_class_instance_static(win, instance "\0" class)
+#define _xwindow_set_class_instance_static(win, instance_class) \
+    xcb_icccm_set_wm_class(globalconf.connection, win, sizeof(instance_class), instance_class)
+
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The only exception is the window for _NET_SUPPORTING_WM_CHECK. That window
already had a _NET_WM_NAME property before and doesn't get a WM_NAME property in
this commit. I just decided for myself that it doesn't need one. :-)

Right after startup with the default config we now have the following situation:

$ xwininfo -root -tree

xwininfo: Window id: 0x2d7 (the root window) (has no name)

  Root window id: 0x2d7 (the root window) (has no name)
  Parent window id: 0x0 (none)
     7 children:
     0x200011 "Awesome drawin": ("awesome" "awesome")  1500x20+0+0  +0+0
     0x200010 "Awesome drawin": ("awesome" "awesome")  1x1+0+0  +0+0
     0x20000d "Awesome drawin": ("awesome" "awesome")  100x30+0+0  +0+0
     0x20000a "Awesome no input window": ("awesome" "awesome")  1x1+-1+-1  +-1+-1
     0x200009 "Awesome systray window": ("awesome" "awesome")  1x1+-1+-1  +-1+-1
     0x200008 "awesome": ("awesome" "awesome")  1x1+-1+-1  +-1+-1
     0x200007 "Awesome WM_Sn selection owner window": ("awesome" "awesome")  1x1+-1+-1  +-1+-1

One of those drawin is the awful.wibox. Another drawin is created by awful.menu.
I guess that the third one is created by awful.tooltip, but I'm not sure. Wow,
so many windows...

Signed-off-by: Uli Schlachter <psychon@znc.in>