### PR TITLE
dont add timestamps to created images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ macro(a_icon_convert match replacement input)
         set(ALL_ICONS ${ALL_ICONS} ${output})
 
         add_custom_command(
-            COMMAND ${CONVERT_EXECUTABLE} ${input} ${ARGN} ${output}
+            COMMAND ${CONVERT_EXECUTABLE} ${input} -strip ${ARGN} ${output}
             OUTPUT  ${output}
             DEPENDS ${input}
             VERBATIM)


### PR DESCRIPTION
This allows for reproducible builds

see also https://reproducible-builds.org/