### PR TITLE
Fix awful.screen.getbycoord when no screens exist

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -86,7 +86,7 @@ end
 -- @param x The x coordinate
 -- @param y The y coordinate
 function screen.getbycoord(x, y)
-    local s = capi.screen[1]
+    local s = capi.screen.primary
     local dist = screen.object.get_square_distance(s, x, y)
     for i in capi.screen do
         local d = screen.object.get_square_distance(i, x, y)

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -35,7 +35,7 @@ local function screen_getbycoord(x, y)
             return capi.screen[i]
         end
     end
-    return capi.screen[1]
+    return capi.screen.primary
 end
 
 -- Get the widget context. This should always return the same table (if


### PR DESCRIPTION
When there are no screens, screen[1] causes an error. Thus, this isn't a safe
fallback for these functions. Instead, this commit makes the code prefer the
primary screen, if possible. If no screen exists, then screen.primary will be
nil, but at least it won't throw an error like screen[1] does.

(This also changes the outdated copy of getbycoord that exists in
wibox.drawable)

Signed-off-by: Uli Schlachter <psychon@znc.in>