### PR TITLE
Return screen objects

### DIFF
--- a/mouse.c
+++ b/mouse.c
@@ -133,13 +133,13 @@ luaA_mouse_index(lua_State *L)
          * having lots of lua errors in this case.
          */
         if (globalconf.focus.client)
-            luaA_pushscreen(L, globalconf.focus.client->screen);
+            luaA_object_push(L, globalconf.focus.client->screen);
         else
-            luaA_pushscreen(L, screen_get_primary());
+            luaA_object_push(L, screen_get_primary());
         return 1;
     }
 
-    luaA_pushscreen(L, screen_getbycoord(mouse_x, mouse_y));
+    luaA_object_push(L, screen_getbycoord(mouse_x, mouse_y));
     return 1;
 }
 

--- a/mouse.c
+++ b/mouse.c
@@ -35,7 +35,7 @@
 
 /** Mouse library.
  *
- * @field screen Mouse screen number.
+ * @field screen Mouse screen.
  * @table mouse
  */
 
@@ -115,7 +115,7 @@ mouse_warp_pointer(xcb_window_t window, int x, int y)
  * \return The number of elements pushed on stack.
  * \luastack
  * \lfield coords Mouse coordinates.
- * \lfield screen Mouse screen number.
+ * \lfield screen Mouse screen.
  */
 static int
 luaA_mouse_index(lua_State *L)

--- a/objects/client.c
+++ b/objects/client.c
@@ -2296,7 +2296,7 @@ luaA_client_get_screen(lua_State *L, client_t *c)
 {
     if(!c->screen)
         return 0;
-    luaA_pushscreen(L, c->screen);
+    luaA_object_push(L, c->screen);
     return 1;
 }
 

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -99,12 +99,6 @@ screen_wipe(screen_t *s)
     screen_output_array_wipe(&s->outputs);
 }
 
-void
-luaA_pushscreen(lua_State *L, screen_t *s)
-{
-    luaA_object_push(L, s);
-}
-
 /** Get a screen argument from the lua stack */
 screen_t *
 luaA_checkscreen(lua_State *L, int sidx)
@@ -501,7 +495,7 @@ screen_client_moveto(client_t *c, screen_t *new_screen, bool doresize)
     {
         luaA_object_push(L, c);
         if(old_screen != NULL)
-            luaA_pushscreen(L, old_screen);
+            luaA_object_push(L, old_screen);
         else
             lua_pushnil(L);
         luaA_object_emit_signal(L, -2, "property::screen", 1);
@@ -540,7 +534,7 @@ screen_client_moveto(client_t *c, screen_t *new_screen, bool doresize)
     {
         luaA_object_push(L, c);
         if(old_screen != NULL)
-            luaA_pushscreen(L, old_screen);
+            luaA_object_push(L, old_screen);
         else
             lua_pushnil(L);
         luaA_object_emit_signal(L, -2, "property::screen", 1);
@@ -658,7 +652,7 @@ luaA_screen_module_call(lua_State *L)
         idx = screen_get_index(luaA_checkscreen(L, 3));
     if (idx >= 0 && idx < globalconf.screens.len)
         /* No +1 needed, index starts at 1, C array at 0 */
-        luaA_pushscreen(L, globalconf.screens.tab[idx]);
+        luaA_object_push(L, globalconf.screens.tab[idx]);
     else
         lua_pushnil(L);
     return 1;

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -102,7 +102,7 @@ screen_wipe(screen_t *s)
 void
 luaA_pushscreen(lua_State *L, screen_t *s)
 {
-    lua_pushinteger(L, screen_get_index(s));
+    luaA_object_push(L, s);
 }
 
 /** Get a screen argument from the lua stack */

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -50,7 +50,6 @@ void screen_client_moveto(client_t *, screen_t *, bool);
 void screen_update_primary(void);
 screen_t *screen_get_primary(void);
 
-void luaA_pushscreen(lua_State *, screen_t *);
 screen_t *luaA_checkscreen(lua_State *, int);
 
 #endif

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -13,7 +13,9 @@ end
 
 -- Make the layoutbox in the default config GC'able
 -- luacheck: globals mywibox mylayoutbox
-mywibox[1].visible = false
+for s in screen do
+    mywibox[s].visible = false
+end
 mywibox = nil
 mylayoutbox = nil
 emit_refresh()

--- a/tests/test-urgent.lua
+++ b/tests/test-urgent.lua
@@ -7,7 +7,7 @@ local runner = require("_runner")
 -- luacheck: globals tags
 
 -- Some basic assertion that the tag is not marked "urgent" already.
-assert(awful.tag.getproperty(tags[1][2], "urgent") == nil)
+assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == nil)
 
 
 -- Setup signal handler which should be called.
@@ -32,16 +32,16 @@ local steps = {
     if count == 1 then  -- Setup.
       urgent_cb_done = false
       -- Select first tag.
-      awful.tag.viewonly(tags[1][1])
+      awful.tag.viewonly(tags[awful.screen.focused()][1])
 
       runner.add_to_default_rules({ rule = { class = "XTerm" },
-        properties = { tag = tags[1][2], focus = true } })
+        properties = { tag = tags[awful.screen.focused()][2], focus = true } })
 
       awful.spawn("xterm")
     end
     if urgent_cb_done then
