### PR TITLE
Upstream shape api part 2.5 and 3

### DIFF
--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -125,6 +125,21 @@ function module.arrow(cr, width, height, head_width, shaft_width, shaft_length)
     cr:close_path()
 end
 
+--- A squeezed hexagon filling the rectangle
+-- @param cr A cairo context
+-- @tparam number width The shape with
+-- @tparam number height The shape height
+function module.hexagon(cr, width, height)
+    cr:move_to(height/2,0)
+    cr:line_to(width-height/2,0)
+    cr:line_to(width,height/2)
+    cr:line_to(width-height/2,height)
+    cr:line_to(height/2,height)
+    cr:line_to(0,height/2)
+    cr:line_to(height/2,0)
+    cr:close_path()
+end
+
 --- Ajust the shape using a transformation object
 --
 -- Apply various transformations to the shape

--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -21,6 +21,7 @@
 -- @release @AWESOME_VERSION@
 -- @module gears.shape
 ---------------------------------------------------------------------------
+local g_matrix = require( "gears.matrix" )
 
 local module = {}
 
@@ -53,6 +54,32 @@ end
 -- @param height The rectangle height
 function module.rounded_bar(cr, width, height)
     module.rounded_rect(cr, width, height, height / 2)
+end
+
+--- Ajust the shape using a transformation object
+--
+-- Apply various transformations to the shape
+--
+-- @usage gears.shape.transform(gears.shape.rounded_bar)
+--    : rotate(math.pi/2)
+--       : translate(10, 10)
+--
+-- @param shape A shape function
+-- @return A transformation handle, also act as a shape function
+function module.transform(shape)
+
+    -- Apply the transformation matrix and apply the shape, then restore
+    local function apply(self, cr, width, height, ...)
+        cr:save()
+        cr:transform(self:to_cairo_matrix())
+        shape(cr, width, height, ...)
+        cr:restore()
+    end
+
+    local matrix = g_matrix.identity:copy()
+    rawset(matrix, "_call", apply)
+
+    return matrix
 end
 
 return module

--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -140,6 +140,23 @@ function module.hexagon(cr, width, height)
     cr:close_path()
 end
 
+--- Double arrow popularized by the vim-powerline module
+-- @param cr A cairo context
+-- @tparam number width The shape with
+-- @tparam number height The shape height
+-- @tparam[opt=height/2] number arrow_depth The width of the arrow part of the shape
+function module.powerline(cr, width, height, arrow_depth)
+    local arrow_depth = arrow_depth or height/2
+    cr:move_to(0                   , 0        )
+    cr:line_to(width - arrow_depth , 0        )
+    cr:line_to(width               , height/2 )
+    cr:line_to(width - arrow_depth , height   )
+    cr:line_to(0                   , height   )
+    cr:line_to(arrow_depth         , height/2 )
+
+    cr:close_path()
+end
+
 --- Ajust the shape using a transformation object
 --
 -- Apply various transformations to the shape

--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -157,6 +157,17 @@ function module.powerline(cr, width, height, arrow_depth)
     cr:close_path()
 end
 
+--- An isosceles triangle
+-- @param cr A cairo context
+-- @tparam number width The shape with
+-- @tparam number height The shape height
+function module.isosceles_triangle(cr, width, height)
+    cr:move_to( width/2, 0      )
+    cr:line_to( width  , height )
+    cr:line_to( 0      , height )
+    cr:close_path()
+end
+
 --- Ajust the shape using a transformation object
 --
 -- Apply various transformations to the shape

--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -56,6 +56,37 @@ function module.rounded_bar(cr, width, height)
     module.rounded_rect(cr, width, height, height / 2)
 end
 
