### PR TITLE
Add code coverage support

### DIFF
--- a/.luacov
+++ b/.luacov
@@ -13,6 +13,10 @@ return {
 
     include = {
         escape_pattern(lib_dir) .. ".+",
+
+        -- For things already having the correct path
+        -- (happens with integration tests)
+        "^lib/",
     },
 
     -- configuration for luacov-coveralls reporter

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,26 @@
+-- Configuration file for LuaCov
+
+-- This variable is set externally
+local build = os.getenv("BUILD_DIRECTORY") or error("$BUILD_DIRECTORY not set")
+local lib_dir = build .. "lib/"
+
+local function escape_pattern(str)
+    return string.gsub(str, "%W", "%%%1")
+end
+
+return {
+    statsfile = build .. "luacov.stats.out",
+
+    include = {
+        escape_pattern(lib_dir) .. ".+",
+    },
+
+    -- configuration for luacov-coveralls reporter
+    coveralls = {
+        pathcorrect = {
+            { escape_pattern(lib_dir), "lib/"},
+        },
+    },
+}
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   matrix:
     # Note: luarocks does not work with Lua 5.0.
     - LUA=5.1 LGIVER=      LUANAME=lua5.1
-    - LUA=5.2 LGIVER=      LUANAME=lua5.2 BUILD_APIDOC=true
+    - LUA=5.2 LGIVER=      LUANAME=lua5.2 BUILD_APIDOC=true DO_COVERAGE=true
     - LUA=5.2 LGIVER=0.7.1 LUANAME=lua5.2
     # luajit: requires --lua-suffix=jit-2.0.0-beta9 in Ubuntu precise.
     # Later versions seem to provide a `luajit` symlink, so `jit` would be enough.
@@ -73,6 +73,9 @@ install:
   - travis_retry sudo luarocks install ldoc
   - travis_retry sudo luarocks install lua-discount
 
+  # Instal luacov-coveralls for code coverage testing.
+  - if [ "$DO_COVERAGE" = "true" ]; then sudo luarocks install luacov-coveralls; fi
+
   # Determine custom version.
   - export AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)"
   - 'if [ "$TRAVIS_PULL_REQUEST" != false ]; then AWESOME_VERSION="${AWESOME_VERSION}-PR${TRAVIS_PULL_REQUEST}"; fi'
@@ -80,7 +83,10 @@ install:
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION"
   - make && sudo env PATH=$PATH make install && awesome --version && tests/run.sh
+  - if [ "$DO_COVERAGE" = "true" ]; then make check-coverage; fi
 
 after_success:
   # Push updated API docs for relevant branches, e.g. non-PRs builds on master.
   - if [ "$BUILD_APIDOC" = "true" ]; then build-utils/travis-apidoc.sh; fi
+  # Push code coverage information
+  - if [ "$DO_COVERAGE" = "true" ]; then BUILD_DIRECTORY="$(pwd)/$(readlink build)/" luacov-coveralls --verbose; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION"
   - make && sudo env PATH=$PATH make install && awesome --version && tests/run.sh
   - if [ "$DO_COVERAGE" = "true" ]; then make check-coverage; fi
+  - if [ "$DO_COVERAGE" = "true" ]; then sed -i "1 i\\require('luacov.runner')('"$(pwd)"/.luacov')" build/awesomerc.lua ; fi
+  - if [ "$DO_COVERAGE" = "true" ]; then BUILD_DIRECTORY="" tests/run.sh; fi
 
 after_success:
   # Push updated API docs for relevant branches, e.g. non-PRs builds on master.

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
   - travis_retry sudo luarocks install lua-discount
 
   # Instal luacov-coveralls for code coverage testing.
-  - if [ "$DO_COVERAGE" = "true" ]; then sudo luarocks install luacov-coveralls; fi
+  - if [ "$DO_COVERAGE" = "true" ]; then sudo luarocks install https://luarocks.org/manifests/moteus/luacov-coveralls-scm-0.rockspec; fi
 
   # Determine custom version.
   - export AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)"
@@ -91,4 +91,4 @@ after_success:
   # Push updated API docs for relevant branches, e.g. non-PRs builds on master.
   - if [ "$BUILD_APIDOC" = "true" ]; then build-utils/travis-apidoc.sh; fi
   # Push code coverage information
-  - if [ "$DO_COVERAGE" = "true" ]; then BUILD_DIRECTORY="$(pwd)/$(readlink build)/" luacov-coveralls --verbose; fi
+  - if [ "$DO_COVERAGE" = "true" ]; then BUILD_DIRECTORY="$(pwd)/$(readlink build)/" luacov-coveralls --verbose --merge; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,14 @@ if(BUSTED_EXECUTABLE)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Running unit tests"
         VERBATIM)
+    add_custom_target(check-coverage
+        "BUILD_DIRECTORY=${CMAKE_BINARY_DIR}/"
+        ${BUSTED_EXECUTABLE} "--helper=${CMAKE_SOURCE_DIR}/spec/preload.lua"
+        "--lpath=${CMAKE_BINARY_DIR}/lib/?.lua;${CMAKE_BINARY_DIR}/lib/?/init.lua;spec/?.lua"
+        "--coverage"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Running unit tests under LuaCov"
+        VERBATIM)
 endif()
 add_custom_target(check-integration
     "${CMAKE_SOURCE_DIR}/tests/run.sh"


### PR DESCRIPTION
This uses coveralls.io and integrates the collection of coverage information
with Travis.

Right now this only tests unit tests. Examples for the results are at https://coveralls.io/builds/4991426.