### PR TITLE
Rules refactor, part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
   # Install build dependencies.
   # See also `apt-cache showsrc awesome | grep -E '^(Version|Build-Depends)'`.
-  - sudo apt-get install -y libcairo2-dev xmlto asciidoc libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
+  - sudo apt-get install -y libcairo2-dev gtk+3.0 xmlto asciidoc libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
 
   # Deps for functional tests.
   - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb rxvt-unicode

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -458,6 +458,11 @@ awful.rules.rules = {
         }
       }, properties = { floating = true }},
 
+    -- Add titlebars to normal clients and dialogs
+    { rule_any = {type = { "normal", "dialog" }
+      }, properties = { titlebars_enabled = true }
+    },
+
     -- Set Firefox to always map on the tag named "2" on screen 1.
     -- { rule = { class = "Firefox" },
     --   properties = { screen = 1, tag = "2" } },
@@ -481,48 +486,48 @@ client.connect_signal("manage", function (c)
         -- Prevent clients from being unreachable after screen count changes.
         awful.placement.no_offscreen(c)
     end
+end)
 
-    local titlebars_enabled = true
-    if titlebars_enabled and (c.type == "normal" or c.type == "dialog") then
-        -- buttons for the titlebar
-        local buttons = awful.util.table.join(
-            awful.button({ }, 1, function()
-                client.focus = c
-                c:raise()
-                awful.mouse.client.move(c)
-            end),
-            awful.button({ }, 3, function()
-                client.focus = c
-                c:raise()
-                awful.mouse.client.resize(c)
-            end)
-        )
+-- Add a titlebar if titlebars_enabled is set to true in the rules.
+client.connect_signal("request::titlebars", function(c)
+    -- buttons for the titlebar
+    local buttons = awful.util.table.join(
+        awful.button({ }, 1, function()
+            client.focus = c
+            c:raise()
+            awful.mouse.client.move(c)
+        end),
+        awful.button({ }, 3, function()
+            client.focus = c
+            c:raise()
+            awful.mouse.client.resize(c)
+        end)
+    )
 
-        awful.titlebar(c) : setup {
-            { -- Left
-                awful.titlebar.widget.iconwidget(c),
-                buttons = buttons,
-                layout  = wibox.layout.fixed.horizontal
+    awful.titlebar(c) : setup {
+        { -- Left
+            awful.titlebar.widget.iconwidget(c),
+            buttons = buttons,
+            layout  = wibox.layout.fixed.horizontal
+        },
+        { -- Middle
+            { -- Title
+                align  = "center",
+                widget = awful.titlebar.widget.titlewidget(c)
             },
-            { -- Middle
-                { -- Title
-                    align  = "center",
-                    widget = awful.titlebar.widget.titlewidget(c)
-                },
-                buttons = buttons,
-                layout  = wibox.layout.flex.horizontal
-            },
-            { -- Right
-                awful.titlebar.widget.floatingbutton (c),
-                awful.titlebar.widget.maximizedbutton(c),
-                awful.titlebar.widget.stickybutton   (c),
-                awful.titlebar.widget.ontopbutton    (c),
-                awful.titlebar.widget.closebutton    (c),
-                layout = wibox.layout.fixed.horizontal()
-            },
-            layout = wibox.layout.align.horizontal
-        }
-    end
+            buttons = buttons,
+            layout  = wibox.layout.flex.horizontal
+        },
+        { -- Right
+            awful.titlebar.widget.floatingbutton (c),
+            awful.titlebar.widget.maximizedbutton(c),
+            awful.titlebar.widget.stickybutton   (c),
+            awful.titlebar.widget.ontopbutton    (c),
+            awful.titlebar.widget.closebutton    (c),
+            layout = wibox.layout.fixed.horizontal()
+        },
+        layout = wibox.layout.align.horizontal
+    }
 end)
 
 -- Enable sloppy focus

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -430,7 +430,10 @@ awful.rules.rules = {
                      focus = awful.client.focus.filter,
                      raise = true,
                      keys = clientkeys,
-                     buttons = clientbuttons } },
+                     buttons = clientbuttons,
+                     placement = awful.placement.no_overlap+awful.placement.no_offscreen
+     }
+    },
 
     -- Floating clients.
     { rule_any = {
@@ -472,17 +475,13 @@ awful.rules.rules = {
 -- {{{ Signals
 -- Signal function to execute when a new client appears.
 client.connect_signal("manage", function (c)
-    if not awesome.startup then
-        -- Set the windows at the slave,
-        -- i.e. put it at the end of others instead of setting it master.
-        -- awful.client.setslave(c)
+    -- Set the windows at the slave,
+    -- i.e. put it at the end of others instead of setting it master.
+    -- if not awesome.startup then awful.client.setslave(c) end
 
-        -- Put windows in a smart way, only if they do not set an initial position.
-        if not c.size_hints.user_position and not c.size_hints.program_position then
-            awful.placement.no_overlap(c)
-            awful.placement.no_offscreen(c)
-        end
-    elseif not c.size_hints.user_position and not c.size_hints.program_position then
+    if awesome.startup and
+      not c.size_hints.user_position
+      and not c.size_hints.program_position then
         -- Prevent clients from being unreachable after screen count changes.
         awful.placement.no_offscreen(c)
     end

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -1,7 +1,6 @@
 -- Standard awesome library
 local gears = require("gears")
 local awful = require("awful")
-awful.rules = require("awful.rules")
 require("awful.autofocus")
 -- Widget and layout library
 local wibox = require("wibox")

--- a/ewmh.c
+++ b/ewmh.c
@@ -399,7 +399,7 @@ ewmh_process_desktop(client_t *c, uint32_t desktop)
     if(desktop == 0xffffffff)
     {
         luaA_object_push(L, c);
-        lua_pushnil(L);
+        lua_pushboolean(L, true);
         luaA_object_emit_signal(L, -2, "request::tag", 1);
         /* Pop the client, arguments are already popped */
         lua_pop(L, 1);

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1122,6 +1122,12 @@ capi.client.add_signal("property::floating")
 
 capi.client.add_signal("property::dockable")
 
+--- Emited when a client need to get a titlebar.
+-- @signal request::titlebars
+-- @tparam[opt=nil] string content The context (like "rules")
+-- @tparam[opt=nil] table hints Some hints.
+capi.client.add_signal("request::titlebars")
+
 --- The client marked signal (deprecated).
 -- @signal .marked
 capi.client.add_signal("marked")

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -177,8 +177,14 @@ end
 --
 -- @client c A client to tag
 -- @tag[opt] t A tag to use. If omitted, then the client is made sticky.
-function ewmh.tag(c, t)
+-- @tparam[opt={}] table hints Extra information
+function ewmh.tag(c, t, hints) --luacheck: no unused
+    -- There is nothing to do
+    if not t and #c:tags() > 0 then return end
+
     if not t then
+        c:to_selected_tags()
+    elseif type(t) == "boolean" and t then
         c.sticky = true
     else
         c.screen = t.screen

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -162,6 +162,10 @@ end
 -- @tparam[opt] table hints A table with additional hints:
 -- @tparam[opt=false] boolean hints.raise should the client be raised?
 function ewmh.activate(c, context, hints) -- luacheck: no unused args
+    hints = hints or  {}
+
+    if c.focusable == false and not hints.force then return end
+
     if c:isvisible() then
         client.focus = c
     end

--- a/lib/awful/init.lua
+++ b/lib/awful/init.lua
@@ -56,6 +56,7 @@ return
     tooltip = require("awful.tooltip");
     ewmh = require("awful.ewmh");
     titlebar = require("awful.titlebar");
+    rules = require("awful.rules");
     spawn = spawn;
 }
 

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -172,8 +172,8 @@ local function area_common(d, new_geo, ignore_border_width)
     -- The C side expect no arguments, nil isn't valid
     local geometry = new_geo and d:geometry(new_geo) or d:geometry()
     local border = ignore_border_width and 0 or d.border_width or 0
-    geometry.x = geometry.x - border
-    geometry.y = geometry.y - border
+    geometry.x = geometry.x
+    geometry.y = geometry.y
     geometry.width = geometry.width + 2 * border
     geometry.height = geometry.height + 2 * border
     return geometry
@@ -511,7 +511,10 @@ function placement.no_offscreen(c, screen)
         geometry.y = screen_geometry.y
     end
 
-    return c:geometry({ x = geometry.x, y = geometry.y })
+    return c:geometry {
+        x = geometry.x,
+        y = geometry.y
+    }
 end
 
 --- Place the client where there's place available with minimum overlap.
@@ -656,8 +659,8 @@ function placement.align(d, args)
     )
 
     geometry_common(d, args, {
-        x      = (pos.x and math.ceil(sgeo.x + pos.x) or dgeo.x) + bw  ,
-        y      = (pos.y and math.ceil(sgeo.y + pos.y) or dgeo.y) + bw  ,
+        x      = (pos.x and math.ceil(sgeo.x + pos.x) or dgeo.x)       ,
+        y      = (pos.y and math.ceil(sgeo.y + pos.y) or dgeo.y)       ,
         width  =            math.ceil(dgeo.width    )            - 2*bw,
         height =            math.ceil(dgeo.height   )            - 2*bw,
     })
@@ -729,15 +732,15 @@ function placement.stretch(d, args)
     local bw   = d.border_width or 0
 
     if args.direction == "left" then
-        ngeo.x      = sgeo.x + bw
+        ngeo.x      = sgeo.x
         ngeo.width  = dgeo.width + (dgeo.x - ngeo.x)
     elseif args.direction == "right" then
-        ngeo.width  = sgeo.width - ngeo.x - bw
+        ngeo.width  = sgeo.width - ngeo.x - 2*bw
     elseif args.direction == "up" then
-        ngeo.y      = sgeo.y + bw
+        ngeo.y      = sgeo.y
         ngeo.height = dgeo.height + (dgeo.y - ngeo.y)
     elseif args.direction == "down" then
-        ngeo.height = sgeo.height - dgeo.y - bw
+        ngeo.height = sgeo.height - dgeo.y - 2*bw
     else
         assert(false)
     end
@@ -788,12 +791,12 @@ function placement.maximize(d, args)
     local bw   = d.border_width or 0
 
     if (not args.axis) or args.axis :match "vertical" then
-        ngeo.y      = sgeo.y + bw
+        ngeo.y      = sgeo.y
         ngeo.height = sgeo.height - 2*bw
     end
 
     if (not args.axis) or args.axis :match "horizontal" then
-        ngeo.x      = sgeo.x + bw
+        ngeo.x      = sgeo.x
         ngeo.width  = sgeo.width - 2*bw
     end
 

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -261,7 +261,7 @@ rules.delayed_properties = {}
 local force_ignore = {
     titlebars_enabled=true, focus=true, screen=true, x=true,
     y=true, width=true, height=true, geometry=true,placement=true,
-    border_width=true,
+    border_width=true,floating=true
 }
 
 function rules.high_priority_properties.tag(c, value)
@@ -377,6 +377,13 @@ function rules.execute(c, props, callbacks)
     if props.border_width then
         c.border_width = type(props.border_width) == "function" and
             props.border_width(c, props) or props.border_width
+    end
+
+    -- Geometry will only work if floating is true, otherwise the "saved"
+    -- geometry will be restored.
+    if props.floating then
+        c.floating = type(props.floating) == "function" and props.floating(c,props)
+            or props.floating
     end
 
     -- Before requesting a tag, make sure the screen is right

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -261,7 +261,7 @@ rules.delayed_properties = {}
 local force_ignore = {
     titlebars_enabled=true, focus=true, screen=true, x=true,
     y=true, width=true, height=true, geometry=true,placement=true,
-    border_width=true,floating=true
+    border_width=true,floating=true,size_hints_honor=true
 }
 
 function rules.high_priority_properties.tag(c, value)
@@ -377,6 +377,13 @@ function rules.execute(c, props, callbacks)
     if props.border_width then
         c.border_width = type(props.border_width) == "function" and
             props.border_width(c, props) or props.border_width
+    end
+
+    -- Size hints will be re-applied when setting width/height unless it is
+    -- disabled first
+    if props.size_hints_honor ~= nil then
+        c.size_hints_honor = type(props.size_hints_honor) == "function" and props.size_hints_honor(c,props)
+            or props.size_hints_honor
     end
 
     -- Geometry will only work if floating is true, otherwise the "saved"

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -16,6 +16,7 @@ local type = type
 local ipairs = ipairs
 local pairs = pairs
 local atag = require("awful.tag")
+local util = require("awful.util")
 local a_place = require("awful.placement")
 
 local rules = {}
@@ -354,6 +355,11 @@ function rules.extra_properties.placement(c, value)
     elseif ty == "string" and a_place[value] then
         a_place[value](c, args)
     end
+end
+
+function rules.extra_properties.tags(c, value)
+    local current = c:tags()
+    c:tags(util.table.merge(current, value))
 end
 
 --- Apply properties and callbacks to a client.

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -361,6 +361,10 @@ end
 -- @tab props Properties to apply.
 -- @tab[opt] callbacks Callbacks to apply.
 function rules.execute(c, props, callbacks)
+    -- This has to be done first, as it will impact geometry related props.
+    if props.titlebars_enabled then
+        c:emit_signal("request::titlebars", "rules", {properties=props})
+    end
 
     -- Before requesting a tag, make sure the screen is right
     if props.screen then

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -273,7 +273,7 @@ function rules.execute(c, props, callbacks)
 
 
         if property ~= "focus" and type(value) == "function" then
-            value = value(c)
+            value = value(c, props)
         end
 
         -- Some properties are handled elsewhere

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -249,6 +249,7 @@ rules.extra_properties = {}
 -- By default, the table has the following functions:
 --
 -- * tag
+-- * new_tag
 --
 -- @tfield table awful.rules.high_priority_properties
 rules.high_priority_properties = {}
@@ -303,6 +304,32 @@ function rules.extra_properties.geometry(c, _, props)
     end
 
     c:geometry(new_geo) --TODO use request::geometry
+end
+
+--- Create a new tag based on a rule.
+-- @tparam client c The client
+-- @tparam boolean|function|string value The value.
+-- @treturn tag The new tag
+function rules.high_priority_properties.new_tag(c, value)
+    local ty = type(value)
+    local t = nil
+
+    if ty == "boolean" then
+        -- Create a new tag named after the client class
+        t = atag.add(c.class or "N/A", {screen=c.screen, volatile=true})
+    elseif ty == "string" then
+        -- Create a tag named after "value"
+        t = atag.add(value, {screen=c.screen, volatile=true})
+    elseif ty == "table" then
+        -- Assume a table of tags properties
+        t = atag.add(value.name or c.class or "N/A", value)
+    else
+        assert(false)
+    end
+
+    add_to_tag(c, t)
+
+    return t
 end
 
 --- Apply properties and callbacks to a client.

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -261,6 +261,7 @@ rules.delayed_properties = {}
 local force_ignore = {
     titlebars_enabled=true, focus=true, screen=true, x=true,
     y=true, width=true, height=true, geometry=true,placement=true,
+    border_width=true,
 }
 
 function rules.high_priority_properties.tag(c, value)
@@ -370,6 +371,12 @@ function rules.execute(c, props, callbacks)
     -- This has to be done first, as it will impact geometry related props.
     if props.titlebars_enabled then
         c:emit_signal("request::titlebars", "rules", {properties=props})
+    end
+
+    -- Border width will also cause geometry related properties to fail
+    if props.border_width then
+        c.border_width = type(props.border_width) == "function" and
+            props.border_width(c, props) or props.border_width
     end
 
     -- Before requesting a tag, make sure the screen is right

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -29,10 +29,6 @@ local function get_screen(s)
     return s and capi.screen[s]
 end
 
--- awful.client is required() at the end of this file so the miss_handler is set
--- before it is being required.
-local client
-
 local tag = {object = {},  mt = {} }
 
 -- Private data
@@ -1369,11 +1365,6 @@ object.properties(capi.tag, {
     getter_fallback = tag.getproperty,
     setter_fallback = tag.setproperty,
 })
-
--- fix a load loop
-client = require("awful.client")
-capi.client.connect_signal("manage", function(c) client.object.to_selected_tags(c) end)
-
 
 return setmetatable(tag, tag.mt)
 

--- a/objects/client.c
+++ b/objects/client.c
@@ -1697,9 +1697,9 @@ client_set_fullscreen(lua_State *L, int cidx, bool s)
             client_set_ontop(L, cidx, false);
         }
         int abs_cidx = luaA_absindex(L, cidx); \
-        lua_pushboolean(L, s);
+        lua_pushstring(L, "fullscreen");
         c->fullscreen = s;
-        luaA_object_emit_signal(L, abs_cidx, "request::fullscreen", 1);
+        luaA_object_emit_signal(L, abs_cidx, "request::geometry", 1);
         luaA_object_emit_signal(L, abs_cidx, "property::fullscreen", 0);
         /* Force a client resize, so that titlebars get shown/hidden */
         client_resize_do(c, c->geometry, true);
@@ -1730,10 +1730,10 @@ client_get_maximized(client_t *c)
         if(c->maximized_##type != s) \
         { \
             int abs_cidx = luaA_absindex(L, cidx); \
-            lua_pushboolean(L, s); \
             int max_before = client_get_maximized(c); \
             c->maximized_##type = s; \
-            luaA_object_emit_signal(L, abs_cidx, "request::maximized_" #type, 1); \
+            lua_pushstring(L, "maximized_"#type);\
+            luaA_object_emit_signal(L, abs_cidx, "request::geometry", 1); \
             luaA_object_emit_signal(L, abs_cidx, "property::maximized_" #type, 0); \
             if(max_before != client_get_maximized(c)) \
                 luaA_object_emit_signal(L, abs_cidx, "property::maximized", 0); \
@@ -3446,17 +3446,14 @@ client_class_setup(lua_State *L)
      */
     signal_add(&client_class.signals, "request::activate");
     /**
-     * @signal request::fullscreen
+     * @signal request::geometry
+     * @tparam client c The client
+     * @tparam string context Why and what to resize. This is used for the
+     * handlers to know if they are capable of applying the new geometry.
+     * @tparam[opt={}] table Additional arguments. Each context handler may
+     * interpret this differently.
      */
-    signal_add(&client_class.signals, "request::fullscreen");
-    /**
-     * @signal request::maximized_horizontal
-     */
-    signal_add(&client_class.signals, "request::maximized_horizontal");
-    /**
-     * @signal request::maximized_vertical
-     */
-    signal_add(&client_class.signals, "request::maximized_vertical");
+    signal_add(&client_class.signals, "request::geometry");
     /**
      * @signal request::tag
      */

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -1,0 +1,32 @@
+local spawn = require("awful.spawn")
+
+-- This file provide a simple, yet flexible, test client.
+-- It is used to test the `awful.rules`
+
+return function(class, title)
+    title = title or 'Awesome test client'
+
+    local cmd = {"lua" , "-e", table.concat {
+        "local lgi = require 'lgi';",
+        "local Gtk = lgi.require('Gtk');",
+        "Gtk.init();",
+        "local class = '",
+        class or 'test_app',"';",
+        "local window = Gtk.Window {",
+        "    default_width  = 100,",
+        "    default_height = 100,",
+        "    title          = '",title,
+        "'};",
+        "window:set_wmclass(class, class);",
+        "local app = Gtk.Application {",
+        "    application_id = 'org.awesomewm.tests.",class,
+        "'};",
+        "function app:on_activate()",
+        "    window.application = self;",
+        "    window:show_all();",
+        "end;",
+        "app:run {''}"
+    }}
+
+    spawn(cmd)
+end

--- a/tests/examples/awful/placement/bottom.lua
+++ b/tests/examples/awful/placement/bottom.lua
@@ -10,6 +10,6 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.bottom(client.focus)
 
-assert(c.x == screen[1].geometry.width/2-40/2--DOC_HIDE
-    and c.y==screen[1].geometry.height-30-c.border_width--DOC_HIDE
+assert(c.x == screen[1].geometry.width/2-40/2-c.border_width--DOC_HIDE
+    and c.y==screen[1].geometry.height-30-2*c.border_width--DOC_HIDE
     and c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/bottom_left.lua
+++ b/tests/examples/awful/placement/bottom_left.lua
@@ -11,8 +11,8 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 awful.placement.bottom_left(client.focus)
 
 assert( --DOC_HIDE
-    c.x == c.border_width --DOC_HIDE
-    and c.y == screen[1].geometry.height-30-c.border_width --DOC_HIDE
+    c.x == 0 --DOC_HIDE
+    and c.y+2*c.border_width == screen[1].geometry.height-30 --DOC_HIDE
     and c.width == 40--DOC_HIDE
     and c.height == 30--DOC_HIDE
 ) --DOC_HIDE

--- a/tests/examples/awful/placement/bottom_right.lua
+++ b/tests/examples/awful/placement/bottom_right.lua
@@ -10,6 +10,6 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.bottom_right(client.focus)
 
-assert(c.x == screen[1].geometry.width-40-c.border_width) --DOC_HIDE
-assert(c.y==screen[1].geometry.height-30-c.border_width) --DOC_HIDE
+assert(c.x == screen[1].geometry.width-40-2*c.border_width) --DOC_HIDE
+assert(c.y==screen[1].geometry.height-30-2*c.border_width) --DOC_HIDE
 assert(c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/center_horizontal.lua
+++ b/tests/examples/awful/placement/center_horizontal.lua
@@ -9,6 +9,6 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.center_horizontal(client.focus)
 
-assert(c.x == screen[1].geometry.width/2-40/2)--DOC_HIDE
+assert(c.x == screen[1].geometry.width/2-40/2-c.border_width)--DOC_HIDE
 assert(c.y==35)--DOC_HIDE
 assert(c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/centered.lua
+++ b/tests/examples/awful/placement/centered.lua
@@ -10,5 +10,6 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.centered(client.focus)
 
-assert(c.x == screen[1].geometry.width/2-40/2 and c.y==screen[1].geometry.height/2-30/2--DOC_HIDE
-    and c.width==40 and c.height==30)--DOC_HIDE
+assert(c.x == screen[1].geometry.width/2-40/2-c.border_width) --DOC_HIDE
+assert(c.y==screen[1].geometry.height/2-30/2-c.border_width) --DOC_HIDE
+assert(c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/closest_mouse.lua
+++ b/tests/examples/awful/placement/closest_mouse.lua
@@ -8,49 +8,50 @@ mouse.coords {x=100,y=100} --DOC_HIDE
  -- Move the mouse to the closest corner of the focused client
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c})
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x-bw and mouse.coords().y == (c.y) + (c.height)/2) --DOC_HIDE
+assert(mouse.coords().x == c.x) --DOC_HIDE
+assert(mouse.coords().y == (c.y) + (c.height)/2+bw) --DOC_HIDE
 
 -- Top left --DOC_HIDE
 mouse.coords {x=60,y=40} --DOC_HIDE
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c}) --DOC_HIDE
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x-bw and mouse.coords().y == c.y-bw) --DOC_HIDE
+assert(mouse.coords().x == c.x and mouse.coords().y == c.y) --DOC_HIDE
 
 -- Top right --DOC_HIDE
 mouse.coords {x=230,y=50} --DOC_HIDE
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c}) --DOC_HIDE
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x+c.width+bw and mouse.coords().y == c.y-bw) --DOC_HIDE
+assert(mouse.coords().x == c.x+c.width+2*bw and mouse.coords().y == c.y) --DOC_HIDE
 
 -- Right --DOC_HIDE
 mouse.coords {x=240,y=140} --DOC_HIDE
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c}) --DOC_HIDE
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x+c.width+bw and mouse.coords().y == c.y+c.height/2) --DOC_HIDE
+assert(mouse.coords().x == c.x+c.width+2*bw and mouse.coords().y == c.y+c.height/2+bw) --DOC_HIDE
 
 -- Bottom right --DOC_HIDE
 mouse.coords {x=210,y=190} --DOC_HIDE
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c}) --DOC_HIDE
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x+c.width+bw and mouse.coords().y == c.y+c.height+bw) --DOC_HIDE
+assert(mouse.coords().x == c.x+c.width+2*bw and mouse.coords().y == c.y+c.height+2*bw) --DOC_HIDE
 
 -- Bottom --DOC_HIDE
 mouse.coords {x=130,y=190} --DOC_HIDE
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c}) --DOC_HIDE
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x+c.width/2 and mouse.coords().y == c.y + c.height + bw) --DOC_HIDE
+assert(mouse.coords().x == c.x+c.width/2+bw and mouse.coords().y == c.y + c.height + 2*bw) --DOC_HIDE
 
 -- Top --DOC_HIDE
 mouse.coords {x=130,y=30} --DOC_HIDE
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c}) --DOC_HIDE
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x + c.width/2 and mouse.coords().y == c.y-bw) --DOC_HIDE
+assert(mouse.coords().x == c.x + c.width/2+bw and mouse.coords().y == c.y) --DOC_HIDE
 
 -- Bottom left + outside of "c" --DOC_HIDE
 mouse.coords {x=0,y=230} --DOC_HIDE
 awful.placement.closest_corner(mouse, {include_sides=true, parent=c}) --DOC_HIDE
 mouse.push_history() --DOC_HIDE
