### PR TITLE
Add `screen::change` signal for Xrandr output change notification events

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -592,6 +592,10 @@ luaA_init(xdgHandle* xdg)
      * @signal exit
      */
     signal_add(&global_signals, "exit");
+    /**
+     * @signal screen::change
+     */
+    signal_add(&global_signals, "screen::change");
 }
 
 static void


### PR DESCRIPTION
This lets users connect to a signal emitted when a monitor is plugged in or unplugged from the system. Here's an example of its use (from my `rc.lua`):

```lua
awesome.connect_signal("screen::change", function(output, state)
    naughty.notify{title="Output changed", text=output.." "..state}
    if output == 'HDMI1' then
        if state == 'Connected' then
            awful.util.spawn_with_shell("xrandr --output HDMI1 --auto --right-of eDP1 --primary")
        elseif state == 'Disconnected' then
            awful.util.spawn_with_shell("xrandr --output eDP1 --auto --primary")
            awful.util.spawn_with_shell("xrandr --output HDMI1 --off")
        end
    end
end)
```