### PR TITLE
surface: Warn when loading failed

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -239,11 +239,8 @@ draw_load_image(lua_State *L, const char *path)
     GdkPixbuf *buf = gdk_pixbuf_new_from_file(path, &error);
 
     if (!buf) {
-        luaL_where(L, 1);
-        lua_pushstring(L, error->message);
-        lua_concat(L, 2);
+        luaA_warn(L, error->message);
         g_error_free(error);
-        lua_error(L);
         return NULL;
     }
 


### PR DESCRIPTION
Otherwise, LGI will crash awesome with an unprotected call

This can happen, for example, if the file exist, but is not
readable or corrupted.

The user need to check if the surface exist before using it,
but without this patch, they wont know where to look, awesome
will have crashed with a binary backtrace.