### PR TITLE
Fix mouse clicks on titlebars

### DIFF
--- a/objects/window.c
+++ b/objects/window.c
@@ -64,6 +64,7 @@ luaA_window_buttons(lua_State *L)
     {
         luaA_button_array_set(L, 1, 2, &window->buttons);
         luaA_object_emit_signal(L, 1, "property::buttons", 0);
+        xwindow_buttons_grab(window_get(window), &window->buttons);
         xwindow_buttons_grab(window->window, &window->buttons);
     }
 


### PR DESCRIPTION
Commit 7dad0b3b876af3c7 made awesome only ask for mouse events on the actual
client window. Obviously, this means that we no longer get reports for clicks on
the titlebar. Whoops.

Fix this by asking for mouse events on *both* the actual client window and the
frame window. The passive grab on the actual client window is actually unneeded,
but we keep it so that the fix that was done by the above commit is still
present (xev will no longer report leave/enter events just for a mouse click).

Since we now get mouse events inside of a client reported twice, the event
handling code in event.c has to be fixed to handle both cases. E.g. x/y are
relative to the top-left corner of the window and thus needs to be fixed for
titlebar size; the second click has to be ignored.

Signed-off-by: Uli Schlachter <psychon@znc.in>