### PR TITLE
Fix screen.fake_add()

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1042,9 +1042,9 @@ luaA_screen_fake_add(lua_State *L)
     s->geometry.y = y;
     s->geometry.width = width;
     s->geometry.height = height;
-    s->valid = true;
+
+    screen_added(L, s);
     luaA_object_push(L, s);
-    luaA_object_emit_signal(L, -1, "added", 0);
 
     return 1;
 }


### PR DESCRIPTION
Commit 8a6787bd54 added screen.fake_add(). Commit 08845c7a4b made us cache a
screen's workarea in the struct screen_t. This new member needs to be
initialized to the screen's geometry when a new screen is added. Since both
these commits were developed concurrently, the workarea was not initialized in
screen.fake_add().

Fix this by calling in fake_add() the helper function added in 08845c7a4b.

Signed-off-by: Uli Schlachter <psychon@znc.in>