### PR TITLE
Cache a screen's workarea

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -1543,14 +1543,6 @@ client_resize(client_t *c, area_t geometry, bool honor_hints)
     return false;
 }
 
-static void
-client_emit_property_workarea_on_screen(lua_State *L, client_t *c)
-{
-    luaA_object_push(L, c->screen);
-    luaA_object_emit_signal(L, -1, "property::workarea", 0);
-    lua_pop(L, 1);
-}
-
 /** Set a client minimized, or not.
  * \param L The Lua VM state.
  * \param cidx The client index.
@@ -1610,7 +1602,7 @@ client_set_minimized(lua_State *L, int cidx, bool s)
             xcb_map_window(globalconf.connection, c->window);
         }
         if(strut_has_value(&c->strut))
-            client_emit_property_workarea_on_screen(L, c);
+            screen_update_workarea(c->screen);
         luaA_object_emit_signal(L, cidx, "property::minimized", 0);
     }
 }
@@ -1630,7 +1622,7 @@ client_set_hidden(lua_State *L, int cidx, bool s)
         c->hidden = s;
         banning_need_update();
         if(strut_has_value(&c->strut))
-            client_emit_property_workarea_on_screen(L, c);
+            screen_update_workarea(c->screen);
         luaA_object_emit_signal(L, cidx, "property::hidden", 0);
     }
 }
@@ -1922,7 +1914,7 @@ client_unmanage(client_t *c, bool window_valid)
     luaA_class_emit_signal(L, &client_class, "list", 0);
 
     if(strut_has_value(&c->strut))
-        client_emit_property_workarea_on_screen(L, c);
+        screen_update_workarea(c->screen);
 
     /* Get rid of all titlebars */
     for (client_titlebar_t bar = CLIENT_TITLEBAR_TOP; bar < CLIENT_TITLEBAR_COUNT; bar++) {

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -323,9 +323,8 @@ drawin_set_visible(lua_State *L, int udx, bool v)
         luaA_object_emit_signal(L, udx, "property::visible", 0);
         if(strut_has_value(&drawin->strut))
         {
-            luaA_object_push(L, screen_getbycoord(drawin->geometry.x, drawin->geometry.y));
-            luaA_object_emit_signal(L, -1, "property::workarea", 0);
-            lua_pop(L, 1);
+            screen_update_workarea(
+                    screen_getbycoord(drawin->geometry.x, drawin->geometry.y));
         }
     }
 }

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -37,6 +37,8 @@ struct a_screen
     bool valid;
     /** Screen geometry */
     area_t geometry;
+    /** Screen workarea */
+    area_t workarea;
     /** The screen outputs informations */
     screen_output_array_t outputs;
     /** Some XID identifying this screen */
@@ -52,6 +54,7 @@ int screen_get_index(screen_t *);
 area_t display_area_get(void);
 void screen_client_moveto(client_t *, screen_t *, bool);
 void screen_update_primary(void);
+void screen_update_workarea(screen_t *);
 screen_t *screen_get_primary(void);
 
 screen_t *luaA_checkscreen(lua_State *, int);

--- a/objects/window.c
+++ b/objects/window.c
@@ -31,6 +31,7 @@
 #include "common/atoms.h"
 #include "common/xutil.h"
 #include "ewmh.h"
+#include "objects/screen.h"
 #include "property.h"
 #include "xwindow.h"
 
@@ -83,14 +84,9 @@ luaA_window_struts(lua_State *L)
         luaA_tostrut(L, 2, &window->strut);
         ewmh_update_strut(window->window, &window->strut);
         luaA_object_emit_signal(L, 1, "property::struts", 0);
-        /* FIXME: Only emit if the workarea actually changed
-         * (= window is visible, only on the right screen)? */
+        /* We don't know the correct screen, update them all */
         foreach(s, globalconf.screens)
-        {
-            luaA_object_push(L, *s);
-            luaA_object_emit_signal(L, -1, "property::workarea", 0);
-            lua_pop(L, 1);
-        }
+            screen_update_workarea(*s);
     }
 
     return luaA_pushstrut(L, window->strut);


### PR DESCRIPTION
Instead of computing the workarea whenever some Lua code asks for it, it is now
remembered explicitly as a property on a screen. This allows us to only emit
property::workarea if the workarea actually changed.

Fixes: https://github.com/awesomeWM/awesome/issues/756
Signed-off-by: Uli Schlachter <psychon@znc.in>