### PR TITLE
remove client.jumpto deprecation warnings

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1091,7 +1091,7 @@ function client.run_or_raise(cmd, matcher, merge)
 
     local c = client.iterate(matcher, start)()
     if c then
-        client.jumpto(c, merge)
+        c:jump_to(merge)
     else
         -- client not found, spawn it
         spawn(cmd)

--- a/lib/awful/client/urgent.lua
+++ b/lib/awful/client/urgent.lua
@@ -54,7 +54,7 @@ end
 function urgent.jumpto(merge)
     local c = client.urgent.get()
     if c then
-        client.jumpto(c, merge)
+        c:jump_to(merge)
     end
 end
 


### PR DESCRIPTION
`client.run_or_raise()` and `client.urgent.jumpto()` use `client.jumpto()` which is deprecated.

This replaces the calls with the suggested `c:jump_to()`.