### PR TITLE
wibox: Add widget and layout metatable for widget creation

### DIFF
--- a/lib/wibox/layout/init.lua
+++ b/lib/wibox/layout/init.lua
@@ -6,9 +6,9 @@
 -- @release @AWESOME_VERSION@
 -- @classmod wibox.layout
 ---------------------------------------------------------------------------
+local base = require("wibox.widget.base")
 
-return
-{
+return setmetatable({
     fixed = require("wibox.layout.fixed");
     align = require("wibox.layout.align");
     flex = require("wibox.layout.flex");
@@ -19,6 +19,6 @@ return
     scroll = require("wibox.layout.scroll");
     ratio = require("wibox.layout.ratio");
     stack = require("wibox.layout.stack");
-}
+}, {__call = function(_, args) return base.make_widget_declarative(args) end})
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/wibox/widget/init.lua
+++ b/lib/wibox/widget/init.lua
@@ -4,14 +4,14 @@
 -- @release @AWESOME_VERSION@
 -- @classmod wibox.widget
 ---------------------------------------------------------------------------
+local base = require("wibox.widget.base")
 
-return
-{
-    base = require("wibox.widget.base");
+return setmetatable({
+    base = base;
     textbox = require("wibox.widget.textbox");
     imagebox = require("wibox.widget.imagebox");
     background = require("wibox.widget.background");
     systray = require("wibox.widget.systray");
-}
+}, {__call = function(_, args) return base.make_widget_declarative(args) end})
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Calling wibox.widget.base.make_widget_declarative{} is too long, so this
commit add wibox.widget{} and wibox.layout{} alias.