### PR TITLE
tooltip: Stop using a fallback font

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -571,7 +571,7 @@ function tooltip.new(args)
     end
 
     local fg = beautiful.tooltip_fg or beautiful.fg_focus or "#000000"
-    local font = beautiful.tooltip_font or beautiful.font or "terminus 6"
+    local font = beautiful.tooltip_font or beautiful.font
 
     -- Set default properties
     self.wibox_properties = {


### PR DESCRIPTION
First, that font isn't very common and it also causes a tiny
tooltip on normal screens. 6px on 1080p laptop screen (not
using HiDPI) is totally unreadable.

Let the default font be used, just as everywhere else.