### PR TITLE
luaA_checkscreen: display number of existing screens with error

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -107,7 +107,8 @@ luaA_checkscreen(lua_State *L, int sidx)
     {
         int screen = lua_tointeger(L, sidx);
         if(screen < 1 || screen > globalconf.screens.len)
-            luaL_error(L, "invalid screen number: %d", screen);
+            luaL_error(L, "invalid screen number: %d (of %d existing)",
+                    screen, globalconf.screens.len);
         return globalconf.screens.tab[screen - 1];
     } else
         return luaA_checkudata(L, sidx, &screen_class);


### PR DESCRIPTION
This is meant to be helpful in the case of 0 existing screens, e.g.
during executing the config initially.