### PR TITLE
Awful.widget.button buttons are not released when the mouse leave the widget

### DIFF
--- a/lib/awful/widget/button.lua
+++ b/lib/awful/widget/button.lua
@@ -39,6 +39,9 @@ function button.new(args)
     end
     w:set_image(args.image)
     w:buttons(abutton({}, 1, function () orig_set_image(w, img_press) end, function () orig_set_image(w, img_release) end))
+
+    w:connect_signal("mouse::leave", function(self) orig_set_image(self, img_release) end)
+
     return w
 end
 

--- a/tests/test-awful-widget-button.lua
+++ b/tests/test-awful-widget-button.lua
@@ -1,0 +1,119 @@
+local runner    = require( "_runner"   )
+local wibox     = require( "wibox"     )
+local awful     = require( "awful"     )
+local beautiful = require( "beautiful" )
+
+local steps = {}
+
+local w
+local img
+local button
+
+-- create a wibox.
+table.insert(steps, function()
+
+    w = wibox {
+        ontop   = true,
+        width   = 250,
+        height  = 250,
+        visible = true,
+    }
+
+    button = awful.widget.button {
+        image = beautiful.awesome_icon
+    }
+
+    w : setup {
+        {
+            {
+                text   = "foo",
+                widget = wibox.widget.textbox,
+            },
+            bg     = "#ff0000",
+            widget = wibox.widget.background
+        },
+        {
+            {
+                widget = button,
+            },
+            bg     = "#ff00ff",
+            widget = wibox.widget.background
+        },
+        {
+            {
+                text   = "foo",
+                widget = wibox.widget.textbox,
+            },
+            bg     = "#0000ff",
+            widget = wibox.widget.background
+        },
+        layout = wibox.layout.flex.vertical
+    }
+
+    awful.placement.centered(w)
+
+    img = button._image
+    assert(img)
+
+    return true
+end)
+
+-- Test a button press
+table.insert(steps, function()
+    awful.placement.centered(mouse)
+
+    root.fake_input("button_press", 1)
+
+    return true
+end)
+
+table.insert(steps, function()
+    assert(button._image ~= img)
+
+    return true
+end)
+
+-- Test a button release
+table.insert(steps, function()
+    root.fake_input("button_release", 1)
+
+    assert(button._image ~= img)
+
+    return true
+end)
+
+-- Test a button press/release outside of the widget
+table.insert(steps, function()
+    assert(button._image == img)
+
+    root.fake_input("button_press", 1)
+
+    return true
+end)
+
+table.insert(steps, function()
+    assert(button._image ~= img)
+
+    return true
+end)
+
+table.insert(steps, function()
+    -- just make sure the button is not released for nothing
+    assert(button._image ~= img)
+
+    -- test if the button is released when the mouse move out
+    awful.placement.right(mouse--[[, {parent = w}]])
+    root.fake_input("button_release", 1)
+
+    return true
+end)
+
+table.insert(steps, function()
+    assert(button._image == img)
+
+    return true
+end)
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This is in turn an issue with `awful.button`. Here is a test that trigger the problem