### PR TITLE
naughty: Don't try to parse our version number

### DIFF
--- a/dbus.c
+++ b/dbus.c
@@ -319,8 +319,9 @@ a_dbus_convert_value(lua_State *L, int idx, DBusMessageIter *iter)
       case dbustype: \
         { \
             const char *s = lua_tostring(L, idx + 1); \
-            if(s) \
-                dbus_message_iter_append_basic(iter, dbustype, &s); \
+            if(!s) \
+                s = ""; \
+            dbus_message_iter_append_basic(iter, dbustype, &s); \
         } \
         break;
     DBUS_MSG_RETURN_HANDLE_TYPE_STRING(DBUS_TYPE_STRING)

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -195,8 +195,8 @@ capi.dbus.connect_signal("org.freedesktop.Notifications", function (data, appnam
            naughty.destroy(obj, naughty.notificationClosedReason.dismissedByCommand)
         end
     elseif data.member == "GetServerInfo" or data.member == "GetServerInformation" then
-        -- name of notification app, name of vender, version
-        return "s", "naughty", "s", "awesome", "s", capi.awesome.version:match("%d.%d"), "s", "1.0"
+        -- name of notification app, name of vender, version, specification version
+        return "s", "naughty", "s", "awesome", "s", capi.awesome.version, "s", "1.0"
     elseif data.member == "GetCapabilities" then
         -- We actually do display the body of the message, we support <b>, <i>
         -- and <u> in the body and we handle static (non-animated) icons.


### PR DESCRIPTION
naughty: Don't try to parse our version number

The code here doesn't always work, so it's best to just don't mess with `awesome.version`, but return it directly.
    
Fixes: https://github.com/awesomeWM/awesome/issues/569