### PR TITLE
Upstream shape api, part 2

### DIFF
--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -24,6 +24,8 @@
 
 local module = {}
 
+local cairo = require( "lgi" ).cairo
+
 --- Add a rounded rectangle to the current path
 -- @note If the radius is bigger than either half side, it will be reduced
 -- @param cr A cairo content
@@ -53,6 +55,96 @@ end
 -- @param height The rectangle height
 function module.rounded_bar(cr, width, height)
     module.rounded_rect(cr, width, height, height / 2)
+end
+
+-- Create a transformation matrix a*b
+local function multiply(a, b)
+    local m = cairo.Matrix()
+    m:multiply(a, b)
+    return m
+end
+
+local transformations = {}
+
+--- Translate a shape
+-- @param self A transformation object
+-- @tparam number x The horizontal translation
+-- @tparam number y The vertical translation
+-- @return A transformation object
+function transformations.translate(self, x, y)
+    local m = cairo.Matrix()
+    cairo.Matrix.init_translate(m, x, y)
+    self.matrix = self.matrix and multiply(self.matrix, m) or m
+    return self
+end
+
+--- Scale a shape
+-- @param self A transformation object
+-- @tparam number x The horizontal scale factor
+-- @tparam number y The vertical scale factor
+-- @return A transformation object
+function transformations.scale(self, x, y)
+    local m = cairo.Matrix()
+    cairo.Matrix.init_scale(m, x, y)
+    self.matrix = self.matrix and multiply(self.matrix, m) or m
+    return self
+end
+
+--- Rotate a shape from the top left corner
+-- @param self A transformation object
+-- @tparam number radiant The angle (-2*math.pi to 2*math.pi)
+-- @return A transformation object
+function transformations.rotate(self, radiant)
+    local m = cairo.Matrix()
+    cairo.Matrix.init_rotate(m, radiant)
+    self.matrix = self.matrix and multiply(self.matrix, m) or m
+    return self
+end
+
+--- Rotate a shape from a custom point
+-- @param self A transformation object
+-- @tparam number x The horizontal rotation point
+-- @tparam number y The vertical rotation point
+-- @tparam number radiant The angle (-2*math.pi to 2*math.pi)
+-- @return A transformation object
+function transformations.rotate_at(self, x, y, radiant)
+    transformations.translate(self, -x, -y)
+    local m = cairo.Matrix()
+    cairo.Matrix.init_rotate(m, radiant)
+    self.matrix = self.matrix and multiply(self.matrix, m) or m
+    transformations.translate(self, x, y)
+    return self
+end
+
+--- Ajust the shape using a transformation object
+--
+-- Apply various transformations to the shape
+--
+-- @usage gears.shape.transform(gears.shape.rounded_bar)
+--    : rotate(math.pi/2)
+--       : translate(10, 10)
+--
+-- @param shape A shape function
+-- @return A transformation handle, also act as a shape function
+function module.transform(shape)
+    local matrix = nil
+
+    -- Apply the transformation matrix and apply the shape, then restore
+    local function apply(self, cr, width, height, ...)
+        cr:save()
+        cr:set_matrix(self.matrix)
+        shape(cr, width, height, ...)
+        cr:restore()
+    end
+
+    local transformation = setmetatable({matrix=matrix}, {
+        __call = apply,
+        __index = function(_, key)
+            return transformations[key]
+        end
+    })
+
+    return transformation
 end
 
 return module

--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -9,6 +9,7 @@ local setmetatable = setmetatable
 local type = type
 local capi = { awesome = awesome }
 local cairo = require("lgi").cairo
+local color = nil
 local gdebug = require("gears.debug")
 
 -- Keep this in sync with build-utils/lgi-check.sh!
@@ -150,6 +151,32 @@ function surface.duplicate_surface(s)
     cr.operator = cairo.Operator.SOURCE
     cr:paint()
     return result
+end
+
+--- Create a surface from a `gears.shape`
+-- Any additional parameters will be passed to the shape function
+-- @tparam number width The surface width
+-- @tparam number height The surface height
+-- @param shape A `gears.shape` compatible function
+-- @param[opt=white] shape_color The shape color or pattern
+-- @param[opt=transparent] bg_color The surface background color
+-- @treturn cairo.surface the new surface
+function surface.load_from_shape(width, height, shape, shape_color, bg_color, ...)
+    color = color or require("gears.color")
+
+    local img = cairo.ImageSurface(cairo.Format.ARGB32, width, height)
+    local cr = cairo.Context(img)
+
+    cr:set_source(color(bg_color or "#00000000"))
+    cr:paint()
+
+    cr:set_source(color(shape_color or "#000000"))
+
+    shape(cr, width, height, ...)
+
+    cr:fill()
+
+    return img
 end
 
 --- Apply a shape to a client or a wibox.

