### PR TITLE
Test & fix a bug with dbus.disconnect_signal

### DIFF
--- a/common/signal.h
+++ b/common/signal.h
@@ -92,6 +92,8 @@ signal_disconnect(signal_array_t *arr, const char *name, const void *ref)
             if(ref == *func)
             {
                 cptr_array_remove(&sigfound->sigfuncs, func);
+                if(sigfound->sigfuncs.len == 0)
+                    signal_array_remove(arr, sigfound);
                 return true;
             }
     }

--- a/tests/test-dbus-error.lua
+++ b/tests/test-dbus-error.lua
@@ -1,0 +1,35 @@
+local runner = require("_runner")
+local awful = require("awful")
+
+local calls_done = 0
+
+local function dbus_callback(data)
+    assert(data.member == "Ping")
+    calls_done = calls_done + 1
+end
+
+dbus.request_name("session", "org.awesomewm.test")
+
+-- Yup, we had a bug that made the following not work
+dbus.connect_signal("org.awesomewm.test", dbus_callback)
+dbus.disconnect_signal("org.awesomewm.test", dbus_callback)
+dbus.connect_signal("org.awesomewm.test", dbus_callback)
+
+for _=1, 2 do
+    awful.spawn({
+        "dbus-send",
+        "--dest=org.awesomewm.test",
+        "--type=method_call",
+        "/",
+        "org.awesomewm.test.Ping",
+        "string:foo"
+    })
+end
+
+runner.run_steps({ function()
+    if calls_done >= 2 then
+        return true
+    end
+end })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The code was written so that it assumes that disconnecting the last signal also
removed the corresponding entry in the signal array. This lead e.g. to an
index-out-of-bounds access in some cases.

Signed-off-by: Uli Schlachter <psychon@znc.in>