### PR TITLE
Deprecate add_signal

### DIFF
--- a/common/array.h
+++ b/common/array.h
@@ -34,13 +34,6 @@
         int len, size;                                                      \
     } pfx##_array_t;
 
-#define ARRAY_TYPE_EXTRA(type_t, pfx, extra)                                \
-    typedef struct pfx##_array_t {                                          \
-        type_t *tab;                                                        \
-        int len, size;                                                      \
-        extra;                                                              \
-    } pfx##_array_t;
-
 #define foreach(var, array) \
     for(int __foreach_index_##var = 0; \
         __foreach_index_##var < (array).len; \

--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -256,9 +256,6 @@ luaA_class_setup(lua_State *L, lua_class_t *class,
 
     signal_add(&class->signals, "new");
 
-    if (parent)
-        class->signals.inherits_from = &parent->signals;
-
     lua_class_array_append(&luaA_classes, class);
 }
 

--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -254,8 +254,6 @@ luaA_class_setup(lua_State *L, lua_class_t *class,
     class->index_miss_handler = LUA_REFNIL;
     class->newindex_miss_handler = LUA_REFNIL;
 
-    signal_add(&class->signals, "new");
-
     lua_class_array_append(&luaA_classes, class);
 }
 

--- a/common/luaclass.h
+++ b/common/luaclass.h
@@ -123,7 +123,7 @@ luaA_checkudataornil(lua_State *L, int udx, lua_class_t *class)
     static inline int                                                          \
     luaA_##prefix##_class_add_signal(lua_State *L)                             \
     {                                                                          \
-        signal_add(&(lua_class).signals, luaL_checkstring(L, 1));              \
+        luaA_deprecate(L, "signal usage without add_signal()");                \
         return 0;                                                              \
     }                                                                          \
                                                                                \

--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -253,8 +253,7 @@ signal_object_emit(lua_State *L, signal_array_t *arr, const char *name, int narg
             lua_remove(L, - nargs - nbfunc - 1 + i);
             luaA_dofunction(L, nargs, 0);
         }
-    } else
-        luaA_warn(L, "Trying to emit unknown signal '%s'", name);
+    }
 
     /* remove args */
     lua_pop(L, nargs);
@@ -304,9 +303,6 @@ luaA_object_emit_signal(lua_State *L, int oud,
             lua_remove(L, - nargs - nbfunc - 2 + i);
             luaA_dofunction(L, nargs + 1, 0);
         }
-    } else {
-        luaA_warn(L, "Trying to emit unknown signal '%s'", name);
-        return;
     }
 
     /* Then emit signal on the class */

--- a/common/luaobject.h
+++ b/common/luaobject.h
@@ -175,7 +175,6 @@ int luaA_object_emit_signal_simple(lua_State *);
         lua_setmetatable(L, -2);                                               \
         luaA_setuservalue(L, -2);                                              \
         lua_pushvalue(L, -1);                                                  \
-        p->signals.inherits_from = &(lua_class).signals;                       \
         luaA_class_emit_signal(L, &(lua_class), "new", 1);                     \
         return p;                                                              \
     }

--- a/common/signal.h
+++ b/common/signal.h
@@ -45,54 +45,18 @@ signal_wipe(signal_t *sig)
     cptr_array_wipe(&sig->sigfuncs);
 }
 
-ARRAY_TYPE_EXTRA(signal_t, signal, struct signal_array_t *inherits_from)
-BARRAY_FUNCS(signal_t, signal, signal_wipe, signal_cmp)
+DO_BARRAY(signal_t, signal, signal_wipe, signal_cmp)
 
 static inline signal_t *
 signal_array_getbyid(signal_array_t *arr, unsigned long id)
 {
     signal_t sig = { .id = id };
-    signal_t *result;
-
-    result = signal_array_lookup(arr, &sig);
-    if(result)
-        return result;
-
-    /* The signal doesn't exist yet. Check if some of our inherits_from have the
-     * signal and if yes, add it.
-     */
-    signal_array_t *inherit = arr->inherits_from;
-    while(inherit != NULL)
-    {
-        if(signal_array_lookup(inherit, &sig))
-            break;
-        inherit = inherit->inherits_from;
-    }
-    if(inherit)
-    {
-        /* Add the signal to this array to pretend it always existed */
-        signal_array_insert(arr, sig);
-        result = signal_array_lookup(arr, &sig);
-        assert(result != NULL);
-    }
-    return result;
+    return signal_array_lookup(arr, &sig);
 }
 
