### PR TITLE
Make xrdb_get_value() behave as documented

### DIFF
--- a/xrdb.c
+++ b/xrdb.c
@@ -65,14 +65,14 @@ int luaA_xrdb_get_value(lua_State *L) {
                                  &resource_type, &resource_value);
   if (resource_code && (strcmp(resource_type, "String") == 0)) {
     lua_pushstring(L, (char *)resource_value.addr);
-    return 1;
   } else {
     if (strlen(resource_class))
       luaA_warn(L, "Failed to get xrdb value '%s' (class '%s').", resource_name, resource_class);
     else
       luaA_warn(L, "Failed to get xrdb value '%s'.", resource_name);
-    return 0;
+    lua_pushnil(L);
   }
+  return 1;
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The documentation states that this function returns nil if the property does not
exist, but it actually returned nothing. And yes, in Lua this is a difference...

@Elv13 Could you test if this fixes your issue?

P.S.: I created this change entirely through the GitHub web interface. Let's see if this actually works...