### PR TITLE
Add various directory getters to awful.util

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -39,7 +39,7 @@ end
 
 -- {{{ Variable definitions
 -- Themes define colours, icons, font and wallpapers.
-beautiful.init("@AWESOME_THEMES_PATH@/default/theme.lua")
+beautiful.init(awful.util.get_themes_dir() .. "default/theme.lua")
 
 -- This is used later as the default terminal and editor to run.
 terminal = "xterm"

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -318,7 +318,7 @@ globalkeys = awful.util.table.join(
                   awful.prompt.run({ prompt = "Run Lua code: " },
                   mypromptbox[awful.screen.focused()].widget,
                   awful.util.eval, nil,
-                  awful.util.getdir("cache") .. "/history_eval")
+                  awful.util.get_cache_dir() .. "/history_eval")
               end,
               {description = "lua execute prompt", group = "awesome"}),
     -- Menubar

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -158,6 +158,18 @@ function util.get_cache_dir()
     return util.get_xdg_cache_home() .. "awesome/"
 end
 
+--- Get the path to the directory where themes are installed.
+-- @return A string with the requested path with a slash at the end.
+function util.get_themes_dir()
+    return "@AWESOME_THEMES_PATH@" .. "/"
+end
+
+--- Get the path to the directory where our icons are installed.
+-- @return A string with the requested path with a slash at the end.
+function util.get_awesome_icon_dir()
+    return "@AWESOME_ICON_PATH@" .. "/"
+end
+
 --- Get the user's config or cache dir.
 -- It first checks XDG_CONFIG_HOME / XDG_CACHE_HOME, but then goes with the
 -- default paths.

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -133,6 +133,31 @@ function util.restart()
     capi.awesome.restart()
 end
 
+--- Get the config home according to the XDG basedir specification.
+-- @return the config home (XDG_CONFIG_HOME) with a slash at the end.
+function util.get_xdg_config_home()
+    return (os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config") .. "/"
+end
+
+--- Get the cache home according to the XDG basedir specification.
+-- @return the cache home (XDG_CACHE_HOME) with a slash at the end.
+function util.get_xdg_cache_home()
+    return (os.getenv("XDG_CACHE_HOME") or os.getenv("HOME") .. "/.cache") .. "/"
+end
+
+--- Get the path to the user's config dir.
+-- This is the directory containing the configuration file ("rc.lua").
+-- @return A string with the requested path with a slash at the end.
+function util.get_configuration_dir()
+    return capi.awesome.conffile:match(".*/") or "./"
+end
+
+--- Get the path to a directory that should be used for caching data.
+-- @return A string with the requested path with a slash at the end.
+function util.get_cache_dir()
+    return util.get_xdg_cache_home() .. "awesome/"
+end
+
 --- Get the user's config or cache dir.
 -- It first checks XDG_CONFIG_HOME / XDG_CACHE_HOME, but then goes with the
 -- default paths.
@@ -140,17 +165,11 @@ end
 -- @return A string containing the requested path.
 function util.getdir(d)
     if d == "config" then
-        local dir = os.getenv("XDG_CONFIG_HOME")
-        if dir then
-            return dir .. "/awesome"
-        end
-        return os.getenv("HOME") .. "/.config/awesome"
+        -- No idea why this is what is returned, I recommend everyone to use
+        -- get_configuration_dir() instead
+        return util.get_xdg_config_home() .. "awesome/"
     elseif d == "cache" then
-        local dir = os.getenv("XDG_CACHE_HOME")
-        if dir then
-            return dir .. "/awesome"
-        end
-        return os.getenv("HOME").."/.cache/awesome"
+        return util.get_cache_dir()
     end
 end
 

--- a/lib/awful/widget/prompt.lua
+++ b/lib/awful/widget/prompt.lua
@@ -27,7 +27,7 @@ local function run(promptbox)
                           promptbox:spawn_and_handle_error(...)
                       end,
                       completion.shell,
-                      util.getdir("cache") .. "/history")
+                      util.get_cache_dir() .. "/history")
 end
 
 local function spawn_and_handle_error(self, ...)

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -315,7 +315,7 @@ function menubar.show(scr)
     awful.prompt.run(prompt_args, instance.prompt.widget,
                 function(s) end,            -- exe_callback function set to do nothing
                 awful.completion.shell,     -- completion_callback
-                awful.util.getdir("cache") .. "/history_menu",
+                awful.util.get_cache_dir() .. "/history_menu",
                 nil,
                 menubar.hide, function(query) menulist_update(query, scr) end,
                 prompt_keypressed_callback


### PR DESCRIPTION
This started as a fix for #218, but ended up with a couple more functions.

The PR adds functions that get various useful directories. Especially, we now have a function that returns the directory containing the configuration. `awful.util.getdir("config")` retains its old (IMO misleading) behavior, just because of backwards compatibility.