### PR TITLE
test/run.sh: Handle updated beauitful.init call in default config

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -131,7 +131,7 @@ if [ "$CI" != true ]; then
     fi
     RC_FILE=$tmp_files/awesomerc.lua
     THEME_FILE=$tmp_files/theme.lua
-    sed -e "s:beautiful.init(\"@AWESOME_THEMES_PATH@/default/theme.lua\"):beautiful.init('$THEME_FILE'):" $root_dir/awesomerc.lua$SED_IN > $RC_FILE
+    sed -e "s:.*beautiful.init(.*default/theme.lua.*:beautiful.init('$THEME_FILE'):" $root_dir/awesomerc.lua$SED_IN > $RC_FILE
     sed -e "s:@AWESOME_THEMES_PATH@/default/titlebar:$root_dir/build/themes/default/titlebar:"  \
         -e "s:@AWESOME_THEMES_PATH@:$root_dir/themes/:" \
         -e "s:@AWESOME_ICON_PATH@:$root_dir/icons:" $root_dir/themes/default/theme.lua$SED_IN > $THEME_FILE


### PR DESCRIPTION
While setting up an environment to run the integration tests in, the run.sh
script uses sed to generate versions of several files that refer to the
not-installed version of files. One of these needs to replace the call to
beautiful.init().

Before commit 20c9723c5b1645, the corresponding line was:

  beautiful.init("@AWESOME_THEMES_PATH@/default/theme.lua")

Now this wants to find and replace the following:

  beautiful.init(awful.util.get_themes_dir() .. "default/theme.lua")

To handle both versions, this commit adds some wildcards to the sed-expression
so that any line containing a call to beautiful.init is found and replaced.