### PR TITLE
RFC awful.placement: Use math.ceil()

### DIFF
--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -396,10 +396,10 @@ luaA_drawin_geometry(lua_State *L)
         area_t wingeom;
 
         luaA_checktable(L, 2);
-        wingeom.x = luaA_getopt_integer(L, 2, "x", drawin->geometry.x);
-        wingeom.y = luaA_getopt_integer(L, 2, "y", drawin->geometry.y);
-        wingeom.width = luaA_getopt_integer(L, 2, "width", drawin->geometry.width);
-        wingeom.height = luaA_getopt_integer(L, 2, "height", drawin->geometry.height);
+        wingeom.x = luaA_getopt_number(L, 2, "x", drawin->geometry.x);
+        wingeom.y = luaA_getopt_number(L, 2, "y", drawin->geometry.y);
+        wingeom.width = luaA_getopt_number(L, 2, "width", drawin->geometry.width);
+        wingeom.height = luaA_getopt_number(L, 2, "height", drawin->geometry.height);
 
         if(wingeom.width > 0 && wingeom.height > 0)
             drawin_moveresize(L, 1, wingeom);


### PR DESCRIPTION
(lua 5.1)

I get a lot of "expected integer, got number" errors when using `awful.placement` (mostly with wibox). In 3.5.x, I don't have this problem.

I don't really like this PR, but umm, it work... I would prefer the C side to do it, but I open this PR instead of a bug because umm... I don't know