--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -179,6 +179,26 @@ function surface.load_from_shape(width, height, shape, shape_color, bg_color, ..
     return img
 end
 
+-- Common code for shape bounding and clip
+local function shape_bounding_common(method, draw, shape, ...)
+    local geo = draw:geometry()
+
+    local img = cairo.ImageSurface(cairo.Format.A1, geo.width, geo.height)
+    local cr = cairo.Context(img)
+
+    cr:set_operator(cairo.Operator.CLEAR)
+    cr:set_source_rgba(0,0,0,1)
+    cr:paint()
+    cr:set_operator(cairo.Operator.SOURCE)
+    cr:set_source_rgba(1,1,1,1)
+
+    shape(cr, geo.width, geo.height, ...)
+
+    cr:fill()
+
+    draw[method] = img._native
+end
+
 --- Apply a shape to a client or a wibox.
 --
 --  If the wibox or client size change, this function need to be called
@@ -188,22 +208,21 @@ end
 --   width and height as parameter.
 -- @param[opt] Any additional parameters will be passed to the shape function
 function surface.apply_shape_bounding(draw, shape, ...)
-  local geo = draw:geometry()
+    shape_bounding_common("shape_bounding", draw, shape, ...)
+end
 
-  local img = cairo.ImageSurface(cairo.Format.A1, geo.width, geo.height)
-  local cr = cairo.Context(img)
-
-  cr:set_operator(cairo.Operator.CLEAR)
-  cr:set_source_rgba(0,0,0,1)
-  cr:paint()
-  cr:set_operator(cairo.Operator.SOURCE)
-  cr:set_source_rgba(1,1,1,1)
-
-  shape(cr, geo.width, geo.height, ...)
-
-  cr:fill()
-
-  draw.shape_bounding = img._native
+--- Apply a shape clip to a client or a wibox.
+--
+-- A shape clip is a non-antialiased border around the content of the drawable
+--
+--  If the wibox or client size change, this function need to be called
+--   again.
+-- @param draw A wibox or a client
+-- @param shape or gears.shape function or a custom function with a context,
+--   width and height as parameter.
+-- @param[opt] Any additional parameters will be passed to the shape function
+function surface.apply_shape_clip(draw, shape, ...)
+    shape_bounding_common("shape_clip", draw, shape, ...)
 end
 
 return setmetatable(surface, surface.mt)

--- a/lib/wibox/widget/imagebox.lua
+++ b/lib/wibox/widget/imagebox.lua
@@ -30,6 +30,12 @@ function imagebox:draw(context, cr, width, height)
 
         cr:scale(aspect, aspect)
     end
+
+    -- Set the clip
+    if self._clip_shape then
+        cr:clip(self._clip_shape(cr, width, height ,unpack(self._clip_args)))
+    end
+
     cr:set_source_surface(self._image, 0, 0)
     cr:paint()
 end
@@ -107,6 +113,19 @@ function imagebox:set_image(image)
     return true
 end
 
+--- Set a clip shape for this imagebox
+-- A clip shape define an area where the content is displayed and one where it
+-- is trimmed.
+--
+-- Any other parameters will be passed to the clip shape function
+--
+-- @param clip_shape A `gears_shape` compatible shape function
+function imagebox:set_clip_shape(clip_shape, ...)
+    self._clip_shape = clip_shape
+    self._clip_args = {...}
+    self:emit_signal("widget::redraw_needed")
+end
+
 --- Should the image be resized to fit into the available space?
 -- @param allowed If false, the image will be clipped, else it will be resized
 --   to fit into the available space.
@@ -117,10 +136,12 @@ function imagebox:set_resize(allowed)
 end
 
 --- Returns a new imagebox
+-- Any other arguments will be passed to the clip shape function
 -- @param image the image to display, may be nil
 -- @param resize_allowed If false, the image will be clipped, else it will be resized
 --   to fit into the available space.
-local function new(image, resize_allowed)
+-- @param clip_shape A `gears.shape` compatible function
+local function new(image, resize_allowed, clip_shape, ...)
     local ret = base.make_widget()
 
     for k, v in pairs(imagebox) do
@@ -135,6 +156,9 @@ local function new(image, resize_allowed)
     if resize_allowed ~= nil then
         ret:set_resize(resize_allowed)
     end
+
+    ret._clip_shape = clip_shape
+    ret._clip_args = {...}
 
     return ret
 end


### PR DESCRIPTION
This part add the transformation API, the shape_clip support (useless without the transformation API, as it require translation), `gears.surface` constructor taking a shape and `wibox.widget.imagebox` clipping shape.