### PR TITLE
Vim modelines and Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# See http://editorconfig.org
+
+# Don't search for other .editconfig files
+root = true
+
+[*]
+
+# Unix-style newlines
+end_of_line = lf
+
+# There a newline at the end of the file
+insert_final_newline = true
+
+# Trailing whitespaces, no one needs them
+trim_trailing_whitespace = true
+
+# Why would anyone use anything else?
+charset = utf-8
+
+# This is just what we use, sorry if you disagree
+indent_style = space
+indent_size = 4
+
+# In a Makefile, the tab is significant and not "just" whitespace
+[Makefile]
+indent_style = tab

--- a/awesome-version-internal.h
+++ b/awesome-version-internal.h
@@ -5,3 +5,5 @@
 #define AWESOME_RELEASE             "@AWESOME_RELEASE@"
 
 #endif //_AWE_VERSION_INTERNAL_H_
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-tests/__builtin_clz.c
+++ b/build-tests/__builtin_clz.c
@@ -10,3 +10,5 @@ main(void)
 
 	return (__builtin_clz(42));
 }
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-utils/atoms-ext.sh
+++ b/build-utils/atoms-ext.sh
@@ -7,3 +7,5 @@ while read atom
 do
     echo extern xcb_atom_t $atom\;
 done < $1
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-utils/atoms-int.sh
+++ b/build-utils/atoms-int.sh
@@ -18,3 +18,5 @@ do
 done < $1
 
 echo '};'
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-utils/dist.sh
+++ b/build-utils/dist.sh
@@ -11,3 +11,5 @@ cd dist
 echo -n $VERSION > awesome-$SVERSION/.version_stamp
 tar cjf awesome-$SVERSION.tar.bz2 awesome-$SVERSION
 tar cJf awesome-$SVERSION.tar.xz awesome-$SVERSION
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-utils/git-version-stamp.sh
+++ b/build-utils/git-version-stamp.sh
@@ -29,3 +29,5 @@ then
     mv "$2.new" "$2"
     echo -n "$CURRENT" > "$1"
 fi
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-utils/lgi-check.sh
+++ b/build-utils/lgi-check.sh
@@ -33,3 +33,5 @@ lua -e '_, _, major_minor, patch = string.find(require("lgi.version"), "^(%d%.%d
 
 # Check for the needed gi files
 lua -e 'l = require("lgi") assert(l.cairo, l.Pango, l.PangoCairo, l.GLib, l.Gio)' || die
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-utils/travis-apidoc.sh
+++ b/build-utils/travis-apidoc.sh
@@ -107,3 +107,5 @@ if [ "$TRAVIS_PULL_REQUEST" != false ]; then
     -d "{\"body\": \"Documentation has been updated for this PR:\n$COMPARE_LINKS\"}" \
     https://api.github.com/repos/awesomeWM/awesome/issues/${TRAVIS_PULL_REQUEST}/comments
 fi
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/common/buffer.c
+++ b/common/buffer.c
@@ -113,3 +113,5 @@ buffer_detach(buffer_t *buf)
     buffer_init(buf);
     return res;
 }
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/common/buffer.h
+++ b/common/buffer.h
@@ -195,3 +195,5 @@ void buffer_addf(buffer_t *buf, const char *fmt, ...)
     __attribute__((format(printf, 2, 3)));
 
 #endif
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/common/lualib.c
+++ b/common/lualib.c
@@ -61,3 +61,5 @@ void luaA_dumpstack(lua_State *L)
     }
     fprintf(stderr, "------- Lua stack dump end ------\n");
 }
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/common/version.h
+++ b/common/version.h
@@ -27,3 +27,5 @@ const char *awesome_version_string(void);
 const char *awesome_release_string(void);
 
 #endif
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/config.h
+++ b/config.h
@@ -10,3 +10,5 @@
 #cmakedefine HAS___BUILTIN_CLZ
 
 #endif //_CONFIG_H_
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -71,4 +71,4 @@ file = {
     }
 }
 
