### PR TITLE
Make rules with 'tag = "3"' work with multiple screens

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -268,7 +268,7 @@ local force_ignore = {
 function rules.high_priority_properties.tag(c, value)
     if value then
         if type(value) == "string" then
-            value = atag.find_by_name(nil, value)
+            value = atag.find_by_name(c.screen, value)
         end
 
         c:tags{ value }


### PR DESCRIPTION
The default config creates the same set of tags for all screens ("1" to "9"). An
awful.rules-rule with e.g. screen = 2, tag = "3" should obviously tag matching
clients with tag "3" of the second screen.

However, the implementation used the first matching tag in the list of all tags
and thus the client ended up tagged with tag "3" from screen 1. Fix this by
calling find_by_name() with the screen that the client is assigned to.

The existing implementation of awful.rules guarantees that any
"screen"-properties are applied before the code touched by this commit is run,
thus this should always work.

This commit does not add a test catching this because we are currently quite bad
at testing multi-screen scenarios and I don't want to invent the necessary
machinery right now.

Fixes: https://github.com/awesomeWM/awesome/issues/988
Signed-off-by: Uli Schlachter <psychon@znc.in>