### PR TITLE
Grab buttons on the child window

### DIFF
--- a/event.c
+++ b/event.c
@@ -223,7 +223,7 @@ event_handle_button(xcb_button_press_event_t *ev)
                              XCB_ALLOW_ASYNC_POINTER,
                              XCB_CURRENT_TIME);
     }
-    else if((c = client_getbyframewin(ev->event)))
+    else if((c = client_getbywin(ev->event)))
     {
         luaA_object_push(L, c);
         /* And handle the button raw button event */

--- a/objects/window.c
+++ b/objects/window.c
@@ -63,7 +63,7 @@ luaA_window_buttons(lua_State *L)
     {
         luaA_button_array_set(L, 1, 2, &window->buttons);
         luaA_object_emit_signal(L, 1, "property::buttons", 0);
-        xwindow_buttons_grab(window_get(window), &window->buttons);
+        xwindow_buttons_grab(window->window, &window->buttons);
     }
 
     return luaA_button_array_get(L, 1, &window->buttons);


### PR DESCRIPTION
Since commit 102063dbbd, awesome is a reparenting WM. That means that we put our
own frame windows around child windows. This means that we have the option of
grabbing input events on the frame window or the child window. This commit chose
the frame window for this.

For keyboard events, this decision was already reverted in 532ec0cd90. This
commit does the same thing for mouse events.

This fixes the spurious leave/enter events that were visible on mouse clicks.
They occurred because the click activated a passive grab (all mouse events now
"belonged" to awesome). This passive grab caused the X server to inform clients
that they "lost" the mouse pointer (with the detail field set to "a grab
activated").

Fixes: https://github.com/awesomeWM/awesome/issues/427
Signed-off-by: Uli Schlachter <psychon@znc.in>