### PR TITLE
docs: add section about gdb to readme

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -55,6 +55,21 @@ If awesome does not start or the configuration file is not producing the
 desired results the user should examine this file to gain insight into the
 problem.
 
+### Debugging tips
+
+You can call `awesome` with `gdb` like this:
+
+    DISPLAY=:2 gdb awesome
+
+Then in gdb set any args and run it:
+
+    (gdb) set arg --replace
+    (gdb) run
+
+Inside gdb you can use the following to print the current Lua stack traceback:
+
+    (gdb) print luaL_dostring(globalconf.L.real_L_dont_use_directly, "print(debug.traceback())")
+
 ## Reporting issues
 
 Please report any issues you may find on [our bugtracker](https://github.com/awesomeWM/awesome/issues).


### PR DESCRIPTION
This should maybe get added to a separate section/page altogether
instead, but in this short form it seems to fit here.

[ci skip]