### PR TITLE
mouse: Fix moving clients between screens

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -255,6 +255,11 @@ function layout.move_handler(c, context, hints) --luacheck: no unused args
     -- Quit if it isn't a mouse.move on a tiled layout, that's handled elsewhere
     if c.floating then return end
     if context ~= "mouse.move" then return end
+
+    if capi.mouse.screen ~= c.screen then
+        c.screen = capi.mouse.screen
+    end
+
     local l = c.screen.selected_tag and c.screen.selected_tag.layout or nil
     if l == layout.suit.floating then return end
 


### PR DESCRIPTION
Reported on IRC. I am not sure why swap() is not enough, but the
old code removed before the mouse refactor did this, so apparently
it is necessary.

The fix has been reported to work by spyroboy on IRC, thanks!