### PR TITLE
Silence warnings in examples

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -106,32 +106,6 @@ function(escape_code path escaped_content pre_header post_header)
     set(${post_header} ${example_post_header} PARENT_SCOPE)
 endfunction()
 
-# Only gears.debug.print_warning are allowed on stderr, everything else will
-# trigger a build failure to catch regressions and problem early.
-function(check_for_problems stderr result)
-
-    # If there is nothing to check, return
-    if (TEST_ERROR STREQUAL "")
-        set(${result} 0 PARENT_SCOPE)
-        return()
-    endif()
-
-    string(REGEX REPLACE "\n" ";" error_lines "${stderr}")
-
-    foreach (LINE ${error_lines})
-
-        # gears.debug.print_warning lines look like:
-        # yyyy-mm-dd hh:mm:ss W: message content
-        if (NOT ${LINE} MATCHES "^[0-9 :-]+ W:")
-            set(${result} 1 PARENT_SCOPE)
-            return()
-        endif()
-
-    endforeach()
-
-    set(${result} 0 PARENT_SCOPE)
-endfunction()
-
 # Execute a lua file.
 function(run_test test_path namespace template escaped_content)
 
@@ -159,8 +133,7 @@ function(run_test test_path namespace template escaped_content)
     )
 
     # If there is something on stderr, exit
-    check_for_problems("${TEST_ERROR}" problems_found)
-    if (${problems_found})
+    if (NOT TEST_ERROR STREQUAL "")
         message("${TEST_OUTPUT}")
         message("${TEST_ERROR}")
         message(FATAL_ERROR ${test_path} " A test failed, bye")

--- a/tests/examples/awful/template.lua
+++ b/tests/examples/awful/template.lua
@@ -22,6 +22,9 @@ pcall(function()
     require("luacov.runner")(luacovpath)
 end)
 
+-- Silence debug warnings
+require("gears.debug").print_warning = function() end
+
 local color     = require( "gears.color" )
 local shape     = require( "gears.shape" )
 local beautiful = require( "beautiful"   )

--- a/tests/examples/gears/shape/template.lua
+++ b/tests/examples/gears/shape/template.lua
@@ -10,6 +10,9 @@ pcall(function()
     require("luacov.runner")(luacovpath)
 end)
 
+-- Silence debug warnings
+require("gears.debug").print_warning = function() end
+
 local function get_surface(p)
     local img = cairo.SvgSurface.create(p, 288, 76)
     return cairo.Context(img)

--- a/tests/examples/text/template.lua
+++ b/tests/examples/text/template.lua
@@ -15,5 +15,8 @@ pcall(function()
     require("luacov.runner")(luacovpath)
 end)
 
+-- Silence debug warnings
+require("gears.debug").print_warning = function() end
+
 -- Execute the test
 loadfile(file_path)()

--- a/tests/examples/wibox/container/defaults/template.lua
+++ b/tests/examples/wibox/container/defaults/template.lua
@@ -21,6 +21,9 @@ pcall(function()
     require("luacov.runner")(luacovpath)
 end)
 
+-- Silence debug warnings
+require("gears.debug").print_warning = function() end
+
 -- Let the test request a size and file format
 local before, after = loadfile(file_path)()
 

--- a/tests/examples/wibox/layout/template.lua
+++ b/tests/examples/wibox/layout/template.lua
@@ -21,6 +21,9 @@ pcall(function()
     require("luacov.runner")(luacovpath)
 end)
 
+-- Silence debug warnings
+require("gears.debug").print_warning = function() end
+
 -- Create a generic rectangle widget to show layout disposition
 local function generic_widget(text)
     return {

--- a/tests/examples/wibox/template.lua
+++ b/tests/examples/wibox/template.lua
@@ -19,6 +19,9 @@ pcall(function()
     require("luacov.runner")(luacovpath)
 end)
 
+-- Silence debug warnings
+require("gears.debug").print_warning = function() end
+
 -- This is the main widget the tests will use as top level
 local container = wibox.layout.fixed.vertical()
 


### PR DESCRIPTION
There was a problem that the examples were considered to have failed as soon as
they produced any kind of output, but there were legitimate cases of warnings
being printed that triggered these checks. Commit 4819be4f4f3037ef3f used a
regular expression to detect and ignore this warnings.

This commit reverts the above commit and instead silences the warnings by
monkey-patching the function that prints the warnings into a no-op.

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @Elv13 