### PR TITLE
Extend bgimage support

### DIFF
--- a/lib/awful/titlebar.lua
+++ b/lib/awful/titlebar.lua
@@ -89,6 +89,7 @@ local function new(c, args)
             local args = bars[position].args
             ret:set_bg(get_color("bg", c, args))
             ret:set_fg(get_color("fg", c, args))
+            ret:set_bgimage(get_color("bgimage", c, args))
         end
 
         bars[position] = {

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -43,6 +43,14 @@ function wibox:set_bg(c)
     self._drawable:set_bg(c)
 end
 
+--- Set the background image of the drawable
+-- If `image` is a function, it will be called with `(context, cr, width, height)`
+-- as arguments. Any other arguments passed to this method will be appended.
+-- @param image A background image or a function
+function wibox:set_bgimage(image, ...)
+    self._drawable:set_bgimage(image, ...)
+end
+
 --- Set the foreground of the wibox
 -- @param c The foreground to use. This must either be a cairo pattern object,
 --   nil or a string that gears.color() understands.

--- a/lib/wibox/widget/background.lua
+++ b/lib/wibox/widget/background.lua
@@ -43,9 +43,13 @@ function background:draw(context, cr, width, height)
         cr:paint()
     end
     if self.bgimage then
-        local pattern = cairo.Pattern.create_for_surface(self.bgimage)
-        cr:set_source(pattern)
-        cr:paint()
+        if type(self.bgimage) == "function" then
+            self.bgimage(context, cr, width, height,unpack(self.bgimage_args))
+        else
+            local pattern = cairo.Pattern.create_for_surface(self.bgimage)
+            cr:set_source(pattern)
+            cr:paint()
+        end
     end
 
 end
@@ -145,8 +149,12 @@ function background:set_shape_border_color(fg)
 end
 
 --- Set the background image to use
-function background:set_bgimage(image)
-    self.bgimage = surface.load(image)
+-- If `image` is a function, it will be called with `(context, cr, width, height)`
+-- as arguments. Any other arguments passed to this method will be appended.
+-- @param image A background image or a function
+function background:set_bgimage(image, ...)
+    self.bgimage = type(image) == "function" and image or surface.load(image)
+    self.bgimage_args = {...}
     self:emit_signal("widget::redraw_needed")
 end
 


### PR DESCRIPTION
This PR still need some work, but generally seem to cause no regressions

Screenshot:
http://i.imgur.com/1QVpnXG.png

In this screenshot, made last week, everything is done using programmatic `bgimage`. A titlebar like this was previously impossible, but now take only ~20 line of code. Also, The `bgimage` function allow the button background to be created with the right width and height using on top of the current API using the default tasklist widget, making the old hack obsolete. This PR doesn't remove the old `awful.widget.common` hack, I want to see how much you hate it first.

I made that code last week, but I wasn't sure myself about it, but it solve real limitations and add a very powerful API without breaking too much in the process.

Edit:

By the way, this is an example of a simple titlebar with rounded corner (+ antialiasing)

```lua
local cols = {
   [true] = color("#ff0000"),
   [false] = color("#00ff00")
}

local bgs = {
    top = function(context, cr, w, h)
        cr:translate(1,1)
        shape.rounded_rect(cr, w-2, h*3, 12)
        cr:set_source(cols[context.has_focus])
        cr:set_line_width(3)
        cr:stroke()
        cr:translate(-2,-2)
    end,
    bottom = function(context, cr, w, h)
        cr:translate(1,-3*h+ 17)
        shape.rounded_rect(cr, w-2, h*3, 12)
        cr:set_source(cols[context.has_focus])
        cr:set_line_width(3)
        cr:stroke()
        cr:translate(-1,-2)
    end,
    left = function(context, cr, w, h)
        cr:set_source_rgb(0,0,0)
        cr:paint()
        cr:set_source(cols[context.has_focus])
        cr:rectangle(0,0,2,h)
        cr:fill()
    end,
    right = function(context, cr, w, h)
        cr:set_source_rgb(0,0,0)
        cr:paint()
        cr:set_source(cols[context.has_focus])
        cr:rectangle(w-2,0,2,h)
        cr:fill()
    end,
}
theme.titlebar_bgimage = function(context, cr, w, h)
    bgs[context.position](context, cr, w, h)
end
```