### PR TITLE
Travis: Install luacov 0.11.0-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,9 +84,9 @@ install:
   - travis_retry sudo luarocks install lua-discount
 
   # Install dependencies for code coverage testing.
-  - if [ "$DO_COVERAGE" = "coveralls" ]; then sudo luarocks install luacov-coveralls; fi
-  - if [ "$DO_COVERAGE" = "codecov" ]; then sudo luarocks install luacov-coveralls; fi
   - if [ "$DO_COVERAGE" = "" ]; then export DO_COVERAGE=0; fi
+  - if [ "$DO_COVERAGE" != "0" ]; then sudo luarocks install luacov 0.11.0-1; fi
+  - if [ "$DO_COVERAGE" = "coveralls" ]; then sudo luarocks install luacov-coveralls; fi
 
   # Determine custom version.
   - export AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)"


### PR DESCRIPTION
With luacov 0.12.0-1 our travis build fails. It was always kinda broken, but now
this breakage is revealed.

What likely happens: Our .luacov errors out because some needed environment
variable to figure out where to put the results is not set. Due to the way we
load luacov, it runs with its default config which luckily happens to work. With
luacov 0.12.0-1 the error is propagated instead and the build fails.

Signed-off-by: Uli Schlachter <psychon@znc.in>