### PR TITLE
fix number check for the screen argument in movetoscreen

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -561,7 +561,9 @@ function client.movetoscreen(c, s)
         if not s then
             s = sel.screen.index + 1
         end
-        if type(s) == "number" and s > sc then s = 1 elseif s < 1 then s = sc end
+        if type(s) == "number" then
+            if s > sc then s = 1 elseif s < 1 then s = sc end
+        end
         s = get_screen(s)
         if get_screen(sel.screen) ~= s then
             local sel_is_focused = sel == capi.client.focus


### PR DESCRIPTION
The check was not done for the elseif case, and caused a comparison
runtime error.