### PR TITLE
Use integer size when creating titlebar

### DIFF
--- a/lib/awful/titlebar.lua
+++ b/lib/awful/titlebar.lua
@@ -64,7 +64,7 @@ end
 local function new(c, args)
     local args = args or {}
     local position = args.position or "top"
-    local size = args.size or beautiful.get_font_height(args.font) * 1.5
+    local size = args.size or math.floor(beautiful.get_font_height(args.font) * 1.5)
     local d = get_titlebar_function(c, position)(c, size)
 
     -- Make sure that there is never more than one titlebar for any given client


### PR DESCRIPTION
I stumbled upon this issue during investigation of a bug. Function `get_titlebar_function()` calls `titlebar_resize()` which requires size as an integer.