### PR TITLE
Geometry overhaul part 3.03 (final part for 3.6)

### DIFF
--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -284,7 +284,6 @@ end
 -- @treturn table The list of widgets.The first element is the biggest
 -- container while the last is the topmost widget. The table contains *x*, *y*,
 -- *width*, *height* and *widget*.
--- @treturn table The list of geometries.
 -- @see wibox.find_widgets
 
 function mouse.object.get_current_widgets()
@@ -308,8 +307,8 @@ end
 -- @property current_widget
 -- @tparam widget|nil widget The widget
 -- @treturn ?widget The widget
--- @treturn ?table The geometry.
 -- @see wibox.find_widgets
+-- @see current_widget_geometry
 
 function mouse.object.get_current_widget()
     local wdgs, geos = mouse.object.get_current_widgets()
@@ -317,6 +316,28 @@ function mouse.object.get_current_widget()
     if wdgs then
         return wdgs[#wdgs], geos[#geos]
     end
+end
+
+--- Get the current widget geometry.
+-- @property current_widget_geometry
+-- @tparam ?table The geometry.
+-- @see current_widget
+
+function mouse.object.get_current_widget_geometry()
+    local _, ret = mouse.object.get_current_widget()
+
+    return ret
+end
+
+--- Get the current widget geometries.
+-- @property current_widget_geometries
+-- @tparam ?table A list of geometry tables.
+-- @see current_widgets
+
+function mouse.object.get_current_widget_geometries()
+    local _, ret = mouse.object.get_current_widgets()
+
+    return ret
 end
 
 --- True if the left mouse button is pressed.

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -598,6 +598,13 @@ function tooltip.new(args)
         end
     end
 
+    -- Apply the properties
+    for k, v in pairs(args) do
+        if tooltip["set_"..k] then
+            self[k] = v
+        end
+    end
+
     return self
 end
 

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -44,16 +44,19 @@ local mouse = mouse
 local timer = require("gears.timer")
 local util = require("awful.util")
 local object = require("gears.object")
+local color = require("gears.color")
 local wibox = require("wibox")
 local a_placement = require("awful.placement")
 local abutton = require("awful.button")
+local shape = require("gears.shape")
 local beautiful = require("beautiful")
 local textbox = require("wibox.widget.textbox")
-local background = require("wibox.container.background")
 local dpi = require("beautiful").xresources.apply_dpi
+local cairo = require("lgi").cairo
 local setmetatable = setmetatable
+local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 local ipairs = ipairs
-local capi = {mouse=mouse}
+local capi = {mouse=mouse, awesome=awesome}
 
 local tooltip = { mt = {}  }
 
@@ -83,7 +86,97 @@ local offset = {
     bottom       = {x =  0, y =  1 },
 }
 
--- Place the tooltip under the mouse.
+--- The tooltip border color.
+-- @beautiful beautiful.tooltip_border_color
+
+--- The tooltip background color.
+-- @beautiful beautiful.tooltip_bg
+
+--- The tooltip foregound (text) color.
+-- @beautiful beautiful.tooltip_fg
+
+--- The tooltip font.
+-- @beautiful beautiful.tooltip_font
+
+--- The tooltip border width.
+-- @beautiful beautiful.tooltip_border_width
+
+--- The tooltip opacity.
+-- @beautiful beautiful.tooltip_opacity
+
+--- The default tooltip shape.
+-- By default, all tooltips are rectangles, however, by setting this variables,
+-- they can default to rounded rectangle or stretched octogons.
+-- @beautiful beautiful.tooltip_shape
+-- @tparam[opt=gears.shape.rectangle] function shape A `gears.shape` compatible function
+-- @see shape
+-- @see gears.shape
+
+local function apply_shape(self)
+    local s = self._private.shape
+
+    local wb = self.wibox
+
+    if not s then
+        -- Clear the shape
+        if wb.shape_bounding then
+            wb.shape_bounding = nil
+            wb:set_bgimage(nil)
+        end
+
+        return
+    end
+
+    local w, h = wb.width, wb.height
+
+    -- First, create a A1 mask for the shape bounding itself
+    local img = cairo.ImageSurface(cairo.Format.A1, w, h)
+    local cr = cairo.Context(img)
+
+    cr:set_source_rgba(1,1,1,1)
+
+    s(cr, w, h, unpack(self._private.shape_args or {}))
+    cr:fill()
+    wb.shape_bounding = img._native
+
+    -- The wibox background uses ARGB32 border so tooltip anti-aliasing works
+    -- when an external compositor is used. This will look better than
+    -- the capi.drawin's own border support.
+    img = cairo.ImageSurface(cairo.Format.ARGB32, w, h)
+    cr  = cairo.Context(img)
+
+    -- Draw the border (multiply by 2, then mask the inner part to save a path)
+    local bw = (self._private.border_width
+        or beautiful.tooltip_border_width
+        or beautiful.border_width or 0) * 2
+
+    -- Fix anti-aliasing
+    if bw > 2 and awesome.composite_manager_running then
+        bw = bw - 1
+    end
+
+    local bc = self._private.border_color
+        or beautiful.tooltip_border_color
+        or beautiful.border_normal
+        or "#ffcb60"
+
+    cr:translate(bw, bw)
+    s(cr, w-2*bw, h-2*bw, unpack(self._private.shape_args or {}))
+    cr:set_line_width(bw)
+    cr:set_source(color(bc))
+    cr:stroke_preserve()
+    cr:clip()
+
+    local bg = self._private.bg
+        or beautiful.tooltip_bg
+        or beautiful.bg_focus or "#ffcb60"
+
+    cr:set_source(color(bg))
+    cr:paint()
+
+    wb:set_bgimage(img)
+end
+
 --
 -- @tparam tooltip self A tooltip object.
 local function set_geometry(self)
@@ -94,6 +187,10 @@ local function set_geometry(self)
 
     local w = self:get_wibox()
     w:geometry({ width = n_w, height = n_h })
+
+    if self._private.shape then
+        apply_shape(self)
+    end
 
     local align  = self._private.align
 
@@ -216,6 +313,24 @@ function tooltip:set_align(value)
     self:emit_signal("property::align")
 end
 
+--- The shape of the tooltip window.
+-- If the shape require some parameters, use `set_shape`.
+-- @property shape
+-- @see gears.shape
+-- @see set_shape
+-- @see beautiful.tooltip_shape
+
+--- Set the tooltip shape.
+-- All other arguments will be passed to the shape function.
+-- @tparam gears.shape s The shape
+-- @see shape
+-- @see gears.shape
+function tooltip:set_shape(s, ...)
+    self._private.shape = s
+    self._private.shape_args = {...}
+    apply_shape(self)
+end
+
 --- Change displayed text.
 --
 -- @property text
@@ -292,6 +407,7 @@ end
 --   seconds.
 -- @tparam[opt=apply_dpi(5)] integer args.margin_leftright The left/right margin for the text.
 -- @tparam[opt=apply_dpi(3)] integer args.margin_topbottom The top/bottom margin for the text.
+-- @tparam[opt=nil] gears.shape args.shape The shape
 -- @treturn awful.tooltip The created tooltip.
 -- @see add_to_object
 -- @see timeout
@@ -306,7 +422,9 @@ function tooltip.new(args)
     rawset(self,"_private", {})
 
     self._private.visible = false
-    self._private.align   = beautiful.tooltip_align  or "right"
+    self._private.align   = args.align or beautiful.tooltip_align  or "right"
+    self._private.shape   = args.shape or beautiful.tooltip_shape
+                                or shape.rectangle
 
     -- private data
     if args.delay_show then
@@ -350,27 +468,26 @@ function tooltip.new(args)
         self.timer:connect_signal("timeout", self.timer_function)
     end
 
+    local fg = beautiful.tooltip_fg or beautiful.fg_focus or "#000000"
+    local font = beautiful.tooltip_font or beautiful.font or "terminus 6"
+
     -- Set default properties
     self.wibox_properties = {
         visible = false,
         ontop = true,
-        border_width = beautiful.tooltip_border_width or beautiful.border_width or 1,
-        border_color = beautiful.tooltip_border_color or beautiful.border_normal or "#ffcb60",
+        border_width = 0,
+        fg = fg,
+        bg = color.transparent,
         opacity = beautiful.tooltip_opacity or 1,
-        bg = beautiful.tooltip_bg_color or beautiful.bg_focus or "#ffcb60"
     }
-    local fg = beautiful.tooltip_fg_color or beautiful.fg_focus or "#000000"
-    local font = beautiful.tooltip_font or beautiful.font or "terminus 6"
 
     self.textbox = textbox()
     self.textbox:set_font(font)
-    self.background = background(self.textbox)
-    self.background:set_fg(fg)
 
     -- Add margin.
     local m_lr = args.margin_leftright or dpi(5)
     local m_tb = args.margin_topbottom or dpi(3)
-    self.marginbox = wibox.container.margin(self.background, m_lr, m_lr, m_tb, m_tb)
+    self.marginbox = wibox.container.margin(self.textbox, m_lr, m_lr, m_tb, m_tb)
 
     -- Add tooltip to objects
     if args.objects then

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -75,7 +75,7 @@ end
 -- @tparam tooltip self The tooltip to show.
 local function show(self)
     -- do nothing if the tooltip is already shown
-    if self.visible then return end
+    if self._private.visible then return end
     if self.timer then
         if not self.timer.started then
             self:timer_function()
@@ -84,7 +84,7 @@ local function show(self)
     end
     set_geometry(self)
     self.wibox.visible = true
-    self.visible = true
+    self._private.visible = true
     self:emit_signal("property::visible")
 end
 
@@ -93,14 +93,14 @@ end
 -- @tparam tooltip self The tooltip to hide.
 local function hide(self)
     -- do nothing if the tooltip is already hidden
-    if not self.visible then return end
+    if not self._private.visible then return end
     if self.timer then
         if self.timer.started then
             self.timer:stop()
         end
     end
     self.wibox.visible = false
-    self.visible = false
+    self._private.visible = false
     self:emit_signal("property::visible")
 end
 
@@ -129,6 +129,20 @@ end
 -- @property visible
 -- @param boolean
 
+function tooltip:get_visible()
+    return self._private.visible
+end
+
+function tooltip:set_visible(value)
+    if self._private.visible == value then return end
+
+    if value then
+        show(self)
+    else
+        hide(self)
+    end
+end
+
 --- Change displayed text.
 --
 -- @property text
@@ -138,7 +152,7 @@ end
 
 function tooltip:set_text(text)
     self.textbox:set_text(text)
-    if self.visible then
+    if self._private.visible then
         set_geometry(self)
     end
 end
@@ -152,7 +166,7 @@ end
 
 function tooltip:set_markup(text)
     self.textbox:set_markup(text)
-    if self.visible then
+    if self._private.visible then
         set_geometry(self)
     end
 end
@@ -218,7 +232,7 @@ function tooltip.new(args)
 
     rawset(self,"_private", {})
 
-    self.visible = false
+    self._private.visible = false
 
     -- private data
     if args.delay_show then

--- a/tests/test-tooltip.lua
+++ b/tests/test-tooltip.lua
@@ -1,0 +1,124 @@
+local runner = require("_runner")
+local place = require("awful.placement")
+local wibox = require("wibox")
+local beautiful = require("beautiful")
+local tooltip = require("awful.tooltip")
+local gears = require("gears")
+
+local steps = {}
+
+local w = wibox {
+    width   = 250,
+    height  = 250,
+    visible = true,
+    ontop   = true
+}
+
+w:setup{
+    image  = beautiful.awesome_icon,
+    widget = wibox.widget.imagebox
+}
+
+-- Center eveything
+place.centered(w)
+place.centered(mouse)
+
+local tt = nil
+
+table.insert(steps, function()
+    tt = tooltip {text = "A long tooltip", visible = true}
+
+    return true
+end)
+
+local align_pos = {
+    "top_left", "left", "bottom_left", "right",
+    "top_right", "bottom_right", "bottom", "top",
+}
+
+-- Test the various alignment code paths
+for _, v in ipairs(align_pos) do
+    table.insert(steps, function()
+        tt.align = v
+
+        return true
+    end)
+end
+
+-- Set a parent object
+table.insert(steps, function()
+    tt:add_to_object(w)
+
+    return true
+end)
+
+-- Test the other mode
+table.insert(steps, function()
+    tt.mode = "outside"
+
+    -- This only work when there is a mouse::enter event, create one
+    place.top_left(mouse)
+    place.centered(mouse)
+
+    return true
+end)
+
+--- Reset the wibox content and use a widget geometry.
+table.insert(steps, function()
+    tt:remove_from_object(w)
+
+    tt.visible = false
+
+    w:setup{
+        {
+            image  = beautiful.awesome_icon,
+            widget = wibox.widget.imagebox,
+            id     = "myimagebox"
+        },
+        top    = 125,
+        bottom = 100,
+        left   = 205,
+        right  = 20 ,
+        layout = wibox.container.margin
+    }
+
+    local imb = w:get_children_by_id("myimagebox")[1]
+    assert(imb)
+
+    tt:add_to_object(imb)
+
+    -- Move the mouse over the widget
+    place.top_left(mouse)
+    mouse.coords {
+        x = w.x + w.width - 20 - 12.5,
+        y = w.y + 125 + 12.5,
+    }
+
+    assert(tt.current_position == "top")
+
+    return true
+end)
+
+-- Try the preferred positions
+table.insert(steps, function()
+    tt.visible = false
+
+    tt.preferred_positions = {"right"}
+
+    tt.visible = true
+
+    assert(tt.current_position == "right")
+
+    return true
+end)
+
+-- Add a shape.
+table.insert(steps, function()
+    tt.shape = gears.shape.octogon
+
+    return true
+end)
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
* Add the last planned placement function [DONE]
* Turn tooltip into a class [DONE]
* Add shape support to tooltips [DONE]
* Support "next to drawable" tooltip mode like Max OS X [DONE]
* Add more tooltip properties and theme options [DONE]
* <s>Remove awful.menu geometry code and use awful.placement</s> later
* <s>Add hot corner support</s> later
* <s>Find a way to get the "smart wibox" (wibox that resize itself to fit a widget and update its own shape) from radical into awful or wibox (not sure yet)</s> later
* Test all this [DONE]

What wont make it (from the original TODO list of this PR serie):

 * Notification shape/placement (this require the dynamic layout system and I wont push it into 3.6)


Closing note:

This is the last PR of the geometry overhaul. After this PR, my Radical module will be 3K line shorted than the 3.5 version. My collision module will be much smaller too (partly because of the shape API too). I think so far it went well. Beside the placement code and the doc, awful also got smaller, but not by much. The first 4 PR were quite big and intrusive, but there was only a few regression reports so far. `awful.placement` may be a huge pile of complex and coupled/spaghetti code, but (I think/hope) it made everything else simpler and less coupled. Plus, this serie gave many cool new features I hope users will love. I hope this code will be the basis of tons of Awesomeness.