-assert(mouse.coords().x == c.x-bw and mouse.coords().y == c.y+c.height+bw) --DOC_HIDE
+assert(mouse.coords().x == c.x and mouse.coords().y == c.y+c.height+2*bw) --DOC_HIDE
  
  -- It is possible to emulate the mouse API to get the closest corner of
  -- random area

--- a/tests/examples/awful/placement/compose.lua
+++ b/tests/examples/awful/placement/compose.lua
@@ -1,0 +1,9 @@
+screen[1]._resize {width = 128, height = 96} --DOC_HIDE
+local awful = {placement = require("awful.placement")} --DOC_HIDE
+local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
+
+local f = (awful.placement.right + awful.placement.left)
+f(client.focus)
+
+assert(c.x == 0 and c.y==screen[1].geometry.height/2-30/2-c.border_width--DOC_HIDE
+    and c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/left.lua
+++ b/tests/examples/awful/placement/left.lua
@@ -10,5 +10,5 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.left(client.focus)
 
-assert(c.x == c.border_width and c.y==screen[1].geometry.height/2-30/2--DOC_HIDE
+assert(c.x == 0 and c.y==screen[1].geometry.height/2-30/2-c.border_width--DOC_HIDE
     and c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/right.lua
+++ b/tests/examples/awful/placement/right.lua
@@ -10,6 +10,6 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.right(client.focus)
 
-assert(c.x == screen[1].geometry.width-40-c.border_width --DOC_HIDE
-    and c.y==screen[1].geometry.height/2-30/2--DOC_HIDE
-    and c.width==40 and c.height==30)--DOC_HIDE
+assert(c.x == screen[1].geometry.width-40-2*c.border_width) --DOC_HIDE
+assert( c.y==screen[1].geometry.height/2-30/2-c.border_width)--DOC_HIDE
+assert( c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/stretch_down.lua
+++ b/tests/examples/awful/placement/stretch_down.lua
@@ -13,5 +13,5 @@ placement.stretch_down(client.focus)
 assert(c.x==45) --DOC_HIDE
 assert(c.y==35) --DOC_HIDE
 assert(c.width == 40) --DOC_HIDE
-assert(c.y+c.height == --DOC_HIDE
+assert(c.y+c.height+2*c.border_width == --DOC_HIDE
     screen[1].geometry.y + screen[1].geometry.height) --DOC_HIDE

--- a/tests/examples/awful/placement/stretch_left.lua
+++ b/tests/examples/awful/placement/stretch_left.lua
@@ -10,5 +10,5 @@ local placement = require("awful.placement") --DOC_HIDE
 local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 placement.stretch_left(client.focus)
 
-assert(c.x == c.border_width and c.y == 35 and c.height == 30 --DOC_HIDE
-    and c.width == 45+40) --DOC_HIDE
+assert(c.x == 0 and c.y == 35 and c.height == 30) --DOC_HIDE
+print(c.width-2*c.border_width  == 45+40) --DOC_HIDE

--- a/tests/examples/awful/placement/stretch_right.lua
+++ b/tests/examples/awful/placement/stretch_right.lua
@@ -11,4 +11,4 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 placement.stretch_right(client.focus)
 
 local right = screen[1].geometry.x + screen[1].geometry.width --DOC_HIDE
-assert(c.height == 30 and c.x == 45 and c.x+c.width+c.border_width == right) --DOC_HIDE
+assert(c.height == 30 and c.x == 45 and c.x+c.width+2*c.border_width == right) --DOC_HIDE

--- a/tests/examples/awful/placement/stretch_up.lua
+++ b/tests/examples/awful/placement/stretch_up.lua
@@ -10,8 +10,8 @@ local placement = require("awful.placement") --DOC_HIDE
 local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 placement.stretch_up(client.focus)
 
-assert(c.y==c.border_width) --DOC_HIDE
+assert(c.y==0) --DOC_HIDE
 assert(c.x==45) --DOC_HIDE
 assert(c.width == 40) --DOC_HIDE
-print(c.height)
-assert(c.height == 35+30) --DOC_HIDE
+print(c.height-2*c.border_width,35+30)
+assert(c.height-2*c.border_width == 35+30) --DOC_HIDE

--- a/tests/examples/awful/placement/top.lua
+++ b/tests/examples/awful/placement/top.lua
@@ -10,5 +10,7 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.top(client.focus)
 
-assert(c.x == screen[1].geometry.width/2-40/2 and c.y==c.border_width--DOC_HIDE
-    and c.width==40 and c.height==30)--DOC_HIDE
+assert(c.x == screen[1].geometry.width/2-40/2-c.border_width)
+assert(c.y==0) --DOC_HIDE
+assert( c.width==40) --DOC_HIDE
+assert(c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/top_left.lua
+++ b/tests/examples/awful/placement/top_left.lua
@@ -10,4 +10,4 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.top_left(client.focus)
 
-assert(c.x == c.border_width and c.y==c.border_width and c.width==40 and c.height==30)--DOC_HIDE
+assert(c.x == 0 and c.y==0 and c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/awful/placement/top_right.lua
+++ b/tests/examples/awful/placement/top_right.lua
@@ -10,5 +10,5 @@ local c = client.gen_fake {x = 45, y = 35, width=40, height=30} --DOC_HIDE
 
 awful.placement.top_right(client.focus)
 
-assert(c.x == screen[1].geometry.width-40-c.border_width and c.y==c.border_width --DOC_HIDE
+assert(c.x == screen[1].geometry.width-40-2*c.border_width and c.y==0 --DOC_HIDE
     and c.width==40 and c.height==30)--DOC_HIDE

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -12,6 +12,7 @@ local function add_signals(c)
     c:add_signal("property::screen")
     c:add_signal("property::geometry")
     c:add_signal("request::geometry")
+    c:add_signal("request::tag")
     c:add_signal("swapped")
     c:add_signal("raised")
     c:add_signal("property::_label") --Used internally

--- a/tests/test-awful-rules.lua
+++ b/tests/test-awful-rules.lua
@@ -1,0 +1,291 @@
+local awful = require("awful")
+local beautiful = require("beautiful")
+local test_client = require("_client")
+local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
+
+local callback_called = false
+
+-- Magic table to store tests
+local tests = {}
+
+local tb_height = awful.util.round(beautiful.get_font_height() * 1.5)
+-- local border_width = beautiful.border_width
+
+local function test_rule(rule)
+    rule.rule = rule.rule or {}
+
+    -- Create a random class. The number need to be large as "rule1" and "rule10" would collide
+    -- The math.ceil is necessary to remove the floating point, this create an invalid dbus name
+    local class = string.format("rule%010d", 42+#tests)
+    rule.rule.class = rule.rule.class or class
+
+    test_client(rule.rule.class, rule.properties.name  or "Foo")
+    if rule.test then
+        local t = rule.test
+        table.insert(tests, function() return t(rule.rule.class) end)
+        rule.test = nil
+    end
+
+    table.insert(awful.rules.rules, rule)
+end
+
+-- Helper function to search clients
+local function get_client_by_class(class)
+    for _, c in ipairs(client.get()) do
+        if class == c.class then
+            return c
+        end
+    end
+end
+
+-- Test callback and floating
+test_rule {
+    properties = { floating = true },
+    callback   = function(c)
+        assert(type(c) == "client")
+        callback_called = true
+    end,
+    test = function(class)
+        -- Test if callbacks works
+        assert(callback_called)
+
+        -- Make sure "smart" dynamic properties are applied
+        assert(get_client_by_class(class).floating)
+
+        -- The size should not have changed
+        local geo = get_client_by_class(class):geometry()
+        assert(geo.width == 100 and geo.height == 100+tb_height)
+
+        return true
+    end
+}
+
+-- Test ontop
+test_rule {
+    properties = { ontop = true },
+    test = function(class)
+        -- Make sure C-API properties are applied
+        assert(get_client_by_class(class).ontop)
+
+        return true
+    end
+}
+
+-- Test placement
+test_rule {
+    properties = {
+        floating  = true,
+        placement = "bottom_right"
+    },
+    test = function(class)
+        -- Test placement
+        local sgeo = mouse.screen.workarea
+        local c    = get_client_by_class(class)
+        local geo  = c:geometry()
+
+        assert(geo.y+geo.height+2*c.border_width == sgeo.y+sgeo.height)
+        assert(geo.x+geo.width+2*c.border_width == sgeo.x+sgeo.width)
+
+        return true
+    end
+}
+
+-- Create a tag named after the class name
+test_rule {
+    properties = { new_tag=true },
+    test = function(class)
+        local c_new_tag1 = get_client_by_class(class)
+
+        assert(#c_new_tag1:tags()[1]:clients() == 1)
+        assert(c_new_tag1:tags()[1].name == class)
+
+        return true
+    end
+}
+
+-- Create a tag named Foo Tag with a magnifier layout
+test_rule {
+    properties = {
+        new_tag = {
+            name   = "Foo Tag",
+            layout = awful.layout.suit.magnifier
+        }
+    },
+    test = function(class)
+        local t_new_tag2 = get_client_by_class(class):tags()[1]
+
+        assert( #t_new_tag2:clients()  == 1           )
+        assert( t_new_tag2.name        == "Foo Tag"   )
+        assert( t_new_tag2.layout.name == "magnifier" )
+
+        return true
+    end
+}
+
+-- Create a tag named "Bar Tag"
+test_rule {
+    properties = { new_tag= "Bar Tag" },
+    test = function(class)
+        local c_new_tag3 = get_client_by_class(class)
+        assert(#c_new_tag3:tags()[1]:clients() == 1)
+        assert(c_new_tag3:tags()[1].name == "Bar Tag")
+
+        return true
+    end
+}
+
+-- Test if setting the geometry work
+test_rule {
+    properties = {
+        floating = true,
+        x        = 200,
+        y        = 200,
+        width    = 200,
+        height   = 200,
+    },
+    test = function(class)
+        local c   = get_client_by_class(class)
+        local geo = c:geometry()
+
+        -- Give it some time
+        if geo.y < 180 then return end
+
+        assert(geo.x      == 200)
+        assert(geo.y      == 200)
+        assert(geo.width  == 200)
+        assert(geo.height == 200)
+
+        return true
+    end
+}
+
+-- Test if setting a partial geometry preserve the other attributes
+test_rule {
+    properties = {
+        floating = true,
+        x        = 200,
+        geometry = {
+            height = 220
+        }
+    },
+    test = function(class)
+        local c   = get_client_by_class(class)
+        local geo = c:geometry()
+
+        -- Give it some time
+        if geo.height < 200 then return end
+
+        assert(geo.x      == 200)
+        assert(geo.width  == 100)
+        assert(geo.height == 220)
+
+        return true
+    end
+}
+
+-- Test maximized_horizontal
+test_rule {
+    properties = { maximized_horizontal = true },
+    test = function(class)
+        local c = get_client_by_class(class)
+        -- Make sure C-API properties are applied
+
+        assert(c.maximized_horizontal)
+
+        local geo = c:geometry()
+        local sgeo = c.screen.workarea
+
+        assert(geo.x==sgeo.x)
+
+        assert(geo.width+2*c.border_width==sgeo.width)
+
+        return true
+    end
+}
+
+-- Test maximized_vertical
+test_rule {
+    properties = { maximized_vertical = true },
+    test = function(class)
+        local c = get_client_by_class(class)
+        -- Make sure C-API properties are applied
+
+        assert(c.maximized_vertical)
+
+        local geo = c:geometry()
+        local sgeo = c.screen.workarea
+
+        assert(geo.y==sgeo.y)
+
+        assert(geo.height+2*c.border_width==sgeo.height)
+
+        return true
+    end
+}
+
+-- Test fullscreen
+test_rule {
+    properties = { fullscreen = true },
+    test = function(class)
+        local c = get_client_by_class(class)
+        -- Make sure C-API properties are applied
+
+        assert(c.fullscreen)
+
+        local geo = c:geometry()
+        local sgeo = c.screen.geometry
+
+        assert(geo.x==sgeo.x)
+        assert(geo.y==sgeo.y)
+        assert(geo.height+2*c.border_width==sgeo.height)
+        assert(geo.width+2*c.border_width==sgeo.width)
+
+        return true
+    end
+}
+
+-- Test tag and switchtotag
+test_rule {
+    properties = {
+        tag         = "9",
+        switchtotag = true
+    },
+    test = function(class)
+        local c = get_client_by_class(class)
+        -- Make sure C-API properties are applied
+
+        assert(#c:tags() == 1)
+        assert(c:tags()[1].name == "9")
+        assert(c.screen.selected_tag.name == "9")
+
+        return true
+    end
+}
+test_rule {
+    properties = {
+        tag         = "8",
+        switchtotag = false
+    },
+    test = function(class)
+        local c = get_client_by_class(class)
+        -- Make sure C-API properties are applied
+
+        assert(#c:tags() == 1)
+        assert(c:tags()[1].name == "8")
+
+        assert(c.screen.selected_tag.name ~= "8")
+
+        return true
+    end
+}
+
+-- Wait until all the auto-generated clients are ready
+local function spawn_clients()
+    if #client.get() >= #tests then
+        -- Set tiled
+        awful.layout.inc(1)
+        return true
+    end
+end
+
+require("_runner").run_steps{spawn_clients, unpack(tests)}

--- a/tests/test-geometry.lua
+++ b/tests/test-geometry.lua
@@ -1,0 +1,243 @@
+--- Tests for drawing geometry
+
+local runner    = require( "_runner"   )
+local awful     = require( "awful"     )
+local wibox     = require( "wibox"     )
+local beautiful = require( "beautiful" )
+
+local w = nil
+local w1_draw, w2_draw
+
+-- Disable automatic placement
+awful.rules.rules = {
+    { rule = { }, properties = {
+            border_width     = 0,
+            size_hints_honor = false,
+            x                = 0,
+            y                = 0,
+            width            = 100,
+            height           = 100,
+            border_color     = beautiful.border_normal
+        }
+    }
+}
+
+local steps = {
+    function()
+        if #client.get() == 0 then
+            return true
+        end
+        for _,c in ipairs(client.get()) do
+            c:kill()
+        end
+    end,
+    -- border_color should get applied via focus signal for first client on tag.
+    function(count)
+        if count == 1 then
+            awful.spawn("xterm")
+        else
+            local c = client.get()[1]
+            if c then
+                assert(c.size_hints_honor  == false )
+                assert(c.border_width      == 0     )
+                assert(c:geometry().x      == 0     )
+                assert(c:geometry().y      == 0     )
+                assert(c:geometry().height == 100   )
+                assert(c:geometry().width  == 100   )
+
+                c:kill()
+
+                return true
+            end
+        end
+    end,
+    function()
+        awful.rules.rules = {
+            -- All clients will match this rule.
+            { rule = { },properties = {
+                    titlebars_enabled = true,
+                    border_width      = 10,
+                    border_color      = "#00ff00",
+                    size_hints_honor  = false,
+                    x                 = 0,
+                    y                 = 0,
+                    width             = 100,
+                    height            = 100
+                }
+            }
+        }
+        return true
+    end,
+    function(count)
+        if count == 1 then
+        awful.spawn("xterm")
+        else
+            local c = client.get()[1]
+            if c then
+                assert(c.border_width      == 10  )
+                assert(c:geometry().x      == 0   )
+                assert(c:geometry().y      == 0   )
+                assert(c:geometry().height == 100 )
+                assert(c:geometry().width  == 100 )
+
+                c.border_width = 20
+
+                return true
+            end
+        end
+    end,
+    function()
+        local c = client.get()[1]
+        assert(c.border_width      == 20  )
+        assert(c:geometry().x      == 0   )
+        assert(c:geometry().y      == 0   )
+        assert(c:geometry().height == 100 )
+        assert(c:geometry().width  == 100 )
+
+        c.border_width = 0
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        assert(not pcall(function() c.border_width = -2000 end))
+        assert(c.border_width==0)
+
+        c.border_width = 125
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        assert(c.border_width       == 125 )
+        assert(c:geometry().x       == 0   )
+        assert(c:geometry().y       == 0   )
+        assert(c:geometry().height  == 100 )
+        assert(c:geometry().width   == 100 )
+
+        -- So it doesn't hide the other tests
+        c:kill()
+
+        return true
+    end,
+    function()
+        w = wibox {
+            ontop        = true,
+            border_width = 20,
+            x            = 100,
+            y            = 100,
+            width        = 100,
+            height       = 100,
+            visible      = true,
+        }
+
+        assert(w)
+        assert(w.border_width == 20  )
+        assert(w.width        == 100 )
+        assert(w.height       == 100 )
+        assert(w.x            == 100 )
+        assert(w.y            == 100 )
+
+        w:setup {
+            fit    = function(_, _, _, height)
+                return height, height -- A square taking the full height
+            end,
+            draw   = function(_, _, cr, width, height)
+
+                assert(width  == 100)
+                assert(height == 100)
+
+                w1_draw = true
+                cr:set_source_rgb(1, 0, 0) -- Red
+                cr:arc(height/2, height/2, height/2, 0, math.pi*2)
+                cr:fill()
+            end,
+            layout = wibox.widget.base.make_widget,
+        }
+
+        return true
+    end,
+    function()
+        w.border_width = 0
+        assert(w1_draw)
+
+        return true
+    end,
+    function()
+        assert(w.border_width == 0   )
+        assert(w.width        == 100 )
+        assert(w.height       == 100 )
+        assert(w.x            == 100 )
+        assert(w.y            == 100 )
+
+        w:setup {
+            fit    = function(_, _, _, height)
+                return height, height -- A square taking the full height
+            end,
+            draw   = function(_, _, cr, width, height)
+
+                assert(width  == 100)
+                assert(height == 100)
+
+                w2_draw = true
+                cr:set_source_rgb(1, 0, 0) -- Red
+                cr:arc(height/2, height/2, height/2, 0, math.pi*2)
+                cr:fill()
+            end,
+            layout = wibox.widget.base.make_widget,
+        }
+
+        w.visible = false
+
+        return true
+    end,
+    function()
+        -- Remove the widget before the size change to avoid the asserts
+        w:setup {
+            fit    = function(_, _, _, height)
+                return height, height -- A square taking the full height
+            end,
+            draw   = function(_, _, cr, _, height)
+                cr:set_source_rgb(1, 0, 1) -- Purple
+                cr:arc(height/2, height/2, height/2, 0, math.pi*2)
+                cr:fill()
+            end,
+            layout = wibox.widget.base.make_widget,
+        }
+
+        w.visible = true
+        assert(w2_draw)
+
+        assert(w.border_width == 0   )
+        assert(w.width        == 100 )
+        assert(w.height       == 100 )
+        assert(w.x            == 100 )
+        assert(w.y            == 100 )
+
+        w.border_width = 5
+
+        w:geometry {
+            x      = 200,
+            y      = 200,
+            width  = 200,
+            height = 200,
+        }
+
+        return true
+    end,
+    function()
+        assert(w.border_width == 5   )
+        assert(w.width        == 200 )
+        assert(w.height       == 200 )
+        assert(w.x            == 200 )
+        assert(w.y            == 200 )
+
+        return true
+    end
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -1,0 +1,90 @@
+--- Tests maximize and fullscreen
+
+local runner = require("_runner")
+local awful = require("awful")
+
+local original_geo = nil
+
+local steps = {
+    function(count)
+        if count == 1 then
+            awful.spawn("xterm")
+        else
+            local c = client.get()[1]
+            if c then
+                original_geo = c:geometry()
+                return true
+            end
+        end
+    end,
+
+    -- maximize horizontally
+    function()
+        local c = client.get()[1]
+        assert(not c.maximized_horizontal)
+        assert(not c.maximized_vertical  )
+        assert(not c.fullscreen          )
+
+        c.maximized_horizontal = true
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        local new_geo = c:geometry()
+        local sgeo = c.screen.workarea
+
+        --assert(new_geo.x-c.border_width==sgeo.x) --FIXME c:geometry({x=1}).x ~= 1
+
+        --assert(new_geo.width+2*c.border_width==sgeo.width) --FIXME off by 4px
+
+        c.maximized_horizontal = false
+        return true
+    end,
+    -- Test restoring a geometry
+    function()
+        local c = client.get()[1]
+
+        local new_geo = c:geometry()
+
+        for k,v in pairs(original_geo) do
+            assert(new_geo[k] == v)
+        end
+
+        c.fullscreen = true
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        local new_geo = c:geometry()
+        local sgeo    = c.screen.geometry
+        local bw      = c.border_width
+
+        assert(c.fullscreen)
+        assert(new_geo.x-bw==sgeo.x)
+        assert(new_geo.y-bw==sgeo.y)
+        assert(new_geo.x+new_geo.width+bw==sgeo.x+sgeo.width)
+        assert(new_geo.y+new_geo.height+bw==sgeo.y+sgeo.height)
+
+        c.fullscreen = false
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        local new_geo = c:geometry()
+
+        for k,v in pairs(original_geo) do
+            assert(new_geo[k] == v)
+        end
+
+        return true
+    end
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -31,8 +31,8 @@ local steps = {
     function()
         local c = client.get()[1]
 
-        local new_geo = c:geometry()
-        local sgeo = c.screen.workarea
+        --local new_geo = c:geometry()
+        --local sgeo = c.screen.workarea
 
         --assert(new_geo.x-c.border_width==sgeo.x) --FIXME c:geometry({x=1}).x ~= 1
 

--- a/tests/test-urgent.lua
+++ b/tests/test-urgent.lua
@@ -55,7 +55,7 @@ local steps = {
       root.fake_input("key_release", "2")
       root.fake_input("key_release", "Super_L")
 
-    elseif awful.tag.selectedlist()[1] == tags[awful.screen.focused()][2] then
+    elseif awful.screen.focused().selected_tags[1] == tags[awful.screen.focused()][2] then
       assert(#client.get() == 1)
       local c = client.get()[1]
       assert(not c.urgent, "Client is not urgent anymore.")
@@ -79,11 +79,11 @@ local steps = {
 
       awful.spawn("xterm")
 
-    elseif awful.tag.selectedlist()[1] == tags[awful.screen.focused()][2] then
+    elseif awful.screen.focused().selected_tags[1] == tags[awful.screen.focused()][2] then
       assert(not urgent_cb_done)
       assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == false)
       assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 0)
-      assert(awful.tag.selectedlist()[2] == nil)
+      assert(awful.screen.focused().selected_tags[2] == nil)
       return true
     end
   end,


### PR DESCRIPTION
Revive https://github.com/awesomeWM/awesome/pull/53

Now that the new property system is merged, it is possible for modules to add extra properties themselves. However, it is limited to "real" client properties. There is still no way to add "rules only" property that are not kept after the initial rules application.

This PR add the ones from #53, [plan to] add unit test and [plan to] document everything properly. It conflict with @psychon other PR and isn't ready at all, but early comments are welcome.

Edit: After adding the tests, I found out that most! properties were broken or had unhandled corner case. So... Nobody ever write complex rules or are they are those powerusers don't know how to report bugs? Whatever:

 * **x**: Broken when "border_width" is set or left titlebars are used
 * **y**: Borken when"border_width" is set or top titlebars are used
 * **width**: See above + right litlebar
 * **height**: Same as above
 * **switchtotag**: Have a race with the "manage" -> "tag.withcurrent" code in `awful.tag`
 * **tag**: Had dead code
 * **screen**: Had a race condition with switchtotag
 * **urgent**: Had a race with screen and another with switchtotag+focus
 * **focusable**: Was broken yet again when request::activate was introduced (and also because of FS1098, that I also fixed)
 * **no_overlap**: The "no_overlap" call in rc.lua "manage" section conflict with the geometry rules as the hints are not set (idk why).
 * **size_hints_honor**: If set to false, it would be applied too late, causing height and width offsets due to placement or various geometry related properties