### PR TITLE
Wallpaper function

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -168,7 +168,12 @@ mytasklist.buttons = awful.util.table.join(
 awful.screen.connect_for_each_screen(function(s)
     -- Wallpaper
     if beautiful.wallpaper then
-        gears.wallpaper.maximized(beautiful.wallpaper, s, true)
+        local wallpaper = beautiful.wallpaper
+        -- If wallpaper is a function, call it with the screen
+        if type(wallpaper) == "function" then
+            wallpaper = wallpaper(s)
+        end
+        gears.wallpaper.maximized(wallpaper, s, true)
     end
 
     -- Each screen has its own tag table.

--- a/themes/xresources/assets.lua
+++ b/themes/xresources/assets.lua
@@ -47,9 +47,10 @@ function theme_assets.taglist_squares_unsel(size, fg)
 end
 
 
-function theme_assets.wallpaper(bg, fg, alt_fg)
-    local height = screen[1].workarea.height
-    local width = screen[1].workarea.width
+function theme_assets.wallpaper(bg, fg, alt_fg, s)
+    s = s or screen.primary
+    local height = s.workarea.height
+    local width = s.workarea.width
     local img = cairo.ImageSurface(cairo.Format.ARGB32, width, height)
     local cr = cairo.Context(img)
 

--- a/themes/xresources/assets.lua
+++ b/themes/xresources/assets.lua
@@ -51,7 +51,8 @@ function theme_assets.wallpaper(bg, fg, alt_fg, s)
     s = s or screen.primary
     local height = s.workarea.height
     local width = s.workarea.width
-    local img = cairo.ImageSurface(cairo.Format.ARGB32, width, height)
+    local img = cairo.RecordingSurface(cairo.Content.COLOR,
+        cairo.Rectangle { x = 0, y = 0, width = width, height = height })
     local cr = cairo.Context(img)
 
     local letter_size = height/10

--- a/themes/xresources/theme.lua
+++ b/themes/xresources/theme.lua
@@ -91,9 +91,9 @@ local wallpaper_alt_fg = xrdb.color12
 if not is_dark_bg then
     wallpaper_bg, wallpaper_fg = wallpaper_fg, wallpaper_bg
 end
-theme.wallpaper = theme_assets.wallpaper(
-    wallpaper_bg, wallpaper_fg, wallpaper_alt_fg
-)
+theme.wallpaper = function(s)
+    return theme_assets.wallpaper(wallpaper_bg, wallpaper_fg, wallpaper_alt_fg, s)
+end
 
 return theme
 


### PR DESCRIPTION
This changes the default config so that `beautiful.wallpaper` can be a function that gets the screen as its argument (so that it can e.g. choose a different wallpaper for VGA1 and LVDS1 or so that a wallpaper with the correct resolution is used).

The following commit changes the xresources theme to make use of that and create a wallpaper only when needed (no permanent references to the wallpaper) and to use a RecordingSurface instead of an ImageSurface.

CC @actionless 