### PR TITLE
Screen GC & stuff

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -88,22 +88,9 @@ local function client_menu_toggle_fn()
 end
 -- }}}
 
--- {{{ Wallpaper
-if beautiful.wallpaper then
-    awful.screen.connect_for_each_screen(function(s)
-        gears.wallpaper.maximized(beautiful.wallpaper, s, true)
-    end)
-end
--- }}}
-
--- {{{ Tags
 -- Define a tag table which hold all screen tags.
+-- This table is filled later
 tags = {}
-awful.screen.connect_for_each_screen(function(s)
-    -- Each screen has its own tag table.
-    tags[s] = awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.layouts[1])
-end)
--- }}}
 
 -- {{{ Menu
 -- Create a launcher widget and a main menu
@@ -183,6 +170,14 @@ mytasklist.buttons = awful.util.table.join(
                                           end))
 
 awful.screen.connect_for_each_screen(function(s)
+    -- Wallpaper
+    if beautiful.wallpaper then
+        gears.wallpaper.maximized(beautiful.wallpaper, s, true)
+    end
+
+    -- Each screen has its own tag table.
+    tags[s] = awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.layouts[1])
+
     -- Create a promptbox for each screen
     mypromptbox[s] = awful.widget.prompt()
     -- Create an imagebox widget which will contains an icon indicating which layout we're using.

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -88,10 +88,6 @@ local function client_menu_toggle_fn()
 end
 -- }}}
 
