### PR TITLE
Fix fallback for the window type

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -574,6 +574,7 @@ ewmh_client_check_hints(client_t *c)
     reply = xcb_get_property_reply(globalconf.connection, c2, NULL);
     if(reply && (data = xcb_get_property_value(reply)))
     {
+        c->has_NET_WM_WINDOW_TYPE = true;
         state = (xcb_atom_t *) data;
         for(int i = 0; i < xcb_get_property_value_length(reply) / ssizeof(xcb_atom_t); i++)
             if(state[i] == _NET_WM_WINDOW_TYPE_DESKTOP)
@@ -590,7 +591,8 @@ ewmh_client_check_hints(client_t *c)
                 c->type = MAX(c->type, WINDOW_TYPE_TOOLBAR);
             else if(state[i] == _NET_WM_WINDOW_TYPE_UTILITY)
                 c->type = MAX(c->type, WINDOW_TYPE_UTILITY);
-    }
+    } else
+        c->has_NET_WM_WINDOW_TYPE = false;
 
     p_delete(&reply);
 }

--- a/objects/client.h
+++ b/objects/client.h
@@ -97,6 +97,8 @@ struct client_t
      * from Lua. */
     bool focusable;
     bool focusable_set;
+    /** True if the client window has a _NET_WM_WINDOW_TYPE proeprty */
+    bool has_NET_WM_WINDOW_TYPE;
     /** Window of the group leader */
     xcb_window_t group_window;
     /** Window holding command needed to start it (session management related) */

--- a/property.c
+++ b/property.c
@@ -114,7 +114,8 @@ property_update_wm_transient_for(client_t *c, xcb_get_property_cookie_t cookie)
     c->transient_for_window = trans;
 
     luaA_object_push(L, c);
-    client_set_type(L, -1, WINDOW_TYPE_DIALOG);
+    if (!c->has_NET_WM_WINDOW_TYPE)
+        client_set_type(L, -1, trans == XCB_NONE ? WINDOW_TYPE_NORMAL : WINDOW_TYPE_DIALOG);
     client_set_above(L, -1, false);
     lua_pop(L, 1);
 


### PR DESCRIPTION
EWMH specifies that

   If _NET_WM_WINDOW_TYPE is not set, then managed windows with WM_TRANSIENT_FOR
   set MUST be taken as [_NET_WM_WINDOW_TYPE_DIALOG].

We implement this by forcing a window's type to be "dialog" when it has a
WM_TRANSIENT_FOR property. For windows that have a _NET_WM_WINDOW_TYPE property,
this type change is then later undone. However, when a window changes its
WM_TRANSIENT_FOR property during runtime, then we would set its type to "dialog"
unconditionally.

This commit fixes this by explicitly tracking if we found a _NET_WM_WINDOW_TYPE
property on the window and only applying the fallback if we did not find such a
property.

Fixes-one-of-the-sub-issues-from: https://github.com/awesomeWM/awesome/issues/889
Signed-off-by: Uli Schlachter <psychon@znc.in>