### PR TITLE
Make the functional test runner more robust

### DIFF
--- a/tests/_runner.lua
+++ b/tests/_runner.lua
@@ -79,6 +79,9 @@ runner.run_steps = function(steps)
     for _,c in ipairs(client.get()) do
       c:kill()
     end
+    if success and result then
+        io.stderr:write("Test finished successfully\n")
+    end
     awesome.quit()
   end) end)
   t:start()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -169,9 +169,10 @@ for f in $tests; do
     # Tail the log and quit, when awesome quits.
     tail -n 100000 -f --pid $awesome_pid $awesome_log
 
-    if grep -q -E '^Error|assertion failed' $awesome_log; then
+    if ! grep -q -E '^Test finished successfully$' $awesome_log ||
+            grep -q -E '[Ee]rror|assertion failed' $awesome_log; then
         echo "===> ERROR running $f! <==="
-        grep --color -o --binary-files=text -E '^Error.*|.*assertion failed.*' $awesome_log
+        grep --color -o --binary-files=text -E '.*[Ee]rror.*|.*assertion failed.*' $awesome_log
         errors=$(expr $errors + 1)
     fi
 done


### PR DESCRIPTION
Currently, an error in the default config in the right place isn't noticed. Fix
this by doing two things:

- Also grep for "error" (this catches runtime errors with a stack trace)
- Make _runner print a "success" message at the end and also grep for that

Fixes: https://github.com/awesomeWM/awesome/issues/689
Signed-off-by: Uli Schlachter <psychon@znc.in>

Note: Travis will fail due to the bug currently present in master. That's expected. If you want, I can rebase after that was fixed or this can just be merged in the hope that Travis becomes happy afterwards.