### PR TITLE
drawable: Add more data to the find_widgets metadata table

### DIFF
--- a/docs/common/widget.ldoc
+++ b/docs/common/widget.ldoc
@@ -68,6 +68,8 @@
 -- @tparam number geometry.width The widget
 -- @tparam number geometry.height The height
 -- @tparam drawable geometry.drawable The `drawable`
+-- @tparam table geometry.matrix_to_parent The relative `gears.matrix`
+-- @tparam table geometry.matrix_to_device The absolute `gears.matrix`
 -- @see mouse
 
 --- When a mouse button is released over the widget.
@@ -85,6 +87,8 @@
 -- @tparam number geometry.width The widget
 -- @tparam number geometry.height The height
 -- @tparam drawable geometry.drawable The `drawable`
+-- @tparam table geometry.matrix_to_parent The relative `gears.matrix`
+-- @tparam table geometry.matrix_to_device The absolute `gears.matrix`
 -- @see mouse
 
 --- When the mouse enter a widget.
@@ -96,6 +100,8 @@
 -- @tparam number geometry.width The widget
 -- @tparam number geometry.height The height
 -- @tparam drawable geometry.drawable The `drawable`
+-- @tparam table geometry.matrix_to_parent The relative `gears.matrix`
+-- @tparam table geometry.matrix_to_device The absolute `gears.matrix`
 -- @see mouse
 
 --- When the mouse leave a widget.
@@ -107,4 +113,6 @@
 -- @tparam number geometry.width The widget
 -- @tparam number geometry.height The height
 -- @tparam drawable geometry.drawable The `drawable`
+-- @tparam table geometry.matrix_to_parent The relative `gears.matrix`
+-- @tparam table geometry.matrix_to_device The absolute `gears.matrix`
 -- @see mouse

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -170,7 +170,9 @@ local function find_widgets(_drawable, result, _hierarchy, x, y)
             0, 0, width, height)
         table.insert(result, {
             x = x3, y = y3, width = w3, height = h3,
-            drawable = _drawable, widget = _hierarchy:get_widget()
+            drawable = _drawable, widget = _hierarchy:get_widget(),
+            matrix_to_device = _hierarchy:get_matrix_to_device(),
+            matrix_to_parent = _hierarchy:get_matrix_to_parent(),
         })
     end
     for _, child in ipairs(_hierarchy:get_children()) do


### PR DESCRIPTION
The metadata commit is necessary to correctly re-implement @kindlycat slider widget using linear algebra. The previous version didn't work when used in a mirror or reflection widget. It also implemented `width` and `vertical` itself instead of using containers. I wont publish my fixed version now, I did say "no more code for 3.6" and I will keep my word on this*. However, it wasn't possible to make it work without this change.

Basically, you have to convert the `{x,y}` coordinate of the mouse to the relative ones compared to the **transformed** origin point of the widget.

\* The widget will be part of my Radical module for now so early adopters can test it.