### PR TITLE
Travis: kill awesome after max. 60s per test file

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -189,6 +189,8 @@ start_awesome() {
 
 # Count errors.
 errors=0
+# Seconds after when awesome gets killed.
+timeout_stale=60
 
 for f in $tests; do
     echo "== Running $f =="
@@ -203,6 +205,13 @@ for f in $tests; do
 
     # Send the test file to awesome.
     cat $f | DISPLAY=$D "$AWESOME_CLIENT" 2>&1
+
+    # Kill awesome after 1 minute (e.g. with errors during test setup).
+    (sleep $timeout_stale
+      if [ "$(ps -o comm= $awesome_pid)" = "${AWESOME##*/}" ]; then
+        echo "Killing (stale?!) awesome (PID $awesome_pid) after $timeout_stale seconds."
+        kill $awesome_pid
+      fi) &
 
     # Tail the log and quit, when awesome quits.
     tail -n 100000 -f --pid $awesome_pid $awesome_log

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -103,7 +103,7 @@ wait_until_success() {
     if [ "$CI" = true ]; then
         set +x
     fi
-    max_wait=60
+    wait_count=60  # 60*0.05s => 3s.
     while true; do
         set +e
         eval reply="\$($2)"
@@ -112,8 +112,8 @@ wait_until_success() {
         if [ $ret = 0 ]; then
             break
         fi
-        max_wait=$(expr $max_wait - 1 || true)
-        if [ "$max_wait" -lt 0 ]; then
+        wait_count=$(expr $wait_count - 1 || true)
+        if [ "$wait_count" -lt 0 ]; then
             echo "Error: failed to $1!"
             echo "Last reply: $reply."
             if [ -f "$awesome_log" ]; then


### PR DESCRIPTION
This is required for when the test setup fails already, e.g. because of
an assertion error at the top of a test file.

Example of a failing build: https://travis-ci.org/awesomeWM/awesome/jobs/134291905.

Should also help with hangs in general: https://api.travis-ci.org/jobs/134295087/log.txt?deansi=true (struts test)