### PR TITLE
Use an uneven screen width/height (1921x1079) in one Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ env:
     - LUA=5.1 LUANAME=lua5.1
     # luajit: installed from source.
     - LUA=5.1 LUANAME=luajit-2.0 LUALIBRARY=/usr/lib/libluajit-5.1.so LUAROCKS_ARGS=--lua-suffix=jit-2.0.4
-    - LUA=5.2 LUANAME=lua5.2 LGIVER=0.7.1
+    # Lua 5.2 with older lgi and screen size not divisible by 2.
+    - LUA=5.2 LUANAME=lua5.2 LGIVER=0.7.1 TESTS_SCREEN_SIZE=1921x1079
     # Lua 5.3 isn't available in Ubuntu Trusty, so some magic below installs it.
     - LUA=5.3 LUANAME=lua5.3 LUALIBRARY=/usr/lib/liblua.so
   global:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -48,7 +48,7 @@ AWESOME=$root_dir/build/awesome
 RC_FILE=$root_dir/build/awesomerc.lua
 AWESOME_CLIENT="$root_dir/utils/awesome-client"
 D=:5
-SIZE=1024x768
+SIZE="${TESTS_SCREEN_SIZE:-1024x768}"
 
 if [ $HEADLESS = 1 ]; then
     "$XVFB" $D -noreset -screen 0 ${SIZE}x24 &


### PR DESCRIPTION
This is meant to trigger issues that would need `math.ceil()` fixes etc.

Ref: https://github.com/awesomeWM/awesome/issues/848#issuecomment-216068831