### PR TITLE
Catch under/overflows

### DIFF
--- a/common/xutil.h
+++ b/common/xutil.h
@@ -28,6 +28,11 @@
 #include "common/atoms.h"
 #include "common/util.h"
 
+#define MAX_X11_COORDINATE INT16_MAX
+#define MIN_X11_COORDINATE INT16_MIN
+#define MAX_X11_SIZE UINT16_MAX
+#define MIN_X11_SIZE 1
+
 static inline char *
 xutil_get_text_property_from_reply(xcb_get_property_reply_t *reply)
 {

--- a/luaa.c
+++ b/luaa.c
@@ -181,7 +181,7 @@ luaA_load_image(lua_State *L)
 static int
 luaA_set_preferred_icon_size(lua_State *L)
 {
-    globalconf.preferred_icon_size = luaL_checknumber(L, 1);
+    globalconf.preferred_icon_size = luaA_checkinteger_range(L, 1, 0, UINT32_MAX);
     return 0;
 }
 

--- a/luaa.h
+++ b/luaa.h
@@ -75,6 +75,18 @@ luaA_typerror(lua_State *L, int narg, const char *tname)
     return luaL_argerror(L, narg, msg);
 }
 
+static inline int
+luaA_rangerror(lua_State *L, int narg, double min, double max)
+{
+    const char *msg = lua_pushfstring(L, "value in [%f, %f] expected, got %f",
+                                      min, max, (double) lua_tonumber(L, narg));
+#if LUA_VERSION_NUM >= 502
+    luaL_traceback(L, L, NULL, 2);
+    lua_concat(L, 2);
+#endif
+    return luaL_argerror(L, narg, msg);
+}
+
 static inline void
 luaA_getuservalue(lua_State *L, int idx)
 {
@@ -162,6 +174,33 @@ luaA_getopt_integer(lua_State *L, int idx, const char *name, lua_Integer def)
     lua_getfield(L, idx, name);
     if (lua_isnil(L, -1) || lua_isnumber(L, -1))
         def = luaA_optinteger(L, -1, def);
+    lua_pop(L, 1);
+    return def;
+}
+
+static inline int
+luaA_checkinteger_range(lua_State *L, int n, int min, int max)
+{
+    int result = luaA_checkinteger(L, n);
+    if (result < min || result > max)
+        luaA_rangerror(L, n, min, max);
+    return result;
+}
+
+static inline lua_Integer
+luaA_optinteger_range(lua_State *L, int narg, lua_Integer def, int min, int max)
+{
+    if (lua_isnoneornil(L, narg))
+        return def;
+    return luaA_checkinteger_range(L, narg, min, max);
+}
+
+static inline int
+luaA_getopt_integer_range(lua_State *L, int idx, const char *name, lua_Integer def, int min, int max)
+{
+    lua_getfield(L, idx, name);
+    if (lua_isnil(L, -1) || lua_isnumber(L, -1))
+        def = luaA_optinteger_range(L, -1, def, min, max);
     lua_pop(L, 1);
     return def;
 }

--- a/mouse.c
+++ b/mouse.c
@@ -31,6 +31,7 @@
 
 #include "mouse.h"
 #include "common/util.h"
+#include "common/xutil.h"
 #include "globalconf.h"
 #include "objects/client.h"
 #include "objects/drawin.h"
