### PR TITLE
Fix bugs luacheck found

### DIFF
--- a/lib/awful/layout/suit/corner.lua
+++ b/lib/awful/layout/suit/corner.lua
@@ -19,6 +19,7 @@ local tag = require("awful.tag")
 -- @param orientation String indicating in which corner is the master window.
 -- Available values are : NE, NW, SW, SE
 local function do_corner(p, orientation)
+    local t = p.tag or tag.selected(p.screen)
     local wa = p.workarea
     local cls = p.clients
 

--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -18,6 +18,7 @@ local capi =
 {
     selection = selection
 }
+local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 local keygrabber = require("awful.keygrabber")
 local util = require("awful.util")
 local beautiful = require("beautiful")

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -79,7 +79,7 @@ function tag.swap(tag1, tag2)
     local src2, src1 = tag.getscreen(tag2), tag.getscreen(tag1)
     tag.setscreen(src1, tag2)
     tag.move(idx1, tag2)
-    tag.setscreen(scr2, tag1)
+    tag.setscreen(src2, tag1)
     tag.move(idx2, tag1)
 end
 

--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -95,7 +95,8 @@ function common.list_update(w, buttons, label, data, objects)
         end
         bgb:set_bg(bg)
         if type(bg_image) == "function" then
-            bg_image = bg_image(tb,o,m,objects,i)
+            -- TODO: Why does this pass nil as an argument?
+            bg_image = bg_image(tb,o,nil,objects,i)
         end
         bgb:set_bgimage(bg_image)
         if icon then

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -200,7 +200,7 @@ function taglist.new(screen, filter, buttons, style, update_function, base_widge
         capi.client.connect_signal("unmanage", uc)
     end
     w._do_taglist_update()
-    local list = instances[s]
+    local list = instances[screen]
     if not list then
         list = setmetatable({}, { __mode = "v" })
         instances[screen] = list

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -224,7 +224,7 @@ function tasklist.new(screen, filter, buttons, style, update_function, base_widg
         capi.client.connect_signal("untagged", u)
         capi.client.connect_signal("unmanage", function(c)
             u(c)
-            for s, i in pairs(instances) do
+            for _, i in pairs(instances) do
                 for _, tlist in pairs(i) do
                     tlist._unmanage(c)
                 end

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -325,7 +325,7 @@ end
 function naughty.reset_timeout(notification, new_timeout)
     if notification.timer then notification.timer:stop() end
 
-    local timeout = timeout or notification.timeout
+    local timeout = new_timeout or notification.timeout
     set_timeout(notification, timeout)
     notification.timeout = timeout
 

--- a/lib/wibox/layout/mirror.lua
+++ b/lib/wibox/layout/mirror.lua
@@ -37,7 +37,7 @@ function mirror:layout(context, cr, width, height)
     m = m:translate(t.x, t.y)
     m = m:scale(s.x, s.y)
 
-    return base.place_widget_via_matrix(widget, m, width, height)
+    return base.place_widget_via_matrix(self.widget, m, width, height)
 end
 
 --- Fit this layout into the given area


### PR DESCRIPTION
This is another PR that splits out some stuff from https://github.com/awesomeWM/awesome/pull/676. These commits fix actual issues that Luacheck identified.

After this, the only remaining warnings about issues which were not yet solved. These are the `test-urgent` test being broken (if we fix this to actual set `urgent_cb_done = false` in step 3, the test starts to fail) and the API docs for `wibox.layout.stack` (the `new` function has arguments copied from, I think, `fixed`, but doesn't use them). When these are figured out as well, I can update #676 so that it is actually about running Luacheck on Travis, because all the warnings are already fixed.

P.S.: Yes, this `local unpack = unpack or table.unpack` stuff is mostly unneeded, because everyone compiles Lua in compatibility mode and thus `unpack` stays a global. Still, we are prepared for when Lua 5.4 drops that compatibility flag (or something like that).