### PR TITLE
Dirty hack to make travis build again

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -352,7 +352,7 @@ endforeach()
 # The examples coverage need to be done again after the configure_file has
 # inserted the additional code. Otherwise, the result will be off, rendering
 # the coverage useless as a tool to track untested code.
-if(GENERATE_DOC AND DO_COVERAGE)
+if(GENERATE_DOC AND DO_COVERAGE AND FALSE) # FIXME: This is broken and causes build failures on travis
     message(STATUS "Running tests again with coverage")
     set(USE_LCOV 1)
 


### PR DESCRIPTION
I'm not really sure what is going on here... the coverage builds on travis set
DO_COVERAGE and thus our CMake machinery tries to re-run the sample-tests with
coverage information. However, $BUILD_DIRECTORY is not set and our .luacov file
bails out. I do not know how this ever worked. Did it ever work?

Signed-off-by: Uli Schlachter <psychon@znc.in>

This half-address #982 by just disabling the broken code. However, a better fix would be to actually fix this instead.