### PR TITLE
.travis.yml: Stop installing rxvt-unicode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - sudo apt-get install -y libcairo2-dev gtk+3.0 xmlto asciidoc libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
 
   # Deps for functional tests.
-  - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb rxvt-unicode
+  - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb
 
   # Install Lua (per env).
   # Note that Lua 5.3 is installed manually, because it is not available in Ubuntu Trusty.


### PR DESCRIPTION
The last place where we used urxvt for testing was removed in 6b4a2625cb1.

Signed-off-by: Uli Schlachter <psychon@znc.in>