### PR TITLE
gears.surface: add a traceback for "Failed to load" errors

### DIFF
--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -92,7 +92,8 @@ local function do_load_and_handle_errors(_surface, func)
     if result then
         return result
     end
-    gdebug.print_error("Failed to load '" .. tostring(_surface) .. "': " .. tostring(err))
+    gdebug.print_error(debug.traceback(
+        "Failed to load '" .. tostring(_surface) .. "': " .. tostring(err)))
     return get_default()
 end
 


### PR DESCRIPTION
This is useful to see where the error is coming from.

But maybe we should have a traceback with `gears.debug.print_error` in general?
