### PR TITLE
Number vs int

### DIFF
--- a/common/luaclass.h
+++ b/common/luaclass.h
@@ -150,7 +150,7 @@ luaA_checkudataornil(lua_State *L, int udx, lua_class_t *class)
     static inline int                                                          \
     luaA_##prefix##_class_instances(lua_State *L)                              \
     {                                                                          \
-        lua_pushnumber(L, (lua_class).instances);                              \
+        lua_pushinteger(L, (lua_class).instances);                             \
         return 1;                                                              \
     }
 

--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -84,7 +84,7 @@ luaA_object_incref(lua_State *L, int tud, int oud)
     /* Get the number of references */
     lua_rawget(L, -2);
     /* Get the number of references and increment it */
-    int count = lua_tonumber(L, -1) + 1;
+    int count = lua_tointeger(L, -1) + 1;
     lua_pop(L, 1);
     /* Push the pointer (key) */
     lua_pushlightuserdata(L, pointer);
@@ -121,8 +121,8 @@ luaA_object_decref(lua_State *L, int tud, const void *pointer)
     /* Get the number of references */
     lua_rawget(L, -2);
     /* Get the number of references and decrement it */
-    int count = lua_tonumber(L, -1) - 1;
-    /* Did we find the item in our table? (tonumber(nil)-1) is -1 */
+    int count = lua_tointeger(L, -1) - 1;
+    /* Did we find the item in our table? (tointeger(nil)-1) is -1 */
     if (count < 0)
     {
         buffer_t buf;

--- a/dbus.c
+++ b/dbus.c
@@ -136,7 +136,7 @@ a_dbus_message_iter(lua_State *L, DBusMessageIter *iter)
                     switch(array_type)
                     {
                       int datalen = 0;
-#define DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(type, dbustype) \
+#define DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(type, dbustype, pusher) \
                       case dbustype: \
                         { \
                             const type *data; \
@@ -144,19 +144,19 @@ a_dbus_message_iter(lua_State *L, DBusMessageIter *iter)
                             lua_createtable(L, datalen, 0); \
                             for(int i = 0; i < datalen; i++) \
                             { \
-                                lua_pushnumber(L, data[i]); \
+                                pusher(L, data[i]); \
                                 lua_rawseti(L, -2, i + 1); \
                             } \
                         } \
                         break;
-                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(int16_t, DBUS_TYPE_INT16)
-                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(uint16_t, DBUS_TYPE_UINT16)
-                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(int32_t, DBUS_TYPE_INT32)
-                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(uint32_t, DBUS_TYPE_UINT32)
-                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(int64_t, DBUS_TYPE_INT64)
-                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(uint64_t, DBUS_TYPE_UINT64)
-                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER(double, DBUS_TYPE_DOUBLE)
-#undef DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER
+                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(int16_t, DBUS_TYPE_INT16, lua_pushinteger)
+                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(uint16_t, DBUS_TYPE_UINT16, lua_pushinteger)
+                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(int32_t, DBUS_TYPE_INT32, lua_pushinteger)
+                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(uint32_t, DBUS_TYPE_UINT32, lua_pushinteger)
+                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(int64_t, DBUS_TYPE_INT64, lua_pushinteger)
+                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(uint64_t, DBUS_TYPE_UINT64, lua_pushinteger)
+                      DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(double, DBUS_TYPE_DOUBLE, lua_pushnumber)
+#undef DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT
                       case DBUS_TYPE_BYTE:
                         {
                             const char *c;
@@ -232,23 +232,23 @@ a_dbus_message_iter(lua_State *L, DBusMessageIter *iter)
             }
             nargs++;
             break;
-#define DBUS_MSG_HANDLE_TYPE_NUMBER(type, dbustype) \
+#define DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(type, dbustype, pusher) \
           case dbustype: \
             { \
                 type ui; \
                 dbus_message_iter_get_basic(iter, &ui); \
-                lua_pushnumber(L, ui); \
+                pusher(L, ui); \
             } \
             nargs++; \
             break;
-          DBUS_MSG_HANDLE_TYPE_NUMBER(int16_t, DBUS_TYPE_INT16)
-          DBUS_MSG_HANDLE_TYPE_NUMBER(uint16_t, DBUS_TYPE_UINT16)
-          DBUS_MSG_HANDLE_TYPE_NUMBER(int32_t, DBUS_TYPE_INT32)
-          DBUS_MSG_HANDLE_TYPE_NUMBER(uint32_t, DBUS_TYPE_UINT32)
-          DBUS_MSG_HANDLE_TYPE_NUMBER(int64_t, DBUS_TYPE_INT64)
-          DBUS_MSG_HANDLE_TYPE_NUMBER(uint64_t, DBUS_TYPE_UINT64)
-          DBUS_MSG_HANDLE_TYPE_NUMBER(double, DBUS_TYPE_DOUBLE)
-#undef DBUS_MSG_HANDLE_TYPE_NUMBER
+          DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(int16_t, DBUS_TYPE_INT16, lua_pushinteger)
+          DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(uint16_t, DBUS_TYPE_UINT16, lua_pushinteger)
+          DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(int32_t, DBUS_TYPE_INT32, lua_pushinteger)
+          DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(uint32_t, DBUS_TYPE_UINT32, lua_pushinteger)
+          DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(int64_t, DBUS_TYPE_INT64, lua_pushinteger)
+          DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(uint64_t, DBUS_TYPE_UINT64, lua_pushinteger)
+          DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT(double, DBUS_TYPE_DOUBLE, lua_pushnumber)
+#undef DBUS_MSG_HANDLE_TYPE_NUMBER_OR_INT
           case DBUS_TYPE_STRING:
             {
                 char *s;

--- a/event.c
+++ b/event.c
@@ -153,9 +153,9 @@ event_emit_button(lua_State *L, xcb_button_press_event_t *ev)
     }
 
     /* Push the event's info */
-    lua_pushnumber(L, ev->event_x);
-    lua_pushnumber(L, ev->event_y);
-    lua_pushnumber(L, ev->detail);
+    lua_pushinteger(L, ev->event_x);
+    lua_pushinteger(L, ev->event_y);
+    lua_pushinteger(L, ev->detail);
     luaA_pushmodifiers(L, ev->state);
     /* And emit the signal */
     luaA_object_emit_signal(L, -5, name, 4);
@@ -480,8 +480,8 @@ event_handle_motionnotify(xcb_motion_notify_event_t *ev)
     if((c = client_getbyframewin(ev->event)))
     {
         luaA_object_push(L, c);
-        lua_pushnumber(L, ev->event_x);
-        lua_pushnumber(L, ev->event_y);
+        lua_pushinteger(L, ev->event_x);
+        lua_pushinteger(L, ev->event_y);
         luaA_object_emit_signal(L, -3, "mouse::move", 2);
 
         /* now check if a titlebar was "hit" */
@@ -491,8 +491,8 @@ event_handle_motionnotify(xcb_motion_notify_event_t *ev)
         {
             luaA_object_push_item(L, -1, d);
             event_drawable_under_mouse(L, -1);
-            lua_pushnumber(L, x);
-            lua_pushnumber(L, y);
+            lua_pushinteger(L, x);
+            lua_pushinteger(L, y);
             luaA_object_emit_signal(L, -3, "mouse::move", 2);
             lua_pop(L, 1);
         }
@@ -504,8 +504,8 @@ event_handle_motionnotify(xcb_motion_notify_event_t *ev)
         luaA_object_push(L, w);
         luaA_object_push_item(L, -1, w->drawable);
         event_drawable_under_mouse(L, -1);
-        lua_pushnumber(L, ev->event_x);
-        lua_pushnumber(L, ev->event_y);
+        lua_pushinteger(L, ev->event_x);
+        lua_pushinteger(L, ev->event_y);
         luaA_object_emit_signal(L, -3, "mouse::move", 2);
         lua_pop(L, 2);
     }

--- a/luaa.c
+++ b/luaa.c
@@ -193,7 +193,7 @@ static int
 luaA_mbstrlen(lua_State *L)
 {
     const char *cmd = luaL_checkstring(L, 1);
-    lua_pushnumber(L, (ssize_t) mbstowcs(NULL, NONULL(cmd), 0));
+    lua_pushinteger(L, (ssize_t) mbstowcs(NULL, NONULL(cmd), 0));
     return 1;
 }
 

--- a/luaa.h
+++ b/luaa.h
@@ -175,13 +175,13 @@ static inline int
 luaA_pusharea(lua_State *L, area_t geometry)
 {
     lua_createtable(L, 0, 4);
-    lua_pushnumber(L, geometry.x);
+    lua_pushinteger(L, geometry.x);
     lua_setfield(L, -2, "x");
-    lua_pushnumber(L, geometry.y);
+    lua_pushinteger(L, geometry.y);
     lua_setfield(L, -2, "y");
-    lua_pushnumber(L, geometry.width);
+    lua_pushinteger(L, geometry.width);
     lua_setfield(L, -2, "width");
-    lua_pushnumber(L, geometry.height);
+    lua_pushinteger(L, geometry.height);
     lua_setfield(L, -2, "height");
     return 1;
 }

--- a/objects/button.c
+++ b/objects/button.c
@@ -102,7 +102,7 @@ luaA_button_array_get(lua_State *L, int oidx, button_array_t *buttons)
     return 1;
 }
 
-LUA_OBJECT_EXPORT_PROPERTY(button, button_t, button, lua_pushnumber);
+LUA_OBJECT_EXPORT_PROPERTY(button, button_t, button, lua_pushinteger);
 LUA_OBJECT_EXPORT_PROPERTY(button, button_t, modifiers, luaA_pushmodifiers);
 
 static int

--- a/objects/button.c
+++ b/objects/button.c
@@ -116,7 +116,7 @@ luaA_button_set_modifiers(lua_State *L, button_t *b)
 static int
 luaA_button_set_button(lua_State *L, button_t *b)
 {
-    b->button = luaL_checknumber(L, -1);
+    b->button = luaL_checkinteger(L, -1);
     luaA_object_emit_signal(L, -3, "property::button", 0);
     return 0;
 }

--- a/root.c
+++ b/root.c
@@ -171,7 +171,7 @@ luaA_root_fake_input(lua_State *L)
         if(lua_type(L, 2) == LUA_TSTRING) {
             detail = _string_to_key_code(lua_tostring(L, 2)); /* keysym */
         } else {
-            detail = luaL_checknumber(L, 2); /* keycode */
+            detail = luaL_checkinteger(L, 2); /* keycode */
         }
     }
     else if(A_STREQ(stype, "key_release"))
