### PR TITLE
tests/run.sh: Set up some useful env vars

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,6 +54,12 @@ AWESOME_CLIENT="$root_dir/utils/awesome-client"
 D=:5
 SIZE=1024x768
 
+# Set up some env vars
+# Disable GDK's screen scaling support
+export GDK_SCALE=1
+# No idea what this does, but it silences a warning that GTK init might print
+export NO_AT_BRIDGE=1
+
 if [ $HEADLESS = 1 ]; then
     "$XVFB" $D -noreset -screen 0 ${SIZE}x24 &
     xserver_pid=$!


### PR DESCRIPTION
GDK_SCALE=1 is needed to overwrite other settings that people might have which
would make geometry-related tests fail.

NO_AT_BRIDGE=1 gets rid of the following message that I am seeing:

** (lua:8321): WARNING **: Error retrieving accessibility bus address:
org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not
provided by any .service files

Signed-off-by: Uli Schlachter <psychon@znc.in>