### PR TITLE
Fix client snapping

### DIFF
--- a/lib/awful/mouse/snap.lua
+++ b/lib/awful/mouse/snap.lua
@@ -224,19 +224,17 @@ function module.snap(c, snap, x, y, fixed_x, fixed_y)
         c:struts(struts)
     end
 
-    geom.x = geom.x - (2 * c.border_width)
-    geom.y = geom.y - (2 * c.border_width)
-
     for _, snapper in ipairs(aclient.visible(c.screen)) do
         if snapper ~= c then
-            geom = snap_outside(geom, snapper:geometry(), snap)
+            local snapper_geom = snapper:geometry()
+            snapper_geom.width = snapper_geom.width + (2 * snapper.border_width)
+            snapper_geom.height = snapper_geom.height + (2 * snapper.border_width)
+            geom = snap_outside(geom, snapper_geom, snap)
         end
     end
 
     geom.width = geom.width - (2 * c.border_width)
     geom.height = geom.height - (2 * c.border_width)
-    geom.x = geom.x + (2 * c.border_width)
-    geom.y = geom.y + (2 * c.border_width)
 
     -- It's easiest to undo changes afterwards if they're not allowed
     if fixed_x then geom.x = cur_geom.x end


### PR DESCRIPTION
First some reminder on how client geometries works (in X11, awesome just copied
that!):

- The position (x,y) defines where the border of the client begins
- This means that the content starts at (x+border_width,y+border_width)
- However, the size is the size of the client without border
- Thus, the client covers the rectangle from (x,y) to (x+2*bw,y+2*bw)

The client snapping code got this wrong. It only deals with rectangles and thus
for things to work as expected, the width/height have to be increased by two
times the border width. When snapping a client against other visible clients,
the geometry of the client to snap against wasn't calculated correctly.

This was apparently noticed at one point and worked around by decreasing the
position by two times the border width. While this is terribly wrong, it
actually makes things work correctly when snapping to the right or bottom edge
of a client, but breaks for the other edges.

Fix this by just calculating things correctly.

This is based on a patch from jk411.

Fixes: https://github.com/awesomeWM/awesome/issues/928
Signed-off-by: Uli Schlachter <psychon@znc.in>