### PR TITLE
Less screen indicies

### DIFF
--- a/lib/awful/autofocus.lua
+++ b/lib/awful/autofocus.lua
@@ -21,7 +21,7 @@ local timer = require("gears.timer")
 local function check_focus(obj)
     -- When no visible client has the focus...
     if not client.focus or not client.focus:isvisible() then
-        local c = aclient.focus.history.get(screen[obj.screen].index, 0, aclient.focus.filter)
+        local c = aclient.focus.history.get(screen[obj.screen], 0, aclient.focus.filter)
         if c then
             c:emit_signal("request::activate", "autofocus.check_focus",
                           {raise=false})
@@ -43,8 +43,8 @@ local function check_focus_tag(t)
     if not s then return end
     s = screen[s]
     check_focus({ screen = s })
-    if client.focus and client.focus.screen ~= s.index then
-        local c = aclient.focus.history.get(s.index, 0, aclient.focus.filter)
+    if client.focus and screen[client.focus.screen] ~= s then
+        local c = aclient.focus.history.get(s, 0, aclient.focus.filter)
         if c then
             c:emit_signal("request::activate", "autofocus.check_focus_tag",
                           {raise=false})

--- a/lib/awful/autofocus.lua
+++ b/lib/awful/autofocus.lua
@@ -21,7 +21,7 @@ local timer = require("gears.timer")
 local function check_focus(obj)
     -- When no visible client has the focus...
     if not client.focus or not client.focus:isvisible() then
-        local c = aclient.focus.history.get(obj.screen, 0, aclient.focus.filter)
+        local c = aclient.focus.history.get(screen[obj.screen].index, 0, aclient.focus.filter)
         if c then
             c:emit_signal("request::activate", "autofocus.check_focus",
                           {raise=false})
@@ -41,9 +41,10 @@ end
 local function check_focus_tag(t)
     local s = atag.getscreen(t)
     if not s then return end
+    s = screen[s]
     check_focus({ screen = s })
-    if client.focus and client.focus.screen ~= s then
-        local c = aclient.focus.history.get(s, 0, aclient.focus.filter)
+    if client.focus and client.focus.screen ~= s.index then
+        local c = aclient.focus.history.get(s.index, 0, aclient.focus.filter)
         if c then
             c:emit_signal("request::activate", "autofocus.check_focus_tag",
                           {raise=false})

--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -64,8 +64,7 @@ local delayed_arrange = {}
 -- @param screen The screen.
 -- @return The layout function.
 function layout.get(screen)
-    screen = get_screen(screen)
-    local t = tag.selected(screen and screen.index)
+    local t = tag.selected(screen)
     return tag.getproperty(t, "layout") or layout.suit.floating
 end
 
@@ -80,7 +79,7 @@ function layout.inc(i, s, layouts)
         layouts, i, s = i, s, layouts
     end
     s = get_screen(s)
-    local t = tag.selected(s and s.index)
+    local t = tag.selected(s)
     layouts = layouts or layout.layouts
     if t then
         local curlayout = layout.get(s)
@@ -131,7 +130,7 @@ end
 --   "geometries" table with client as keys and geometry as value
 function layout.parameters(t, screen)
     screen = get_screen(screen)
-    t = t or tag.selected(screen and screen.index)
+    t = t or tag.selected(screen)
 
     if not t then return end
 
@@ -141,7 +140,7 @@ function layout.parameters(t, screen)
 
     p.workarea = screen.workarea
 
