### PR TITLE
Fix wallpaper setting after RandR monitor changes

### DIFF
--- a/lib/gears/wallpaper.lua.in
+++ b/lib/gears/wallpaper.lua.in
@@ -40,6 +40,14 @@ local function prepare_wallpaper(s)
         -- No wallpaper yet, create an image surface for just the part we need
         img = cairo.ImageSurface(cairo.Format.RGB24, geom.width, geom.height)
         img:set_device_offset(-geom.x, -geom.y)
+    else
+        -- Some wallpaper yet, copy it to a new surface
+        local new_img = img:create_similar(cairo.Content.COLOR, root_geom.width, root_geom.height)
+        local cr = cairo.Context(new_img)
+        cr.operator = cairo.Operator.SOURCE
+        cr:set_source_surface(img, 0, 0)
+        cr:paint()
+        img = new_img
     end
 
     local cr = cairo.Context(img)


### PR DESCRIPTION
[Please note: This pull request targets the 3.5 branch, not master!]

A co-worker of mine has a laptop with a small display and two larger displays.
When enabling the larger displays (and disabling the built-in display), the
wallpaper was set incorrectly. Only the size of the old, smaller screen actually
contained the wallpaper and the left was black.

The reason for this is that the code directly draws the new wallpaper to the
pixmap containing the old wallpaper. However, because the old display was
smaller, this pixmap isn't as large as the screen and so couldn't contain all of
the new wallpaper.

Fix this by explicitly creating a surface of the needed size and copying the old
wallpaper into it (because we might be setting only the wallpaper of some
screen, not all of them).

Special-thanks-to: vsp
Signed-off-by: Uli Schlachter <psychon@znc.in>