### PR TITLE
tag: Fix restoring invalid tags from history

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -395,7 +395,9 @@ function tag.history.restore(screen, idx)
     tag.viewnone(s)
     -- select tags from the history entry
     for _, t in ipairs(data.history[s][i]) do
-        t.selected = true
+        if t.activated and t.screen then
+            t.selected = true
+        end
     end
     -- update currently selected tags table
     data.history[s].current = data.history[s][i]


### PR DESCRIPTION
If:

 1) An app is open in a tag
 2) A new tag is created
 3) The app is closed in the first tag
 4) The first tag is deleted
 5) The new tag is deleted

Then the history would try to restore an inactive tag without
a screen. Bad things will then happen.