### PR TITLE
Attempt at more correct handling of NET_CURRENT_DESKTOP property.

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -228,6 +228,12 @@ ewmh_init(void)
     luaA_class_connect_signal(L, &client_class, "property::titlebar_left" , ewmh_client_update_frame_extents);
     luaA_class_connect_signal(L, &client_class, "property::border_width" , ewmh_client_update_frame_extents);
     luaA_class_connect_signal(L, &client_class, "manage", ewmh_client_update_frame_extents);
+    /* NET_CURRENT_DESKTOP handling */
+    luaA_class_connect_signal(L, &client_class, "focus", ewmh_update_net_current_desktop);
+    luaA_class_connect_signal(L, &client_class, "unfocus", ewmh_update_net_current_desktop);
+    luaA_class_connect_signal(L, &client_class, "tagged", ewmh_update_net_current_desktop);
+    luaA_class_connect_signal(L, &client_class, "untagged", ewmh_update_net_current_desktop);
+    luaA_class_connect_signal(L, &tag_class, "property::selected", ewmh_update_net_current_desktop);
 }
 
 /** Set the client list in stacking order, bottom to top.
@@ -256,14 +262,15 @@ ewmh_update_net_numbers_of_desktop(void)
 			_NET_NUMBER_OF_DESKTOPS, XCB_ATOM_CARDINAL, 32, 1, &count);
 }
 
-void
-ewmh_update_net_current_desktop(void)
+int
+ewmh_update_net_current_desktop(lua_State *L)
 {
-    uint32_t idx = tags_get_first_selected_index();
+    uint32_t idx = tags_get_current_or_first_selected_index();
 
     xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
                         globalconf.screen->root,
                         _NET_CURRENT_DESKTOP, XCB_ATOM_CARDINAL, 32, 1, &idx);
+    return 0;
 }
 
 void

--- a/ewmh.h
+++ b/ewmh.h
@@ -31,7 +31,7 @@ typedef struct client_t client_t;
 
 void ewmh_init(void);
 void ewmh_update_net_numbers_of_desktop(void);
-void ewmh_update_net_current_desktop(void);
+int ewmh_update_net_current_desktop(lua_State *);
 void ewmh_update_net_desktop_names(void);
 int ewmh_process_client_message(xcb_client_message_event_t *);
 void ewmh_update_net_client_list_stacking(void);

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -91,23 +91,6 @@
  * @function set_newindex_miss_handler
  */
 
-/** Tag type */
-struct tag
-{
-    LUA_OBJECT_HEADER
-    /** Tag name */
-    char *name;
-    /** true if activated */
-    bool activated;
-    /** true if selected */
-    bool selected;
-    /** clients in this tag */
-    client_array_t clients;
-};
-
-static lua_class_t tag_class;
-LUA_OBJECT_FUNCS(tag_class, tag_t, tag)
-
 
 void
 tag_unref_simplified(tag_t **tag)
@@ -139,7 +122,6 @@ tag_view(lua_State *L, int udx, bool view)
     {
         tag->selected = view;
         banning_need_update();
-        ewmh_update_net_current_desktop();
 
         luaA_object_emit_signal(L, udx, "property::selected", 0);
     }
@@ -220,15 +202,29 @@ is_client_tagged(client_t *c, tag_t *t)
     return false;
 }
 
-/** Get the index of the first selected tag.
- * \return Its index.
+/** Get the index of the tag with focused client or first selected 
+ * \return Its index
  */
 int
-tags_get_first_selected_index(void)
+tags_get_current_or_first_selected_index(void)
 {
+    /* Consider "current desktop" a tag, that has focused window,
+     * basically a tag user actively interacts with.
+     * If no focused windows are present, fallback to first selected.
+     */
+    if(globalconf.focus.client)
+    {
+        foreach(tag, globalconf.tags)
+        {
+            if((*tag)->selected && is_client_tagged(globalconf.focus.client, *tag))
+                return tag_array_indexof(&globalconf.tags, tag);
+        }
+    }
     foreach(tag, globalconf.tags)
+    {
         if((*tag)->selected)
             return tag_array_indexof(&globalconf.tags, tag);
+    }
     return 0;
 }
 

--- a/objects/tag.h
+++ b/objects/tag.h
@@ -24,13 +24,30 @@
 
 #include "client.h"
 
-int tags_get_first_selected_index(void);
+int tags_get_current_or_first_selected_index(void);
 void tag_client(lua_State *, client_t *);
 void untag_client(client_t *, tag_t *);
 bool is_client_tagged(client_t *, tag_t *);
 void tag_unref_simplified(tag_t **);
 
 ARRAY_FUNCS(tag_t *, tag, tag_unref_simplified)
+
+/** Tag type */
+struct tag
+{
+    LUA_OBJECT_HEADER
+    /** Tag name */
+    char *name;
+    /** true if activated */
+    bool activated;
+    /** true if selected */
+    bool selected;
+    /** clients in this tag */
+    client_array_t clients;
+};
+
+lua_class_t tag_class;
+LUA_OBJECT_FUNCS(tag_class, tag_t, tag)
 
 void tag_class_setup(lua_State *);
 


### PR DESCRIPTION
First attempt at fixing issue #170 

Update NET_CURRENT_DESKTOP property on:
1) Tag select;
2) Focus change;
3) Client screen change (mostly to support the case when client is dragged between screens by mouse).

NET_CURRENT_DESKTOP is assigned value equal to index of the first tag that is:
1) Selected;
2) Belongs to currently focused screen.

Caveats:
1) "Focused screen" is screen under the mouse cursor. Judging by awful.screen.focused that may not always be the case, but pulling lua state properties and functions that are not already there into the C layer is beyond my understanding of how to do it right for now.
2) For the same reason as previous: tag is considered belonging to screen if it has at least one client, belonging to that screen. This means that when mouse is on empty tag, it won't be set as current desktop. Also if no tags found this way at all - default to old behaviour (just first selected tag). Hacky...
3) I don't like really calling ewmh_update_net_current_desktop each time in client_resize_do: if we move windows by mouse from screen to screen, then in screen_client_moveto it should get refocused and refocusing does the update, so update effectively gets called twice. In reality, for some reason, it only works when moving from secondary to primary screen, not the other way around. I'm not sure on performance implications, maybe it's ok to let it be.