### PR TITLE
Make benchmarks less exact

### DIFF
--- a/tests/test-benchmark.lua
+++ b/tests/test-benchmark.lua
@@ -5,7 +5,10 @@ local awful = require("awful")
 local GLib = require("lgi").GLib
 local create_wibox = require("_wibox_helper").create_wibox
 
-local not_under_travis = not os.getenv("CI")
+local BENCHMARK_EXACT = os.getenv("BENCHMARK_EXACT")
+if not BENCHMARK_EXACT then
+    print("Doing quick and inexact measurements. Set BENCHMARK_EXACT=1 as an environment variable when you actually want to look at the results.")
+end
 
 local measure, benchmark
 do
@@ -26,7 +29,7 @@ do
         local time_per_iter, time_total = measure(f, iters)
         -- To improve precision, we want to loop for this long
         local target_time = 1
-        while time_total < target_time and not_under_travis do
+        while time_total < target_time and BENCHMARK_EXACT do
             iters = math.ceil(target_time / time_per_iter)
             time_per_iter, time_total = measure(f, iters)
         end


### PR DESCRIPTION
The benchmarks in tests/test-benchmark.lua have two modes. When CI=1 is set in
the environment, only a "quick" and less exact test is done. Otherwise, a slower
and more exact measurements is taken. This was added so that we do not waste CPU
time on travis.

However, most of the time the user running "make check" doesn't want exact
measurements either. So instead of only being quick when CI=1 is set, this
commit changes the logic to always being quick unless BENCHMARK_EXACT=1 is set.
Additionally, a message is printed next to the benchmark results so that the
user is reminded to set this var if the measurements should actually mean
something.

Signed-off-by: Uli Schlachter <psychon@znc.in>