--- vim: filetype=lua
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/hotkeys_popup/init.lua
+++ b/lib/awful/hotkeys_popup/init.lua
@@ -14,3 +14,5 @@ local hotkeys_popup = {
 }
 hotkeys_popup.show_help = hotkeys_popup.widget.show_help
 return hotkeys_popup
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/hotkeys_popup/keys/init.lua
+++ b/lib/awful/hotkeys_popup/keys/init.lua
@@ -12,3 +12,5 @@ local keys = {
   vim = require("awful.hotkeys_popup.keys.vim")
 }
 return keys
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/layout/suit/fair.lua
+++ b/lib/awful/layout/suit/fair.lua
@@ -95,3 +95,5 @@ function fair.arrange(p)
 end
 
 return fair
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/layout/suit/floating.lua
+++ b/lib/awful/layout/suit/floating.lua
@@ -100,3 +100,5 @@ end
 floating.name = "floating"
 
 return floating
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/layout/suit/init.lua
+++ b/lib/awful/layout/suit/init.lua
@@ -16,3 +16,5 @@ return
     magnifier = require("awful.layout.suit.magnifier");
     spiral = require("awful.layout.suit.spiral");
 }
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/layout/suit/magnifier.lua
+++ b/lib/awful/layout/suit/magnifier.lua
@@ -141,3 +141,5 @@ end
 magnifier.name = "magnifier"
 
 return magnifier
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/layout/suit/max.lua
+++ b/lib/awful/layout/suit/max.lua
@@ -49,3 +49,5 @@ function max.fullscreen.arrange(p)
 end
 
 return max
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/layout/suit/tile.lua
+++ b/lib/awful/layout/suit/tile.lua
@@ -321,3 +321,5 @@ tile.mouse_resize_handler = tile.right.mouse_resize_handler
 tile.name = tile.right.name
 
 return tile
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/mouse/finder.lua
+++ b/lib/awful/mouse/finder.lua
@@ -167,4 +167,4 @@ end
 
 return setmetatable(finder, finder.mt)
 
--- vim: ft=lua:et:sw=4:ts=4:sts=4:tw=78
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -284,4 +284,4 @@ end
 
 return setmetatable(tooltip, tooltip.mt)
 
--- vim: ft=lua:et:sw=4:ts=4:sts=4:tw=78
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/spec/preload.lua
+++ b/spec/preload.lua
@@ -2,3 +2,5 @@
 -- won't be cleared and reloaded by Busted. This is needed for lgi because lgi
 -- is not safe to reload and yet Busted manages to do this.
 require("lgi")
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/_runner.lua
+++ b/tests/_runner.lua
@@ -85,3 +85,5 @@ runner.run_steps = function(steps)
 end
 
 return runner
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/_wibox_helper.lua
+++ b/tests/_wibox_helper.lua
@@ -30,3 +30,5 @@ return { create_wibox = function()
 
     return wb, textclock, img, left_layout, right_layout, layout
 end }
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -184,3 +184,5 @@ if ! [ $errors = 0 ]; then
     exit 1
 fi
 exit 0
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-benchmark.lua
+++ b/tests/test-benchmark.lua
@@ -73,3 +73,5 @@ benchmark(redraw_textclock, "redraw textclock")
 benchmark(e2e_tag_switch, "tag switch")
 
 require("_runner").run_steps({ function() return true end })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-focus.lua
+++ b/tests/test-focus.lua
@@ -46,3 +46,5 @@ local steps = {
 }
 
 require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -80,3 +80,5 @@ prepare_for_collect = emit_refresh
 collectable(create_wibox())
 
 require("_runner").run_steps({ function() return true end })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-spawn-snid.lua
+++ b/tests/test-spawn-snid.lua
@@ -40,3 +40,5 @@ local steps = {
 }
 
 require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -43,3 +43,5 @@ local steps = {
 }
 
 require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-urgent.lua