@@ -180,25 +180,25 @@ luaA_root_fake_input(lua_State *L)
         if(lua_type(L, 2) == LUA_TSTRING) {
             detail = _string_to_key_code(lua_tostring(L, 2)); /* keysym */
         } else {
-            detail = luaL_checknumber(L, 2); /* keycode */
+            detail = luaL_checkinteger(L, 2); /* keycode */
         }
     }
     else if(A_STREQ(stype, "button_press"))
     {
         type = XCB_BUTTON_PRESS;
-        detail = luaL_checknumber(L, 2); /* button number */
+        detail = luaL_checkinteger(L, 2); /* button number */
     }
     else if(A_STREQ(stype, "button_release"))
     {
         type = XCB_BUTTON_RELEASE;
-        detail = luaL_checknumber(L, 2); /* button number */
+        detail = luaL_checkinteger(L, 2); /* button number */
     }
     else if(A_STREQ(stype, "motion_notify"))
     {
         type = XCB_MOTION_NOTIFY;
         detail = luaA_checkboolean(L, 2); /* relative to the current position or not */
-        x = luaL_checknumber(L, 3);
-        y = luaL_checknumber(L, 4);
+        x = luaL_checkinteger(L, 3);
+        y = luaL_checkinteger(L, 4);
     }
     else
         return 0;

