### PR TITLE
Fix/silence various ldoc warnings in menubar

### DIFF
--- a/lib/menubar/icon_theme.lua
+++ b/lib/menubar/icon_theme.lua
@@ -237,7 +237,7 @@ end
 -- @tparam string icon_name Icon name to be looked up
 -- @tparam number icon_size Prefereable icon size
 -- @treturn string Absolute path to the icon file, or nil if not found
-icon_theme.find_icon_path = function(self, icon_name, icon_size)
+function icon_theme:find_icon_path(icon_name, icon_size)
     if not icon_name or icon_name == "" then
         return nil
     end

--- a/lib/menubar/index_theme.lua
+++ b/lib/menubar/index_theme.lua
@@ -32,6 +32,7 @@ local THRESHOLD = "Threshold"
 local index_theme = { mt = {} }
 
 --- Class constructor of `index_theme`
+-- @tparam table cls Metatable that will be used. Should always be `index_theme.mt`.
 -- @tparam string icon_theme_name Internal name of icon theme
 -- @tparam table base_directories Paths used for lookup
 -- @treturn table An instance of the class `index_theme`
@@ -150,7 +151,7 @@ end
 -- @treturn[3] number VAlue of the `MinSize` key
 -- @treturn[4] number Value of the `MaxSize` key
 -- @treturn[5] number Value of the `Threshold` key
-index_theme.get_per_directory_keys = function(self, subdirectory)
+function index_theme:get_per_directory_keys(subdirectory)
     local keys = self.per_directory_keys[subdirectory]
     return keys[TYPE], keys[SIZE], keys[MINSIZE], keys[MAXSIZE], keys[THRESHOLD]
 end

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -149,7 +149,7 @@ end
 
 local lookup_icon_cache = {}
 --- Lookup an icon in different folders of the filesystem (cached).
--- @param icon_file Short or full name of the icon.
+-- @param icon Short or full name of the icon.
 -- @return full name of the icon.
 function utils.lookup_icon(icon)
     if not lookup_icon_cache[icon] and lookup_icon_cache[icon] ~= false then


### PR DESCRIPTION
I don't think `menubar.index_theme.new` really should be a public / should get the metatable for the created object via an argument, but whatever. This is the way it is....