### PR TITLE
Stop restarting on RandR changes

### DIFF
--- a/event.c
+++ b/event.c
@@ -400,8 +400,7 @@ event_handle_configurenotify(xcb_configure_notify_event_t *ev)
     xcb_screen_t *screen = globalconf.screen;
 
     if(ev->window == screen->root)
-        /* it's not that we panic, but restart */
-        awesome_restart();
+        globalconf.screen_need_refresh = true;
 
     /* Copy what XRRUpdateConfiguration() would do: Update the configuration */
     if(ev->window == screen->root) {
@@ -782,7 +781,7 @@ event_handle_randr_screen_change_notify(xcb_randr_screen_change_notify_event_t *
         globalconf.screen->height_in_pixels = ev->height;
     }
 
-    awesome_restart();
+    globalconf.screen_need_refresh = true;
 }
 
 /** XRandR event handler for RRNotify subtype XRROutputChangeNotifyEvent

--- a/event.c
+++ b/event.c
@@ -992,10 +992,8 @@ void event_init(void)
     const xcb_query_extension_reply_t *reply;
 
     reply = xcb_get_extension_data(globalconf.connection, &xcb_randr_id);
-    if (reply && reply->present) {
-        xcb_randr_select_input(globalconf.connection, globalconf.screen->root, XCB_RANDR_NOTIFY_MASK_OUTPUT_CHANGE);
+    if (reply && reply->present)
         globalconf.event_base_randr = reply->first_event;
-    }
 
     reply = xcb_get_extension_data(globalconf.connection, &xcb_shape_id);
     if (reply && reply->present)

--- a/event.h
+++ b/event.h
@@ -38,9 +38,13 @@ void drawin_refresh(void);
 void client_focus_refresh(void);
 void client_border_refresh(void);
 
+/* objects/screen.c */
+void screen_refresh(void);
+
 static inline int
 awesome_refresh(void)
 {
+    screen_refresh();
     luaA_emit_refresh();
     banning_refresh();
     stack_refresh();

--- a/globalconf.h
+++ b/globalconf.h
@@ -92,6 +92,10 @@ typedef struct
     xcb_window_t selection_owner_window;
     /** Do we have RandR 1.3 or newer? */
     bool have_randr_13;
+    /** Do we have RandR 1.5 or newer? */
+    bool have_randr_15;
+    /** Do we have a RandR screen update pending? */
+    bool screen_need_refresh;
     /** Check for XTest extension */
     bool have_xtest;
     /** Check for SHAPE extension */

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -446,12 +446,14 @@ function client.object.to_selected_tags(self)
         end
     end
 
-    if #tags == 0 then
-        tags = self.screen.selected_tags
-    end
+    if self.screen then
+        if #tags == 0 then
+            tags = self.screen.selected_tags
+        end
 
-    if #tags == 0 then
-        tags = self.screen.tags
+        if #tags == 0 then
+            tags = self.screen.tags
+        end
     end
 
     if #tags ~= 0 then

--- a/lib/awful/wibox.lua
+++ b/lib/awful/wibox.lua
@@ -285,6 +285,14 @@ end
 capi.client.connect_signal("property::struts", update_wiboxes_on_struts)
 capi.client.connect_signal("unmanage", update_wiboxes_on_struts)
 
+capi.screen.connect_signal("removed", function(s)
+    for _, wprop in ipairs(wiboxes) do
+        if wprop.screen == s then
+            wprop.wibox.visible = false
+        end
+    end
+end)
+
 function awfulwibox.mt:__call(...)
     return awfulwibox.new(...)
 end

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -371,6 +371,11 @@ screen_scan_randr(lua_State *L, screen_array_t *screens)
 
     globalconf.have_randr_13 = minor_version >= 3;
 
+    /* We want to know when something changes */
+    xcb_randr_select_input(globalconf.connection,
+                           globalconf.screen->root,
+                           XCB_RANDR_NOTIFY_MASK_OUTPUT_CHANGE);
+
     if (minor_version >= 5)
         screen_scan_randr_monitors(L, screens);
     else

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -37,6 +37,8 @@ struct a_screen
     area_t geometry;
     /** The screen outputs informations */
     screen_output_array_t outputs;
+    /** Some XID identifying this screen */
+    uint32_t xid;
 };
 ARRAY_FUNCS(screen_t *, screen, DO_NOTHING)
 

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -33,6 +33,8 @@ ARRAY_TYPE(screen_output_t, screen_output)
 struct a_screen
 {
     LUA_OBJECT_HEADER
+    /** Is this screen still valid and may be used? */
+    bool valid;
     /** Screen geometry */
     area_t geometry;
     /** The screen outputs informations */


### PR DESCRIPTION
Here is it, the "big" PR that fixes https://github.com/awesomeWM/awesome/issues/672!

This should hopefully contain the necessary changes to the C code. Note that none of this is really tested since I couldn't find anything to test this with. I don't want to break my X session!

A bit of a problem might be commit https://github.com/awesomeWM/awesome/commit/d985c23edae96f47014e333d0a1617e95a1c6564, but as far as I know the nvidia blob doesn't hit that problem any more, so I'll just hope for the best with it and assume it works.

Note that this does not yet handle anything on the Lua side, so there are e.g. lots of leaks, tags for removed screens aren't removed, `awful.wibox`es assigned to a removed screened aren't removed etc. If you want, feel free to work on this stuff.