+--- A rounded rectangle with a triangle at the top
+-- @param cr A cairo context
+-- @tparam number width The shape with
+-- @tparam number height The shape height
+-- @tparam[opt=5] number corner_radius The corner radius
+-- @tparam[opt=10] number arrow_size The width and height of the arrow
+-- @tparam[opt=width/2 - arrow_size/2] number arrow_position The position of the arrow
+function module.infobubble(cr, width, height, corner_radius, arrow_size, arrow_position)
+    local corner_radius  = corner_radius  or 5
+    local arrow_size     = arrow_size     or 10
+    local arrow_position = arrow_position or width/2 - arrow_size/2
+
+    cr:move_to(0 ,corner_radius)
+
+    -- Top left corner
+    cr:arc(corner_radius, corner_radius+arrow_size, (corner_radius), math.pi, 3*(math.pi/2))
+
+    -- The arrow triangle (still at the top)
+    cr:line_to(arrow_position                , arrow_size )
+    cr:line_to(arrow_position + arrow_size   , 0          )
+    cr:line_to(arrow_position + 2*arrow_size , arrow_size )
+
+    -- Complete the rounded rounded rectangle
+    cr:arc(width-corner_radius, corner_radius+arrow_size  , (corner_radius) , 3*(math.pi/2) , math.pi*2 )
+    cr:arc(width-corner_radius, height-(corner_radius)    , (corner_radius) , math.pi*2     , math.pi/2 )
+    cr:arc(corner_radius      , height-(corner_radius)    , (corner_radius) , math.pi/2     , math.pi   )
+
+    -- Close path
+    cr:close_path()
+end
+
 --- Ajust the shape using a transformation object
 --
 -- Apply various transformations to the shape

