### PR TITLE
Fix leak test

### DIFF
--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -8,10 +8,9 @@
 ---------------------------------------------------------------------------
 
 local setmetatable = setmetatable
-local capi = { screen = screen }
+local capi = { screen = screen, tag = tag }
 local layout = require("awful.layout")
 local tooltip = require("awful.tooltip")
-local tag = require("awful.tag")
 local beautiful = require("beautiful")
 local imagebox = require("wibox.widget.imagebox")
 
@@ -47,9 +46,9 @@ function layoutbox.new(screen)
 
     -- Do we already have the update callbacks registered?
     if boxes == nil then
-        boxes = setmetatable({}, { __mode = "v" })
-        tag.attached_connect_signal(nil, "property::selected", update_from_tag)
-        tag.attached_connect_signal(nil, "property::layout", update_from_tag)
+        boxes = setmetatable({}, { __mode = "kv" })
+        capi.tag.connect_signal("property::selected", update_from_tag)
+        capi.tag.connect_signal("property::layout", update_from_tag)
         layoutbox.boxes = boxes
     end
 
@@ -64,6 +63,13 @@ function layoutbox.new(screen)
     end
 
     return w
+end
+
+-- Clear the box (for memory leak tests)
+function layoutbox.clear()
+    boxes = nil
+    capi.tag.disconnect_signal("property::selected", update_from_tag)
+    capi.tag.disconnect_signal("property::layout", update_from_tag)
 end
 
 function layoutbox.mt:__call(...)

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -31,7 +31,6 @@ local function collectable(a, b, c, d, e, f, g, h, last)
     end
     collectgarbage("collect")
     collectgarbage("collect")
-    collectgarbage("collect")
     -- Check if the table is now empty
     for _, v in pairs(objs) do
         print("Some object was not garbage collected!")
@@ -63,6 +62,12 @@ collectable(wibox.layout.align.horizontal())
 collectable(awful.widget.launcher({ image = cairo.ImageSurface(cairo.Format.ARGB32, 20, 20), command = "bash" }))
 collectable(awful.widget.prompt())
 collectable(awful.widget.textclock())
+
+-- Test the layout box. As its widgets are a singleton (per screen), clear them
+-- first.
+awful.widget.layoutbox.clear()
+collectgarbage("collect")
+collectgarbage("collect")
 collectable(awful.widget.layoutbox(1))
 
 -- Some widgets do things via timer.delayed_call


### PR DESCRIPTION
So, I did some tests locally and could reproduce the issue. It is not just luajit, the normal lua also eventually hit the bug that has been causing build issues for some weeks.

Apparently, it was just a question of time. if you rename the test `test-aaaaaaa-leaks.lua`, it will **never** hit the problem, but if it is being run later, it gets more and more common (~15% for luajit, ~3% for normal lua).

The problem is simply that the widget is a singleton and is for some reasons kept (it __is__ leaking). There was also a new leak when screen are removed. Finally, this was yet another useless `attached_connect_signal`.

So, this is it. I think (after 100 test run) that this is fixed once and for all.

Edit: The clear method is left undocumented on purpose, it has no value beyond the tests as the "kv" mode should now handle the only relevant use case (removing screens).