### PR TITLE
Travis: use new GH_APIDOC_TOKEN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     # Lua 5.3 isn't available in Ubuntu Trusty, so some magic below installs it.
     - LUA=5.3 LUANAME=lua5.3 LUALIBRARY=/usr/lib/liblua.so
   global:
-    # Secure token to push to gh-pages.
-    - secure: "LZxt9559+V3qJMdVgmKW4RYTt8ZINooex/qsnoEJUtZloj/eFNG4COT2z6a2yeH2tKWzknCsmV9nLPJiNEA2KLcyqDhjFQvJwKmsBuhGUmLyeQgfenjweorRjO8NT18X1SAEUXAMnClPu+OeTDs4BAuVn5foGZ7xpcRg2E+j2mc="
+    # Secure GH_APIDOC_TOKEN to push to awesomeWM/apidoc.
+    - secure: "R/HYDclnws1I1+v9Yjt+RKa4CsFhbBT9tiwE3EfPhEj2KCYX4sFRMxuZvLf5sq0XWdrQaPhQ54fgAZGr3f054JKRXcTB0g9J6nhSHz9kIjPh446gafUhEeDQcZRwM/MeCWiwFIkiZm6smYoDFE9JTWu6quNV+lQ4kcVDOp2ibEc="
 
 before_install:
   - if [ -z $LUAINCLUDE ]; then LUAINCLUDE=/usr/include/${LUANAME}; fi

--- a/build-utils/travis-apidoc.sh
+++ b/build-utils/travis-apidoc.sh
@@ -12,18 +12,16 @@ echo "Post-processing (API) documentation."
 echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
 
-# GH_TOKEN won't be available for PRs from forks.
-# (http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests).
-if [ -z "$GH_TOKEN" ]; then
-  echo "No GH_TOKEN available. Skipping."
+if [ -z "$GH_APIDOC_TOKEN" ]; then
+  echo "No GH_APIDOC_TOKEN available. Skipping."
   exit
 fi
 
-# NOTE: DO NOT USE "set -x", or anything else that would reveal GH_TOKEN!
+# NOTE: DO NOT USE "set -x", or anything else that would reveal GH_APIDOC_TOKEN!
 set -e
 set +x
 
-REPO_APIDOC="https://${GH_TOKEN}@github.com/awesomeWM/apidoc"
+REPO_APIDOC="https://${GH_APIDOC_TOKEN}@github.com/awesomeWM/apidoc"
 REPO_DIR="$PWD"
 
 # Export these to not add "git config" calls to the long command.
@@ -113,7 +111,7 @@ echo "Compare links:\n$COMPARE_LINKS"
 
 # Post a comment to the PR.
 if [ "$TRAVIS_PULL_REQUEST" != false ]; then
-  curl -H "Authorization: token $GH_TOKEN" \
+  curl -H "Authorization: token $GH_APIDOC_TOKEN" \
     -d "{\"body\": \"Documentation has been updated for this PR:\n$COMPARE_LINKS\"}" \
     "https://api.github.com/repos/awesomeWM/awesome/issues/${TRAVIS_PULL_REQUEST}/comments"
 fi

--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -19,7 +19,7 @@ After building is finished, you can either install via `make install`:
 or by auto-generating a .deb or .rpm package, for easy removal later on:
 
     make package
-    
+
     sudo dpkg -i awesome-x.y.z.deb
     # or
     sudo rpm -Uvh awesome-x.y.z.rpm


### PR DESCRIPTION
While still being used via Travis' `secure` env mechanism, we could
additionally set it through an env for the repo (not displayed by
default), and revoke/regenerate it when it gets revealed.
The token provides access only to the `apidoc` repo.