@@ -111,7 +112,7 @@ mouse_query_pointer_root(int16_t *x, int16_t *y, xcb_window_t *child, uint16_t *
  * \param y Y-coordinate inside window.
  */
 static inline void
-mouse_warp_pointer(xcb_window_t window, int x, int y)
+mouse_warp_pointer(xcb_window_t window, int16_t x, int16_t y)
 {
     xcb_warp_pointer(globalconf.connection, XCB_NONE, window,
                      0, 0, 0, 0, x, y);
@@ -223,8 +224,8 @@ luaA_mouse_coords(lua_State *L)
         if(!mouse_query_pointer_root(&mouse_x, &mouse_y, NULL, &mask))
             return 0;
 
-        x = luaA_getopt_number(L, 1, "x", mouse_x);
-        y = luaA_getopt_number(L, 1, "y", mouse_y);
+        x = luaA_getopt_integer_range(L, 1, "x", mouse_x, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+        y = luaA_getopt_integer_range(L, 1, "y", mouse_y, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
 
         if(ignore_enter_notify)
             client_ignore_enterleave_events();

--- a/objects/client.c
+++ b/objects/client.c
@@ -2538,7 +2538,7 @@ luaA_client_titlebar_ ## name(lua_State *L)                       \
         if (lua_isnil(L, 2))                                      \
             titlebar_resize(L, 1, c, index, 0);                   \
         else                                                      \
-            titlebar_resize(L, 1, c, index, luaL_checknumber(L, 2)); \
+            titlebar_resize(L, 1, c, index, luaA_checkinteger_range(L, 2, 0, MAX_X11_SIZE)); \
     }                                                             \
                                                                   \
     luaA_object_push_item(L, 1, titlebar_get_drawable(L, c, 1, index)); \
@@ -2566,8 +2566,8 @@ luaA_client_geometry(lua_State *L)
         area_t geometry;
 
         luaA_checktable(L, 2);
-        geometry.x = luaA_getopt_number(L, 2, "x", c->geometry.x);
-        geometry.y = luaA_getopt_number(L, 2, "y", c->geometry.y);
+        geometry.x = luaA_getopt_integer_range(L, 2, "x", c->geometry.x, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+        geometry.y = luaA_getopt_integer_range(L, 2, "y", c->geometry.y, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
         if(client_isfixed(c))
         {
             geometry.width = c->geometry.width;
@@ -2575,8 +2575,8 @@ luaA_client_geometry(lua_State *L)
         }
         else
         {
-            geometry.width = luaA_getopt_number(L, 2, "width", c->geometry.width);
-            geometry.height = luaA_getopt_number(L, 2, "height", c->geometry.height);
+            geometry.width = luaA_getopt_integer_range(L, 2, "width", c->geometry.width, MIN_X11_SIZE, MAX_X11_SIZE);
+            geometry.height = luaA_getopt_integer_range(L, 2, "height", c->geometry.height, MIN_X11_SIZE, MAX_X11_SIZE);
         }
 
         client_resize(c, geometry, c->size_hints_honor);
@@ -2600,8 +2600,8 @@ luaA_client_apply_size_hints(lua_State *L)
     area_t geometry = c->geometry;
     if(!client_isfixed(c))
     {
-        geometry.width = luaL_checknumber(L, 2);
-        geometry.height = luaL_checknumber(L, 3);
+        geometry.width = luaA_checkinteger_range(L, 2, MIN_X11_SIZE, MAX_X11_SIZE);
+        geometry.height = luaA_checkinteger_range(L, 3, MIN_X11_SIZE, MAX_X11_SIZE);
     }
 
     if (c->size_hints_honor)

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -34,6 +34,7 @@
 #include "drawin.h"
 #include "common/atoms.h"
 #include "common/xcursor.h"
+#include "common/xutil.h"
 #include "event.h"
 #include "ewmh.h"
 #include "objects/client.h"
@@ -406,10 +407,10 @@ luaA_drawin_geometry(lua_State *L)
         area_t wingeom;
 
         luaA_checktable(L, 2);
-        wingeom.x = luaA_getopt_number(L, 2, "x", drawin->geometry.x);
-        wingeom.y = luaA_getopt_number(L, 2, "y", drawin->geometry.y);
-        wingeom.width = luaA_getopt_number(L, 2, "width", drawin->geometry.width);
-        wingeom.height = luaA_getopt_number(L, 2, "height", drawin->geometry.height);
+        wingeom.x = luaA_getopt_integer_range(L, 2, "x", drawin->geometry.x, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+        wingeom.y = luaA_getopt_integer_range(L, 2, "y", drawin->geometry.y, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+        wingeom.width = luaA_getopt_integer_range(L, 2, "width", drawin->geometry.width, MIN_X11_SIZE, MAX_X11_SIZE);
+        wingeom.height = luaA_getopt_integer_range(L, 2, "height", drawin->geometry.height, MIN_X11_SIZE, MAX_X11_SIZE);
 
         if(wingeom.width > 0 && wingeom.height > 0)
             drawin_moveresize(L, 1, wingeom);
@@ -426,7 +427,8 @@ LUA_OBJECT_EXPORT_PROPERTY(drawin, drawin_t, visible, lua_pushboolean)
 static int
 luaA_drawin_set_x(lua_State *L, drawin_t *drawin)
 {
-    drawin_moveresize(L, -3, (area_t) { .x = luaA_checkinteger(L, -1),
+    int x = luaA_checkinteger_range(L, -1, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+    drawin_moveresize(L, -3, (area_t) { .x = x,
                                         .y = drawin->geometry.y,
                                         .width = drawin->geometry.width,
                                         .height = drawin->geometry.height });
@@ -443,8 +445,9 @@ luaA_drawin_get_x(lua_State *L, drawin_t *drawin)
 static int
 luaA_drawin_set_y(lua_State *L, drawin_t *drawin)
 {
+    int y = luaA_checkinteger_range(L, -1, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
     drawin_moveresize(L, -3, (area_t) { .x = drawin->geometry.x,
-                                        .y = luaA_checkinteger(L, -1),
+                                        .y = y,
                                         .width = drawin->geometry.width,
                                         .height = drawin->geometry.height });
     return 0;
@@ -460,9 +463,7 @@ luaA_drawin_get_y(lua_State *L, drawin_t *drawin)
 static int
 luaA_drawin_set_width(lua_State *L, drawin_t *drawin)
 {
-    int width = luaA_checkinteger(L, -1);
-    if(width <= 0)
-        luaL_error(L, "invalid width");
+    int width = luaA_checkinteger_range(L, -1, MIN_X11_SIZE, MAX_X11_SIZE);
     drawin_moveresize(L, -3, (area_t) { .x = drawin->geometry.x,
                                         .y = drawin->geometry.y,
                                         .width = width,
@@ -480,9 +481,7 @@ luaA_drawin_get_width(lua_State *L, drawin_t *drawin)
 static int
 luaA_drawin_set_height(lua_State *L, drawin_t *drawin)
 {
-    int height = luaA_checkinteger(L, -1);
-    if(height <= 0)
-        luaL_error(L, "invalid height");
+    int height = luaA_checkinteger_range(L, -1, MIN_X11_SIZE, MAX_X11_SIZE);
     drawin_moveresize(L, -3, (area_t) { .x = drawin->geometry.x,
                                        .y = drawin->geometry.y,
                                        .width = drawin->geometry.width,

--- a/objects/window.c
+++ b/objects/window.c
@@ -29,6 +29,7 @@
 
 #include "objects/window.h"
 #include "common/atoms.h"
+#include "common/xutil.h"
 #include "ewmh.h"
 #include "property.h"
 #include "xwindow.h"
@@ -352,7 +353,7 @@ window_set_xproperty(lua_State *L, xcb_window_t window, int prop_idx, int value_
         } else if(prop->type == PROP_NUMBER || prop->type == PROP_BOOLEAN)
         {
             if (prop->type == PROP_NUMBER)
-                number = luaL_checkinteger(L, value_idx);
+                number = luaA_checkinteger_range(L, value_idx, 0, UINT32_MAX);
             else
                 number = luaA_checkboolean(L, value_idx);
             data = &number;
@@ -475,7 +476,7 @@ window_translate_type(window_type_t type)
 static int
 luaA_window_set_border_width(lua_State *L, window_t *c)
 {
-    window_set_border_width(L, -3, luaL_checknumber(L, -1));
+    window_set_border_width(L, -3, luaA_checkinteger_range(L, -1, 0, MAX_X11_SIZE));
     return 0;
 }
 

--- a/root.c
+++ b/root.c
@@ -30,6 +30,7 @@
 
 #include "common/atoms.h"
 #include "common/xcursor.h"
+#include "common/xutil.h"
 #include "objects/button.h"
 #include "xwindow.h"
 
@@ -265,8 +266,8 @@ luaA_root_fake_input(lua_State *L)
     {
         type = XCB_MOTION_NOTIFY;
         detail = luaA_checkboolean(L, 2); /* relative to the current position or not */
-        x = luaL_checkinteger(L, 3);
-        y = luaL_checkinteger(L, 4);
+        x = luaA_checkinteger_range(L, 3, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+        y = luaA_checkinteger_range(L, 4, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
     }
     else
         return 0;

--- a/strut.c
+++ b/strut.c
@@ -51,10 +51,10 @@ void
 luaA_tostrut(lua_State *L, int idx, strut_t *strut)
 {
     luaA_checktable(L, idx);
-    strut->left = luaA_getopt_integer(L, idx, "left", strut->left);
-    strut->right = luaA_getopt_integer(L, idx, "right", strut->right);
-    strut->top = luaA_getopt_integer(L, idx, "top", strut->top);
-    strut->bottom = luaA_getopt_integer(L, idx, "bottom", strut->bottom);
+    strut->left = luaA_getopt_integer_range(L, idx, "left", strut->left, 0, UINT16_MAX);
+    strut->right = luaA_getopt_integer_range(L, idx, "right", strut->right, 0, UINT16_MAX);
+    strut->top = luaA_getopt_integer_range(L, idx, "top", strut->top, 0, UINT16_MAX);
+    strut->bottom = luaA_getopt_integer_range(L, idx, "bottom", strut->bottom, 0, UINT16_MAX);
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/systray.c
+++ b/systray.c
@@ -21,6 +21,7 @@
 
 #include "systray.h"
 #include "common/atoms.h"
+#include "common/xutil.h"
 #include "objects/drawin.h"
 #include "xwindow.h"
 #include "globalconf.h"
@@ -324,13 +325,13 @@ luaA_systray(lua_State *L)
     {
         size_t bg_len;
         drawin_t *w = luaA_checkudata(L, 1, &drawin_class);
-        int x = luaL_checkinteger(L, 2);
-        int y = luaL_checkinteger(L, 3);
-        int base_size = luaL_checkinteger(L, 4);
+        int x = luaA_checkinteger_range(L, 2, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+        int y = luaA_checkinteger_range(L, 3, MIN_X11_COORDINATE, MAX_X11_COORDINATE);
+        int base_size = luaA_checkinteger_range(L, 4, MIN_X11_SIZE, MAX_X11_SIZE);
         bool horiz = lua_toboolean(L, 5);
         const char *bg = luaL_checklstring(L, 6, &bg_len);
         bool revers = lua_toboolean(L, 7);
-        int spacing = luaL_checkinteger(L, 8);
+        int spacing = luaA_checkinteger_range(L, 8, 0, MAX_X11_COORDINATE);
         color_t bg_color;
         bool force_redraw = false;
 


### PR DESCRIPTION
Previously, `c:geometry { width = -42 }` would mean that the C side assigns the value -42 to an `uint16_t` and thus the result was `UINT16_MAX-42`. This commit adds range checking to everything that I could spot. Some things (e.g. fake input) are not checked, but mostly because I didn't figure out good limits.