### PR TITLE
prompt: Fix hooks when number or caps lock are set

### DIFF
--- a/lib/awful/key.lua
+++ b/lib/awful/key.lua
@@ -22,9 +22,9 @@ local key = { mt = {}, hotkeys = {} }
 -- By default this is initialized as { "Lock", "Mod2" }
 -- so the Caps Lock or Num Lock modifier are not taking into account by awesome
 -- when pressing keys.
--- @name ignore_modifiers
+-- @name awful.key.ignore_modifiers
 -- @class table
-local ignore_modifiers = { "Lock", "Mod2" }
+key.ignore_modifiers = { "Lock", "Mod2" }
 
 --- Convert the modifiers into pc105 key names
 local conversion = {
@@ -83,7 +83,7 @@ function key.new(mod, _key, press, release, data)
         release=nil
     end
     local ret = {}
-    local subsets = util.subsets(ignore_modifiers)
+    local subsets = util.subsets(key.ignore_modifiers)
     for _, set in ipairs(subsets) do
         ret[#ret + 1] = capi.key({ modifiers = util.table.join(mod, set),
                                    key = _key })

--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -22,6 +22,7 @@ local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility
 local keygrabber = require("awful.keygrabber")
 local util = require("awful.util")
 local beautiful = require("beautiful")
+local akey = require("awful.key")
 
 local prompt = {}
 
@@ -360,15 +361,24 @@ function prompt.run(args, textbox, exe_callback, completion_callback,
             end
         end
 
+        local filtered_modifiers = {}
+
         -- User defined cases
         if hooks[key] then
+            -- Remove caps and num lock
+            for _, m in ipairs(modifiers) do
+                if not util.table.hasitem(akey.ignore_modifiers, m) then
+                    table.insert(filtered_modifiers, m)
+                end
+            end
+
             for _,v in ipairs(hooks[key]) do
-                if #modifiers == #v[1] then
+                if #filtered_modifiers == #v[1] then
                     local match = true
                     for _,v2 in ipairs(v[1]) do
                         match = match and mod[v2]
                     end
-                    if match or #modifiers == 0 then
+                    if match or #filtered_modifiers == 0 then
                         local cb
                         local ret = v[3](command)
                         if ret then


### PR DESCRIPTION
I don't know why I never noticed this. Prompt hooks are not working when number lock was set.