### PR TITLE
Fix awful.util.pread() return value

### DIFF
--- a/lib/awful/init.lua
+++ b/lib/awful/init.lua
@@ -32,6 +32,7 @@ end
 util.pread = function()
     util.deprecate("Use io.popen() directly or look at awful.spawn.easy_async() "
             .. "for an asynchronous alternative")
+    return ""
 end
 
 return


### PR DESCRIPTION
The deprecation wrapper that we still have for this function didn't return
anything. However, awful.util.pread() used to return strings. This breaks
script.

Work around this by returning an empty string. That way code will still break,
but at least it should not error out.

Signed-off-by: Uli Schlachter <psychon@znc.in>