### PR TITLE
screen: XRandR 1.5 support

### DIFF
--- a/event.c
+++ b/event.c
@@ -399,9 +399,7 @@ event_handle_configurenotify(xcb_configure_notify_event_t *ev)
 {
     xcb_screen_t *screen = globalconf.screen;
 
-    if(ev->window == screen->root
-       && (ev->width != screen->width_in_pixels
-           || ev->height != screen->height_in_pixels))
+    if(ev->window == screen->root)
         /* it's not that we panic, but restart */
         awesome_restart();
 


### PR DESCRIPTION
XRandR 1.5 adds support for the new monitor objects.

'Monitor' is a rectangular subset of the screen which represents a
coherent collection of pixels presented to the user. Each Monitor is be
associated with a list of outputs (which may be empty).

The patch below matches 1:1 screens in AwesomeWM with XRandR's Monitors.
This way I get one screen across my 4K monitor, which is represented by
two CRTCs.

One missing thing is handling change in monitor configuration: I don't
see a way to get XCB generate event about this.

Background info: http://keithp.com/blogs/MST-monitors/