### PR TITLE
Fix the titlebar minimize button

### DIFF
--- a/lib/awful/titlebar.lua
+++ b/lib/awful/titlebar.lua
@@ -278,7 +278,7 @@ end
 --- Create a new minimize button for a client.
 -- @param c The client for which the button is wanted.
 function titlebar.widget.minimizebutton(c)
-    local widget = titlebar.widget.button(c, "minimize", function(cl) return cl.minimized end, function(cl) cl.minimized = not cl.minimized end)
+    local widget = titlebar.widget.button(c, "minimize", function() return "" end, function(cl) cl.minimized = not cl.minimized end)
     c:connect_signal("property::minimized", widget.update)
     return widget
 end

--- a/themes/default/theme.lua
+++ b/themes/default/theme.lua
@@ -53,8 +53,9 @@ theme.menu_width  = 100
 -- Define the image to load
 theme.titlebar_close_button_normal = "@AWESOME_THEMES_PATH@/default/titlebar/close_normal.png"
 theme.titlebar_close_button_focus  = "@AWESOME_THEMES_PATH@/default/titlebar/close_focus.png"
-theme.titlebar_minimize_button_normal_inactive = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_normal.png"
-theme.titlebar_minimize_button_focus_inactive  = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_focus.png"
+
+theme.titlebar_minimize_button_normal = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_normal.png"
+theme.titlebar_minimize_button_focus  = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_focus.png"
 
 theme.titlebar_ontop_button_normal_inactive = "@AWESOME_THEMES_PATH@/default/titlebar/ontop_normal_inactive.png"
 theme.titlebar_ontop_button_focus_inactive  = "@AWESOME_THEMES_PATH@/default/titlebar/ontop_focus_inactive.png"

--- a/themes/sky/theme.lua
+++ b/themes/sky/theme.lua
@@ -61,6 +61,9 @@ theme.menu_width            = 100
 theme.titlebar_close_button_normal = "@AWESOME_THEMES_PATH@/default/titlebar/close_normal.png"
 theme.titlebar_close_button_focus = "@AWESOME_THEMES_PATH@/default/titlebar/close_focus.png"
 
+theme.titlebar_minimize_button_normal = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_normal.png"
+theme.titlebar_minimize_button_focus  = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_focus.png"
+
 theme.titlebar_ontop_button_normal_inactive = "@AWESOME_THEMES_PATH@/default/titlebar/ontop_normal_inactive.png"
 theme.titlebar_ontop_button_focus_inactive = "@AWESOME_THEMES_PATH@/default/titlebar/ontop_focus_inactive.png"
 theme.titlebar_ontop_button_normal_active = "@AWESOME_THEMES_PATH@/default/titlebar/ontop_normal_active.png"

--- a/themes/xresources/assets.lua
+++ b/themes/xresources/assets.lua
@@ -158,6 +158,7 @@ end
 function theme_assets.recolor_titlebar_normal(theme, color)
     for _, titlebar_icon in ipairs({
         'titlebar_close_button_normal',
+        'titlebar_minimize_button_normal',
         'titlebar_ontop_button_normal_inactive',
         'titlebar_ontop_button_normal_active',
         'titlebar_sticky_button_normal_inactive',
@@ -166,7 +167,6 @@ function theme_assets.recolor_titlebar_normal(theme, color)
         'titlebar_floating_button_normal_active',
         'titlebar_maximized_button_normal_inactive',
         'titlebar_maximized_button_normal_active',
-        'titlebar_minimize_button_normal_inactive',
     }) do
         theme[titlebar_icon] = recolor_image(theme[titlebar_icon], color)
     end
@@ -176,6 +176,7 @@ end
 function theme_assets.recolor_titlebar_focus(theme, color)
     for _, titlebar_icon in ipairs({
         'titlebar_close_button_focus',
+        'titlebar_minimize_button_normal',
         'titlebar_ontop_button_focus_inactive',
         'titlebar_ontop_button_focus_active',
         'titlebar_sticky_button_focus_inactive',
@@ -184,7 +185,6 @@ function theme_assets.recolor_titlebar_focus(theme, color)
         'titlebar_floating_button_focus_active',
         'titlebar_maximized_button_focus_inactive',
         'titlebar_maximized_button_focus_active',
-        'titlebar_minimize_button_focus_inactive',
     }) do
         theme[titlebar_icon] = recolor_image(theme[titlebar_icon], color)
     end

--- a/themes/zenburn/theme.lua
+++ b/themes/zenburn/theme.lua
@@ -106,6 +106,9 @@ theme.layout_cornerse   = "@AWESOME_THEMES_PATH@/zenburn/layouts/cornerse.png"
 theme.titlebar_close_button_focus  = "@AWESOME_THEMES_PATH@/zenburn/titlebar/close_focus.png"
 theme.titlebar_close_button_normal = "@AWESOME_THEMES_PATH@/zenburn/titlebar/close_normal.png"
 
+theme.titlebar_minimize_button_normal = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_normal.png"
+theme.titlebar_minimize_button_focus  = "@AWESOME_THEMES_PATH@/default/titlebar/minimize_focus.png"
+
 theme.titlebar_ontop_button_focus_active  = "@AWESOME_THEMES_PATH@/zenburn/titlebar/ontop_focus_active.png"
 theme.titlebar_ontop_button_normal_active = "@AWESOME_THEMES_PATH@/zenburn/titlebar/ontop_normal_active.png"
 theme.titlebar_ontop_button_focus_inactive  = "@AWESOME_THEMES_PATH@/zenburn/titlebar/ontop_focus_inactive.png"


### PR DESCRIPTION
Commit 0318c6132840413b1f added an image for the minimize button which was
missing before. However, only the default theme and xresources where fixed to
contain the path to the image.

This commit adds the path to all themes.

Also, minimized clients aren't visible, just as closed (=killed) clients aren't
visible. Thus, we don't need an "active" version of this image.

This commit makes us handle the image for the minimize button just like we
handle the close button: There is no difference between "active" and "inactive"
and the file path in the theme doesn't get any path suffix.

Fixes: https://github.com/awesomeWM/awesome/issues/387
Signed-off-by: Uli Schlachter <psychon@znc.in>