--- a/spawn.c
+++ b/spawn.c
@@ -151,7 +151,7 @@ spawn_monitor_event(SnMonitorEvent *event, void *data)
                 lua_setfield(L, -2, "description");
             }
 
-            lua_pushnumber(L, sn_startup_sequence_get_workspace(sequence));
+            lua_pushinteger(L, sn_startup_sequence_get_workspace(sequence));
             lua_setfield(L, -2, "workspace");
 
             if((s = sn_startup_sequence_get_binary_name(sequence)))
@@ -352,11 +352,11 @@ child_exit_callback(GPid pid, gint status, gpointer user_data)
     /* 'Decode' the exit status */
     if (WIFEXITED(status)) {
         lua_pushliteral(L, "exit");
-        lua_pushnumber(L, WEXITSTATUS(status));
+        lua_pushinteger(L, WEXITSTATUS(status));
     } else {
         assert(WIFSIGNALED(status));
         lua_pushliteral(L, "signal");
-        lua_pushnumber(L, WTERMSIG(status));
+        lua_pushinteger(L, WTERMSIG(status));
     }
 
     lua_rawgeti(L, LUA_REGISTRYINDEX, exit_callback);
@@ -461,7 +461,7 @@ luaA_spawn(lua_State *L)
     }
 
     /* push pid on stack */
