### PR TITLE
Revert "screen: Fix potential nil index"

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -230,11 +230,7 @@ end
 --   present currently.
 function screen.focused(args)
     args = args or screen.default_focused_args or {}
-    return get_screen(
-        (args.client and args.client.screen) or
-        (capi.client.focus and capi.client.focus.screen) or
-        capi.mouse.screen
-    )
+    return get_screen(args.client and capi.client.screen or capi.mouse.screen)
 end
 
 --- Get a placement bounding geometry.


### PR DESCRIPTION
This reverts commit facf676b1367e6915235a45ce3e7ef11790b0411.

Using capi.client.focus.screen to decide which screen is focused breaks
a multiscreen setup. At least makes it extremely annoying to use.

In particular, if you have a focused client on screen 1, move the mouse
to screen 2 and launch a new client, the new client appears in screen 1,
since screen.focused reports that current focused screen is 1, not 2
because of the focused client.