### PR TITLE
awful.placement.no_overlap: use screen.workarea as fallback

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -555,8 +555,13 @@ function placement.no_overlap(c)
     end
 
     -- We did not find an area with enough space for our size:
-    -- just take the biggest available one and go in
+    -- just take the biggest available one and go in.
+    -- This makes sure to have the whole screen's area in case it has been
+    -- removed.
     if not found then
+        if #areas == 0 then
+            areas = { screen.workarea }
+        end
         for _, r in ipairs(areas) do
             if r.width * r.height > new.width * new.height then
                 new = r


### PR DESCRIPTION
When there is a maximized and floating client,
`awful.placement.no_overlap` would end up with an empty list of areas to
place the client into.

This patch fixes it to use the default `screen.workarea` in that case.

Closes https://github.com/awesomeWM/awesome/issues/813.