--- Define a tag table which hold all screen tags.
--- This table is filled later
-tags = {}
-
 -- {{{ Menu
 -- Create a launcher widget and a main menu
 myawesomemenu = {
@@ -176,7 +172,7 @@ awful.screen.connect_for_each_screen(function(s)
     end
 
     -- Each screen has its own tag table.
-    tags[s] = awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.layouts[1])
+    awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.layouts[1])
 
     -- Create a promptbox for each screen
     mypromptbox[s] = awful.widget.prompt()

--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -162,6 +162,11 @@ function layout.arrange(screen)
     delayed_arrange[screen] = true
 
     timer.delayed_call(function()
+        if not screen.valid then
+            -- Screen was removed
+            delayed_arrange[screen] = nil
+            return
+        end
         if arrange_lock then return end
         arrange_lock = true
 

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -305,7 +305,10 @@ function tag.object.delete(self, fallback_tag)
     if target_scr.selected_tag == nil and ntags > 0 then
         tag.history.restore(nil, 1)
         if target_scr.selected_tag == nil then
-            tags[tags[1] == self and 2 or 1].selected = true
+            local other_tag = tags[tags[1] == self and 2 or 1]
+            if other_tag then
+                other_tag.selected = true
+            end
         end
     end
 

--- a/lib/awful/wibox.lua
+++ b/lib/awful/wibox.lua
@@ -12,7 +12,6 @@
 -- Grab environment we need
 local capi =
 {
-    awesome = awesome,
     screen = screen,
     client = client
 }
@@ -26,7 +25,7 @@ local beautiful = require("beautiful")
 local round = require("awful.util").round
 
 local function get_screen(s)
-    return s and screen[s]
+    return s and capi.screen[s]
 end
 
 local awfulwibox = { mt = {} }

--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -47,7 +47,7 @@ function layoutbox.new(screen)
 
     -- Do we already have the update callbacks registered?
     if boxes == nil then
-        boxes = setmetatable({}, { __mode = "v" })
+        boxes = setmetatable({}, { __mode = "kv" })
         tag.attached_connect_signal(nil, "property::selected", update_from_tag)
         tag.attached_connect_signal(nil, "property::layout", update_from_tag)
         layoutbox.boxes = boxes

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -175,7 +175,7 @@ function taglist.new(screen, filter, buttons, style, update_function, base_widge
         end
     end
     if instances == nil then
-        instances = {}
+        instances = setmetatable({}, { __mode = "k" })
         local function u(s)
             local i = instances[get_screen(s)]
             if i then

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -190,7 +190,7 @@ function tasklist.new(screen, filter, buttons, style, update_function, base_widg
         data[c] = nil
     end
     if instances == nil then
-        instances = {}
+        instances = setmetatable({}, { __mode = "k" })
         local function us(s)
             local i = instances[get_screen(s)]
             if i then

--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -47,8 +47,8 @@ end
 
 -- Test movetotag
 
-local t  = tags[mouse.screen][1]
-local t2 = tags[mouse.screen][2]
+local t  = mouse.screen.tags[1]
+local t2 = mouse.screen.tags[2]
 
 c:tags{t}
 assert(c:tags()[1] == t)

--- a/tests/test-urgent.lua
+++ b/tests/test-urgent.lua
@@ -3,11 +3,8 @@
 local awful = require("awful")
 local runner = require("_runner")
 
--- This uses the global "tags" array set in the default config
--- luacheck: globals tags
-
 -- Some basic assertion that the tag is not marked "urgent" already.
-assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == nil)
+assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent") == nil)
 
 
 -- Setup signal handler which should be called.
@@ -32,7 +29,7 @@ local steps = {
     if count == 1 then  -- Setup.
       urgent_cb_done = false
       -- Select first tag.
-      tags[awful.screen.focused()][1]:view_only()
+      awful.screen.focused().tags[1]:view_only()
 
       runner.add_to_default_rules({ rule = { class = "XTerm" },
         properties = { tag = "2", focus = true } })
@@ -40,8 +37,8 @@ local steps = {
       awful.spawn("xterm")
     end
     if urgent_cb_done then
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == true)
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 1)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent") == true)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent_count") == 1)
       return true
     end
   end,
@@ -55,13 +52,13 @@ local steps = {
       root.fake_input("key_release", "2")
       root.fake_input("key_release", "Super_L")
 
-    elseif awful.screen.focused().selected_tags[1] == tags[awful.screen.focused()][2] then
+    elseif awful.screen.focused().selected_tags[1] == awful.screen.focused().tags[2] then
       assert(#client.get() == 1)
       local c = client.get()[1]
       assert(not c.urgent, "Client is not urgent anymore.")
       assert(c == client.focus, "Client is focused.")
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == false)
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 0)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent") == false)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent_count") == 0)
       return true
     end
   end,
@@ -72,17 +69,17 @@ local steps = {
       urgent_cb_done = false
 
       -- Select first tag.
-      tags[awful.screen.focused()][1]:view_only()
+      awful.screen.focused().tags[1]:view_only()
 
       runner.add_to_default_rules({ rule = { class = "XTerm" },
         properties = { tag = "2", focus = true, switchtotag = true }})
 
       awful.spawn("xterm")
 
-    elseif awful.screen.focused().selected_tags[1] == tags[awful.screen.focused()][2] then
+    elseif awful.screen.focused().selected_tags[1] == awful.screen.focused().tags[2] then
       assert(not urgent_cb_done)
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == false)
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 0)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent") == false)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent_count") == 0)
       assert(awful.screen.focused().selected_tags[2] == nil)
       return true
     end
@@ -103,8 +100,8 @@ local steps = {
     end
     if manage_cb_done then
       assert(client.get()[1].urgent == false)
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent") == false)
-      assert(awful.tag.getproperty(tags[awful.screen.focused()][2], "urgent_count") == 0)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent") == false)
+      assert(awful.tag.getproperty(awful.screen.focused().tags[2], "urgent_count") == 0)
       return true
     end
   end,


### PR DESCRIPTION
This started as some preparation for "make sure that screens can be garbage collected", but I got a bit carried away.

Commit https://github.com/awesomeWM/awesome/commit/e8d1c50a1db647a129e618b74da7ae142b4c7932 might be a bit controversial. It removes the `tags` table from the default config, since people should use e.g. `screen[1].tags` instead. This requires finding `.tags` in the documentation, but such is life...