### PR TITLE
Lua 5.3: Disable Lua 5.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
       wget http://www.lua.org/ftp/lua-5.3.2.tar.gz -O lua.tar.gz
       tar -xvzf lua.tar.gz
       cd lua-*
-      (cd src && make SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="gcc -shared -ldl -o" liblua.so) || exit 1
+      (cd src && make SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="gcc -shared -ldl -o" liblua.so) || exit 1
       sudo make INSTALL_TOP=/usr/ INSTALL_INC=${LUAINCLUDE} TO_LIB=liblua.so linux install || exit 1
       cd ..
     else


### PR DESCRIPTION
Lua 5.3's build system provides the LUA_COMPAT_5_2 and LUA_COMPAT_5_1 defines to
enable some compatibility with these older Lua versions. LUA_COMPAT_5_2 is
defined by default while LUA_COMPAT_5_1 is not.

This commit also disables LUA_COMPAT_5_2 on the Lua version that we build on
Travis so that the build will hopefully break if some feature is used that was
removed.

Signed-off-by: Uli Schlachter <psychon@znc.in>