### PR TITLE
Spawn exit code

### DIFF
--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -91,20 +91,24 @@ end
 
 --- Spawn a program and asynchronously and capture its output line by line.
 -- @tparam string|table cmd The command.
--- @tparam[opt] function stdout_callback Function that is called with each line of
---   output on stdout, e.g. `stdout_callback(line)`.
--- @tparam[opt] function stderr_callback Function that is called with each line of
---   output on stderr, e.g. `stderr_callback(line)`.
--- @tparam[opt] function done_callback Function to call when no more output is
---   produced.
--- @tparam[opt] function exit_callback Function to call when the spawned process
+-- @tab callbacks Table containing callbacks that should be
+--   invoked on various conditions.
+-- @tparam[opt] function callbacks.stdout Function that is called with each line of
+--   output on stdout, e.g. `stdout(line)`.
+-- @tparam[opt] function callbacks.stderr Function that is called with each line of
+--   output on stderr, e.g. `stderr(line)`.
+-- @tparam[opt] function callbacks.output_done Function to call when no more output
+--   is produced.
+-- @tparam[opt] function callbacks.exit Function to call when the spawned process
 -- exits. This function gets the exit reason and code as its argument. The
 -- reason can be "exit" or "signal". For "exit", the second argument is the exit
 -- code. For "signal", the second argument is the signal causing process
 -- termination.
 -- @treturn[1] Integer the PID of the forked process.
 -- @treturn[2] string Error message.
-function spawn.with_line_callback(cmd, stdout_callback, stderr_callback, done_callback, exit_callback)
+function spawn.with_line_callback(cmd, callbacks)
+    local stdout_callback, stderr_callback, done_callback, exit_callback =
+        callbacks.stdout, callbacks.stderr, callbacks.output_done, callbacks.exit
     local have_stdout, have_stderr = stdout_callback ~= nil, stderr_callback ~= nil
     local pid, sn_id, stdin, stdout, stderr = capi.awesome.spawn(cmd,
             false, false, have_stdout, have_stderr, exit_callback)

--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -97,11 +97,17 @@ end
 --   output on stderr, e.g. `stderr_callback(line)`.
 -- @tparam[opt] function done_callback Function to call when no more output is
 --   produced.
+-- @tparam[opt] function exit_callback Function to call when the spawned process
+-- exits. This function gets the exit reason and code as its argument. The
+-- reason can be "exit" or "signal". For "exit", the second argument is the exit
+-- code. For "signal", the second argument is the signal causing process
+-- termination.
 -- @treturn[1] Integer the PID of the forked process.
 -- @treturn[2] string Error message.
-function spawn.with_line_callback(cmd, stdout_callback, stderr_callback, done_callback)
+function spawn.with_line_callback(cmd, stdout_callback, stderr_callback, done_callback, exit_callback)
     local have_stdout, have_stderr = stdout_callback ~= nil, stderr_callback ~= nil
-    local pid, sn_id, stdin, stdout, stderr = capi.awesome.spawn(cmd, false, false, have_stdout, have_stderr)
+    local pid, sn_id, stdin, stdout, stderr = capi.awesome.spawn(cmd,
+            false, false, have_stdout, have_stderr, exit_callback)
     if type(pid) == "string" then
         -- Error
         return pid

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -3,6 +3,7 @@
 local spawn = require("awful.spawn")
 
 local spawns_done = 0
