### PR TITLE
spawn: Fix crash when called with an empty table.

### DIFF
--- a/spawn.c
+++ b/spawn.c
@@ -414,8 +414,12 @@ luaA_spawn(lua_State *L)
     if(!argv || !argv[0])
     {
         g_strfreev(argv);
-        luaA_warn(L, "spawn: parse error: %s", error->message);
-        g_error_free(error);
+        if (error) {
+            luaA_warn(L, "spawn: parse error: %s", error->message);
+            g_error_free(error);
+        }
+        else
+            luaA_warn(L, "spawn: There is nothing to execute");
         return 1;
     }
 

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -6,6 +6,9 @@ local spawn = require("awful.spawn")
 local spawns_done = 0
 local exit_yay, exit_snd = nil, nil
 
+-- * Using spawn with array is already covered by the test client.
+-- * spawn with startup notification is covered by test-spawn-snid.lua
+
 local steps = {
   function(count)
     if count == 1 then
@@ -61,6 +64,17 @@ local steps = {
       assert(exit_snd == 42)
       return true
     end
+  end,
+  function()
+    -- Test empty command table
+    spawn{}
+    return true
+  end,
+  function()
+    -- Test empty command string
+    spawn("")
+    assert(#client.get() == 0)
+    return true
   end,
 }
 


### PR DESCRIPTION
The spawn code didn't properly handle the case where there
is an empty command stream. In that case, no error is
reported as there is simply nothing to do. The error message
was probed and this caused an invalid read and crash.

Fix #1033