### PR TITLE
Add C-API for root window size

### DIFF
--- a/lib/gears/wallpaper.lua
+++ b/lib/gears/wallpaper.lua
@@ -9,18 +9,14 @@ local cairo = require("lgi").cairo
 local color = require("gears.color")
 local surface = require("gears.surface")
 local timer = require("gears.timer")
+local root = root
 
 local wallpaper = { mt = {} }
 
--- The size of the root window
-local root_geom = { x = 0, y = 0, width = 0, height = 0 }
-
--- Gears should not depend on awful or C-API, this should be fixed eventually
-require("awful.screen").connect_for_each_screen(function(s)
-    local g = s.geometry
-    root_geom.width = math.max(root_geom.width, g.x + g.width)
-    root_geom.height = math.max(root_geom.height, g.y + g.height)
-end)
+local function root_geometry()
+    local width, height = root.size()
+    return { x = 0, y = 0, width = width, height = height }
+end
 
 -- A cairo surface that we still want to set as the wallpaper
 local pending_wallpaper = nil
@@ -33,14 +29,14 @@ local pending_wallpaper = nil
 -- @return[1] The available geometry (table with entries width and height)
 -- @return[1] A cairo context that the wallpaper should be drawn to
 function wallpaper.prepare_context(s)
-    local geom = s and screen[s].geometry or root_geom
+    local geom = s and screen[s].geometry or root_geometry()
     local cr
 
     if not pending_wallpaper then
         -- Prepare a pending wallpaper
         local wp = surface(root.wallpaper())
 
-        pending_wallpaper = wp:create_similar(cairo.Content.COLOR, root_geom.width, root_geom.height)
+        pending_wallpaper = wp:create_similar(cairo.Content.COLOR, root.size())
 
         -- Copy the old wallpaper to the new one
         cr = cairo.Context(pending_wallpaper)

--- a/root.c
+++ b/root.c
@@ -428,6 +428,20 @@ luaA_root_wallpaper(lua_State *L)
     return 1;
 }
 
+/** Get the size of the root window.
+ *
+ * @return Width of the root window.
+ * @return height of the root window.
+ * @function size
+ */
+static int
+luaA_root_size(lua_State *L)
+{
+    lua_pushinteger(L, globalconf.screen->width_in_pixels);
+    lua_pushinteger(L, globalconf.screen->height_in_pixels);
+    return 2;
+}
+
 /** Get the attached tags.
  * @return A table with all tags.
  * @function tags
@@ -453,6 +467,7 @@ const struct luaL_Reg awesome_root_lib[] =
     { "fake_input", luaA_root_fake_input },
     { "drawins", luaA_root_drawins },
     { "wallpaper", luaA_root_wallpaper },
+    { "size", luaA_root_size },
     { "tags", luaA_root_tags },
     { "__index", luaA_default_index },
     { "__newindex", luaA_default_newindex },


### PR DESCRIPTION
Instead of having `gears.wallpaper` do magic to get the size of the root window, it now asks the C code for the correct numbers.