### PR TITLE
More travis variance: Try an out-of-tree build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   matrix:
     - LUA=5.2 LUANAME=lua5.2 BUILD_APIDOC=true DO_COVERAGE=true
     # Note: luarocks does not work with Lua 5.0.
-    - LUA=5.1 LUANAME=lua5.1
+    - LUA=5.1 LUANAME=lua5.1 BUILD_IN_DIR=/tmp/awesome-build
     # luajit: installed from source.
     - LUA=5.1 LUANAME=luajit-2.0 LUALIBRARY=/usr/lib/libluajit-5.1.so LUAROCKS_ARGS=--lua-suffix=jit-2.0.4
     - LUA=5.2 LUANAME=lua5.2 LGIVER=0.7.1
@@ -91,6 +91,13 @@ install:
 
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION"
+  - |
+    if [ -n "$BUILD_IN_DIR" ]; then
+        SOURCE_DIRECTORY="$PWD"
+        mkdir "$BUILD_IN_DIR"
+        cd "$BUILD_IN_DIR"
+        cmake $CMAKE_ARGS "$SOURCE_DIRECTORY"
+    fi
   - make && sudo env PATH=$PATH make install && awesome --version && make check
   - |
     if [ "$DO_COVERAGE" = "true" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,7 @@ endif()
 # {{{ Tests
 set(CHECK_TARGETS check-integration)
 add_custom_target(check-integration
-    "${CMAKE_SOURCE_DIR}/tests/run.sh"
+    sh -c "CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${CMAKE_SOURCE_DIR}/tests/run.sh"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
     VERBATIM)


### PR DESCRIPTION
This PR makes the Lua 5.1 build on Travis build inside of `/tmp` and use `cmake` directly instead of using our wrapper Makefile which builds inside of `build/` in the source directory. Apparently enough people use this kind of build that we should test it. (Otherwise, we should just declare this as unsupported...)

Achieving this goal only required changes to `tests/run.sh`, because it needs to know both the source directory and the build directory.