### PR TITLE
"Fix" client properties which can be absent

### DIFF
--- a/common/luaobject.h
+++ b/common/luaobject.h
@@ -195,6 +195,16 @@ int luaA_object_emit_signal_simple(lua_State *);
         return 1; \
     }
 
+#define LUA_OBJECT_EXPORT_OPTIONAL_PROPERTY(pfx, type, field, pusher, empty_value) \
+    static int \
+    luaA_##pfx##_get_##field(lua_State *L, type *object) \
+    { \
+        if (object->field == empty_value) \
+            return 0; \
+        pusher(L, object->field); \
+        return 1; \
+    }
+
 int luaA_object_tostring(lua_State *);
 
 #define LUA_OBJECT_META(prefix) \

--- a/objects/client.c
+++ b/objects/client.c
@@ -2770,15 +2770,16 @@ luaA_client_get_icon_name(lua_State *L, client_t *c)
     return 1;
 }
 
+LUA_OBJECT_EXPORT_OPTIONAL_PROPERTY(client, client_t, screen, luaA_object_push, NULL)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, class, lua_pushstring)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, instance, lua_pushstring)
-LUA_OBJECT_EXPORT_PROPERTY(client, client_t, machine, lua_pushstring)
+LUA_OBJECT_EXPORT_OPTIONAL_PROPERTY(client, client_t, machine, lua_pushstring, NULL)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, role, lua_pushstring)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, transient_for, luaA_object_push)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, skip_taskbar, lua_pushboolean)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, leader_window, lua_pushinteger)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, group_window, lua_pushinteger)
-LUA_OBJECT_EXPORT_PROPERTY(client, client_t, pid, lua_pushinteger)
+LUA_OBJECT_EXPORT_OPTIONAL_PROPERTY(client, client_t, pid, lua_pushinteger, 0)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, hidden, lua_pushboolean)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, minimized, lua_pushboolean)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, fullscreen, lua_pushboolean)
@@ -2816,15 +2817,6 @@ luaA_client_get_content(lua_State *L, client_t *c)
 
     /* lua has to make sure to free the ref or we have a leak */
     lua_pushlightuserdata(L, surface);
-    return 1;
-}
-
-static int
-luaA_client_get_screen(lua_State *L, client_t *c)
-{
-    if(!c->screen)
-        return 0;
-    luaA_object_push(L, c->screen);
     return 1;
 }
 


### PR DESCRIPTION
A client c could have no c.machine or no c.pid because the corresponding
properties are not set on its window. Previously, the C code would return an
empty string or 0 for these values. This commit makes the C code give Lua no
value instead (not even a nil).

Signed-off-by: Uli Schlachter <psychon@znc.in>