### PR TITLE
Fix integer overflow in overflow checking functions

### DIFF
--- a/luaa.h
+++ b/luaa.h
@@ -206,7 +206,7 @@ luaA_getopt_integer(lua_State *L, int idx, const char *name, lua_Integer def)
 }
 
 static inline int
-luaA_checkinteger_range(lua_State *L, int n, int min, int max)
+luaA_checkinteger_range(lua_State *L, int n, lua_Number min, lua_Number max)
 {
     int result = luaA_checkinteger(L, n);
     if (result < min || result > max)
@@ -215,7 +215,7 @@ luaA_checkinteger_range(lua_State *L, int n, int min, int max)
 }
 
 static inline lua_Integer
-luaA_optinteger_range(lua_State *L, int narg, lua_Integer def, int min, int max)
+luaA_optinteger_range(lua_State *L, int narg, lua_Integer def, lua_Number min, lua_Number max)
 {
     if (lua_isnoneornil(L, narg))
         return def;
@@ -223,7 +223,7 @@ luaA_optinteger_range(lua_State *L, int narg, lua_Integer def, int min, int max)
 }
 
 static inline int
-luaA_getopt_integer_range(lua_State *L, int idx, const char *name, lua_Integer def, int min, int max)
+luaA_getopt_integer_range(lua_State *L, int idx, const char *name, lua_Integer def, lua_Number min, lua_Number max)
 {
     lua_getfield(L, idx, name);
     if (lua_isnil(L, -1) || lua_isnumber(L, -1))


### PR DESCRIPTION
The min/max arguments to the integer range checking functions are integer. We
call these with UINT32_MAX in two places and this value (notice the "U" for
"unsigned") does not fit into a signed integer. Hence, there is an integer
overflow at compile time and the maximum value that is actually checked for is
-1.

Fix this by using lua_Number (double) instead of int.

Fixes: https://github.com/awesomeWM/awesome/issues/840
Signed-off-by: Uli Schlachter <psychon@znc.in>