### PR TITLE
Screen area signals

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -277,6 +277,20 @@ end
 
 capi.client.connect_signal("request::geometry", layout.move_handler)
 
+-- When a screen is moved, make (floating) clients follow it
+capi.screen.connect_signal("property::geometry", function(s, old_geom)
+    local geom = s.geometry
+    local xshift = geom.x - old_geom.x
+    local yshift = geom.y - old_geom.y
+    for _, c in ipairs(capi.client.get(s)) do
+        local cgeom = c:geometry()
+        c:geometry({
+            x = cgeom.x + xshift,
+            y = cgeom.y + yshift
+        })
+    end
+end)
+
 return layout
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -550,9 +550,11 @@ screen_modified(screen_t *existing_screen, screen_t *other_screen)
     lua_State *L = globalconf_get_lua_State();
 
     if(!AREA_EQUAL(existing_screen->geometry, other_screen->geometry)) {
+        area_t old_geometry = existing_screen->geometry;
         existing_screen->geometry = other_screen->geometry;
         luaA_object_push(L, existing_screen);
-        luaA_object_emit_signal(L, -1, "property::geometry", 0);
+        luaA_pusharea(L, old_geometry);
+        luaA_object_emit_signal(L, -2, "property::geometry", 1);
         lua_pop(L, 1);
         screen_update_workarea(existing_screen);
     }
@@ -1101,6 +1103,7 @@ luaA_screen_fake_resize(lua_State *L)
     int y = luaL_checkinteger(L, 3);
     int width = luaL_checkinteger(L, 4);
     int height = luaL_checkinteger(L, 5);
+    area_t old_geometry = screen->geometry;
 
     screen->geometry.x = x;
     screen->geometry.y = y;
@@ -1109,7 +1112,8 @@ luaA_screen_fake_resize(lua_State *L)
 
     screen_update_workarea(screen);
 
-    luaA_object_emit_signal(L, 1, "property::geometry", 0);
+    luaA_pusharea(L, old_geometry);
+    luaA_object_emit_signal(L, 1, "property::geometry", 1);
 
     return 0;
 }

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -775,10 +775,12 @@ void screen_update_workarea(screen_t *screen)
     if (AREA_EQUAL(area, screen->workarea))
         return;
 
+    area_t old_workarea = screen->workarea;
     screen->workarea = area;
     lua_State *L = globalconf_get_lua_State();
     luaA_object_push(L, screen);
-    luaA_object_emit_signal(L, -1, "property::workarea", 0);
+    luaA_pusharea(L, old_workarea);
+    luaA_object_emit_signal(L, -2, "property::workarea", 1);
     lua_pop(L, 1);
 }
 

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -89,6 +89,10 @@
 /**
  * The screen coordinates.
  *
+ * **Signal:**
+ *
+ *  * *property::geometry*
+ *
  * **Immutable:** true
  * @property geometry
  * @param table


### PR DESCRIPTION
Here is some stuff around screens. `property::geometry` and `property::workarea` get the old area as arguments and clients are moved to follow their screen if the screen moves. This should help with https://github.com/awesomeWM/awesome/issues/976.