### PR TITLE
menubar.utils.parse_dir: Ask Gio for file type

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -254,7 +254,8 @@ function utils.parse_dir(dir_path, callback)
     local function parser(dir, programs)
         local f = gio.File.new_for_path(dir)
         -- Except for "NONE" there is also NOFOLLOW_SYMLINKS
-        local enum, err = f:async_enumerate_children("standard::name", gio.FileQueryInfoFlags.NONE)
+        local query = gio.FILE_ATTRIBUTE_STANDARD_NAME .. "," .. gio.FILE_ATTRIBUTE_STANDARD_TYPE
+        local enum, err = f:async_enumerate_children(query, gio.FileQueryInfoFlags.NONE)
         if not enum then
             debug.print_error(err)
             return


### PR DESCRIPTION
When not including standard::type in the query for children of a file then Gio
may not look up this information. This might work on some file systems (e.g.
ext4), but other (apparently XFS) do not provide the needed file type
information (see man readdir on the d_type field). The result was that the
menubar contained no entries because no .desktop files were identified as
regular files and thus read.

Fix this by including standard::type in the queries.

Also, this commit makes the code use some pre-defined string constants from Gio
to make "double sure" that typos are caught.

Thanks to @Jajauma for doing the hard part on debugging this.

Fixes: https://github.com/awesomeWM/awesome/issues/863
Signed-off-by: Uli Schlachter <psychon@znc.in>