### PR TITLE
wibox.widget: Minor enhancements

### DIFF
--- a/lib/wibox/layout/fixed.lua
+++ b/lib/wibox/layout/fixed.lua
@@ -164,9 +164,17 @@ function fixed:swap_widgets(widget1, widget2, recursive)
     local idx1, l1 = self:index(widget1, recursive)
     local idx2, l2 = self:index(widget2, recursive)
 
-    if idx1 and l1 and idx2 and l2 then
-        l1:set(idx1, widget2)
-        l2:set(idx2, widget1)
+    if idx1 and l1 and idx2 and l2 and (l1.set or l1.set_widget) and (l2.set or l2.set_widget) then
+        if l1.set then
+            l1:set(idx1, widget2)
+        elseif l1.set_widget then
+            l1:set_widget(widget2)
+        end
+        if l2.set then
+            l2:set(idx2, widget1)
+        elseif l2.set_widget then
+            l2:set_widget(widget1)
+        end
 
         return true
     end

--- a/lib/wibox/layout/ratio.lua
+++ b/lib/wibox/layout/ratio.lua
@@ -215,6 +215,14 @@ function ratio:set_ratio(index, percent)
     self:emit_signal("widget::layout_changed")
 end
 
+--- The the ratio at `index`
+-- @tparam number index The widget index to query
+-- @treturn number The index (between 0 and 1)
+function ratio:get_ratio(index)
+    if not index then return end
+    return self._ratios[index]
+end
+
 --- Set the ratio of "widget"
 -- @param widget The widget to ajust
 -- @tparam number percent An floating point value between 0 and 1

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -460,7 +460,7 @@ function base.make_widget_declarative(args)
     rawset(w, "get_children_by_id", get_children_by_id)
 
     mt.__tostring = function()
-        return string.format("%s (%s)", id, orig_string)
+        return string.format("%s (%s)", id or w.widget_name or "N/A", orig_string)
     end
 
     return setmetatable(w, mt)


### PR DESCRIPTION
 * Better widget names when using the declarative syntax
 * Add ratio.get_ratio to avoid using the private API
 * Also support `set_widget` when swapping widgets