### PR TITLE
Fix #599 (issue with focus on multiple instances)

### DIFF
--- a/event.c
+++ b/event.c
@@ -580,6 +580,12 @@ event_handle_enternotify(xcb_enter_notify_event_t *ev)
         }
         lua_pop(L, 1);
     }
+    else if (ev->event == globalconf.screen->root) {
+        /* for when there are multiple X screens with awesome running
+         * separate instances, reset focus
+         */
+        globalconf.focus.need_update = true;
+    }
 }
 
 /** The focus in event handler.


### PR DESCRIPTION
This fixes #599 as far as I'm concerned - meaning it changes behavior to fix the issues I was seeing with running multiple instances of awesome on separate screens.

The awesomeConfig.cmake I accidentally checked in prior to this branch, and now github wants it unconditionally, and I can't seem to deselect it. However, if you do require lua v5.3, it does fix an issue with FindLua when there are multiple versions of lua installed on the system (since lua doesn't really do pkg config very well)