-/** Add a signal to a signal array.
- * Signals have to be added before they can be added or emitted.
- * \param arr The signal array.
- * \param name The signal name.
- */
 static inline void
 signal_add(signal_array_t *arr, const char *name)
 {
-    unsigned long tok = a_strhash((const unsigned char *) name);
-    signal_t *sigfound = signal_array_getbyid(arr, tok);
-    if(!sigfound)
-    {
-        signal_t sig = { .id = tok };
-        signal_array_insert(arr, sig);
-    }
 }
 
 /** Connect a signal inside a signal array.
@@ -109,7 +73,11 @@ signal_connect(signal_array_t *arr, const char *name, const void *ref)
     if(sigfound)
         cptr_array_append(&sigfound->sigfuncs, ref);
     else
-        warn("Trying to connect to unknown signal '%s'", name);
+    {
+        signal_t sig = { .id = tok };
+        cptr_array_append(&sig.sigfuncs, ref);
+        signal_array_insert(arr, sig);
+    }
 }
 
 /** Disconnect a signal inside a signal array.
@@ -131,8 +99,7 @@ signal_disconnect(signal_array_t *arr, const char *name, const void *ref)
                 cptr_array_remove(&sigfound->sigfuncs, func);
                 break;
             }
-    } else
-        warn("Trying to disconnect from unknown signal '%s'", name);
+    }
 }
 
 #endif

--- a/common/signal.h
+++ b/common/signal.h
@@ -54,11 +54,6 @@ signal_array_getbyid(signal_array_t *arr, unsigned long id)
     return signal_array_lookup(arr, &sig);
 }
 
-static inline void
-signal_add(signal_array_t *arr, const char *name)
-{
-}
-
 /** Connect a signal inside a signal array.
  * You are in charge of reference counting.
  * \param arr The signal array.

--- a/dbus.c
+++ b/dbus.c
@@ -773,10 +773,7 @@ luaA_dbus_connect_signal(lua_State *L)
     if(sig)
         luaA_warn(L, "cannot add signal %s on D-Bus, already existing", name);
     else
-    {
-        signal_add(&dbus_signals, name);
         signal_connect(&dbus_signals, name, luaA_object_ref(L, 2));
-    }
     return 0;
 }
 

--- a/docs/common/object.ldoc
+++ b/docs/common/object.ldoc
@@ -2,7 +2,6 @@
 --- Disonnect to a signal.
 -- @tparam string name The name of the signal
 -- @tparam function func The callback that should be disconnected
--- @see add_signal
 -- @function disconnect_signal
 
 --- Emit a signal.
@@ -13,15 +12,9 @@
 --   that are given to emit_signal()
 -- @function emit_signal
 
---- Add a signal to an object. All signals must be added before they can be used.
---
--- @tparam string name The name of the new signal.
--- @function add_signal
-
 --- Connect to a signal.
 -- @tparam string name The name of the signal
 -- @tparam function func The callback to call when the signal is emitted
--- @see add_signal 
 -- @function connect_signal
 
 --- Connect to a signal weakly. This allows the callback function to be garbage

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1159,25 +1159,17 @@ end
 
 --- The last geometry when client was floating.
 -- @signal property::floating_geometry
-capi.client.add_signal("property::floating_geometry")
-
-capi.client.add_signal("property::floating")
-
-capi.client.add_signal("property::dockable")
 
 --- Emited when a client need to get a titlebar.
 -- @signal request::titlebars
 -- @tparam[opt=nil] string content The context (like "rules")
 -- @tparam[opt=nil] table hints Some hints.
-capi.client.add_signal("request::titlebars")
 
 --- The client marked signal (deprecated).
 -- @signal .marked
-capi.client.add_signal("marked")
 
 --- The client unmarked signal (deprecated).
 -- @signal unmarked
-capi.client.add_signal("unmarked")
 
 -- Add clients during startup to focus history.
 -- This used to happen through ewmh.activate, but that only handles visible

--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -222,8 +222,6 @@ local function arrange_tag(t)
     layout.arrange(t.screen)
 end
 
-capi.screen.add_signal("arrange")
-
 capi.tag.connect_signal("property::master_width_factor", arrange_tag)
 capi.tag.connect_signal("property::master_count", arrange_tag)
 capi.tag.connect_signal("property::column_count", arrange_tag)

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -558,7 +558,6 @@ attach = function(d, position_f, args)
     end
 
     -- Create a way to detach a placement function
-    d:add_signal("property::detach_callback")
     function d.detach_callback()
         d:disconnect_signal("property::width"       , tracker)
         d:disconnect_signal("property::height"      , tracker)

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -465,8 +465,6 @@ function screen.object.set_selected_tag() end
 --- When the tag history changed.
 -- @signal tag::history::update
 
-capi.screen.add_signal("padding")
-
 -- Extend the luaobject
 object.properties(capi.screen, {
     getter_class = screen.object,

--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -297,7 +297,5 @@ capi.awesome.connect_signal("spawn::canceled" , spawn.on_snid_cancel   )
 capi.awesome.connect_signal("spawn::timeout"  , spawn.on_snid_cancel   )
 capi.client.connect_signal ("manage"          , spawn.on_snid_callback )
 
-capi.client.add_signal    ("spawn::completed_with_payload"            )
-
 return setmetatable(spawn, { __call = function(_, ...) return spawn.spawn(...) end })
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -1323,22 +1323,6 @@ capi.client.connect_signal("untagged", client_untagged)
 capi.client.connect_signal("tagged", client_tagged)
 capi.tag.connect_signal("request::select", tag.object.view_only)
 
-capi.tag.add_signal("property::hide")
-capi.tag.add_signal("property::icon")
-capi.tag.add_signal("property::icon_only")
-capi.tag.add_signal("property::layout")
-capi.tag.add_signal("property::mwfact")
-capi.tag.add_signal("property::master_width_factor")
-capi.tag.add_signal("property::useless_gap")
-capi.tag.add_signal("property::master_fill_policy")
-capi.tag.add_signal("property::ncol")
-capi.tag.add_signal("property::column_count")
-capi.tag.add_signal("property::nmaster")
-capi.tag.add_signal("property::master_count")
-capi.tag.add_signal("property::windowfact")
-capi.tag.add_signal("property::screen")
-capi.tag.add_signal("property::index")
-
 --- True when a tagged client is urgent
 -- @signal property::urgent
 -- @see client.urgent
@@ -1346,15 +1330,6 @@ capi.tag.add_signal("property::index")
 --- The number of urgent tagged clients
 -- @signal property::urgent_count
 -- @see client.urgent
-
-capi.tag.add_signal("property::urgent")
-
-capi.tag.add_signal("property::urgent_count")
-capi.tag.add_signal("property::volatile")
-capi.tag.add_signal("request::screen")
-capi.tag.add_signal("removal-pending")
-
-capi.screen.add_signal("tag::history::update")
 
 capi.screen.connect_signal("tag::history::update", tag.history.update)
 

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -196,7 +196,6 @@ end
 -- @see set_markup
 tooltip.new = function(args)
     local self = setmetatable(object(), instance_mt)
-    self:add_signal("property::visible")
     self.visible = false
 
     -- private data

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -341,11 +341,9 @@ function awfulwibar.new(arg)
     w._screen  = screen --HACK When a screen is removed, then getbycoords wont work
     w._stretch = arg.stretch == nil and has_to_stretch or arg.stretch
 
-    w:add_signal("property::position")
     w.get_position = get_position
     w.set_position = set_position
 
-    w:add_signal("property::stretch")
     w.get_stretch = get_stretch
     w.set_stretch = set_stretch
     w.remove      = remove

--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -97,11 +97,6 @@ local timer_instance_mt = {
 timer.new = function(args)
     local ret = object()
 
-    ret:add_signal("property::timeout")
-    ret:add_signal("timeout")
-    ret:add_signal("start")
-    ret:add_signal("stop")
-
     ret.data = { timeout = 0 }
     setmetatable(ret, timer_instance_mt)
 

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -298,7 +298,6 @@ local function setup_signals(_drawable)
     local d = _drawable.drawable
 
     local function clone_signal(name)
-        _drawable:add_signal(name)
         -- When "name" is emitted on wibox.drawin, also emit it on wibox
         d:connect_signal(name, function(_, ...)
             _drawable:emit_signal(name, ...)

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -89,7 +89,6 @@ end
 local function setup_signals(_wibox)
     local obj
     local function clone_signal(name)
-        _wibox:add_signal(name)
         -- When "name" is emitted on wibox.drawin, also emit it on wibox
         obj:connect_signal(name, function(_, ...)
             _wibox:emit_signal(name, ...)
@@ -224,8 +223,6 @@ local function new(args)
 
     return ret
 end
-
-capi.drawin.add_signal("property::get_wibox")
 
 --- Redraw a wibox. You should never have to call this explicitely because it is
 -- automatically called when needed.

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -556,18 +556,8 @@ function base.make_widget(proxy, widget_name, args)
         class             = args.class,
     }
 
-    -- This signal is used by layouts to find out when they have to update.
-    ret:add_signal("widget::layout_changed")
-    ret:add_signal("widget::redraw_needed")
-    -- Mouse input, oh noes!
-    ret:add_signal("button::press")
-    ret:add_signal("button::release")
-    ret:add_signal("mouse::enter")
-    ret:add_signal("mouse::leave")
-
     -- Backwards compatibility
     -- TODO: Remove this
-    ret:add_signal("widget::updated")
     ret:connect_signal("widget::updated", function()
         ret:emit_signal("widget::layout_changed")
         ret:emit_signal("widget::redraw_needed")
@@ -648,7 +638,7 @@ end
 function base.check_widget(widget)
     assert(type(widget) == "table", "Type should be table, but is " .. tostring(type(widget)))
     assert(widget.is_widget, "Argument is not a widget!")
-    for _, func in pairs({ "add_signal", "connect_signal", "disconnect_signal" }) do
+    for _, func in pairs({ "connect_signal", "disconnect_signal" }) do
         assert(type(widget[func]) == "function", func .. " is not a function")
     end
 end

--- a/luaa.c
+++ b/luaa.c
@@ -723,19 +723,6 @@ luaA_init(xdgHandle* xdg)
     lua_getfield(L, 1, "loaded");
 
     lua_pop(L, 2); /* pop "package" and "package.loaded" */
