### PR TITLE
awful.layout: Allow parameters to be called when no tags is selected

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -132,15 +132,13 @@ function layout.parameters(t, screen)
     screen = get_screen(screen)
     t = t or tag.selected(screen)
 
-    if not t then return end
-
-    screen = get_screen(tag.getscreen(t) or 1)
+    screen = get_screen(t and tag.getscreen(t) or 1)
 
     local p = {}
 
     p.workarea = screen.workarea
 
-    local useless_gap = tag.getgap(t, #client.tiled(screen))
+    local useless_gap = t and tag.getgap(t, #client.tiled(screen)) or 0
 
     -- Handle padding
     local padding = ascreen.padding(screen) or {}


### PR DESCRIPTION
There seem to be a little race condition (either in my layout code or
elsewhere) when playing with multiple screens. As most properties do
not depend on the tag, there is no point in returning early anyway.

It just remove a not so necessary limitation. It isn't a bug fix.