### PR TITLE
tag: Avoid a race condition when deleting tags.

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -295,7 +295,6 @@ function tag.object.delete(self, fallback_tag, force)
 
     -- delete the tag
     data.tags[self].screen = nil
-    data.tags[self] = nil
     self.activated = false
 
     -- Update all indexes
@@ -1387,7 +1386,10 @@ capi.screen.connect_signal("removed", function(s)
     -- If any tag survived until now, forcefully get rid of it
     for _, t in pairs(s.tags) do
         t.activated = false
-        data.tags[t] = nil
+
+        if data.tags[t] then
+            data.tags[t].screen = nil
+        end
     end
 end)
 


### PR DESCRIPTION
Since the screen removal patchset, the tags properties were
cleaned too early. This caused code connecting to "property::activated"
to be called with the tag already partially deleted. For code depending
on those properties, such as radical.impl.taglist, this caused errors.