-
-    signal_add(&global_signals, "debug::error");
-    signal_add(&global_signals, "debug::deprecation");
-    signal_add(&global_signals, "debug::index::miss");
-    signal_add(&global_signals, "debug::newindex::miss");
-    signal_add(&global_signals, "systray::update");
-    signal_add(&global_signals, "wallpaper_changed");
-    signal_add(&global_signals, "xkb::map_changed");
-    signal_add(&global_signals, "xkb::group_changed");
-    signal_add(&global_signals, "refresh");
-    signal_add(&global_signals, "startup");
-    signal_add(&global_signals, "exit");
-    signal_add(&global_signals, "screen::change");
 }
 
 static void

--- a/luaa.c
+++ b/luaa.c
@@ -67,6 +67,54 @@ extern const struct luaL_Reg awesome_root_lib[];
 extern const struct luaL_Reg awesome_mouse_methods[];
 extern const struct luaL_Reg awesome_mouse_meta[];
 
+/** A call into the lua code aborted with an error
+ * @signal debug::error
+ */
+
+/** A deprecated lua function was called
+ * @signal debug::deprecation
+ */
+
+/** An invalid key was read from an object (e.g. c.foo)
+ * @signal debug::index::miss
+ */
+
+/** An invalid key was written to an object (e.g. c.foo = "bar")
+ * @signal debug::newindex::miss
+ */
+
+/**
+ * @signal systray::update
+ */
+
+/**
+ * @signal wallpaper_changed
+ */
+
+/**
+ * @signal xkb::map_changed
+ */
+
+/**
+ * @signal xkb::group_changed
+ */
+
+/**
+ * @signal refresh
+ */
+
+/**
+ * @signal startup
+ */
+
+/**
+ * @signal exit
+ */
+
+/**
+ * @signal screen::change
+ */
+
 /** Path to config file */
 static char *conffile;
 
@@ -676,53 +724,17 @@ luaA_init(xdgHandle* xdg)
 
     lua_pop(L, 2); /* pop "package" and "package.loaded" */
 
-    /** A call into the lua code aborted with an error
-     * @signal debug::error
-     */
     signal_add(&global_signals, "debug::error");
-    /** A deprecated lua function was called
-     * @signal debug::deprecation
-     */
     signal_add(&global_signals, "debug::deprecation");
-    /** An invalid key was read from an object (e.g. c.foo)
-     * @signal debug::index::miss
-     */
     signal_add(&global_signals, "debug::index::miss");
-    /** An invalid key was written to an object (e.g. c.foo = "bar")
-     * @signal debug::newindex::miss
-     */
     signal_add(&global_signals, "debug::newindex::miss");
-    /**
-     * @signal systray::update
-     */
     signal_add(&global_signals, "systray::update");
-    /**
-     * @signal wallpaper_changed
-     */
     signal_add(&global_signals, "wallpaper_changed");
-    /**
-     * @signal xkb::map_changed
-     */
     signal_add(&global_signals, "xkb::map_changed");
-    /**
-     * @signal xkb::group_changed
-     */
     signal_add(&global_signals, "xkb::group_changed");
-    /**
-     * @signal refresh
-     */
     signal_add(&global_signals, "refresh");
-    /**
-     * @signal startup
-     */
     signal_add(&global_signals, "startup");
-    /**
-     * @signal exit
-     */
     signal_add(&global_signals, "exit");
-    /**
-     * @signal screen::change
-     */
     signal_add(&global_signals, "screen::change");
 }
 

--- a/objects/button.c
+++ b/objects/button.c
@@ -59,6 +59,24 @@
  * @function set_newindex_miss_handler
  */
 
+/** When bound mouse button + modifiers are pressed.
+ * @param ... One or more arguments are possible
+ * @signal .press
+ */
+
+/** When property changes.
+ * @signal property::button
+ */
+
+/** When property changes.
+ * @signal property::modifiers
+ */
+
+/** When bound mouse button + modifiers are pressed.
+ * @param ... One or more arguments are possible
+ * @signal .release
+ */
+
 /** Create a new mouse button bindings.
  * \param L The Lua VM state.
  * \return The number of elements pushed on stack.
@@ -161,23 +179,9 @@ button_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_button_get_modifiers,
                             (lua_class_propfunc_t) luaA_button_set_modifiers);
 
-    /** When bound mouse button + modifiers are pressed.
-     * @param ... One or more arguments are possible
-     * @signal .press
-     */
     signal_add(&button_class.signals, "press");
-    /** When property changes.
-     * @signal property::button
-     */
     signal_add(&button_class.signals, "property::button");
-    /** When property changes.
-     * @signal property::modifiers
-     */
     signal_add(&button_class.signals, "property::modifiers");
-    /** When bound mouse button + modifiers are pressed.
-     * @param ... One or more arguments are possible
-     * @signal .release
-     */
     signal_add(&button_class.signals, "release");
 }
 

--- a/objects/button.c
+++ b/objects/button.c
@@ -178,11 +178,6 @@ button_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_button_set_modifiers,
                             (lua_class_propfunc_t) luaA_button_get_modifiers,
                             (lua_class_propfunc_t) luaA_button_set_modifiers);
-
-    signal_add(&button_class.signals, "press");
-    signal_add(&button_class.signals, "property::button");
-    signal_add(&button_class.signals, "property::modifiers");
-    signal_add(&button_class.signals, "release");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/client.c
+++ b/objects/client.c
@@ -109,6 +109,100 @@
  * @table object
  */
 
