### PR TITLE
Fix a bug moving between a tiled and a floating screen.

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -1506,7 +1506,7 @@ client_resize_do(client_t *c, area_t geometry, bool force_notice)
     bool java_is_broken = true;
 
     screen_t *new_screen = c->screen;
-    if(!screen_coord_in_screen(new_screen, geometry.x, geometry.y))
+    if(!screen_area_in_screen(new_screen, geometry))
         new_screen = screen_getbycoord(geometry.x, geometry.y);
 
     if(c->geometry.width == geometry.width

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -731,6 +731,20 @@ screen_coord_in_screen(screen_t *s, int x, int y)
            && (y >= s->geometry.y && y < s->geometry.y + s->geometry.height);
 }
 
+/** Is there any overlap between the given geometry and a given screen?
+ * \param screen The logical screen number.
+ * \param geom The geometry
+ * \return True if there is any overlap between the geometry and a given screen.
+ */
+bool
+screen_area_in_screen(screen_t *s, area_t geom)
+{
+        return (geom.x < s->geometry.x + s->geometry.width)
+               && (geom.x + geom.width > s->geometry.x )
+               && (geom.y < s->geometry.y + s->geometry.height)
+               && (geom.y + geom.height > s->geometry.y);
+}
+
 void screen_update_workarea(screen_t *screen)
 {
     area_t area = screen->geometry;

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -50,6 +50,7 @@ void screen_class_setup(lua_State *L);
 void screen_scan(void);
 screen_t *screen_getbycoord(int, int);
 bool screen_coord_in_screen(screen_t *, int, int);
+bool screen_area_in_screen(screen_t *, area_t);
 int screen_get_index(screen_t *);
 area_t display_area_get(void);
 void screen_client_moveto(client_t *, screen_t *, bool);


### PR DESCRIPTION
When dragging a client with the mouse from a tiled screen on the left to a floating screen on the right the client will flicker when the mouse is on the right screen but the left side of the client is on the left.


This is because the screen is changed when the mouse moves screen, but is then reset if the left most edge isn't on this screen. This fix checks if any part of the client is on the new screen instead.


--
Check if any of the window is on the screen it is moved to, not just
the topmost leftmost edge.

Signed-off-by: blueusername <blueusername@github>