### PR TITLE
Add clear() function to awful.widget.graph and doc fixes

### DIFF
--- a/lib/awful/widget/graph.lua
+++ b/lib/awful/widget/graph.lua
@@ -161,8 +161,9 @@ function graph.fit(_graph)
 end
 
 --- Add a value to the graph
--- @param _graph The graph.
--- @param value The value between 0 and 1.
+--
+-- @function add_value
+-- @param value The value to be added to the graph
 -- @param group The stack color group index.
 local function add_value(_graph, value, group)
     if not _graph then return end

--- a/lib/awful/widget/graph.lua
+++ b/lib/awful/widget/graph.lua
@@ -197,6 +197,16 @@ local function add_value(_graph, value, group)
     return _graph
 end
 
+--- Clear the graph.
+--
+-- @function clear
+local function clear(_graph)
+    if not _graph then return end
+
+    _graph._data.values = {}
+    _graph:emit_signal("widget::redraw_needed")
+    return _graph
+end
 
 --- Set the graph height.
 -- @param height The height to set.
@@ -254,6 +264,7 @@ function graph.new(args)
 
     -- Set methods
     _graph.add_value = add_value
+    _graph.clear = clear
     _graph.draw = graph.draw
     _graph.fit = graph.fit
 

--- a/lib/awful/widget/graph.lua
+++ b/lib/awful/widget/graph.lua
@@ -162,51 +162,44 @@ end
 
 --- Add a value to the graph
 --
--- @function add_value
 -- @param value The value to be added to the graph
 -- @param group The stack color group index.
-local function add_value(_graph, value, group)
-    if not _graph then return end
-
+function graph:add_value(value, group)
     value = value or 0
-    local values = _graph._data.values
-    local max_value = _graph._data.max_value
+    local values = self._data.values
+    local max_value = self._data.max_value
     value = math.max(0, value)
-    if not _graph._data.scale then
+    if not self._data.scale then
         value = math.min(max_value, value)
     end
 
-    if _graph._data.stack and group then
-        if not  _graph._data.values[group]
-        or type(_graph._data.values[group]) ~= "table"
+    if self._data.stack and group then
+        if not  self._data.values[group]
+        or type(self._data.values[group]) ~= "table"
         then
-            _graph._data.values[group] = {}
+            self._data.values[group] = {}
         end
-        values = _graph._data.values[group]
+        values = self._data.values[group]
     end
     table.insert(values, value)
 
     local border_width = 0
-    if _graph._data.border_color then border_width = 2 end
+    if self._data.border_color then border_width = 2 end
 
     -- Ensure we never have more data than we can draw
-    while #values > _graph._data.width - border_width do
+    while #values > self._data.width - border_width do
         table.remove(values, 1)
     end
 
-    _graph:emit_signal("widget::redraw_needed")
-    return _graph
+    self:emit_signal("widget::redraw_needed")
+    return self
 end
 
 --- Clear the graph.
---
--- @function clear
-local function clear(_graph)
-    if not _graph then return end
-
-    _graph._data.values = {}
-    _graph:emit_signal("widget::redraw_needed")
-    return _graph
+function graph:clear()
+    self._data.values = {}
+    self:emit_signal("widget::redraw_needed")
+    return self
 end
 
 --- Set the graph height.
@@ -264,8 +257,8 @@ function graph.new(args)
     _graph._data = { width = width, height = height, values = {}, max_value = 1 }
 
     -- Set methods
-    _graph.add_value = add_value
-    _graph.clear = clear
+    _graph.add_value = graph["add_value"]
+    _graph.clear = graph["clear"]
     _graph.draw = graph.draw
     _graph.fit = graph.fit
 


### PR DESCRIPTION
1. There hasn't been an easy way to clear a graph widget. `awful.widget.graph.clear()` provides an easy way to clear the graph.
2. `awful.widget.graph.add_value()` did not show up in the generated HTML documentation.