+/** When a client gains focus.
+ * @signal .focus
+ */
+
+/** Before manage, after unmanage, and when clients swap.
+ * @signal .list
+ */
+
+/** When 2 clients are swapped
+ * @tparam client client The other client
+ * @tparam boolean is_source If self is the source or the destination of the swap
+ * @signal .swapped
+ */
+
+/**
+ * @signal .manage
+ */
+
+/**
+ * @signal button::press
+ */
+
+/**
+ * @signal button::release
+ */
+
+/**
+ * @signal mouse::enter
+ */
+
+/**
+ * @signal mouse::leave
+ */
+
+/**
+ * @signal mouse::move
+ */
+
+/**
+ * @signal property::window
+ */
+
+/** When a client should get activated (focused and/or raised).
+ *
+ * Default implementation: `awful.ewmh.activate`.
+ * @signal request::activate
+ * @tparam string context The context where this signal was used.
+ * @tparam[opt] table hints A table with additional hints:
+ * @tparam[opt=false] boolean hints.raise should the client be raised?
+ */
+
+/**
+ * @signal request::geometry
+ * @tparam client c The client
+ * @tparam string context Why and what to resize. This is used for the
+ * handlers to know if they are capable of applying the new geometry.
+ * @tparam[opt={}] table Additional arguments. Each context handler may
+ * interpret this differently.
+ */
+
+/**
+ * @signal request::tag
+ */
+
+/**
+ * @signal request::urgent
+ */
+
+/** When a client gets tagged.
+ * @signal .tagged
+ * @tag t The tag object.
+ */
+
+/** When a client gets unfocused.
+ * @signal .unfocus
+ */
+
+/**
+ * @signal .unmanage
+ */
+
+/** When a client gets untagged.
+ * @signal .untagged
+ * @tag t The tag object.
+ */
+
+/**
+ * @signal .raised
+ */
+
+/**
+ * @signal .lowered
+ */
+
 /**
  * The focused `client` or nil (in case there is none).
  *
@@ -3336,46 +3430,15 @@ client_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_client_get_first_tag,
                             NULL);
 
-    /** When a client gains focus.
-     * @signal .focus
-     */
     signal_add(&client_class.signals, "focus");
-    /** Before manage, after unmanage, and when clients swap.
-     * @signal .list
-     */
     signal_add(&client_class.signals, "list");
-    /** When 2 clients are swapped
-     * @tparam client client The other client
-     * @tparam boolean is_source If self is the source or the destination of the swap
-     * @signal .swapped
-     */
     signal_add(&client_class.signals, "swapped");
-    /**
-     * @signal .manage
-     */
     signal_add(&client_class.signals, "manage");
-    /**
-     * @signal button::press
-     */
     signal_add(&client_class.signals, "button::press");
-    /**
-     * @signal button::release
-     */
     signal_add(&client_class.signals, "button::release");
-    /**
-     * @signal mouse::enter
-     */
     signal_add(&client_class.signals, "mouse::enter");
-    /**
-     * @signal mouse::leave
-     */
     signal_add(&client_class.signals, "mouse::leave");
-    /**
-     * @signal mouse::move
-     */
     signal_add(&client_class.signals, "mouse::move");
-
-    /* Those signals are documented elsewhere */
     signal_add(&client_class.signals, "property::above");
     signal_add(&client_class.signals, "property::below");
     signal_add(&client_class.signals, "property::class");
@@ -3416,63 +3479,18 @@ client_class_setup(lua_State *L)
     signal_add(&client_class.signals, "property::type");
     signal_add(&client_class.signals, "property::urgent");
     signal_add(&client_class.signals, "property::width");
-    /**
-     * @signal property::window
-     */
     signal_add(&client_class.signals, "property::window");
     signal_add(&client_class.signals, "property::x");
     signal_add(&client_class.signals, "property::y");
-    /** When a client should get activated (focused and/or raised).
-     *
-     * Default implementation: `awful.ewmh.activate`.
-     * @signal request::activate
-     * @tparam string context The context where this signal was used.
-     * @tparam[opt] table hints A table with additional hints:
-     * @tparam[opt=false] boolean hints.raise should the client be raised?
-     */
     signal_add(&client_class.signals, "request::activate");
-    /**
-     * @signal request::geometry
-     * @tparam client c The client
-     * @tparam string context Why and what to resize. This is used for the
-     * handlers to know if they are capable of applying the new geometry.
-     * @tparam[opt={}] table Additional arguments. Each context handler may
-     * interpret this differently.
-     */
     signal_add(&client_class.signals, "request::geometry");
-    /**
-     * @signal request::tag
-     */
     signal_add(&client_class.signals, "request::tag");
-    /**
-     * @signal request::urgent
-     */
     signal_add(&client_class.signals, "request::urgent");
-    /** When a client gets tagged.
-     * @signal .tagged
-     * @tag t The tag object.
-     */
     signal_add(&client_class.signals, "tagged");
-    /** When a client gets unfocused.
-     * @signal .unfocus
-     */
     signal_add(&client_class.signals, "unfocus");
-    /**
-     * @signal .unmanage
-     */
     signal_add(&client_class.signals, "unmanage");
-    /** When a client gets untagged.
-     * @signal .untagged
-     * @tag t The tag object.
-     */
     signal_add(&client_class.signals, "untagged");
-    /**
-     * @signal .raised
-     */
     signal_add(&client_class.signals, "raised");
-    /**
-     * @signal .lowered
-     */
     signal_add(&client_class.signals, "lowered");
 }
 

--- a/objects/client.c
+++ b/objects/client.c
@@ -3429,69 +3429,6 @@ client_class_setup(lua_State *L)
                             NULL,
                             (lua_class_propfunc_t) luaA_client_get_first_tag,
                             NULL);
