### PR TITLE
Replace various calls to warn() with luaA_warn()

### DIFF
--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -254,7 +254,7 @@ signal_object_emit(lua_State *L, signal_array_t *arr, const char *name, int narg
             luaA_dofunction(L, nargs, 0);
         }
     } else
-        warn("Trying to emit unknown signal '%s'", name);
+        luaA_warn(L, "Trying to emit unknown signal '%s'", name);
 
     /* remove args */
     lua_pop(L, nargs);
@@ -273,11 +273,11 @@ luaA_object_emit_signal(lua_State *L, int oud,
     lua_class_t *lua_class = luaA_class_get(L, oud);
     lua_object_t *obj = luaA_toudata(L, oud, lua_class);
     if(!obj) {
-        warn("Trying to emit signal '%s' on non-object", name);
+        luaA_warn(L, "Trying to emit signal '%s' on non-object", name);
         return;
     }
     else if(lua_class->checker && !lua_class->checker(obj)) {
-        warn("Trying to emit signal '%s' on invalid object", name);
+        luaA_warn(L, "Trying to emit signal '%s' on invalid object", name);
         return;
     }
     signal_t *sigfound = signal_array_getbyid(&obj->signals,
@@ -304,8 +304,10 @@ luaA_object_emit_signal(lua_State *L, int oud,
             lua_remove(L, - nargs - nbfunc - 2 + i);
             luaA_dofunction(L, nargs + 1, 0);
         }
-    } else
-        warn("Trying to emit unknown signal '%s'", name);
+    } else {
+        luaA_warn(L, "Trying to emit unknown signal '%s'", name);
+        return;
+    }
 
     /* Then emit signal on the class */
     lua_pushvalue(L, oud);

--- a/objects/key.c
+++ b/objects/key.c
@@ -91,14 +91,14 @@ luaA_keystore(lua_State *L, int ud, const char *str, ssize_t len)
 
             if(!g_utf8_validate(str, -1, NULL))
             {
-                warn("failed to convert \"%s\" into keysym (invalid UTF-8 string)", str);
+                luaA_warn(L, "failed to convert \"%s\" into keysym (invalid UTF-8 string)", str);
                 return;
             }
 
             length = g_utf8_strlen(str, -1); /* This function counts combining characters. */
             if(length <= 0)
             {
-                warn("failed to convert \"%s\" into keysym (empty UTF-8 string)", str);
+                luaA_warn(L, "failed to convert \"%s\" into keysym (empty UTF-8 string)", str);
                 return;
             }
             else if(length > 1)
@@ -107,7 +107,7 @@ luaA_keystore(lua_State *L, int ud, const char *str, ssize_t len)
                 if(g_utf8_strlen(composed, -1) != 1)
                 {
                     p_delete(&composed);
-                    warn("failed to convert \"%s\" into keysym (failed to compose a single character)", str);
+                    luaA_warn(L, "failed to convert \"%s\" into keysym (failed to compose a single character)", str);
                     return;
                 }
                 unicode = g_utf8_get_char(composed);
@@ -118,7 +118,7 @@ luaA_keystore(lua_State *L, int ud, const char *str, ssize_t len)
 
             if(unicode == (gunichar)-1 || unicode == (gunichar)-2)
             {
-                warn("failed to convert \"%s\" into keysym (neither keysym nor single unicode)", str);
+                luaA_warn(L, "failed to convert \"%s\" into keysym (neither keysym nor single unicode)", str);
                 return;
             }
 
@@ -132,7 +132,7 @@ luaA_keystore(lua_State *L, int ud, const char *str, ssize_t len)
                 key->keysym = unicode | (1 << 24);
             else
             {
-                warn("failed to convert \"%s\" into keysym (unicode out of range): \"%u\"", str, unicode);
+                luaA_warn(L, "failed to convert \"%s\" into keysym (unicode out of range): \"%u\"", str, unicode);
                 return;
             }
         }

--- a/objects/window.c
+++ b/objects/window.c
@@ -295,7 +295,7 @@ luaA_window_set_type(lua_State *L, window_t *w)
         type = WINDOW_TYPE_NORMAL;
     else
     {
-        warn("Unknown window type '%s'", buf);
+        luaA_warn(L, "Unknown window type '%s'", buf);
         return 0;
     }
 

--- a/spawn.c
+++ b/spawn.c
@@ -419,9 +419,7 @@ luaA_spawn(lua_State *L)
     if(!argv || !argv[0])
     {
         g_strfreev(argv);
-        /* push error on stack */
-        lua_pushfstring(L, "spawn: parse error: %s", error->message);
-        warn("%s", lua_tostring(L, -1));
+        luaA_warn(L, "spawn: parse error: %s", error->message);
         g_error_free(error);
         return 1;
     }
@@ -447,9 +445,7 @@ luaA_spawn(lua_State *L)
     g_strfreev(argv);
     if(!retval)
     {
-        /* push error on stack */
-        lua_pushstring(L, error->message);
-        warn("%s", lua_tostring(L, -1));
+        luaA_warn(L, "%s", error->message);
         g_error_free(error);
         if(context)
             sn_launcher_context_complete(context);


### PR DESCRIPTION
luaA_warn() prints a Lua backtrace and thus generates more useful output. warn()
should only be used in awesome-internal places (e.g. receiving an error from the
X11 server).