-    lua_pushnumber(L, pid);
+    lua_pushinteger(L, pid);
 
     /* push sn on stack */
     if (context)

--- a/strut.c
+++ b/strut.c
@@ -51,10 +51,10 @@ void
 luaA_tostrut(lua_State *L, int idx, strut_t *strut)
 {
     luaA_checktable(L, idx);
-    strut->left = luaA_getopt_number(L, idx, "left", strut->left);
-    strut->right = luaA_getopt_number(L, idx, "right", strut->right);
-    strut->top = luaA_getopt_number(L, idx, "top", strut->top);
-    strut->bottom = luaA_getopt_number(L, idx, "bottom", strut->bottom);
+    strut->left = luaA_getopt_integer(L, idx, "left", strut->left);
+    strut->right = luaA_getopt_integer(L, idx, "right", strut->right);
+    strut->top = luaA_getopt_integer(L, idx, "top", strut->top);
+    strut->bottom = luaA_getopt_integer(L, idx, "bottom", strut->bottom);
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/strut.c
+++ b/strut.c
@@ -31,13 +31,13 @@ int
 luaA_pushstrut(lua_State *L, strut_t strut)
 {
     lua_createtable(L, 4, 0);
-    lua_pushnumber(L, strut.left);
+    lua_pushinteger(L, strut.left);
     lua_setfield(L, -2, "left");
-    lua_pushnumber(L, strut.right);
+    lua_pushinteger(L, strut.right);
     lua_setfield(L, -2, "right");
-    lua_pushnumber(L, strut.top);
+    lua_pushinteger(L, strut.top);
     lua_setfield(L, -2, "top");
-    lua_pushnumber(L, strut.bottom);
+    lua_pushinteger(L, strut.bottom);
     lua_setfield(L, -2, "bottom");
     return 1;
 }

--- a/xkb.c
+++ b/xkb.c
@@ -247,7 +247,7 @@ event_handle_xkb_notify(xcb_generic_event_t* event)
 
           if (state_notify_event->changed & XCB_XKB_STATE_PART_GROUP_STATE)
           {
-              lua_pushnumber(L, state_notify_event->group);
+              lua_pushinteger(L, state_notify_event->group);
               signal_object_emit(L, &global_signals, "xkb::group_changed", 1);
           }
 


### PR DESCRIPTION
This makes the C code use `lua_pushinteger` and `luaA_opt_integer` in more places where it previously used the `number`-version instead. I was careful to allow e.g. setting a client's width to 42.5. Requiring an integer here would break lots of code for no good reason.

The idea for this is from one of @actionless's recent pull requests where he noticed that the `spawn`-API provides numbers instead of integers as exit codes, but I can't find that comment right now...