### PR TITLE
Fix build

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -107,6 +107,32 @@ function(escape_code path escaped_content pre_header post_header)
     set(${post_header} ${example_post_header} PARENT_SCOPE)
 endfunction()
 
+# Only gears.debug.print_warning are allowed on stderr, everything else will
+# trigger a build failure to catch regressions and problem early.
+function(check_for_problems stderr result)
+
+    # If there is nothing to check, return
+    if (TEST_ERROR STREQUAL "")
+        set(${result} 0 PARENT_SCOPE)
+        return()
+    endif()
+
+    string(REGEX REPLACE "\n" ";" error_lines "${stderr}")
+
+    foreach (LINE ${error_lines})
+
+        # gears.debug.print_warning lines look like:
+        # yyyy-mm-dd hh:mm:ss W: message content
+        if (NOT ${LINE} MATCHES "^[0-9 :-]+ W:")
+            set(${result} 1 PARENT_SCOPE)
+            return()
+        endif()
+
+    endforeach()
+
+    set(${result} 0 PARENT_SCOPE)
+endfunction()
+
 # Execute a lua file.
 function(run_test test_path namespace template escaped_content)
 
@@ -129,7 +155,8 @@ function(run_test test_path namespace template escaped_content)
     )
 
     # If there is something on stderr, exit
-    if (NOT TEST_ERROR STREQUAL "")
+    check_for_problems("${TEST_ERROR}" problems_found)
+    if (${problems_found})
         message("${TEST_OUTPUT}")
         message("${TEST_ERROR}")
         message(FATAL_ERROR ${test_path} " A test failed, bye")


### PR DESCRIPTION
@psychon I will merge this soon, feel free to revert the commits with a better idea. The build need to be fixed soon.

A better idea may be to disable generating the documentation by default generate the doc tests only when an additional cmake flag is passed, but this wont fix travis, so it isn't a practical solution for now.

To quote myself:

> So, it is #787 that "broke" the build because both PR were developed in parallel and made different 
> assumptions. Last week new test framework assumed only CAPI normally print on stderr and #787 
> assume printing warnings on stderr has no consequences. Both assumptions were true when the
> code  was published, but they no longer were by the time #787 was merged.
