### PR TITLE
Compatibility tweak for minimize and 3.5 themes

### DIFF
--- a/lib/awful/titlebar.lua
+++ b/lib/awful/titlebar.lua
@@ -226,7 +226,6 @@ function titlebar.widget.button(c, name, selector, action)
                     img = "inactive"
                 end
             end
-            -- First try with a prefix based on the client's focus state
             local prefix = "normal"
             if capi.client.focus == c then
                 prefix = "focus"
@@ -234,11 +233,12 @@ function titlebar.widget.button(c, name, selector, action)
             if img ~= "" then
                 prefix = prefix .. "_"
             end
+            -- First try with a prefix based on the client's focus state,
+            -- then try again without that prefix if nothing was found,
+            -- and finally, try a fallback for compatibility with Awesome 3.5 themes
             local theme = beautiful["titlebar_" .. name .. "_button_" .. prefix .. img]
-            if not theme then
-                -- Then try again without that prefix if nothing was found
-                theme = beautiful["titlebar_" .. name .. "_button_" .. img]
-            end
+                       or beautiful["titlebar_" .. name .. "_button_" .. img]
+                       or beautiful["titlebar_" .. name .. "_button_" .. prefix .. "_inactive"]
             if theme then
                 img = theme
             end


### PR DESCRIPTION
Awesome 3.5.9 accepts `_active`/`_inactive` names for `beautiful` minimize keys (such as "titlebar_minimize_button_focus_inactive"). Some themes rely on those, meaning that when they loaded under the current Git, the minimize button went missing. This adds a fallback, to improve compatibility with the existing themes.

Without this commit, I'd have to edit existing themes like this to make them work in both versions:

```lua
-- for Awesome 3.6/git:
theme.titlebar_minimize_button_hover  = "~/.config/awesome/themes/neon/titlebar/minimize_hover.png"
theme.titlebar_minimize_button_focus  = "~/.config/awesome/themes/neon/titlebar/minimize_focus.png"
theme.titlebar_minimize_button_normal = "~/.config/awesome/themes/neon/titlebar/minimize_normal.png"

-- for Awesome 3.5:
theme.titlebar_minimize_button_focus_active = theme.titlebar_minimize_button_focus
theme.titlebar_minimize_button_focus_inactive = theme.titlebar_minimize_button_focus
theme.titlebar_minimize_button_normal_active = theme.titlebar_minimize_button_normal
theme.titlebar_minimize_button_normal_inactive = theme.titlebar_minimize_button_normal
```