-    local useless_gap = tag.getgap(t, #client.tiled(screen.index))
+    local useless_gap = tag.getgap(t, #client.tiled(screen))
 
     -- Handle padding
     local padding = ascreen.padding(screen) or {}
@@ -243,10 +242,10 @@ capi.tag.connect_signal("tagged", arrange_tag)
 
 for s = 1, capi.screen.count() do
     capi.screen[s]:connect_signal("property::workarea", function(screen)
-        layout.arrange(screen.index)
+        layout.arrange(screen)
     end)
     capi.screen[s]:connect_signal("padding", function (screen)
-        layout.arrange(screen.index)
+        layout.arrange(screen)
     end)
 end
 

--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -120,8 +120,8 @@ local function item_position(_menu, child)
 end
 
 
-local function set_coords(_menu, screen_idx, m_coords)
-    local s_geometry = capi.screen[screen_idx].workarea
+local function set_coords(_menu, s, m_coords)
+    local s_geometry = s.workarea
     local screen_w = s_geometry.x + s_geometry.width
     local screen_h = s_geometry.y + s_geometry.height
 
@@ -313,10 +313,10 @@ end
 function menu:show(args)
     args = args or {}
     local coords = args.coords or nil
-    local screen_index = screen.focused()
+    local s = capi.screen[screen.focused()]
 
     if not set_size(self) then return end
-    set_coords(self, screen_index, coords)
+    set_coords(self, s, coords)
 
     keygrabber.run(self._keygrabber)
     self.wibox.visible = true

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -150,7 +150,7 @@ end
 function placement.no_overlap(c)
     local geometry = get_area(c)
     local screen   = get_screen(c.screen or a_screen.getbycoord(geometry.x, geometry.y))
-    local cls = client.visible(screen.index)
+    local cls = client.visible(screen)
     local curlay = layout.get()
     local areas = { screen.workarea }
     for _, cl in pairs(cls) do

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -23,6 +23,10 @@ local layout = require("awful.layout")
 local a_screen = require("awful.screen")
 local dpi = require("beautiful").xresources.apply_dpi
 
+local function get_screen(s)
+    return s and capi.screen[s]
+end
+
 local placement = {}
 
 --- Check if an area intersect another area.
@@ -121,8 +125,8 @@ end
 function placement.no_offscreen(c, screen)
     c = c or capi.client.focus
     local geometry = get_area(c)
-    screen = screen or c.screen or a_screen.getbycoord(geometry.x, geometry.y)
-    local screen_geometry = capi.screen[screen].workarea
+    screen = get_screen(screen or c.screen or a_screen.getbycoord(geometry.x, geometry.y))
+    local screen_geometry = screen.workarea
 
     if geometry.x + geometry.width > screen_geometry.x + screen_geometry.width then
         geometry.x = screen_geometry.x + screen_geometry.width - geometry.width
@@ -145,10 +149,10 @@ end
 -- @param c The client.
 function placement.no_overlap(c)
     local geometry = get_area(c)
-    local screen   = c.screen or a_screen.getbycoord(geometry.x, geometry.y)
-    local cls = client.visible(screen)
+    local screen   = get_screen(c.screen or a_screen.getbycoord(geometry.x, geometry.y))
+    local cls = client.visible(screen.index)
     local curlay = layout.get()
-    local areas = { capi.screen[screen].workarea }
+    local areas = { screen.workarea }
     for _, cl in pairs(cls) do
         if cl ~= c and cl.type ~= "desktop" and (client.floating.get(cl) or curlay == layout.suit.floating) then
             areas = area_remove(areas, get_area(cl))
@@ -249,12 +253,12 @@ end
 function placement.centered(c, p)
     c = c or capi.client.focus
     local c_geometry = get_area(c)
-    local screen = c.screen or a_screen.getbycoord(c_geometry.x, c_geometry.y)
+    local screen = get_screen(c.screen or a_screen.getbycoord(c_geometry.x, c_geometry.y))
     local s_geometry
     if p then
         s_geometry = get_area(p)
     else
-        s_geometry = capi.screen[screen].geometry
+        s_geometry = screen.geometry
     end
     return c:geometry({ x = s_geometry.x + (s_geometry.width - c_geometry.width) / 2,
                         y = s_geometry.y + (s_geometry.height - c_geometry.height) / 2 })
@@ -267,12 +271,12 @@ end
 function placement.center_horizontal(c, p)
     c = c or capi.client.focus
     local c_geometry = get_area(c)
-    local screen = c.screen or a_screen.getbycoord(c_geometry.x, c_geometry.y)
+    local screen = get_screen(c.screen or a_screen.getbycoord(c_geometry.x, c_geometry.y))
     local s_geometry
     if p then
         s_geometry = get_area(p)
     else
-        s_geometry = capi.screen[screen].geometry
+        s_geometry = screen.geometry
     end
     return c:geometry({ x = s_geometry.x + (s_geometry.width - c_geometry.width) / 2 })
 end
@@ -284,12 +288,12 @@ end
 function placement.center_vertical(c, p)
     c = c or capi.client.focus
     local c_geometry = get_area(c)
-    local screen = c.screen or a_screen.getbycoord(c_geometry.x, c_geometry.y)
+    local screen = get_screen(c.screen or a_screen.getbycoord(c_geometry.x, c_geometry.y))
     local s_geometry
     if p then
         s_geometry = get_area(p)
     else
-        s_geometry = capi.screen[screen].geometry
+        s_geometry = screen.geometry
     end
     return c:geometry({ y = s_geometry.y + (s_geometry.height - c_geometry.height) / 2 })
 end

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -101,7 +101,7 @@ function screen.focus(_screen)
    -- move cursor without triggering signals mouse::enter and mouse::leave
     capi.mouse.coords(pos, true)
 
-    local c = client.focus.history.get(_screen.index, 0)
+    local c = client.focus.history.get(_screen, 0)
     if c then
         c:emit_signal("request::activate", "screen.focus", {raise=false})
     end

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -50,7 +50,7 @@ tag.history.limit = 20
 function tag.move(new_index, target_tag)
     target_tag = target_tag or tag.selected()
     local scr = get_screen(tag.getscreen(target_tag))
-    local tmp_tags = tag.gettags(scr and scr.index)
+    local tmp_tags = tag.gettags(scr)
 
     if (not new_index) or (new_index < 1) or (new_index > #tmp_tags) then
         return
@@ -218,7 +218,7 @@ end
 --- Update the tag history.
 -- @param obj Screen object.
 function tag.history.update(obj)
-    local s = get_screen(obj.index)
+    local s = get_screen(obj)
     local curtags = tag.selectedlist(s)
     -- create history table
     if not data.history[s] then
@@ -524,7 +524,7 @@ function tag.incnmaster(add, t, sensible)
     if sensible then
         client = client or require("awful.client")
         local screen = get_screen(tag.getscreen(t))
-        local ntiled = #client.tiled(screen and screen.index)
+        local ntiled = #client.tiled(screen)
 
         local nmaster = tag.getnmaster(t)
         if nmaster > ntiled then
@@ -583,7 +583,7 @@ function tag.incncol(add, t, sensible)
     if sensible then
         client = client or require("awful.client")
         local screen = get_screen(tag.getscreen(t))
-        local ntiled = #client.tiled(screen and screen.index)
+        local ntiled = #client.tiled(screen)
         local nmaster = tag.getnmaster(t)
         local nsecondary = ntiled - nmaster
 

--- a/lib/awful/wibox.lua
+++ b/lib/awful/wibox.lua
@@ -25,6 +25,10 @@ local wibox = require("wibox")
 local beautiful = require("beautiful")
 local round = require("awful.util").round
 
+local function get_screen(s)
+    return s and screen[s]
+end
+
 local awfulwibox = { mt = {} }
 
 --- Array of table with wiboxes inside.
@@ -49,7 +53,7 @@ end
 -- @param screen If the wibox it not attached to a screen, specified on which
 -- screen the position should be set.
 function awfulwibox.set_position(wb, position, screen)
-    local area = capi.screen[screen].geometry
+    local area = get_screen(screen).geometry
 
     -- The "length" of a wibox is always chosen to be the optimal size
     -- (non-floating).
@@ -107,8 +111,9 @@ end
 -- will be attached.
 -- @param wb The wibox to attach.
 -- @param position The position of the wibox: top, bottom, left or right.
--- @param screen TODO, this seems to be unused
+-- @param screen The screen to attach to
 function awfulwibox.attach(wb, position, screen)
+    screen = get_screen(screen)
     -- Store wibox as attached in a weak-valued table
     local wibox_prop_table
     -- Start from end since we sometimes remove items
@@ -144,10 +149,11 @@ end
 -- @param wb The wibox.
 -- @param align The alignment: left, right or center.
 -- @param screen If the wibox is not attached to any screen, you can specify the
--- screen where to align. Otherwise 1 is assumed.
+-- screen where to align.
 function awfulwibox.align(wb, align, screen)
+    screen = get_screen(screen)
     local position = awfulwibox.get_position(wb)
-    local area = capi.screen[screen].workarea
+    local area = screen.workarea
 
     if position == "right" then
         if align == "right" then
@@ -192,8 +198,9 @@ end
 -- @param screen The screen to stretch on, or the wibox screen.
 function awfulwibox.stretch(wb, screen)
     if screen then
+        screen = get_screen(screen)
         local position = awfulwibox.get_position(wb)
-        local area = capi.screen[screen].workarea
+        local area = screen.workarea
         if position == "right" or position == "left" then
             wb.height = area.height - (2 * wb.border_width)
             wb.y = area.y
@@ -216,7 +223,7 @@ function awfulwibox.new(arg)
     arg = arg or {}
     local position = arg.position or "top"
     local has_to_stretch = true
-    local screen = arg.screen or 1
+    local screen = get_screen(arg.screen or 1)
 
     arg.type = arg.type or "dock"
 
@@ -234,7 +241,7 @@ function awfulwibox.new(arg)
             if arg.screen then
                 local hp = tostring(arg.height):match("(%d+)%%")
                 if hp then
-                    arg.height = round(capi.screen[arg.screen].geometry.height * hp / 100)
+                    arg.height = round(screen.geometry.height * hp / 100)
                 end
             end
         end
@@ -245,7 +252,7 @@ function awfulwibox.new(arg)
             if arg.screen then
                 local wp = tostring(arg.width):match("(%d+)%%")
                 if wp then
-                    arg.width = round(capi.screen[arg.screen].geometry.width * wp / 100)
+                    arg.width = round(screen.geometry.width * wp / 100)
                 end
             end
         end

--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -25,7 +25,7 @@ local boxes = nil
 
 local function update(w, screen)
     screen = get_screen(screen)
-    local name = layout.getname(layout.get(screen and screen.index))
+    local name = layout.getname(layout.get(screen))
     w._layoutbox_tooltip:set_text(name or "[no name]")
     w:set_image(name and beautiful["layout_" .. name])
 end

--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -8,24 +8,30 @@
 ---------------------------------------------------------------------------
 
 local setmetatable = setmetatable
+local capi = { screen = screen }
 local layout = require("awful.layout")
 local tooltip = require("awful.tooltip")
 local tag = require("awful.tag")
 local beautiful = require("beautiful")
 local imagebox = require("wibox.widget.imagebox")
 
+local function get_screen(s)
+    return s and capi.screen[s]
+end
+
 local layoutbox = { mt = {} }
 
 local boxes = nil
 
 local function update(w, screen)
-    local name = layout.getname(layout.get(screen))
+    screen = get_screen(screen)
+    local name = layout.getname(layout.get(screen and screen.index))
     w._layoutbox_tooltip:set_text(name or "[no name]")
     w:set_image(name and beautiful["layout_" .. name])
 end
 
 local function update_from_tag(t)
-    local screen = tag.getscreen(t)
+    local screen = get_screen(tag.getscreen(t))
     local w = boxes[screen]
     if w then
         update(w, screen)
@@ -37,7 +43,7 @@ end
 -- @param screen The screen number that the layout will be represented for.
 -- @return An imagebox widget configured as a layoutbox.
 function layoutbox.new(screen)
-    screen = screen or 1
+    screen = get_screen(screen or 1)
 
     -- Do we already have the update callbacks registered?
     if boxes == nil then

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -23,6 +23,10 @@ local fixed = require("wibox.layout.fixed")
 local surface = require("gears.surface")
 local timer = require("gears.timer")
 
+local function get_screen(s)
+    return s and capi.screen[s]
+end
+
 local taglist = { mt = {} }
 taglist.filter = {}
 
@@ -153,6 +157,7 @@ end
 -- @param[opt] base_widget.squares_resize True or false to resize squares.
 -- @param base_widget.font The font.
 function taglist.new(screen, filter, buttons, style, update_function, base_widget)
+    screen = get_screen(screen)
     local uf = update_function or common.list_update
     local w = base_widget or fixed.horizontal()
 
@@ -172,7 +177,7 @@ function taglist.new(screen, filter, buttons, style, update_function, base_widge
     if instances == nil then
         instances = {}
         local function u(s)
-            local i = instances[s]
+            local i = instances[get_screen(s)]
             if i then
                 for _, tlist in pairs(i) do
                     tlist._do_taglist_update()

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -274,7 +274,7 @@ function tasklist.filter.currenttags(c, screen)
     if get_screen(c.screen) ~= screen then return false end
     -- Include sticky client too
     if c.sticky then return true end
-    local tags = tag.gettags(screen.index)
+    local tags = tag.gettags(screen)
     for _, t in ipairs(tags) do
         if t.selected then
             local ctags = c:tags()
@@ -300,7 +300,7 @@ function tasklist.filter.minimizedcurrenttags(c, screen)
     if not c.minimized then return false end
     -- Include sticky client
     if c.sticky then return true end
-    local tags = tag.gettags(screen.index)
+    local tags = tag.gettags(screen)
     for _, t in ipairs(tags) do
         -- Select only minimized clients
         if t.selected then

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -21,6 +21,10 @@ local tag = require("awful.tag")
 local flex = require("wibox.layout.flex")
 local timer = require("gears.timer")
 
+local function get_screen(s)
+    return s and screen[s]
+end
+
 local tasklist = { mt = {} }
 
 local instances
@@ -165,6 +169,7 @@ end
 -- @param base_widget.maximized_vertical Symbol to use for clients that have been vertically maximized.
 -- @param base_widget.font The font.
 function tasklist.new(screen, filter, buttons, style, update_function, base_widget)
+    screen = get_screen(screen)
     local uf = update_function or common.list_update
     local w = base_widget or flex.horizontal()
 
@@ -187,7 +192,7 @@ function tasklist.new(screen, filter, buttons, style, update_function, base_widg
     if instances == nil then
         instances = {}
         local function us(s)
-            local i = instances[s]
+            local i = instances[get_screen(s)]
             if i then
                 for _, tlist in pairs(i) do
                     tlist._do_tasklist_update()
@@ -256,7 +261,7 @@ end
 -- @return true if c is on screen, false otherwise
 function tasklist.filter.alltags(c, screen)
     -- Only print client on the same screen as this widget
-    return c.screen == screen
+    return get_screen(c.screen) == get_screen(screen)
 end
 
 --- Filtering function to include only the clients from currently selected tags.
@@ -264,11 +269,12 @@ end
 -- @param screen The screen we are drawing on.
 -- @return true if c is in a selected tag on screen, false otherwise
 function tasklist.filter.currenttags(c, screen)
+    screen = get_screen(screen)
     -- Only print client on the same screen as this widget
-    if c.screen ~= screen then return false end
+    if get_screen(c.screen) ~= screen then return false end
     -- Include sticky client too
     if c.sticky then return true end
-    local tags = tag.gettags(screen)
+    local tags = tag.gettags(screen.index)
     for _, t in ipairs(tags) do
         if t.selected then
             local ctags = c:tags()
@@ -287,13 +293,14 @@ end
 -- @param screen The screen we are drawing on.
 -- @return true if c is in a selected tag on screen and is minimized, false otherwise
 function tasklist.filter.minimizedcurrenttags(c, screen)
+    screen = get_screen(screen)
     -- Only print client on the same screen as this widget
-    if c.screen ~= screen then return false end
+    if get_screen(c.screen) ~= screen then return false end
     -- Check client is minimized
     if not c.minimized then return false end
     -- Include sticky client
     if c.sticky then return true end
-    local tags = tag.gettags(screen)
+    local tags = tag.gettags(screen.index)
     for _, t in ipairs(tags) do
         -- Select only minimized clients
         if t.selected then
@@ -314,7 +321,7 @@ end
 -- @return true if c is focused on screen, false otherwise
 function tasklist.filter.focused(c, screen)
     -- Only print client on the same screen as this widget
-    return c.screen == screen and capi.client.focus == c
+    return get_screen(c.screen) == get_screen(screen) and capi.client.focus == c
 end
 
 function tasklist.mt:__call(...)

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -9,6 +9,7 @@
 
 -- Grab environment
 local awesome = awesome
+local screen = screen
 local round = require("awful.util").round
 local gears_debug = require("gears.debug")
 
@@ -66,10 +67,15 @@ end
 
 local dpi_per_screen = {}
 
+local function get_screen(s)
+    return s and screen[s]
+end
+
 --- Get global or per-screen DPI value falling back to xrdb.
--- @tparam[opt=focused] integer s The screen.
+-- @tparam[opt] integer|screen s The screen.
 -- @treturn number DPI value.
 function xresources.get_dpi(s)
+    s = get_screen(s)
     if dpi_per_screen[s] then
         return dpi_per_screen[s]
     end
@@ -84,6 +90,7 @@ end
 -- @tparam number dpi DPI value.
 -- @tparam[opt] integer s Screen.
 function xresources.set_dpi(dpi, s)
+    s = get_screen(s)
     if not s then
         xresources.dpi = dpi
     else
@@ -94,7 +101,7 @@ end
 
 --- Compute resulting size applying current DPI value (optionally per screen).
 -- @tparam number size Size
--- @tparam[opt] integer s The screen.
+-- @tparam[opt] integer|screen s The screen.
 -- @treturn integer Resulting size (rounded to integer).
 function xresources.apply_dpi(size, s)
     return round(size / 96 * xresources.get_dpi(s))

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -31,6 +31,10 @@ local common = require("awful.widget.common")
 local theme = require("beautiful")
 local wibox = require("wibox")
 
+local function get_screen(s)
+    return s and capi.screen[s]
+end
+
 -- menubar
 local menubar = { mt = {}, menu_entries = {} }
 menubar.menu_gen = require("menubar.menu_gen")
@@ -122,9 +126,10 @@ end
 --- Cut item list to return only current page.
 -- @tparam table all_items All items list.
 -- @tparam str query Search query.
--- @tparam number scr Screen number
+-- @tparam number|screen scr Screen
 -- @return table List of items for current page.
 local function get_current_page(all_items, query, scr)
+    scr = get_screen(scr)
     if not instance.prompt.width then
         instance.prompt.width = compute_text_width(instance.prompt.prompt, scr)
     end
@@ -161,7 +166,7 @@ end
 
 --- Update the menubar according to the command entered by user.
 -- @tparam str query Search query.
--- @tparam number scr Screen number
+-- @tparam number|screen scr Screen
 local function menulist_update(query, scr)
     query = query or ""
     shownitems = {}
@@ -288,7 +293,7 @@ local function prompt_keypressed_callback(mod, key, comm)
 end
 
 --- Show the menubar on the given screen.
--- @param scr Screen number.
+-- @param scr Screen.
 function menubar.show(scr)
     if not instance.wibox then
         initialize()
@@ -300,6 +305,7 @@ function menubar.show(scr)
 
     -- Set position and size
     scr = scr or awful.screen.focused() or 1
+    scr = get_screen(scr)
     local scrgeom = capi.screen[scr].workarea
     local geometry = menubar.geometry
     instance.geometry = {x = geometry.x or scrgeom.x,

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -12,6 +12,7 @@ local io = io
 local table = table
 local ipairs = ipairs
 local string = string
+local screen = screen
 local awful_util = require("awful.util")
 local theme = require("beautiful")
 local glib = require("lgi").GLib
@@ -257,17 +258,17 @@ end
 
 --- Compute textbox width.
 -- @tparam wibox.widget.textbox textbox Textbox instance.
--- @tparam number s Screen number
+-- @tparam number|screen s Screen
 -- @treturn int Text width.
 function utils.compute_textbox_width(textbox, s)
-    s = s or mouse.screen
+    s = screen[s or mouse.screen]
     local w, _ = textbox:get_preferred_size(s)
     return w
 end
 
 --- Compute text width.
 -- @tparam str text Text.
--- @tparam number s Screen number
+-- @tparam number|screen s Screen
 -- @treturn int Text width.
 function utils.compute_text_width(text, s)
     return utils.compute_textbox_width(wibox.widget.textbox(awful_util.escape(text)), s)

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -593,7 +593,7 @@ function naughty.notify(args)
 
     -- calculate the width
     if not width then
-        local w, _ = textbox:get_preferred_size(s.index)
+        local w, _ = textbox:get_preferred_size(s)
         width = w + (iconbox and icon_w + 2 * margin or 0) + 2 * margin
     end
 
@@ -604,7 +604,7 @@ function naughty.notify(args)
     -- calculate the height
     if not height then
         local w = width - (iconbox and icon_w + 2 * margin or 0) - 2 * margin
-        local h = textbox:get_height_for_width(w, s.index)
+        local h = textbox:get_height_for_width(w, s)
         if iconbox and icon_h + 2 * margin > h + 2 * margin then
             height = icon_h + 2 * margin
         else

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -10,7 +10,8 @@
 local drawable = {}
 local capi = {
     awesome = awesome,
-    root = root
+    root = root,
+    screen = screen
 }
 local beautiful = require("beautiful")
 local cairo = require("lgi").cairo
@@ -32,10 +33,10 @@ local function screen_getbycoord(x, y)
         local geometry = screen[i].geometry
         if x >= geometry.x and x < geometry.x + geometry.width
            and y >= geometry.y and y < geometry.y + geometry.height then
-            return i
+            return capi.screen[i]
         end
     end
-    return 1
+    return capi.screen[1]
 end
 
 -- Get the widget context. This should always return the same table (if

--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -66,7 +66,7 @@ end
 --- Get the preferred size of a textbox.
 -- This returns the size that the textbox would use if infinite space were
 -- available.
--- @tparam integer s The screen number on which the textbox will be displayed.
+-- @tparam integer|screen s The screen on which the textbox will be displayed.
 -- @treturn number The preferred width.
 -- @treturn number The preferred height.
 function textbox:get_preferred_size(s)
@@ -77,7 +77,7 @@ end
 -- This returns the height that the textbox would use when it is limited to the
 -- given width.
 -- @tparam number width The available width.
--- @tparam integer s The screen number on which the textbox will be displayed.
+-- @tparam integer|screen s The screen on which the textbox will be displayed.
 -- @treturn number The needed height.
 function textbox:get_height_for_width(width, s)
     return self:get_height_for_width_at_dpi(width, beautiful.xresources.get_dpi(s))


### PR DESCRIPTION
As a first step towards https://github.com/awesomeWM/awesome/issues/672, this makes all the Lua code (hopefully) handle screen objects where it currently expects screen numbers.

This should not really cause any issues. The only API-change that I am aware of is that widget contexts (the argument to `fit`, `layout`, `draw` etc) now contains a screen object as `context.screen` instead of a number.

The next step after this would then be to deprecate screen numbers, I guess...