### PR TITLE
Fix images in the documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,6 @@ set(AWE_DOC_FILES
     ${AWE_DOC_DIR}/02-contributing.md
     ${SOURCE_DIR}/LICENSE)
 
-if (GENERATE_DOC)
-   set(AWE_DOC_IMAGES
-        ${AWE_DOC_DIR}/images/widgetlayout1.png
-        ${AWE_DOC_DIR}/images/widgetlayout2.png
-    )
-endif()
-
 set(AWE_SRCS
     ${BUILD_DIR}/awesome.c
     ${BUILD_DIR}/banning.c
@@ -267,7 +260,7 @@ if(GENERATE_DOC)
     file(GLOB_RECURSE AWE_MD_FILES ${AWE_DOC_DIR}/*.md)
 
     # Copy the images to the build directory
-    file(COPY ${SOURCE_DIR}/docs/images DESTINATION ${AWE_DOC_DIR})
+    file(COPY ${SOURCE_DIR}/docs/images DESTINATION ${BUILD_DIR}/doc)
 
     # Run ldoc and make it fail if any warnings are generated. The
     # redirection-magic swaps stdout and stderr and awk exits with a non-zero
@@ -352,7 +345,6 @@ install(DIRECTORY ${SOURCE_DIR}/themes DESTINATION ${AWESOME_DATA_PATH}
 install(DIRECTORY ${BUILD_DIR}/themes DESTINATION ${AWESOME_DATA_PATH}
     PATTERN "*.lua")
 install(FILES ${AWE_DOC_FILES}  DESTINATION ${AWESOME_DOC_PATH})
-install(FILES ${AWE_DOC_IMAGES} DESTINATION ${AWESOME_DOC_PATH}/images)
 install(FILES "awesome.desktop" DESTINATION ${AWESOME_XSESSION_PATH})
 if(GENERATE_DOC)
     install(DIRECTORY ${BUILD_DIR}/doc DESTINATION ${AWESOME_DOC_PATH})

--- a/docs/03-declarative-layout.md
+++ b/docs/03-declarative-layout.md
@@ -75,7 +75,7 @@ Code:
 
 
 Result:
-![Example2 screenshot](../../docs/images/widgetlayout1.png)
+![Example2 screenshot](../images/widgetlayout1.png)
 
 
 ## Use an `wibox.layout.align` layout
@@ -114,7 +114,7 @@ Code:
     }
 
 Result:
-![Example4 screenshot](../../docs/images/widgetlayout2.png)
+![Example4 screenshot](../images/widgetlayout2.png)
 
 For more information about how to draw widgets, refer to the `Cairo` api:
 


### PR DESCRIPTION
Instead of copying images to ${BUILD_DIR}/docs/images, which is the directory
with the input to ldoc, this now copies the images to ${BUILD_DIR}/doc/images,
which is where ldoc generates its output. That way, the images are together with
the html files and are automatically picked up by a lot of stuff.

Fixes: https://github.com/awesomeWM/awesome/issues/681
Signed-off-by: Uli Schlachter <psychon@znc.in>