### PR TITLE
Allow relative path in theme

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -133,11 +133,11 @@ function beautiful.init(config)
                             theme[k] = v:gsub("^%./", configdir .. "/")
                         end
                     end
-                end
-            -- expand '~'
-            elseif type(config) == 'table' then
-                for k, v in pairs(theme) do
-                    if type(v) == "string" then theme[k] = v:gsub("^~/", homedir .. "/") end
+                -- expand '~'
+                elseif type(config) == 'table' then
+                    for k, v in pairs(theme) do
+                        if type(v) == "string" then theme[k] = v:gsub("^~/", homedir .. "/") end
+                    end
                 end
             end
 

--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -111,26 +111,27 @@ end
 function beautiful.init(config)
     if config then
         local homedir = os.getenv("HOME")
+        local theme_path = ""
 
         -- If `config` is the path to a theme file, run this file,
         -- otherwise if it is a theme table, save it.
         if type(config) == 'string' then
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
-            configdir = config:gsub("/[^/]+$", "")
             theme = protected_call(dofile, config)
+            theme_path = config:gsub("/[^/]+$", "")
         elseif type(config) == 'table' then
             theme = config
         end
 
         if theme then
-            -- expand '~' and './'
             if homedir then
+                -- expand '~' and './'
                 if type(config) == "string" then
                     for k, v in pairs(theme) do
                         if type(v) == "string" then
                             theme[k] = v:gsub("^~/", homedir .. "/")
-                            theme[k] = v:gsub("^%./", configdir .. "/")
+                            theme[k] = v:gsub("^%./", theme_path .. "/")
                         end
                     end
                 -- expand '~'

--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -117,14 +117,25 @@ function beautiful.init(config)
         if type(config) == 'string' then
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
+            configdir = config:gsub("/[^/]+$", "")
             theme = protected_call(dofile, config)
         elseif type(config) == 'table' then
             theme = config
         end
 
         if theme then
-            -- expand '~'
+            -- expand '~' and './'
             if homedir then
+                if type(config) == "string" then
+                    for k, v in pairs(theme) do
+                        if type(v) == "string" then
+                            theme[k] = v:gsub("^~/", homedir .. "/")
+                            theme[k] = v:gsub("^%./", configdir .. "/")
+                        end
+                    end
+                end
+            -- expand '~'
+            elseif type(config) == 'table' then
                 for k, v in pairs(theme) do
                     if type(v) == "string" then theme[k] = v:gsub("^~/", homedir .. "/") end
                 end


### PR DESCRIPTION
For example:

Before, we can only use absolute path or `~/` in theme.lua file

``` lua
theme.wallpaper = "/usr/local/share/awesome/themes/default/background.png"
```

Now, we can use relative path

``` lua
theme.wallpaper = "./background.png"
```
