### PR TITLE
Print LuaJIT version in --version

### DIFF
--- a/common/version.c
+++ b/common/version.c
@@ -36,8 +36,14 @@ void
 eprint_version(void)
 {
     lua_State *L = luaL_newstate();
-    luaopen_base(L);
+    luaL_openlibs(L);
     lua_getglobal(L, "_VERSION");
+    lua_getglobal(L, "jit");
+
+    if (lua_istable(L, 2))
+        lua_getfield(L, 2, "version");
+    else
+        lua_pop(L, 1);
 
 #ifdef WITH_DBUS
     const char *has_dbus = "✔";


### PR DESCRIPTION
When called with "--version", awesome prints the Lua version that it was
compiled against and the one that it is running against. This commit makes the
code detect LuaJIT and makes it print the LuaJIT version instead of an
unspecific "Lua 5.1".

Signed-off-by: Uli Schlachter <psychon@znc.in>