### PR TITLE
[RFC] naughty: display improvement of the notification client actions

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -543,7 +543,7 @@ function naughty.notify(args)
             actionmarginbox:set_widget(actiontextbox)
             actiontextbox:set_valign("middle")
             actiontextbox:set_font(font)
-            actiontextbox:set_markup(string.format('<b>%s</b>', action))
+            actiontextbox:set_markup(string.format('☛ <u>%s</u>', action))
             -- calculate the height and width
             local w, h = actiontextbox:get_preferred_size(s)
             local action_height = h + 2 * margin

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -137,24 +137,20 @@ capi.dbus.connect_signal("org.freedesktop.Notifications", function (data, appnam
         if actions then
             args.actions = {}
 
-            local actionid
-            -- create actions callbacks
-            for i , v in ipairs(actions) do
-                if i % 2 == 1 then
-                    actionid = v
-                elseif actionid == "default" then
+            for i = 1,#actions,2 do
+                local action_id = actions[i]
+                local action_text = actions[i + 1]
+
+                if action_id == "default" then
                     args.run = function()
                         sendActionInvoked(notification.id, "default")
                         naughty.destroy(notification, naughty.notificationClosedReason.dismissedByUser)
                     end
-                    actionid = nil
-                elseif actionid ~= nil then
-                    local action = actionid
-                    args.actions[actionid] = function()
-                        sendActionInvoked(notification.id, action)
+                elseif action_id ~= nil and action_text ~= nil then
+                    args.actions[action_text] = function()
+                        sendActionInvoked(notification.id, action_id)
                         naughty.destroy(notification, naughty.notificationClosedReason.dismissedByUser)
                     end
-                    actionid = nil
                 end
             end
         end


### PR DESCRIPTION
As the commit messages have got an ample background introduction let's put the long story short: a notification popup looks like this ATM:
![action-id](https://cloud.githubusercontent.com/assets/11892063/15214119/4fc92f06-185c-11e6-9650-4dae6b74e8c6.png)
while it could look like that:
![action-text](https://cloud.githubusercontent.com/assets/11892063/15214125/5a82f684-185c-11e6-9882-323540229215.png)
Note the bottom line of a text which renders a stack of available actions along with the notification being sent by the notification client (over DBus and directly using the naughty API). The former picture has some action identifier (`disable-connected-notifications`) exposed directly to the user, while the latter one has the action ID replaced with a localized formal text passed by the notification client which clearly states that the user can opt out of any notifications regarding that kind of event. The action markup has been changed as well to emphasize the fact that the bottom area is clickable (hence the unicode hand and the styled link).

I guess this slight modification is going to be seen controversial since 
- ~~it introduces some naughty API breakage (the layout of the `actions` parameter of `naughty.notify` was altered to pass the description)~~
- someone might not like the new action markup.

I am ready to fix my work as you consider appropriate if it worths.