### PR TITLE
gears.screen: Merge into awful.screen

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -91,7 +91,7 @@ end
 
 -- {{{ Wallpaper
 if beautiful.wallpaper then
-    gears.screen.connect_for_each_screen(function(s)
+    awful.screen.connect_for_each_screen(function(s)
         gears.wallpaper.maximized(beautiful.wallpaper, s, true)
     end)
 end
@@ -100,7 +100,7 @@ end
 -- {{{ Tags
 -- Define a tag table which hold all screen tags.
 tags = {}
-gears.screen.connect_for_each_screen(function(s)
+awful.screen.connect_for_each_screen(function(s)
     -- Each screen has its own tag table.
     tags[s] = awful.tag({ 1, 2, 3, 4, 5, 6, 7, 8, 9 }, s, awful.layout.layouts[1])
 end)
@@ -175,7 +175,7 @@ mytasklist.buttons = awful.util.table.join(
                                               awful.client.focus.byidx(-1)
                                           end))
 
-gears.screen.connect_for_each_screen(function(s)
+awful.screen.connect_for_each_screen(function(s)
     -- Create a promptbox for each screen
     mypromptbox[s] = awful.widget.prompt()
     -- Create an imagebox widget which will contains an icon indicating which layout we're using.

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -242,6 +242,22 @@ function screen.get_bounding_geometry(s, args)
     return geo
 end
 
+--- Call a function for each existing and created-in-the-future screen.
+-- @tparam function func The function to call.
+-- @tparam screen func.screen The screen
+function screen.connect_for_each_screen(func)
+    for s in capi.screen do
+        func(s)
+    end
+    capi.screen.connect_signal("added", func)
+end
+
+--- Undo the effect of connect_for_each_screen.
+-- @tparam function func The function that should no longer be called.
+function screen.disconnect_for_each_screen(func)
+    capi.screen.disconnect_signal("added", func)
+end
+
 capi.screen.add_signal("padding")
 
 -- Extend the luaobject

--- a/lib/gears/screen.lua
+++ b/lib/gears/screen.lua
@@ -5,23 +5,23 @@
 -- @classmod gears.screen
 ---------------------------------------------------------------------------
 
-local screen = screen
+local ascreen =  require("awful.screen")
+local util = require("awful.util")
 
 local module = {}
 
 --- Call a function for each existing and created-in-the-future screen.
 -- @tparam function func The function to call.
 function module.connect_for_each_screen(func)
-    for s in screen do
-        func(s)
-    end
-    screen.connect_signal("added", func)
+    util.deprecate("Use awful.screen.connect_for_each_screen")
+    ascreen.connect_for_each_screen(func)
 end
 
 --- Undo the effect of connect_for_each_screen.
 -- @tparam function func The function that should no longer be called.
 function module.disconnect_for_each_screen(func)
-    screen.disconnect_signal("added", func)
+    util.deprecate("Use awful.screen.disconnect_for_each_screen")
+    ascreen.disconnect_for_each_screen(func)
 end
 
 return module

--- a/lib/gears/wallpaper.lua
+++ b/lib/gears/wallpaper.lua
@@ -14,7 +14,9 @@ local wallpaper = { mt = {} }
 
 -- The size of the root window
 local root_geom = { x = 0, y = 0, width = 0, height = 0 }
-require("gears.screen").connect_for_each_screen(function(s)
+
+-- Gears should not depend on awful or C-API, this should be fixed eventually
+require("awful.screen").connect_for_each_screen(function(s)
     local g = s.geometry
     root_geom.width = math.max(root_geom.width, g.x + g.width)
     root_geom.height = math.max(root_geom.height, g.y + g.height)

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -143,7 +143,7 @@ local suspended = false
 -- @field id Unique notification id based on a counter
 -- @table notifications
 naughty.notifications = { suspended = { } }
-require("gears.screen").connect_for_each_screen(function(s)
+screen.connect_for_each_screen(function(s)
     naughty.notifications[s] = {
         top_left = {},
         top_middle = {},


### PR DESCRIPTION
gears modules usually don't depend on Awesome C-API. This code has
been placed there for unclear reasons.

Also, there is ongoing work to unify each "concepts" API into one
single page. Having `gears.screen` go against this effort.

@psychon, sorry for not complaining sooner and breaking the API 48 hours after it was introduced. However, `gears.screen` isn't compatible with my work on the API cleanup. I would really like to avoid multi-file-for-the-same-concept problems again. Also, that would be the only gears code to depend on CAPI (beside a soft dependency on xresources to get the DPI and `load_image`). Increasing coupling at this point isn't something I like. Wayland is coming, and *I* will make it happen (I hacked a prototype, it's not *that* hard after all), but in my plan, the C core has to go (for Wayland only, X11 would still use it, I don't plan some funky abstraction, just expose the same CAPI where possible). It wont be for this year, I have already too many WIP code to upstream and almost nobody use Wayland yet anyway.