### PR TITLE
Randr stuff

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -637,6 +637,8 @@ main(int argc, char **argv)
     query = xcb_get_extension_data(globalconf.connection, &xcb_shape_id);
     globalconf.have_shape = query->present;
 
+    event_init();
+
     /* Allocate the key symbols */
     globalconf.keysyms = xcb_key_symbols_alloc(globalconf.connection);
 

--- a/event.c
+++ b/event.c
@@ -771,22 +771,18 @@ event_handle_unmapnotify(xcb_unmap_notify_event_t *ev)
 static void
 event_handle_randr_screen_change_notify(xcb_randr_screen_change_notify_event_t *ev)
 {
-    /* Code  of  XRRUpdateConfiguration Xlib  function  ported to  XCB
-     * (only the code relevant  to RRScreenChangeNotify) as the latter
-     * doesn't provide this kind of function */
-    if(ev->rotation & (XCB_RANDR_ROTATION_ROTATE_90 | XCB_RANDR_ROTATION_ROTATE_270))
-        xcb_randr_set_screen_size(globalconf.connection, ev->root, ev->height, ev->width,
-                                  ev->mheight, ev->mwidth);
-    else
-        xcb_randr_set_screen_size(globalconf.connection, ev->root, ev->width, ev->height,
-                                  ev->mwidth, ev->mheight);
+    /* Ignore events for other roots (do we get them at all?) */
+    if (ev->root != globalconf.screen->root)
+        return;
 
-    /* XRRUpdateConfiguration also executes the following instruction
-     * but it's not useful because SubpixelOrder is not used at all at
-     * the moment
-     *
-     * XRenderSetSubpixelOrder(dpy, snum, scevent->subpixel_order);
-     */
+    /* Do (part of) what XRRUpdateConfiguration() would do (update our state) */
+    if (ev->rotation & (XCB_RANDR_ROTATION_ROTATE_90 | XCB_RANDR_ROTATION_ROTATE_270)) {
+        globalconf.screen->width_in_pixels = ev->height;
+        globalconf.screen->height_in_pixels = ev->width;
+    } else {
+        globalconf.screen->width_in_pixels = ev->width;
+        globalconf.screen->height_in_pixels = ev->height;
+    }
 
     awesome_restart();
 }

--- a/event.c
+++ b/event.c
@@ -397,13 +397,19 @@ event_handle_configurerequest(xcb_configure_request_event_t *ev)
 static void
 event_handle_configurenotify(xcb_configure_notify_event_t *ev)
 {
-    const xcb_screen_t *screen = globalconf.screen;
+    xcb_screen_t *screen = globalconf.screen;
 
     if(ev->window == screen->root
        && (ev->width != screen->width_in_pixels
            || ev->height != screen->height_in_pixels))
         /* it's not that we panic, but restart */
         awesome_restart();
+
+    /* Copy what XRRUpdateConfiguration() would do: Update the configuration */
+    if(ev->window == screen->root) {
+        screen->width_in_pixels = ev->width;
+        screen->height_in_pixels = ev->height;
+    }
 }
 
 /** The destroy notify event handler.

--- a/event.h
+++ b/event.h
@@ -50,6 +50,7 @@ awesome_refresh(void)
     return xcb_flush(globalconf.connection);
 }
 
+void event_init(void);
 void event_handle(xcb_generic_event_t *);
 void event_drawable_under_mouse(lua_State *, int);
 

--- a/globalconf.h
+++ b/globalconf.h
@@ -82,8 +82,6 @@ typedef struct
     screen_array_t screens;
     /** The primary screen, access through screen_get_primary() */
     screen_t *primary_screen;
-    /** Do we have RandR 1.3 or newer? */
-    bool have_randr_13;
     /** Root window key bindings */
     key_array_t keys;
     /** Root window mouse bindings */
@@ -92,10 +90,15 @@ typedef struct
     xcb_atom_t selection_atom;
     /** Window owning the WM_Sn selection */
     xcb_window_t selection_owner_window;
+    /** Do we have RandR 1.3 or newer? */
+    bool have_randr_13;
     /** Check for XTest extension */
     bool have_xtest;
     /** Check for SHAPE extension */
     bool have_shape;
+    uint8_t event_base_shape;
+    uint8_t event_base_xkb;
+    uint8_t event_base_randr;
     /** Clients list */
     client_array_t clients;
     /** Embedded windows */


### PR DESCRIPTION
I noticed this due to #672 and it's a small step towards in. When the size of the root window changes, we will now update our in-memory idea of how big the root window is and then restart. Right now that's useless, but it's useful for when we stop restarting on this kind of change.