### PR TITLE
Fix test-urgent.lua

### DIFF
--- a/tests/test-urgent.lua
+++ b/tests/test-urgent.lua
@@ -69,7 +69,7 @@ local steps = {
   -- Step 3: tag 2 should not be urgent, but switched to.
   function(count)
     if count == 1 then  -- Setup.
-      local urgent_cb_done = false
+      urgent_cb_done = false
 
       -- Select first tag.
       awful.tag.viewonly(tags[1][1])
@@ -80,7 +80,7 @@ local steps = {
       awful.spawn("xterm")
 
     elseif awful.tag.selectedlist()[1] == tags[1][2] then
-      assert(urgent_cb_done)
+      assert(not urgent_cb_done)
       assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
       assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
       assert(awful.tag.selectedlist()[2] == nil)


### PR DESCRIPTION
Step 1 starts a client and uses awful.rules to move it to a not-selected tag.
Because this rule still has focus=true, this calls awful.ewmh.activate() via the
request::activate signal. This function makes the client urgent because it is on
a not-selected tag.

Step 3 does the same thing, but also uses switchtotag=true. Now
awful.ewmh.activate() doesn't make the client urgent because it successfully
focused this client. However, the test was wrongly assuming that the client
became urgent (copy&paste error? I don't know).

The fix is of course not to require the client to become urgent.

Signed-off-by: Uli Schlachter <psychon@znc.in>

@blueyed Does the above sound sensible?