### PR TITLE
tests: fail if $AWESOME does not exist / is not executable

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -45,6 +45,10 @@ export TEST_PAUSE_ON_ERRORS  # Used in tests/_runner.lua.
 XEPHYR=Xephyr
 XVFB=Xvfb
 AWESOME=$root_dir/build/awesome
+if ! [ -x "$AWESOME" ]; then
+    echo "$AWESOME is not executable." >&2
+    exit 1
+fi
 RC_FILE=$root_dir/build/awesomerc.lua
 AWESOME_CLIENT="$root_dir/utils/awesome-client"
 D=:5


### PR DESCRIPTION
Without this the stdout/stderr rediraction when launching it makes the
error regarding the "program not found" disappear(?!).

[ci skip]