### PR TITLE
Indexless screen iteration

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -91,7 +91,7 @@ end
 
 -- {{{ Wallpaper
 if beautiful.wallpaper then
-    for s = 1, screen.count() do
+    for s in screen do
         gears.wallpaper.maximized(beautiful.wallpaper, s, true)
     end
 end
@@ -100,7 +100,7 @@ end
 -- {{{ Tags
 -- Define a tag table which hold all screen tags.
 tags = {}
-for s = 1, screen.count() do
+for s in screen do
     -- Each screen has its own tag table.
     tags[s] = awful.tag({ 1, 2, 3, 4, 5, 6, 7, 8, 9 }, s, awful.layout.layouts[1])
 end
@@ -175,7 +175,7 @@ mytasklist.buttons = awful.util.table.join(
                                               awful.client.focus.byidx(-1)
                                           end))
 
-for s = 1, screen.count() do
+for s in screen do
     -- Create a promptbox for each screen
     mypromptbox[s] = awful.widget.prompt()
     -- Create an imagebox widget which will contains an icon indicating which layout we're using.

--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -244,7 +244,7 @@ capi.screen.connect_signal("padding", layout.arrange)
 capi.client.connect_signal("raised", function(c) layout.arrange(c.screen) end)
 capi.client.connect_signal("lowered", function(c) layout.arrange(c.screen) end)
 capi.client.connect_signal("list", function()
-                                   for screen = 1, capi.screen.count() do
+                                   for screen in capi.screen do
                                        layout.arrange(screen)
                                    end
                                end)

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -60,7 +60,7 @@ end
 function screen.getbycoord(x, y)
     local s = capi.screen[1]
     local dist = screen.getdistance_sq(s, x, y)
-    for i = 2, capi.screen:count() do
+    for i in capi.screen do
         local d = screen.getdistance_sq(i, x, y)
         if d < dist then
             s, dist = capi.screen[i], d
@@ -115,7 +115,7 @@ function screen.focus_bydirection(dir, _screen)
     local sel = get_screen(_screen or screen.focused())
     if sel then
         local geomtbl = {}
-        for s = 1, capi.screen.count() do
+        for s in capi.screen do
             geomtbl[s] = capi.screen[s].geometry
         end
         local target = util.get_rectangle_in_direction(dir, geomtbl, sel.geometry)

--- a/lib/gears/wallpaper.lua
+++ b/lib/gears/wallpaper.lua
@@ -21,7 +21,7 @@ do
         width = geom.x + geom.width,
         height = geom.y + geom.height
     }
-    for s = 1, screen.count() do
+    for s in screen do
         local g = screen[s].geometry
         root_geom.width = math.max(root_geom.width, g.x + g.width)
         root_geom.height = math.max(root_geom.height, g.y + g.height)

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -143,7 +143,7 @@ local suspended = false
 -- @field id Unique notification id based on a counter
 -- @table notifications
 naughty.notifications = { suspended = { } }
-for s = 1, capi.screen.count() do
+for s in capi.screen do
     naughty.notifications[get_screen(s)] = {
         top_left = {},
         top_middle = {},
@@ -294,8 +294,7 @@ end
 -- @return notification object if it was found, nil otherwise
 function naughty.getById(id)
     -- iterate the notifications to get the notfications with the correct ID
-    for s = 1, capi.screen.count() do
-        s = get_screen(s)
+    for s in pairs(naughty.notifications) do
         for p in pairs(naughty.notifications[s]) do
             for _, notification in pairs(naughty.notifications[s][p]) do
                 if notification.id == id then

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -29,7 +29,7 @@ local wallpaper = nil
 -- This is awful.screen.getbycoord() which we sadly cannot use from here (cyclic
 -- dependencies are bad!)
 local function screen_getbycoord(x, y)
-    for i = 1, screen:count() do
+    for i in screen do
         local geometry = screen[i].geometry
         if x >= geometry.x and x < geometry.x + geometry.width
            and y >= geometry.y and y < geometry.y + geometry.height then

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -624,6 +624,30 @@ luaA_screen_module_index(lua_State *L)
     return luaA_object_push(L, luaA_checkscreen(L, 2));
 }
 
+/** Iterate over screens.
+ * @usage
+ * for s in screen do
+ *     print("Oh, wow, we have screen " .. tostring(s))
+ * end
+ * @function screen
+ */
+static int
+luaA_screen_module_call(lua_State *L)
+{
+    int idx;
+
+    if (lua_isnoneornil(L, 3))
+        idx = 0;
+    else
+        idx = screen_get_index(luaA_checkscreen(L, 3));
+    if (idx >= 0 && idx < globalconf.screens.len)
+        /* No +1 needed, index starts at 1, C array at 0 */
+        luaA_pushscreen(L, globalconf.screens.tab[idx]);
+    else
+        lua_pushnil(L);
+    return 1;
+}
+
 LUA_OBJECT_EXPORT_PROPERTY(screen, screen_t, geometry, luaA_pusharea)
 
 static int
@@ -680,6 +704,7 @@ screen_class_setup(lua_State *L)
         { "count", luaA_screen_count },
         { "__index", luaA_screen_module_index },
         { "__newindex", luaA_default_newindex },
+        { "__call", luaA_screen_module_call },
         { NULL, NULL }
     };
 


### PR DESCRIPTION
This adds a new way to iterate over screens without using a screen index:
```lua
for s in screen do
    print("I'm seeing screen " .. tostring(s))
end
```
Right now this is equivalent to `for s=1, screen.count() do`, but it can easily be changed to iterate over screen objects on the C side.

Note that this conflicts with https://github.com/awesomeWM/awesome/pull/745 (It does some changes that is also done in there). I'm only submitting this for review right now and will rebase this on master once that other PR is merged.
Edit: Done!

(I'm especially curious about complaints on the syntax `for s in screen do` and suggestions what to do instead.)

Edit: This is one more step forward for https://github.com/awesomeWM/awesome/issues/672 (and I mention this here so that the issue has a nice list of all the related pull requests embedded)