### PR TITLE
tag: Fix index calculation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ install:
   - travis_retry sudo luarocks install luacheck
 
   # Install ldoc for building docs.
-  - travis_retry sudo luarocks install ldoc
+  - travis_retry sudo luarocks install ldoc 1.4.4
   - travis_retry sudo luarocks install lua-discount
 
   # Install dependencies for code coverage testing.

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -412,7 +412,7 @@ function screen.object.get_tags(s, unordered)
     -- Avoid infinite loop, + save some time
     if not unordered then
         table.sort(tags, function(a, b)
-            return (a.index or 9999) < (b.index or 9999)
+            return (a.index or math.huge) < (b.index or math.huge)
         end)
     end
 

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -74,6 +74,12 @@ function tag.object.set_index(self, idx)
     -- screen.tags cannot be used as it depend on index
     local tmp_tags = raw_tags(scr)
 
+    -- sort the tags by index
+    table.sort(tmp_tags, function(a, b)
+        local ia, ib = tag.getproperty(a, "index"), tag.getproperty(b, "index")
+        return (ia or math.huge) < (ib or math.huge)
+    end)
+
     if (not idx) or (idx < 1) or (idx > #tmp_tags) then
         return
     end
@@ -97,12 +103,13 @@ function tag.object.set_index(self, idx)
 end
 
 function tag.object.get_index(query_tag)
-    -- Get an unordered list of tags
-    local tags = raw_tags(query_tag.screen)
 
     local idx = tag.getproperty(query_tag, "index")
 
     if idx then return idx end
+
+    -- Get an unordered list of tags
+    local tags = raw_tags(query_tag.screen)
 
     -- Too bad, lets compute it
     for i, t in ipairs(tags) do

--- a/tests/test-awful-tag.lua
+++ b/tests/test-awful-tag.lua
@@ -3,6 +3,14 @@ local beautiful = require("beautiful")
 
 awful.util.deprecate = function() end
 
+local function check_order()
+    local tags = mouse.screen.tags
+
+    for k, v in ipairs(tags) do
+        assert(k == v.index)
+    end
+end
+
 local has_spawned = false
 local steps = {
 
@@ -20,28 +28,38 @@ local tags = mouse.screen.tags
 
 assert(#mouse.screen.tags == 9)
 
-for k, v in ipairs(tags) do
-    assert(k == v.index)
-end
+check_order()
 
 tags[7].index = 9
 assert(tags[7].index == 9)
 
+check_order()
+
 tags[7].index = 4
 assert(tags[7].index == 4)
+
+check_order()
 
 awful.tag.move(5, tags[7])
 assert(tags[7].index == 5)
 
+check_order()
+
 tags[1]:swap(tags[3])
+
+check_order()
 
 assert(tags[1].index == 3)
 assert(tags[3].index == 1)
+
+check_order()
 
 awful.tag.swap(tags[1], tags[3])
 
 assert(tags[3].index == 3)
 assert(tags[1].index == 1)
+
+check_order()
 
 -- Test add, icon and delete
 
@@ -51,6 +69,8 @@ assert(c and client.focus == c)
 assert(beautiful.awesome_icon)
 
 local t = awful.tag.add("Test", {clients={c}, icon = beautiful.awesome_icon})
+
+check_order()
 
 local found = false
 


### PR DESCRIPTION
The index was updated on an unordered table. As the elements
order did not match the relative indices once they have been
changed, further calls to set_index produced garbage.

The default taglist didn't notice because it use screen.tags
table index instead of the tag index. A debug using

echo 'for _,t in ipairs(mouse.screen.tags) do
  print("INDEX:", _, t.index, t.name) end' | awesome-client

Would have shown two or more elements with the same index. To
debug issues related to tag indices, this bash script can be
enabled:

while true; do
  echo 'for _,t in ipairs(mouse.screen.tags) do
  assert( _==t.index) end' | awesome-client
  sleep 0.5
done