+++ b/tests/test-urgent.lua
@@ -107,3 +107,5 @@ local steps = {
 }
 
 require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/themes/default/theme.lua
+++ b/themes/default/theme.lua
@@ -103,4 +103,5 @@ theme.awesome_icon = "@AWESOME_ICON_PATH@/awesome16.png"
 theme.icon_theme = nil
 
 return theme
+
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/themes/sky/theme.lua
+++ b/themes/sky/theme.lua
@@ -82,4 +82,5 @@ theme.titlebar_maximized_button_normal_active = "@AWESOME_THEMES_PATH@/default/t
 theme.titlebar_maximized_button_focus_active = "@AWESOME_THEMES_PATH@/default/titlebar/maximized_focus_active.png"
 
 return theme
+
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/themes/xresources/theme.lua
+++ b/themes/xresources/theme.lua
@@ -96,4 +96,5 @@ theme.wallpaper = theme_assets.wallpaper(
 )
 
 return theme
+
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/themes/zenburn/theme.lua
+++ b/themes/zenburn/theme.lua
@@ -129,3 +129,5 @@ theme.titlebar_maximized_button_normal_inactive = "@AWESOME_THEMES_PATH@/zenburn
 -- }}}
 
 return theme
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -62,3 +62,5 @@ then
 else
     a_dbus_send "$(cat)"
 fi
+
+# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/xkb.c
+++ b/xkb.c
@@ -315,3 +315,5 @@ xkb_free(void)
                           0);
     xkb_free_keymap();
 }
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/xkb.h
+++ b/xkb.h
@@ -33,5 +33,6 @@ int luaA_xkb_set_layout_group(lua_State *L);
 int luaA_xkb_get_layout_group(lua_State *L);
 int luaA_xkb_get_group_names(lua_State *L);
 
-
 #endif
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/xrdb.c
+++ b/xrdb.c
@@ -74,3 +74,5 @@ int luaA_xrdb_get_value(lua_State *L) {
     return 0;
   }
 }
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/xrdb.h
+++ b/xrdb.h
@@ -26,5 +26,6 @@
 
 int luaA_xrdb_get_value(lua_State *L);
 
-
 #endif
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Thanks to @blueyed's comment on https://github.com/psychon/awesome/commit/ec21093917e60775d3f31a992ced178fdb14a6b4, I know about editorconfig.org. This PR first updates various vim modelines and then adds an editorconfig config file.

For finding missing modelines, the following was used:
```sh
git ls-tree HEAD -r |
  grep -v manpages/awesome |
  cut -c 54- |
  grep -v png |
  while read file
  do
    printf "%s " "$file"
    tail -n 1 "$file"
  done  |
  grep -v '// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80' |
  grep -v -- '-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80' |
  grep -v '# vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80' |
  grep -v '# vim: filetype=cmake:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80:foldmethod=marker'
```
After the commits in this PR, the above produces the following output:
```
.editorconfig indent_style = tab
.gitignore /awesome
.travis.yml   - if [ "$BUILD_APIDOC" = "true" ]; then build-utils/travis-apidoc.sh; fi
LICENSE Public License instead of this License.
Makefile .PHONY: cmake-build cmake install distclean $(BUILDLN) tags
README.md or [v3](http://www.gnu.org/licenses/gpl.html)).
awesome.desktop Type=Application
awesomerc.lua -- }}}
common/atoms.list AWESOME_CLIENT_ORDER
docs/00-authors.md all copies or substantial portions of the Software.
docs/01-readme.md or [v3](http://www.gnu.org/licenses/gpl.html)).
docs/02-contributing.md   it first by sending email to yourself.
spec/menubar/icons/awesome/index.theme Size=64
themes/default/README     Licensed under CC-BY-SA-3.0
```
(I don't know why `awesomerc.lua` doesn't have a modeline, but it's always been like this and I will just keep it this way)