-
-    signal_add(&client_class.signals, "focus");
-    signal_add(&client_class.signals, "list");
-    signal_add(&client_class.signals, "swapped");
-    signal_add(&client_class.signals, "manage");
-    signal_add(&client_class.signals, "button::press");
-    signal_add(&client_class.signals, "button::release");
-    signal_add(&client_class.signals, "mouse::enter");
-    signal_add(&client_class.signals, "mouse::leave");
-    signal_add(&client_class.signals, "mouse::move");
-    signal_add(&client_class.signals, "property::above");
-    signal_add(&client_class.signals, "property::below");
-    signal_add(&client_class.signals, "property::class");
-    signal_add(&client_class.signals, "property::focusable");
-    signal_add(&client_class.signals, "property::fullscreen");
-    signal_add(&client_class.signals, "property::geometry");
-    signal_add(&client_class.signals, "property::group_window");
-    signal_add(&client_class.signals, "property::height");
-    signal_add(&client_class.signals, "property::hidden");
-    signal_add(&client_class.signals, "property::icon");
-    signal_add(&client_class.signals, "property::icon_name");
-    signal_add(&client_class.signals, "property::instance");
-    signal_add(&client_class.signals, "property::keys");
-    signal_add(&client_class.signals, "property::machine");
-    signal_add(&client_class.signals, "property::maximized");
-    signal_add(&client_class.signals, "property::maximized_horizontal");
-    signal_add(&client_class.signals, "property::maximized_vertical");
-    signal_add(&client_class.signals, "property::minimized");
-    signal_add(&client_class.signals, "property::modal");
-    signal_add(&client_class.signals, "property::name");
-    signal_add(&client_class.signals, "property::ontop");
-    signal_add(&client_class.signals, "property::pid");
-    signal_add(&client_class.signals, "property::role");
-    signal_add(&client_class.signals, "property::screen");
-    signal_add(&client_class.signals, "property::shape_bounding");
-    signal_add(&client_class.signals, "property::shape_client_bounding");
-    signal_add(&client_class.signals, "property::shape_client_clip");
-    signal_add(&client_class.signals, "property::shape_clip");
-    signal_add(&client_class.signals, "property::size_hints_honor");
-    signal_add(&client_class.signals, "property::skip_taskbar");
-    signal_add(&client_class.signals, "property::sticky");
-    signal_add(&client_class.signals, "property::struts");
-    signal_add(&client_class.signals, "property::titlebar_bottom");
-    signal_add(&client_class.signals, "property::titlebar_left");
-    signal_add(&client_class.signals, "property::titlebar_right");
-    signal_add(&client_class.signals, "property::titlebar_top");
-    signal_add(&client_class.signals, "property::transient_for");
-    signal_add(&client_class.signals, "property::type");
-    signal_add(&client_class.signals, "property::urgent");
-    signal_add(&client_class.signals, "property::width");
-    signal_add(&client_class.signals, "property::window");
-    signal_add(&client_class.signals, "property::x");
-    signal_add(&client_class.signals, "property::y");
-    signal_add(&client_class.signals, "request::activate");
-    signal_add(&client_class.signals, "request::geometry");
-    signal_add(&client_class.signals, "request::tag");
-    signal_add(&client_class.signals, "request::urgent");
-    signal_add(&client_class.signals, "tagged");
-    signal_add(&client_class.signals, "unfocus");
-    signal_add(&client_class.signals, "unmanage");
-    signal_add(&client_class.signals, "untagged");
-    signal_add(&client_class.signals, "raised");
-    signal_add(&client_class.signals, "lowered");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -240,18 +240,6 @@ drawable_class_setup(lua_State *L)
                             NULL,
                             (lua_class_propfunc_t) luaA_drawable_get_surface,
                             NULL);
-
-    signal_add(&drawable_class.signals, "button::press");
-    signal_add(&drawable_class.signals, "button::release");
-    signal_add(&drawable_class.signals, "mouse::enter");
-    signal_add(&drawable_class.signals, "mouse::leave");
-    signal_add(&drawable_class.signals, "mouse::move");
-    signal_add(&drawable_class.signals, "property::geometry");
-    signal_add(&drawable_class.signals, "property::height");
-    signal_add(&drawable_class.signals, "property::width");
-    signal_add(&drawable_class.signals, "property::x");
-    signal_add(&drawable_class.signals, "property::y");
-    signal_add(&drawable_class.signals, "property::surface");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -43,6 +43,50 @@
  * @function drawable
  */
 
+/**
+ * @signal button::press
+ */
+
+/**
+ * @signal button::release
+ */
+
+/**
+ * @signal mouse::enter
+ */
+
+/**
+ * @signal mouse::leave
+ */
+
+/**
+ * @signal mouse::move
+ */
+
+/**
+ * @signal property::geometry
+ */
+
+/**
+ * @signal property::height
+ */
+
+/**
+ * @signal property::width
+ */
+
+/**
+ * @signal property::x
+ */
+
+/**
+ * @signal property::y
+ */
+
+/**
+ * @signal property::surface
+ */
+
 /** Get the number of instances.
  *
  * @return The number of drawable objects alive.
@@ -197,49 +241,16 @@ drawable_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_drawable_get_surface,
                             NULL);
 
-    /**
-     * @signal button::press
-     */
     signal_add(&drawable_class.signals, "button::press");
-    /**
-     * @signal button::release
-     */
     signal_add(&drawable_class.signals, "button::release");
-    /**
-     * @signal mouse::enter
-     */
     signal_add(&drawable_class.signals, "mouse::enter");
-    /**
-     * @signal mouse::leave
-     */
     signal_add(&drawable_class.signals, "mouse::leave");
-    /**
-     * @signal mouse::move
-     */
     signal_add(&drawable_class.signals, "mouse::move");
-    /**
-     * @signal property::geometry
-     */
     signal_add(&drawable_class.signals, "property::geometry");
-    /**
-     * @signal property::height
-     */
     signal_add(&drawable_class.signals, "property::height");
-    /**
-     * @signal property::width
-     */
     signal_add(&drawable_class.signals, "property::width");
-    /**
-     * @signal property::x
-     */
     signal_add(&drawable_class.signals, "property::x");
-    /**
-     * @signal property::y
-     */
     signal_add(&drawable_class.signals, "property::y");
-    /**
-     * @signal property::surface
-     */
     signal_add(&drawable_class.signals, "property::surface");
 }
 

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -759,18 +759,6 @@ drawin_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_drawin_set_shape_clip,
                             (lua_class_propfunc_t) luaA_drawin_get_shape_clip,
                             (lua_class_propfunc_t) luaA_drawin_set_shape_clip);
-
-    signal_add(&drawin_class.signals, "property::geometry");
-    signal_add(&drawin_class.signals, "property::shape_bounding");
-    signal_add(&drawin_class.signals, "property::shape_clip");
-    signal_add(&drawin_class.signals, "property::border_width");
-    signal_add(&drawin_class.signals, "property::cursor");
-    signal_add(&drawin_class.signals, "property::height");
-    signal_add(&drawin_class.signals, "property::ontop");
-    signal_add(&drawin_class.signals, "property::visible");
-    signal_add(&drawin_class.signals, "property::width");
-    signal_add(&drawin_class.signals, "property::x");
-    signal_add(&drawin_class.signals, "property::y");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -67,6 +67,50 @@
  * @table drawin
  */
 
+/**
+ * @signal property::geometry
+ */
+
+/**
+ * @signal property::shape_bounding
+ */
+
+/**
+ * @signal property::shape_clip
+ */
+
+/**
+ * @signal property::border_width
+ */
+
+/**
+ * @signal property::cursor
+ */
+
+/**
+ * @signal property::height
+ */
+
+/**
+ * @signal property::ontop
+ */
+
+/**
+ * @signal property::visible
+ */
+
+/**
+ * @signal property::width
+ */
+
+/**
+ * @signal property::x
+ */
+
+/**
+ * @signal property::y
+ */
+
 /** Get or set mouse buttons bindings to a drawin.
  *
  * @param buttons_table A table of buttons objects, or nothing.
@@ -716,49 +760,16 @@ drawin_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_drawin_get_shape_clip,
                             (lua_class_propfunc_t) luaA_drawin_set_shape_clip);
 
-    /**
-     * @signal property::geometry
-     */
     signal_add(&drawin_class.signals, "property::geometry");
