### PR TITLE
client: Add swapped, raised and lowered signals

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -205,7 +205,8 @@ for s = 1, capi.screen.count() do
     end)
 end
 
-capi.client.connect_signal("focus", function(c) layout.arrange(c.screen) end)
+capi.client.connect_signal("raised", function(c) layout.arrange(c.screen) end)
+capi.client.connect_signal("lowered", function(c) layout.arrange(c.screen) end)
 capi.client.connect_signal("list", function()
                                    for screen = 1, capi.screen.count() do
                                        layout.arrange(screen)

--- a/objects/client.h
+++ b/objects/client.h
@@ -208,6 +208,12 @@ client_raise(client_t *c)
 
     /* Push c on top of the stack. */
     stack_client_append(c);
+
+    /* Notify the listeners */
+    lua_State *L = globalconf_get_lua_State();
+    luaA_object_push(L, c);
+    luaA_object_emit_signal(L, -1, "raised", 0);
+    lua_pop(L, 1);
 }
 
 /** Check if a client has fixed size.


### PR DESCRIPTION
#### Hello world, beware: here I come

This is the first pull request of a rather long stream. Eventually, if everything get merged, it will add stateful layout support to Awesome, including tabs, fancy extension widgets for third party module, limitless flexibility and dynamic layout (split where you want when you want).

The change itself will at first add a parallel implementation of most `awful.layout.suit`. It will be disabled by default and only enabled when the use `require` the system in `rc.lua`. It provide a drop-in replacement of the existing system. By default, it will <s>only add bugs</s> provide nothing new compared with the current system. In the first iteration, any cool stuff will be provided by extensions. The change is already scary enough in itself, no need to add a million line of <s>cool hacks</s> code.

The first few pull requests will make low level to existing APIs to increase flexibility. The second will add new helper code for the new layout system. The last batch, once the first 2 are merged, will add the new suits. The "final" version is available in the "dynamic_layout2" branch of my fork. It is good enough to be used in production as long as you don't play to hard with it. There is still some bugs, mainly in the most neglected layout suits and in the mouse resize code. Overall, I use it, it's stable-ish for daily use if you set your expectations low. If it end up not being merged, it I will create yet another external module called `leaning` for the code. The minimal code to get stateful layouts working is about +300 line. However, with all (I hope) the corner case handled it grows a lot larger, around +2.5k. Then again, it is mostly boring new code, not critical code path changes.

#### This Pull request

This allow layout "arrange" to be called less often and react on
the cause of the change itself rather than it's consequences
(usually, the "focus" signal).

Previously, the layout were re-arranged everytime the focus changed.
Now, with "raised" and "lowered", it require less "arrange".

"swapped" allow smarted layouts. Currently, swapped cause a full
re-arrange. It re-read the "index" list from scratch and create
a "new" layout. With "swapped", incremental layout changes are
possible.

Fixes https://github.com/awesomeWM/awesome/issues/616