### PR TITLE
doc: fix usage of "mouse.move" as a string

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -246,8 +246,8 @@ capi.client.connect_signal("list", function()
                                    end
                                end)
 
---- Default handler for tiled clients request::geometry with the `mouse.move`
--- context.
+--- Default handler for `request::geometry` signals for tiled clients with
+-- the "mouse.move" context.
 -- @tparam client c The client
 -- @tparam string context The context
 -- @tparam table hints Additional hints

--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -222,7 +222,7 @@ function mouse.client.resize(c, corner, args)
     return corner
 end
 
---- Default handler for `request::geometry` signals with `mouse.resize` context.
+--- Default handler for `request::geometry` signals with "mouse.resize" context.
 -- @signalhandler awful.mouse.resize_handler
 -- @tparam client c The client
 -- @tparam string context The context


### PR DESCRIPTION
Ref: https://github.com/awesomeWM/awesome/issues/834#issuecomment-216141389.