-    /**
-     * @signal property::shape_bounding
-     */
     signal_add(&drawin_class.signals, "property::shape_bounding");
-    /**
-     * @signal property::shape_clip
-     */
     signal_add(&drawin_class.signals, "property::shape_clip");
-    /**
-     * @signal property::border_width
-     */
     signal_add(&drawin_class.signals, "property::border_width");
-    /**
-     * @signal property::cursor
-     */
     signal_add(&drawin_class.signals, "property::cursor");
-    /**
-     * @signal property::height
-     */
     signal_add(&drawin_class.signals, "property::height");
-    /**
-     * @signal property::ontop
-     */
     signal_add(&drawin_class.signals, "property::ontop");
-    /**
-     * @signal property::visible
-     */
     signal_add(&drawin_class.signals, "property::visible");
-    /**
-     * @signal property::width
-     */
     signal_add(&drawin_class.signals, "property::width");
-    /**
-     * @signal property::x
-     */
     signal_add(&drawin_class.signals, "property::x");
-    /**
-     * @signal property::y
-     */
     signal_add(&drawin_class.signals, "property::y");
 }
 

--- a/objects/key.c
+++ b/objects/key.c
@@ -373,11 +373,6 @@ key_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_key_set_modifiers,
                             (lua_class_propfunc_t) luaA_key_get_modifiers,
                             (lua_class_propfunc_t) luaA_key_set_modifiers);
-
-    signal_add(&key_class.signals, "press");
-    signal_add(&key_class.signals, "property::key");
-    signal_add(&key_class.signals, "property::modifiers");
-    signal_add(&key_class.signals, "release");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/key.c
+++ b/objects/key.c
@@ -56,6 +56,22 @@
  * @table key
  */
 
+/**
+ * @signal .press
+ */
+
+/**
+ * @signal property::key
+ */
+
+/**
+ * @signal property::modifiers
+ */
+
+/**
+ * @signal .release
+ */
+
 /** Get the number of instances.
  *
  * @return The number of key objects alive.
@@ -358,21 +374,9 @@ key_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_key_get_modifiers,
                             (lua_class_propfunc_t) luaA_key_set_modifiers);
 
-    /**
-     * @signal .press
-     */
     signal_add(&key_class.signals, "press");
-    /**
-     * @signal property::key
-     */
     signal_add(&key_class.signals, "property::key");
-    /**
-     * @signal property::modifiers
-     */
     signal_add(&key_class.signals, "property::modifiers");
-    /**
-     * @signal .release
-     */
     signal_add(&key_class.signals, "release");
 }
 

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1128,13 +1128,6 @@ screen_class_setup(lua_State *L)
                             NULL,
                             (lua_class_propfunc_t) luaA_screen_get_workarea,
                             NULL);
-
-    signal_add(&screen_class.signals, "property::workarea");
-    signal_add(&screen_class.signals, "property::geometry");
-    signal_add(&screen_class.signals, "property::outputs");
-    signal_add(&screen_class.signals, "primary_changed");
-    signal_add(&screen_class.signals, "added");
-    signal_add(&screen_class.signals, "removed");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -66,6 +66,20 @@
  *
  */
 
+/**
+ * @signal .primary_changed
+ */
+
+/**
+ * This signal is emitted when a new screen is added to the current setup.
+ * @signal .added
+ */
+
+/**
+ * This signal is emitted when a screen is removed from the setup.
+ * @signal removed
+ */
+
  /**
   * The primary screen.
   *
@@ -1118,19 +1132,8 @@ screen_class_setup(lua_State *L)
     signal_add(&screen_class.signals, "property::workarea");
     signal_add(&screen_class.signals, "property::geometry");
     signal_add(&screen_class.signals, "property::outputs");
-    /**
-     * @signal .primary_changed
-     */
     signal_add(&screen_class.signals, "primary_changed");
-    /**
-     * This signal is emitted when a new screen is added to the current setup.
-     * @signal .added
-     */
     signal_add(&screen_class.signals, "added");
-    /**
-     * This signal is emitted when a screen is removed from the setup.
-     * @signal removed
-     */
     signal_add(&screen_class.signals, "removed");
 }
 

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -425,13 +425,6 @@ tag_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_tag_set_activated,
                             (lua_class_propfunc_t) luaA_tag_get_activated,
                             (lua_class_propfunc_t) luaA_tag_set_activated);
-
-    signal_add(&tag_class.signals, "property::name");
-    signal_add(&tag_class.signals, "property::selected");
-    signal_add(&tag_class.signals, "property::activated");
-    signal_add(&tag_class.signals, "request::select");
-    signal_add(&tag_class.signals, "tagged");
-    signal_add(&tag_class.signals, "untagged");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -43,6 +43,20 @@
 #include "luaa.h"
 
 /**
+ * @signal request::select
+ */
+
+/** When a client gets tagged with this tag.
+ * @signal tagged
+ * @client c The tagged client.
+ */
+
+/** When a client gets untagged with this tag.
+ * @signal untagged
+ * @client c The untagged client.
+ */
+
+/**
  * Tag name.
  *
  * **Signal:**
@@ -415,19 +429,8 @@ tag_class_setup(lua_State *L)
     signal_add(&tag_class.signals, "property::name");
     signal_add(&tag_class.signals, "property::selected");
     signal_add(&tag_class.signals, "property::activated");
-    /**
-     * @signal request::select
-     */
     signal_add(&tag_class.signals, "request::select");
-    /** When a client gets tagged with this tag.
-     * @signal tagged
-     * @client c The tagged client.
-     */
     signal_add(&tag_class.signals, "tagged");
-    /** When a client gets untagged with this tag.
-     * @signal untagged
-     * @client c The untagged client.
-     */
     signal_add(&tag_class.signals, "untagged");
 }
 

--- a/objects/window.c
+++ b/objects/window.c
@@ -543,13 +543,6 @@ window_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_window_set_border_width,
                             (lua_class_propfunc_t) luaA_window_get_border_width,
                             (lua_class_propfunc_t) luaA_window_set_border_width);
-
-    signal_add(&window_class.signals, "property::border_color");
-    signal_add(&window_class.signals, "property::border_width");
-    signal_add(&window_class.signals, "property::buttons");
-    signal_add(&window_class.signals, "property::opacity");
-    signal_add(&window_class.signals, "property::struts");
-    signal_add(&window_class.signals, "property::type");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/window.c
+++ b/objects/window.c
@@ -27,6 +27,30 @@
  * @classmod xproperties
  */
 
+/**
+ * @signal property::border_color
+ */
+
+/**
+ * @signal property::border_width
+ */
+
+/**
+ * @signal property::buttons
+ */
+
+/**
+ * @signal property::opacity
+ */
+
+/**
+ * @signal property::struts
+ */
+
+/**
+ * @signal property::type
+ */
+
 #include "objects/window.h"
 #include "common/atoms.h"
 #include "common/xutil.h"
