### PR TITLE
try menu_* colors before regular normal/focus

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -102,9 +102,9 @@ end
 -- @return item name, item background color, background image, item icon.
 local function label(o)
     if o.focused then
-        return colortext(o.name, theme.fg_focus), theme.bg_focus, nil, o.icon
+        return colortext(o.name, (theme.menu_fg_focus or theme.fg_focus)), (theme.menu_bg_focus or theme.bg_focus), nil, o.icon
     else
-        return o.name, theme.bg_normal, nil, o.icon
+        return o.name, (theme.menu_bg_normal or theme.bg_normal), nil, o.icon
     end
 end
 


### PR DESCRIPTION
This resolves #941. This lets users customize the menubar separately from the tasklist in the same way the popup menu is.