### PR TITLE
Fix awful.ewmh to handle window gravities

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -70,11 +70,11 @@ local function fullscreen(window, set)
     if set then
         store_geometry(window, "fullscreen")
         data[window].fullscreen.border_width = window.border_width
-        window:geometry(screen[window.screen].geometry)
         window.border_width = 0
+        window:geometry(screen[window.screen].geometry)
     elseif data[window] and data[window].fullscreen then
-        window:geometry(data[window].fullscreen)
         window.border_width = data[window].fullscreen.border_width
+        window:geometry(data[window].fullscreen)
     end
 end
 


### PR DESCRIPTION
Since commit b2aaefd095c964491f2c93a, we correctly handle window gravities when
the border width of a client changes. Since most windows out there have a
NorthWest gravity, this means that most windows do not have this problem.
However, e.g. mplayer uses gravity "Static" and this causes this issue (any
gravity other than NorthWest will do).

This affects the fullscreen handling in awful.ewmh. The code has to set the
border width before it changes a client's geometry so that the move when the
border width changes doesn't matter.

No new integration test for this since I didn't find anything usable with a
non-NorthWest gravity. A test would be easy to write, just test if `c.fullscreen
= true ; c.fullscreen = false` restores the previous window geometry.

Fixes: https://github.com/awesomeWM/awesome/issues/697
Signed-off-by: Uli Schlachter <psychon@znc.in>