@@ -520,29 +544,11 @@ window_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_window_get_border_width,
                             (lua_class_propfunc_t) luaA_window_set_border_width);
 
-    /**
-     * @signal property::border_color
-     */
     signal_add(&window_class.signals, "property::border_color");
-    /**
-     * @signal property::border_width
-     */
     signal_add(&window_class.signals, "property::border_width");
-    /**
-     * @signal property::buttons
-     */
     signal_add(&window_class.signals, "property::buttons");
-    /**
-     * @signal property::opacity
-     */
     signal_add(&window_class.signals, "property::opacity");
-    /**
-     * @signal property::struts
-     */
     signal_add(&window_class.signals, "property::struts");
-    /**
-     * @signal property::type
-     */
     signal_add(&window_class.signals, "property::type");
 }
 

--- a/property.c
+++ b/property.c
@@ -530,15 +530,8 @@ luaA_register_xproperty(lua_State *L)
     }
     else
     {
-        buffer_t buf;
-        buffer_inita(&buf, a_strlen(name) + a_strlen("xproperty::") + 1);
-        buffer_addf(&buf, "xproperty::%s", name);
-
         property.name = a_strdup(name);
         xproperty_array_insert(&globalconf.xproperties, property);
-        signal_add(&window_class.signals, buf.s);
-        signal_add(&global_signals, buf.s);
-        buffer_wipe(&buf);
     }
 
     return 0;

--- a/spawn.c
+++ b/spawn.c
@@ -27,6 +27,31 @@
  * @module awesome
  */
 
+/** For some reason the application aborted startup
+ * @param arg Table which only got the "id" key set
+ * @signal spawn::canceled
+ */
+
+/** When one of the fields from the @{spawn::initiated} table changes
+ * @param arg Table which describes the spawn event
+ * @signal spawn::change
+ */
+
+/** An application finished starting
+ * @param arg Table which only got the "id" key set
+ * @signal spawn::completed
+ */
+
+/** When a new client is beginning to start
+ * @param arg Table which describes the spawn event
+ * @signal spawn::initiated
+ */
+
+/** An application started a spawn event but didn't start in time.
+ * @param arg Table which only got the "id" key set
+ * @signal spawn::timeout
+ */
+
 #include "spawn.h"
 
 #include <unistd.h>
@@ -245,30 +270,10 @@ spawn_init(void)
                                                   spawn_monitor_event,
                                                   NULL, NULL);
 
-    /** For some reason the application aborted startup
-     * @param arg Table which only got the "id" key set
-     * @signal spawn::canceled
-     */
     signal_add(&global_signals, "spawn::canceled");
-    /** When one of the fields from the @{spawn::initiated} table changes
-     * @param arg Table which describes the spawn event
-     * @signal spawn::change
-     */
     signal_add(&global_signals, "spawn::change");
-    /** An application finished starting
-     * @param arg Table which only got the "id" key set
-     * @signal spawn::completed
-     */
     signal_add(&global_signals, "spawn::completed");
-    /** When a new client is beginning to start
-     * @param arg Table which describes the spawn event
-     * @signal spawn::initiated
-     */
     signal_add(&global_signals, "spawn::initiated");
-    /** An application started a spawn event but didn't start in time.
-     * @param arg Table which only got the "id" key set
-     * @signal spawn::timeout
-     */
     signal_add(&global_signals, "spawn::timeout");
 }
 

--- a/spawn.c
+++ b/spawn.c
@@ -112,8 +112,6 @@ spawn_monitor_timeout(gpointer sequence)
              }
              lua_pop(L, 1);
          }
-         else
-             warn("spawn::timeout signal is missing");
     }
     sn_startup_sequence_unref(sequence);
     return FALSE;
@@ -218,8 +216,6 @@ spawn_monitor_event(SnMonitorEvent *event, void *data)
         }
         lua_pop(L, 1);
     }
