### PR TITLE
awesome-client: send command line arguments to awesome

### DIFF
--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -17,7 +17,7 @@ then
     then
         if [ "$A_RERUN" = "" ]
         then
-            A_RERUN="no" exec $RLWRAP $0
+            A_RERUN="no" exec $RLWRAP $0 "$@"
         fi
         READ_CMD="read"
     else
@@ -50,7 +50,12 @@ a_dbus_send()
     fi
 }
 
-if [ "$ISATTY" = 0 ]
+if [ $# -ne 0 ]
+then
+    for arg in "$@" ; do
+        a_dbus_send "$arg"
+    done
+elif [ "$ISATTY" = 0 ]
 then
     while $READ_CMD -p "awesome# " -r line
     do


### PR DESCRIPTION
In some languages, invoking commands with command-line arguments is
significantly simpler than setting up pipes for writing to a command's
standard input.

This adds an additional way for sending commands through awesome-client;
so all of these will be equivalent:

  $ awesome-client 'awesome.restart()'
  $ echo 'awesome.restart()' | awesome-client
  $ awesome-client <<<'awesome.restart()'
  $ awesome-client
  awesome# awesome.restart()
  awesome# ^D
  $

Note that this sends each command line argument as a separate message
over dbus.