### PR TITLE
xresources: Prevent tonumber(nil)

### DIFF
--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -82,7 +82,7 @@ function xresources.get_dpi(s)
     if not xresources.dpi then
         -- Might not be present when run under unit tests
         if awesome and awesome.xrdb_get_value then
-            xresources.dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi"))
+            xresources.dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi") or 96)
         end
         if not xresources.dpi then
             xresources.dpi = 96


### PR DESCRIPTION

```lua
stack traceback:
	[C]: in function 'tonumber'
	...usr/local/share/awesome/lib/beautiful/xresources.lua:85: in function 'get_dpi'
	/usr/local/share/awesome/lib/beautiful/init.lua:55: in function 'load_font'
	/usr/local/share/awesome/lib/beautiful/init.lua:74: in function 'set_font'
	/usr/local/share/awesome/lib/beautiful/init.lua:155: in main chunk
	[C]: in function 'require'
	/home/elv13/.config/awesome/utils/tools.lua:7: in main chunk
	[C]: in function 'require'
	/home/elv13/.config/awesome/utils/init.lua:2: in main chunk
	[C]: in function 'require'
	/home/elv13/.config/awesome/rc.lua:8: in main chunk
error: ...usr/local/share/awesome/lib/beautiful/xresources.lua:85: bad argument #1 to 'tonumber' (value expected)
error while running function
```