--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -87,6 +87,20 @@ function module.infobubble(cr, width, height, corner_radius, arrow_size, arrow_p
     cr:close_path()
 end
 
+--- A rectangle terminated by an arrow
+-- @param cr A cairo context
+-- @tparam number width The shape with
+-- @tparam number height The shape height
+function module.rectangular_tag(cr, width, height)
+    cr:move_to(0        , height/2)
+    cr:line_to(height/2 , 0       )
+    cr:line_to(width    , 0       )
+    cr:line_to(width    , height  )
+    cr:line_to(height/2 , height  )
+
+    cr:close_path()
+end
+
 --- Ajust the shape using a transformation object
 --
 -- Apply various transformations to the shape

--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -101,6 +101,30 @@ function module.rectangular_tag(cr, width, height)
     cr:close_path()
 end
 
+--- A simple arrow shape
+-- @param cr A cairo context
+-- @tparam number width The shape with
+-- @tparam number height The shape height
+-- @tparam[opt=head_width] number head_width The width of the head (/\) of the arrow
+-- @tparam[opt=width /2] number shaft_width The width of the shaft of the arrow
+-- @tparam[opt=height/2] number shaft_length The head_length of the shaft (the rest is the head)
+function module.arrow(cr, width, height, head_width, shaft_width, shaft_length)
+    local shaft_length = shaft_length or height / 2
+    local shaft_width  = shaft_width  or width  / 2
+    local head_width   = head_width   or width
+    local head_length  = height - shaft_length
+
+    cr:move_to    ( width/2                     , 0            )
+    cr:rel_line_to( head_width/2                , head_length  )
+    cr:rel_line_to( -(head_width-shaft_width)/2 , 0            )
+    cr:rel_line_to( 0                           , shaft_length )
+    cr:rel_line_to( -shaft_width                , 0            )
+    cr:rel_line_to( 0           , -shaft_length                )
+    cr:rel_line_to( -(head_width-shaft_width)/2 , 0            )
+
+    cr:close_path()
+end
+
 --- Ajust the shape using a transformation object
 --
 -- Apply various transformations to the shape

--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -9,6 +9,7 @@ local setmetatable = setmetatable
 local type = type
 local capi = { awesome = awesome }
 local cairo = require("lgi").cairo
+local color = nil
 local gdebug = require("gears.debug")
 
 -- Keep this in sync with build-utils/lgi-check.sh!
@@ -150,6 +151,32 @@ function surface.duplicate_surface(s)
     cr.operator = cairo.Operator.SOURCE
     cr:paint()
     return result
+end
+
+--- Create a surface from a `gears.shape`
+-- Any additional parameters will be passed to the shape function
+-- @tparam number width The surface width
+-- @tparam number height The surface height
+-- @param shape A `gears.shape` compatible function
+-- @param[opt=white] shape_color The shape color or pattern
+-- @param[opt=transparent] bg_color The surface background color
+-- @treturn cairo.surface the new surface
+function surface.load_from_shape(width, height, shape, shape_color, bg_color, ...)
+    color = color or require("gears.color")
+
+    local img = cairo.ImageSurface(cairo.Format.ARGB32, width, height)
+    local cr = cairo.Context(img)
+
+    cr:set_source(color(bg_color or "#00000000"))
+    cr:paint()
+
+    cr:set_source(color(shape_color or "#000000"))
+
+    shape(cr, width, height, ...)
+
+    cr:fill()
+
+    return img
 end
 
 --- Apply a shape to a client or a wibox.

--- a/lib/wibox/widget/imagebox.lua
+++ b/lib/wibox/widget/imagebox.lua
@@ -12,6 +12,7 @@ local pairs = pairs
 local type = type
 local pcall = pcall
 local print = print
+local unpack = unpack or table.unpack
 
 local imagebox = { mt = {} }
 
@@ -30,6 +31,12 @@ function imagebox:draw(context, cr, width, height)
 
         cr:scale(aspect, aspect)
     end
+
+    -- Set the clip
+    if self._clip_shape then
+        cr:clip(self._clip_shape(cr, width, height, unpack(self._clip_args)))
+    end
+
     cr:set_source_surface(self._image, 0, 0)
     cr:paint()
 end
@@ -107,6 +114,19 @@ function imagebox:set_image(image)
     return true
 end
 
+--- Set a clip shape for this imagebox
+-- A clip shape define an area where the content is displayed and one where it
+-- is trimmed.
+--
+-- Any other parameters will be passed to the clip shape function
+--
+-- @param clip_shape A `gears_shape` compatible shape function
+function imagebox:set_clip_shape(clip_shape, ...)
+    self._clip_shape = clip_shape
+    self._clip_args = {...}
+    self:emit_signal("widget::redraw_needed")
+end
+
 --- Should the image be resized to fit into the available space?
 -- @param allowed If false, the image will be clipped, else it will be resized
 --   to fit into the available space.
@@ -117,10 +137,12 @@ function imagebox:set_resize(allowed)
 end
 
 --- Returns a new imagebox
+-- Any other arguments will be passed to the clip shape function
 -- @param image the image to display, may be nil
 -- @param resize_allowed If false, the image will be clipped, else it will be resized
 --   to fit into the available space.
-local function new(image, resize_allowed)
+-- @param clip_shape A `gears.shape` compatible function
+local function new(image, resize_allowed, clip_shape)
     local ret = base.make_widget()
 
     for k, v in pairs(imagebox) do
@@ -135,6 +157,9 @@ local function new(image, resize_allowed)
     if resize_allowed ~= nil then
         ret:set_resize(resize_allowed)
     end
+
+    ret._clip_shape = clip_shape
+    ret._clip_args = {}
 
     return ret
 end


### PR DESCRIPTION
This replace the other pull request.

* More shapes are added
* Use `gears.matrix` directly instead of cairo.matrix
* Remove the wibox `shape_clip` commit, it is pointless, better use the wibox `after_draw_children`, it produce a much nicer effect. The shapes are usually not rectangles, so it always produce an ugly pixelated output.
* Remove the ... args from imagebox constructor
* Add `rotate_at` to `gears.matrix` and allow it to keep a `__call` function (undocumented hack used by `gears.shape`, `gears.pattern` and `gears.pixmap`)
* Add a new method to `gears.surface` to build from iconified vector fonts.