### PR TITLE
Travis: fix return/exit usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,18 +43,17 @@ install:
   # Install Lua (per env).
   # Note that Lua 5.3 is installed manually, because it is not available in Ubuntu Trusty.
   - |
+    set -ev
     if [[ "$LUA" == "5.3" ]]; then
       wget http://www.lua.org/ftp/lua-5.3.2.tar.gz -O lua.tar.gz
       tar -xvzf lua.tar.gz
-      cd lua-*
-      (cd src && make SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2 -DLUA_USE_APICHECK" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="gcc -shared -ldl -o" liblua.so) || exit 1
-      sudo make INSTALL_TOP=/usr/ INSTALL_INC=${LUAINCLUDE} TO_LIB=liblua.so linux install || exit 1
-      cd ..
+      (cd lua-5.3.2/src \
+        && make SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2 -DLUA_USE_APICHECK" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="gcc -shared -ldl -o" liblua.so \
+        && cd .. \
+        && sudo make INSTALL_TOP=/usr/ INSTALL_INC=${LUAINCLUDE} TO_LIB=liblua.so linux install)
     elif [[ "$LUANAME" == "luajit-2.0" ]]; then
       git clone http://luajit.org/git/luajit-2.0.git
-      cd luajit-2.0
-      sudo make install PREFIX=/usr
-      cd ..
+      (cd luajit-2.0 && sudo make install PREFIX=/usr)
 
       # "Create" /usr/bin/lua if needed (Yup, this is a bad hack)
       if [ ! -e "/usr/bin/lua" ]; then sudo ln -s /usr/bin/luajit /usr/bin/lua; fi
@@ -66,11 +65,10 @@ install:
   - |
     travis_retry wget https://keplerproject.github.io/luarocks/releases/luarocks-2.3.0.tar.gz
     tar xf luarocks-2.3.0.tar.gz
-    cd luarocks-2.3.0
-    ./configure --lua-version=$LUA --with-lua-include=${LUAINCLUDE} ${LUAROCKS_ARGS}
-    make build
-    sudo make install
-    cd ..
+    (cd luarocks-2.3.0 \
+      && ./configure --lua-version=$LUA --with-lua-include=${LUAINCLUDE} ${LUAROCKS_ARGS} \
+      && make build \
+      && sudo make install)
 
   # lgi.
   - sudo apt-get install -y gir1.2-pango-1.0 libgirepository1.0-dev
@@ -101,10 +99,11 @@ install:
   - |
     do_codecov() {
       if [ "$DO_COVERAGE" = "codecov" ]; then
-        (cd build && luacov) || exit 1
-        travis_retry bash /tmp/codecov-bash -F "$1" || exit 1
+        (cd build && luacov) || return 1
+        travis_retry bash /tmp/codecov-bash -F "$1" || return 1
         rm build/luacov.stats.out
       fi
+      return 0
     }
 
   # Functions for custom Travis folds.
@@ -129,6 +128,7 @@ install:
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION -D DO_COVERAGE=${DO_COVERAGE}"
   - |
+    set -ev
     if [ -n "$BUILD_IN_DIR" ]; then
       # Explicitly remove the Makefile to not build from the src dir accidentally.
       rm Makefile
@@ -148,6 +148,7 @@ script:
       do_codecov samples
     fi
   - |
+    set -ev
     if [ "$TRAVIS_TEST_RESULT" = 0 ]; then
       if [ "$DO_COVERAGE" != "0" ]; then
         travis_fold_start "DO_COVERAGE"
@@ -158,12 +159,13 @@ script:
          && do_codecov functionaltests)
         ret=$?
         travis_fold_end
-        exit $ret
+        [ "$ret" = 0 ]
       else
         travis_run_in_fold "make.check" make check
       fi
     fi
   - |
+    set -ev
     if [ "$TEST_PREV_COMMITS" = 1 ] && ! [ "$TRAVIS_PULL_REQUEST" = false ]; then
       # Check each commit separately (to make git-bisect less annoying).
       echo "Testing previous commits based on TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
@@ -187,7 +189,7 @@ script:
       done
       if [ -n "$failed" ]; then
         echo "Checks failed for these commits:$failed"
-        exit 1
+        false
       fi
     fi
 


### PR DESCRIPTION
Return 0 (success) in do_codecov function.  It is used in "&&" chains,
and should just do nothing for "coverall", but not break it.

This also makes use of "set -ev" instead of "exit" in general.

The "exit" caused the whole build to stop, but it was still green!
https://travis-ci.org/awesomeWM/awesome/jobs/151943526

"exit" is not really supported:
https://docs.travis-ci.com/user/customizing-the-build/#How-does-this-work%3F-(Or%2C-why-you-should-not-use-exit-in-build-steps)

This also wraps (most of) the "cd" commands in a subshell, to ensure
being in the repo directory all the time (except for $BUILD_IN_DIR).