### PR TITLE
Add an option to set the preferred client icon size

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -543,6 +543,9 @@ main(int argc, char **argv)
     /* We have no clue where the input focus is right now */
     globalconf.focus.need_update = true;
 
+    /* set the default preferred icon size */
+    globalconf.preferred_icon_size = 0;
+
     /* XLib sucks */
     XkbIgnoreExtension(True);
 

--- a/ewmh.h
+++ b/ewmh.h
@@ -41,7 +41,7 @@ void ewmh_process_client_strut(client_t *);
 void ewmh_update_strut(xcb_window_t, strut_t *);
 void ewmh_update_window_type(xcb_window_t window, uint32_t type);
 xcb_get_property_cookie_t ewmh_window_icon_get_unchecked(xcb_window_t);
-cairo_surface_t *ewmh_window_icon_get_reply(xcb_get_property_cookie_t);
+cairo_surface_t *ewmh_window_icon_get_reply(xcb_get_property_cookie_t, uint32_t preferred_size);
 
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/globalconf.h
+++ b/globalconf.h
@@ -167,6 +167,8 @@ typedef struct
     struct xkb_context *xkb_ctx;
     /* xkb state of dead keys on keyboard */
     struct xkb_state *xkb_state;
+    /** The preferred size of client icons for this screen */
+    uint32_t preferred_icon_size;
 } awesome_t;
 
 extern awesome_t globalconf;

--- a/luaa.c
+++ b/luaa.c
@@ -162,6 +162,21 @@ luaA_load_image(lua_State *L)
     return 1;
 }
 
+/** Set the preferred size for client icons.
+ *
+ * The closest equal or bigger size is picked if present, otherwise the closest
+ * smaller size is picked. The default is 0 pixels, ie. the smallest icon.
+ *
+ * @param size The size of the icons in pixels.
+ * @function set_preferred_icon_size
+ */
+static int
+luaA_set_preferred_icon_size(lua_State *L)
+{
+    globalconf.preferred_icon_size = luaL_checknumber(L, 1);
+    return 0;
+}
+
 /** UTF-8 aware string length computing.
  * \param L The Lua VM state.
  * \return The number of elements pushed on stack.
@@ -407,6 +422,7 @@ luaA_init(xdgHandle* xdg)
         { "emit_signal", luaA_awesome_emit_signal },
         { "systray", luaA_systray },
         { "load_image", luaA_load_image },
+        { "set_preferred_icon_size", luaA_set_preferred_icon_size },
         { "register_xproperty", luaA_register_xproperty },
         { "set_xproperty", luaA_set_xproperty },
         { "get_xproperty", luaA_get_xproperty },

--- a/property.c
+++ b/property.c
@@ -273,7 +273,7 @@ property_get_net_wm_icon(client_t *c)
 void
 property_update_net_wm_icon(client_t *c, xcb_get_property_cookie_t cookie)
 {
-    cairo_surface_t *surface = ewmh_window_icon_get_reply(cookie);
+    cairo_surface_t *surface = ewmh_window_icon_get_reply(cookie, globalconf.preferred_icon_size);
 
     if(!surface)
         return;


### PR DESCRIPTION
Hi guys :)

I tried to get this merged in a (less than satisfactory) per-screen form some years ago... I figured I'm never gonna do this properly, so I simplified the implementation to just one global setting. While this doesn't take DPI into account etc., it's better than nothing... Right? :)

Adds a awesome.set_preferred_icon_size() method to set the preferred icon size of the clients.