-    else
-        warn("%s signal is missing", event_type_str);
 }
 
 /** Tell the spawn module that an app has been started.

--- a/spawn.c
+++ b/spawn.c
@@ -265,12 +265,6 @@ spawn_init(void)
                                                   globalconf.default_screen,
                                                   spawn_monitor_event,
                                                   NULL, NULL);
-
-    signal_add(&global_signals, "spawn::canceled");
-    signal_add(&global_signals, "spawn::change");
-    signal_add(&global_signals, "spawn::completed");
-    signal_add(&global_signals, "spawn::initiated");
-    signal_add(&global_signals, "spawn::timeout");
 }
 
 static gboolean

--- a/spec/awful/screen_spec.lua
+++ b/spec/awful/screen_spec.lua
@@ -6,7 +6,6 @@
 local fake_screens = {}
 
 _G.screen = setmetatable({
-    add_signal = function() end,
     set_index_miss_handler = function() end,
     set_newindex_miss_handler = function() end,
 }, {

--- a/spec/gears/object_spec.lua
+++ b/spec/gears/object_spec.lua
@@ -9,31 +9,6 @@ describe("gears.object", function()
     local obj
     before_each(function()
         obj = object()
-        obj:add_signal("signal")
-    end)
-
-    it("strong connect non-existent signal", function()
-        assert.has.errors(function()
-            obj:connect_signal("foo", function() end)
-        end)
-    end)
-
-    it("weak connect non-existent signal", function()
-        assert.has.errors(function()
-            obj:weak_connect_signal("foo", function() end)
-        end)
-    end)
-
-    it("strong disconnect non-existent signal", function()
-        assert.has.errors(function()
-            obj:disconnect_signal("foo", function() end)
-        end)
-    end)
-
-    it("emitting non-existent signal", function()
-        assert.has.errors(function()
-            obj:emit_signal("foo")
-        end)
     end)
 
     it("strong connecting and emitting signal", function()
@@ -188,7 +163,6 @@ describe("gears.object", function()
 
     it("auto emit disabled", function()
         local got_it = false
-        obj:add_signal("property::foo")
         obj:connect_signal("property::foo", function() got_it=true end)
 
         obj.foo = 42
@@ -199,19 +173,11 @@ describe("gears.object", function()
     it("auto emit enabled", function()
         local got_it = false
         local obj2 = object{enable_auto_signals=true, enable_properties=true}
-        obj2:add_signal("property::foo")
         obj2:connect_signal("property::foo", function() got_it=true end)
 
         obj2.foo = 42
 
         assert.is_true(got_it)
-    end)
-
-    it("auto emit enabled", function()
-        assert.has.errors(function()
-            local obj2 = object{enable_auto_signals=true, enable_properties=true}
-            obj2.foo = "bar"
-        end)
     end)
 
     it("auto emit without dynamic properties", function()

--- a/spec/wibox/test_utils.lua
+++ b/spec/wibox/test_utils.lua
@@ -83,8 +83,6 @@ return {
     widget_stub = function(width, height)
         local w = object()
         w._private = {}
-        w:add_signal("widget::redraw_needed")
-        w:add_signal("widget::layout_changed")
         w.is_widget = true
         w._private.visible = true
         w._private.opacity = 1

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -17,12 +17,6 @@ local function _shim_fake_class()
         return obj._connect_signal(obj, name, func)
     end
 
-    obj._add_signal = obj.add_signal
-
-    function obj.add_signal(name)
-        return obj._add_signal(obj, name)
-    end
-
     function obj.set_index_miss_handler(handler)
         meta.__index = handler
     end
@@ -49,11 +43,6 @@ awesome.startup = true
 
 function awesome.register_xproperty()
 end
-
-awesome.add_signal("refresh")
-awesome.add_signal("wallpaper_changed")
-awesome.add_signal("spawn::canceled")
-awesome.add_signal("spawn::timeout")
 
 return awesome
 

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -4,20 +4,6 @@ local clients = {}
 
 local client, meta = awesome._shim_fake_class()
 
-local function add_signals(c)
-    c:add_signal("property::width")
-    c:add_signal("property::height")
-    c:add_signal("property::x")
-    c:add_signal("property::y")
-    c:add_signal("property::screen")
-    c:add_signal("property::geometry")
-    c:add_signal("request::geometry")
-    c:add_signal("request::tag")
-    c:add_signal("swapped")
-    c:add_signal("raised")
-    c:add_signal("property::_label") --Used internally
-end
-
 -- Keep an history of the geometry for validation and images
 local function push_geometry(c)
     table.insert(c._old_geo, c:geometry())
@@ -45,9 +31,6 @@ function client.gen_fake(args)
     for _, v in ipairs{"x","y","width","height"} do
         ret[v] = ret[v] or 1
     end
-
-
-    add_signals(ret)
 
     -- Emulate capi.client.geometry
     function ret:geometry(new)
@@ -141,37 +124,6 @@ function client.get(s)
 
     return ret
 end
-
-client:_add_signal("manage")
-client:_add_signal("unmanage")
-client:_add_signal("property::urgent")
-client:_add_signal("untagged")
-client:_add_signal("tagged")
-client:_add_signal("property::shape_client_bounding")
-client:_add_signal("property::shape_client_clip")
-client:_add_signal("property::width")
-client:_add_signal("property::height")
-client:_add_signal("property::x")
-client:_add_signal("property::y")
-client:_add_signal("property::geometry")
-client:_add_signal("focus")
-client:_add_signal("new")
-client:_add_signal("property::size_hints_honor")
-client:_add_signal("property::struts")
-client:_add_signal("property::minimized")
-client:_add_signal("property::maximized_horizontal")
-client:_add_signal("property::maximized_vertical")
-client:_add_signal("property::sticky")
-client:_add_signal("property::fullscreen")
-client:_add_signal("property::border_width")
-client:_add_signal("property::hidden")
-client:_add_signal("property::screen")
-client:_add_signal("request::tag")
-client:_add_signal("request::geometry")
-client:_add_signal("request::activate")
-client:_add_signal("raised")
-client:_add_signal("lowered")
-client:_add_signal("list")
 
 return client
 

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -7,10 +7,6 @@ screen.count = 1
 local function create_screen(args)
     local s = gears_obj()
 
-    s:add_signal("property::workarea")
-    s:add_signal("property::index")
-    s:add_signal("padding")
-
     -- Copy the geo in case the args are mutated
     local geo = {
         x      = args.x     ,
@@ -98,10 +94,6 @@ function screen._setup_grid(w, h, rows, args)
 end
 
 screen._add_screen {width=320, height=240}
-
-screen.add_signal("property::workarea")
-screen.add_signal("added")
-screen.add_signal("removed")
 
 return screen
 

--- a/tests/examples/shims/tag.lua
+++ b/tests/examples/shims/tag.lua
@@ -5,20 +5,6 @@ local tag, meta = awesome._shim_fake_class()
 local function new_tag(_, args)
     local ret = gears_obj()
 
-    ret:add_signal("property::layout")
-    ret:add_signal("property::name")
-    ret:add_signal("property::geometry")
-    ret:add_signal("property::screen")
-    ret:add_signal("property::master_width_factor")
-    ret:add_signal("property::mwfact")
-    ret:add_signal("property::ncol")
-    ret:add_signal("property::column_count")
-    ret:add_signal("property::master_count")
-    ret:add_signal("property::nmaster")
-    ret:add_signal("property::index")
-    ret:add_signal("property::useless_gap")
-    ret:add_signal("property::_wa_tracker")
-
     ret.name = args.name or "test"
     ret.activated = true
     ret.selected = true
@@ -41,12 +27,6 @@ local function new_tag(_, args)
         __newindex = function(...) return meta.__newindex(...) end
     })
 end
-
-tag:_add_signal("request::select")
-tag:_add_signal("property::selected")
-tag:_add_signal("property::activated")
-tag:_add_signal("tagged")
-tag:_add_signal("untagged")
 
 return setmetatable(tag, {
     __call      = new_tag,

--- a/tests/examples/text/gears/object/properties.lua
+++ b/tests/examples/text/gears/object/properties.lua
@@ -31,8 +31,6 @@ local o = gears.object {
     enable_auto_signals = true,
 }
 
-o:add_signal "property::foo"
-
 print(o.foo)
  
 o.foo = 42
@@ -42,7 +40,6 @@ print(o.foo)
 o:method(1, 2, 3)
 
  -- Random properties can also be added, the signal will be emited automatically.
-o:add_signal "property::something"
 
 o:connect_signal("property::something", function(obj, value)
     print("In the connection handler!", obj, value)

--- a/tests/examples/text/gears/object/signal.lua
+++ b/tests/examples/text/gears/object/signal.lua
@@ -2,9 +2,6 @@ local gears = require("gears") --DOC_HIDE
 
 local o = gears.object{}
  
- -- Add a new signals to the object. This is used to catch typos
-o:add_signal "my_signal"
- 
  -- Function can be attached to signals
 local function slot(obj, a, b, c)
     print("In slot", obj, a, b, c)

--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -18,7 +18,6 @@ client.focus = client.get()[1]
 local c  = client.focus
 -- local c2 = client.get()[2]
 
-client.add_signal("property::foo")
 c.foo = "bar"
 
 -- Check if the property system works


### PR DESCRIPTION
Based on some recent comment from @Elv13 (Sorry, I don't remember where exactly) and his work with `gears.object` allowing arbitrary properties to be changed and signaled (i.e.. `property::name`), it became clear that having to add signals before they can be used has outlived its usefulness. Catching typos is nice, but making it a lot harder to write code is bad. Thus, this PR deprecated `add_signal` and makes other functions automatically add signals when needed.