### PR TITLE
Enable titlebars by default

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -475,7 +475,7 @@ client.connect_signal("manage", function (c)
         awful.placement.no_offscreen(c)
     end
 
-    local titlebars_enabled = false
+    local titlebars_enabled = true
     if titlebars_enabled and (c.type == "normal" or c.type == "dialog") then
         -- buttons for the titlebar
         local buttons = awful.util.table.join(


### PR DESCRIPTION
This means that titlebars, which are an important feature, get more testing. As
was recently shown, they don't get enough testing currently. Also, new users
will likely expect titlebars these days.

Everyone who doesn't want titlebars can easily disable them.

Signed-off-by: Uli Schlachter <psychon@znc.in>