+local exit_yay, exit_snd = nil, nil
 
 local steps = {
   function(count)
@@ -16,11 +17,16 @@ local steps = {
         assert(steps_yay == 1)
         steps_yay = steps_yay + 1
         spawns_done = spawns_done + 1
+      end, function(reason, code)
+        assert(reason == "exit")
+        assert(exit_yay == nil)
+        assert(code == 0)
+        exit_yay = code
       end)
 
       local steps_count = 0
       local err_count = 0
-      spawn.with_line_callback({ "sh", "-c", "printf line1\\\\nline2\\\\nline3 ; echo err >&2" },
+      spawn.with_line_callback({ "sh", "-c", "printf line1\\\\nline2\\\\nline3 ; echo err >&2 ; exit 42" },
       function(line)
         assert(steps_count < 3)
         steps_count = steps_count + 1
@@ -34,9 +40,16 @@ local steps = {
         assert(err_count == 1)
         steps_count = steps_count + 1
         spawns_done = spawns_done + 1
+      end, function(reason, code)
+        assert(reason == "exit")
+        assert(exit_snd == nil)
+        assert(code == 42)
+        exit_snd = code
       end)
     end
     if spawns_done == 2 then
+      assert(exit_yay == 0)
+      assert(exit_snd == 42)
       return true
     end
   end,

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -9,43 +9,51 @@ local steps = {
   function(count)
     if count == 1 then
       local steps_yay = 0
-      spawn.with_line_callback("echo yay", function(line)
-        assert(line == "yay", "line == '" .. tostring(line) .. "'")
-        assert(steps_yay == 0)
-        steps_yay = steps_yay + 1
-      end, nil, function()
-        assert(steps_yay == 1)
-        steps_yay = steps_yay + 1
-        spawns_done = spawns_done + 1
-      end, function(reason, code)
-        assert(reason == "exit")
-        assert(exit_yay == nil)
-        assert(code == 0)
-        exit_yay = code
-      end)
+      spawn.with_line_callback("echo yay", {
+          stdout = function(line)
+              assert(line == "yay", "line == '" .. tostring(line) .. "'")
+              assert(steps_yay == 0)
+              steps_yay = steps_yay + 1
+          end,
+          output_done = function()
+              assert(steps_yay == 1)
+              steps_yay = steps_yay + 1
+              spawns_done = spawns_done + 1
+          end,
+          exit = function(reason, code)
+              assert(reason == "exit")
+              assert(exit_yay == nil)
+              assert(code == 0)
+              exit_yay = code
+          end
+      })
 
       local steps_count = 0
       local err_count = 0
-      spawn.with_line_callback({ "sh", "-c", "printf line1\\\\nline2\\\\nline3 ; echo err >&2 ; exit 42" },
-      function(line)
-        assert(steps_count < 3)
-        steps_count = steps_count + 1
-        assert(line == "line" .. steps_count, "line == '" .. tostring(line) .. "'")
-      end, function(line)
-        assert(err_count == 0)
-        err_count = err_count + 1
-        assert(line == "err", "line == '" .. tostring(line) .. "'")
-      end, function()
-        assert(steps_count == 3)
-        assert(err_count == 1)
-        steps_count = steps_count + 1
-        spawns_done = spawns_done + 1
-      end, function(reason, code)
-        assert(reason == "exit")
-        assert(exit_snd == nil)
-        assert(code == 42)
-        exit_snd = code
-      end)
+      spawn.with_line_callback({ "sh", "-c", "printf line1\\\\nline2\\\\nline3 ; echo err >&2 ; exit 42" }, {
+          stdout = function(line)
+              assert(steps_count < 3)
+              steps_count = steps_count + 1
+              assert(line == "line" .. steps_count, "line == '" .. tostring(line) .. "'")
+          end,
+          stderr = function(line)
+              assert(err_count == 0)
+              err_count = err_count + 1
+              assert(line == "err", "line == '" .. tostring(line) .. "'")
+          end,
+          output_done = function()
+              assert(steps_count == 3)
+              assert(err_count == 1)
+              steps_count = steps_count + 1
+              spawns_done = spawns_done + 1
+          end,
+          exit = function(reason, code)
+              assert(reason == "exit")
+              assert(exit_snd == nil)
+              assert(code == 42)
+              exit_snd = code
+          end
+      })
     end
     if spawns_done == 2 then
       assert(exit_yay == 0)


### PR DESCRIPTION
This adds support for getting a spawned processes exit status. Just because @blueyed wanted this. :-)

Some question: Should the last two arguments to `with_line_callback` be swapped? I guess it makes more sense to have the exit callback first and then the done callback.
And before someone asks: The done callback is called when the streams for stdout and stderr are closed. This is something else than "the spawned process exits", because it can in turn start other processes that share stdout and keep it open, etc.