### PR TITLE
Reset layout group number to default when update_layout() is called

### DIFF
--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -250,6 +250,7 @@ local function update_layout(self)
         -- is greater by one than the real group number.
         self._layout[v.group_idx - 1] = layout_name
     end
+    awesome.xkb_set_layout_group(0);
     update_status(self)
 end
 


### PR DESCRIPTION
This reset is needed to keep the internal state of XKB consistent; otherwise, `awesome.xkb_get_layout_group()` returns the value for the previous XKB setting, and that confuses
`keyboardlayout.update_status()`, in particular, when `self._current` happens to be larger than `#self._layout`.

To be more specific, suppose we've just switched from a layout group to another via `setxkbmap`, and that the number of the layouts contained in the former group is larger than that in the latter.  Then, it is possible that the layout ID number we chose for the previous layout group is larger than the total number of the layouts contained in the current layout group.  

If that is the case, Awesome naturally raises a warning like
```
Oops, an error happened!
/usr/local/share/awesome/lib/awful/widget/keyboardlayout.lua:122: attempt to concatenate a nil value (field '?')
```
because `#self._layout < self._current`.

The proposed patch fixes that.