### PR TITLE
restore client.border_width after fullscreen

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -278,6 +278,7 @@ local function store_geometry(d, reqtype)
     if not data[d][reqtype] then data[d][reqtype] = {} end
     data[d][reqtype] = d:geometry()
     data[d][reqtype].screen = d.screen
+    data[d][reqtype].border_width = d.border_width
 end
 
 --- Get the margins and offset
@@ -1161,6 +1162,9 @@ function placement.restore(d, args)
     if not memento then return false end
 
     memento.screen = nil --TODO use it
+
+    d.border_width = memento.border_width
+
     d:geometry(memento)
     return true
 end

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -45,7 +45,9 @@ local steps = {
     -- Test restoring client.border_width
     function()
         local c = client.get()[1]
-        local test_width = 2
+
+        -- pick an arbitrary border_width distinct from the default one
+        local test_width = c.border_width + 1
 
         c.border_width = test_width
 

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -41,6 +41,22 @@ local steps = {
         c.maximized_horizontal = false
         return true
     end,
+
+    -- Test restoring client.border_width
+    function()
+        local c = client.get()[1]
+        local test_width = 2
+
+        c.border_width = test_width
+
+        c.fullscreen = true
+        c.fullscreen = false
+
+        assert(c.border_width == test_width)
+
+        return true
+    end,
+
     -- Test restoring a geometry
     function()
         local c = client.get()[1]


### PR DESCRIPTION
client.border_width is not reset to its original value after fullscreen which results in the client borders effectively beeing removed after toggling fullscreen.

This should fix this behaviour (i.e. restore client.border_width to the original value before fullscreen).