### PR TITLE
Added value check of required 'Name' entry in .desktop parsing

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -188,6 +188,9 @@ function utils.parse(file)
     -- In case [Desktop Entry] was not found
     if not desktop_entry then return nil end
 
+    -- In case the (required) 'Name' entry was not found
+    if not program.Name or program.Name == '' then return nil end
+
     -- Don't show program if NoDisplay attribute is false
     if program.NoDisplay and string.lower(program.NoDisplay) == "true" then
         program.show = false


### PR DESCRIPTION
I encountered a problem recently caused by a malformed .desktop file missing the 'Name' entry.
This invalid .desktop file broke the entire menubar.
It only adds a non-empty/nil check on the 'Name' entry, which is declared 'required' by the desktop entry specifications.
