### PR TITLE
Fix client icons

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -694,7 +694,7 @@ ewmh_window_icon_from_reply(xcb_get_property_reply_t *r, uint32_t preferred_size
         bool better_because_bigger =  found_icon_too_small && size > found_size;
         bool better_because_smaller = found_icon_too_large &&
             size >= preferred_size && size < found_size;
-        if (!icon_empty && (better_because_bigger || better_because_smaller))
+        if (!icon_empty && (better_because_bigger || better_because_smaller || found_size == 0))
         {
             found_data = data;
             found_size = size;

--- a/ewmh.c
+++ b/ewmh.c
@@ -686,10 +686,15 @@ ewmh_window_icon_from_reply(xcb_get_property_reply_t *r, uint32_t preferred_size
 
         /* use the greater of the two dimensions to match against the preferred size */
         uint32_t size = MAX(data[0], data[1]);
+
         /* pick the icon if it's a better match than the one we already have */
-        if (data[0] && data[1] && (
-            (found_size < preferred_size && size > found_size) ||
-            (found_size > preferred_size && size >= preferred_size && size < found_size)))
+        bool found_icon_too_small = found_size < preferred_size;
+        bool found_icon_too_large = found_size > preferred_size;
+        bool icon_empty = data[0] == 0 || data[1] == 0;
+        bool better_because_bigger =  found_icon_too_small && size > found_size;
+        bool better_because_smaller = found_icon_too_large &&
+            size >= preferred_size && size < found_size;
+        if (!icon_empty && (better_because_bigger || better_because_smaller))
         {
             found_data = data;
             found_size = size;


### PR DESCRIPTION
Since commit ea94f7f7e64fd2b, the code has a preferred icon size and it tries to find the closest matching icon. However, the default size of 0 and thus this never returned any icon at all (no icon matches better than an icon of size 0x0).

Fix this by saying "every icon is better than no icon at all".

@lukash Any complaints?

Edit: This fixes chromium's icon for me. However, I was thinking that before this all icons are broken, but that's not actually the case. My thunderbird does have an icon...