### PR TITLE
Make client key bindings for e.g. xeyes work again

### DIFF
--- a/event.c
+++ b/event.c
@@ -673,7 +673,7 @@ event_handle_key(xcb_key_press_event_t *ev)
         /* get keysym ignoring all modifiers */
         xcb_keysym_t keysym = xcb_key_symbols_get_keysym(globalconf.keysyms, ev->detail, 0);
         client_t *c;
-        if((c = client_getbywin(ev->event)))
+        if((c = client_getbywin(ev->event)) || (c = client_getbynofocuswin(ev->event)))
         {
             luaA_object_push(L, c);
             event_key_callback(ev, &c->keys, L, -1, 1, &keysym);

--- a/objects/client.h
+++ b/objects/client.h
@@ -51,6 +51,8 @@ typedef enum {
 struct client_t
 {
     WINDOW_OBJECT_HEADER
+    /** Window we use for input focus and no-input clients */
+    xcb_window_t nofocus_window;
     /** Client logical screen */
     screen_t *screen;
     /** Client name */
@@ -139,6 +141,7 @@ LUA_OBJECT_FUNCS(client_class, client_t, client)
 
 bool client_on_selected_tags(client_t *);
 client_t * client_getbywin(xcb_window_t);
+client_t * client_getbynofocuswin(xcb_window_t);
 client_t * client_getbyframewin(xcb_window_t);
 
 void client_ban(client_t *);

--- a/xkb.c
+++ b/xkb.c
@@ -199,6 +199,8 @@ xkb_reload_keymap(void)
     {
         client_t *c = *_c;
         xwindow_grabkeys(c->window, &c->keys);
+        if (c->nofocus_window)
+            xwindow_grabkeys(c->nofocus_window, &c->keys);
     }
 }
 


### PR DESCRIPTION
Instead of focusing the root window, we now create a "focus window" inside of
our frame window. This window is placed so that it is not visible, but we can
grab key bindings on it to simulate the window having the input focus.

Fixes: https://github.com/awesomeWM/awesome/issues/699
Signed-off-by: Uli Schlachter <psychon@znc.in>