### PR TITLE
Add pause() and continue() methods to clients

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -433,7 +433,7 @@ ewmh_process_client_message(xcb_client_message_event_t *ev)
     else if(ev->type == _NET_CLOSE_WINDOW)
     {
         if((c = client_getbywin(ev->window)))
-           client_kill(c);
+           client_kill(c, -1);
     }
     else if(ev->type == _NET_WM_DESKTOP)
     {

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1205,6 +1205,22 @@ function client.object.is_transient_for(self, c2)
     return nil
 end
 
+--- Pause a client.
+-- This force the client to stop using power. This is the equivalent of `CTRL+Z`
+-- in a terminal.
+-- @function client.pause
+-- @see client.continue
+function client.object.pause(self)
+    self:kill(client.posix_signal.SIGSTOP)
+end
+
+--- Restore a paused client.
+-- @function client.continue
+-- @see client.pause
+function client.object.continue(self)
+    self:kill(client.posix_signal.SIGCONT)
+end
+
 -- Register standards signals
 
 --- The last geometry when client was floating.

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1208,6 +1208,14 @@ end
 --- Pause a client.
 -- This force the client to stop using power. This is the equivalent of `CTRL+Z`
 -- in a terminal.
+--
+-- To add this to your `rc.lua`, add to the `clientkeys` section:
+--
+--    awful.key({ modkey,           }, "z", function (c) c:pause() end,
+--              {description = "pause", group = "client"}),
+--    awful.key({ modkey, "Shift"   }, "z", function (c) c:continue() end,
+--              {description = "continue", group = "client"}),
+--
 -- @function client.pause
 -- @see client.continue
 function client.object.pause(self)

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -59,6 +59,56 @@ client.property = {}
 client.shape = require("awful.client.shape")
 client.focus = require("awful.client.focus")
 
+--- The POSIX signal table.
+--
+-- This table was extracted from
+--
+--    man 7 signal
+--
+-- @table awful.client.posix_signal
+-- @field SIGHUP Hangup detected on controlling terminal or death of controlling process
+-- @field SIGINT Interrupt from keyboard
+-- @field SIGQUIT Quit from keyboard
+-- @field SIGILL Illegal Instruction
+-- @field SIGABRT Abort signal from abort(3)
+-- @field SIGKILL Kill signal
+-- @field SIGSEGV Invalid memory reference
+-- @field SIGALRM Timer signal from alarm(2)
+-- @field SIGTERM Termination signal
+-- @field SIGUSR1 User-defined signal 1
+-- @field SIGUSR2 User-defined signal 2
+-- @field SIGCONT Continue if stopped
+-- @field SIGSTOP Stop process
+-- @field SIGTSTP Stop typed at terminal
+-- @field SIGURG Urgent condition on socket (4.2BSD)
+-- @field SIGXCPU CPU time limit exceeded (4.2BSD)
+-- @field SIGXFSZ File size limit exceeded (4.2BSD)
+-- @field SIGIO I/O now possible (4.2BSD)
+-- @field SIGWINCH Window resize signal (4.3BSD, Sun)
+-- @see kill
+client.posix_signal = {
+    SIGHUP   = 1,
+    SIGINT   = 2,
+    SIGQUIT  = 3,
+    SIGILL   = 4,
+    SIGABRT  = 6,
+    SIGKILL  = 9,
+    SIGSEGV  = 11,
+    SIGALRM  = 14,
+    SIGTERM  = 15,
+    SIGUSR1  = 10,
+    SIGUSR2  = 12,
+    SIGCONT  = 18,
+    SIGSTOP  = 19,
+    SIGTSTP  = 20,
+    SIGURG   = 16,
+    SIGXCPU  = 24,
+    SIGXFSZ  = 25,
+    SIGIO    = 23,
+    SIGWINCH = 28,
+}
+
+
 --- Jump to the given client.
 -- Takes care of focussing the screen, the right tag, etc.
 --

--- a/objects/client.c
+++ b/objects/client.c
@@ -2166,8 +2166,19 @@ out:
  *
  * This can be used to pause or wakeup some clients or to save energy.
  *
+ * @usage -- Close the focused client normally
+ * if client.focus then
+ *     client.focus:kill()
+ * end
+ *
+ * -- Force kill the focused client
+ * if client.focus then
+ *     client.focus:kill(awful.client.posix_signal.SIGKILL)
+ * end
+ *
  * @tparam[opt=nil] integer signal The POSIX signal number.
  * @function kill
+ * @see posix_signal
  */
 static int
 luaA_client_kill(lua_State *L)

--- a/objects/client.c
+++ b/objects/client.c
@@ -98,8 +98,9 @@
 #include "systray.h"
 #include "xwindow.h"
 
-#include "math.h"
+#include <math.h>
 
+#include <signal.h>
 #include <xcb/xcb_atom.h>
 #include <xcb/shape.h>
 #include <cairo-xcb.h>
@@ -1985,27 +1986,34 @@ client_unmanage(client_t *c, bool window_valid)
  * \param c The client to kill.
  */
 void
-client_kill(client_t *c)
+client_kill(client_t *c, int sig)
 {
-    if(client_hasproto(c, WM_DELETE_WINDOW))
+    if (sig == -1)
     {
-        xcb_client_message_event_t ev;
+        if(client_hasproto(c, WM_DELETE_WINDOW))
+        {
+            xcb_client_message_event_t ev;
 
-        /* Initialize all of event's fields first */
-        p_clear(&ev, 1);
+            /* Initialize all of event's fields first */
+            p_clear(&ev, 1);
 
-        ev.response_type = XCB_CLIENT_MESSAGE;
-        ev.window = c->window;
-        ev.format = 32;
-        ev.data.data32[1] = globalconf.timestamp;
-        ev.type = WM_PROTOCOLS;
-        ev.data.data32[0] = WM_DELETE_WINDOW;
+            ev.response_type = XCB_CLIENT_MESSAGE;
+            ev.window = c->window;
+            ev.format = 32;
+            ev.data.data32[1] = globalconf.timestamp;
+            ev.type = WM_PROTOCOLS;
+            ev.data.data32[0] = WM_DELETE_WINDOW;
 
-        xcb_send_event(globalconf.connection, false, c->window,
-                       XCB_EVENT_MASK_NO_EVENT, (char *) &ev);
+            xcb_send_event(globalconf.connection, false, c->window,
+                        XCB_EVENT_MASK_NO_EVENT, (char *) &ev);
+        }
+        else
+            xcb_kill_client(globalconf.connection, c->window);
     }
     else
-        xcb_kill_client(globalconf.connection, c->window);
+    {
+        kill(c->pid, sig);
+    }
 }
 
 /** Get all clients into a table.
@@ -2153,13 +2161,29 @@ out:
 
 /** Kill a client.
  *
+ * By default, this will use the normal X11 way of closing a client (the `X`
+ * button). If a signal number is provided, it will be used instead.
+ *
+ * This can be used to pause or wakeup some clients or to save energy.
+ *
+ * @tparam[opt=nil] integer signal The POSIX signal number.
  * @function kill
  */
 static int
 luaA_client_kill(lua_State *L)
 {
     client_t *c = luaA_checkudata(L, 1, &client_class);
-    client_kill(c);
+    int sig = -1;
+
+    /* Allow a signal number */
+    if(lua_gettop(L) == 2)
+    {
+        luaA_checkinteger(L, 2);
+
+        sig = lua_tointeger(L, 2);
+    }
+
+    client_kill(c, sig);
     return 0;
 }
 

--- a/objects/client.h
+++ b/objects/client.h
@@ -23,6 +23,7 @@
 #define AWESOME_OBJECTS_CLIENT_H
 
 #include "stack.h"
+#include <signal.h>
 #include "objects/window.h"
 
 #define CLIENT_SELECT_INPUT_EVENT_MASK (XCB_EVENT_MASK_STRUCTURE_NOTIFY \
@@ -122,7 +123,7 @@ struct client_t
     /** Role of the client */
     char *role;
     /** Client pid */
-    uint32_t pid;
+    pid_t pid;
     /** Window it is transient for */
     client_t *transient_for;
     /** Value of WM_TRANSIENT_FOR */
@@ -154,7 +155,7 @@ void client_unban(client_t *);
 void client_manage(xcb_window_t, xcb_get_geometry_reply_t *, xcb_get_window_attributes_reply_t *);
 bool client_resize(client_t *, area_t, bool);
 void client_unmanage(client_t *, bool);
-void client_kill(client_t *);
+void client_kill(client_t *, int);
 void client_set_sticky(lua_State *, int, bool);
 void client_set_above(lua_State *, int, bool);
 void client_set_below(lua_State *, int, bool);
@@ -166,7 +167,7 @@ void client_set_maximized_horizontal(lua_State *, int, bool);
 void client_set_maximized_vertical(lua_State *, int, bool);
 void client_set_minimized(lua_State *, int, bool);
 void client_set_urgent(lua_State *, int, bool);
-void client_set_pid(lua_State *, int, uint32_t);
+void client_set_pid(lua_State *, int, pid_t);
 void client_set_role(lua_State *, int, char *);
 void client_set_machine(lua_State *, int, char *);
 void client_set_icon_name(lua_State *, int, char *);


### PR DESCRIPTION
This was asked many time, there is a few implementations floating around using spawn, but this implement is directly in Awesome. The main advantage is to be able to use this in `awful.rules` or create some kind of modules to pause hidden tags clients.

This cannot be added to the default config as some clients have multiple client per `pid`, so there is no generic/magic rules for this.

Edit: the pause and continue methods have been tested manually, so are the usage examples.