-      assert(awful.tag.getproperty(tags[1][2], "urgent") == true)
-      assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 1)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == true)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 1)
       return true
     end
   end,
@@ -55,13 +55,13 @@ local steps = {
       root.fake_input("key_release", "2")
       root.fake_input("key_release", "Super_L")
 
-    elseif awful.tag.selectedlist()[1] == tags[1][2] then
+    elseif awful.tag.selectedlist()[1] == tags[awful.screen.focused()][2] then
       assert(#client.get() == 1)
       local c = client.get()[1]
       assert(not c.urgent, "Client is not urgent anymore.")
       assert(c == client.focus, "Client is focused.")
-      assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
-      assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == false)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 0)
       return true
     end
   end,
@@ -72,17 +72,17 @@ local steps = {
       urgent_cb_done = false
 
       -- Select first tag.
-      awful.tag.viewonly(tags[1][1])
+      awful.tag.viewonly(tags[awful.screen.focused()][1])
 
       runner.add_to_default_rules({ rule = { class = "XTerm" },
-        properties = { tag = tags[1][2], focus = true, switchtotag = true }})
+        properties = { tag = tags[awful.screen.focused()][2], focus = true, switchtotag = true }})
 
       awful.spawn("xterm")
 
-    elseif awful.tag.selectedlist()[1] == tags[1][2] then
+    elseif awful.tag.selectedlist()[1] == tags[awful.screen.focused()][2] then
       assert(not urgent_cb_done)
-      assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
-      assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == false)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 0)
       assert(awful.tag.selectedlist()[2] == nil)
       return true
     end
@@ -97,14 +97,14 @@ local steps = {
       manage_cb_done = false
 
       runner.add_to_default_rules({rule = { class = "XTerm" },
-        properties = { tag = tags[1][2], focus = false }})
+        properties = { tag = tags[awful.screen.focused()][2], focus = false }})
 
       awful.spawn("xterm")
     end
     if manage_cb_done then
       assert(client.get()[1].urgent == false)
-      assert(awful.tag.getproperty(tags[1][2], "urgent") == false)
-      assert(awful.tag.getproperty(tags[1][2], "urgent_count") == 0)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == false)
+      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 0)
       return true
     end
   end,


### PR DESCRIPTION
Another step towards the deprecation of screen indicies. Instead of numbers, the C API (e.g. `mouse.screen`, `c.screen` etc) now return screen objects. This should cause some breakage.

https://github.com/awesomeWM/awesome/issues/672