### PR TITLE
Fix #1091

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -428,6 +428,7 @@ awful.rules.rules = {
                      raise = true,
                      keys = clientkeys,
                      buttons = clientbuttons,
+                     screen = awful.screen.preferred,
                      placement = awful.placement.no_overlap+awful.placement.no_offscreen
      }
     },

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -12,7 +12,8 @@ local capi =
 {
     mouse = mouse,
     screen = screen,
-    client = client
+    client = client,
+    awesome = awesome,
 }
 local util = require("awful.util")
 local object = require("gears.object")
@@ -211,6 +212,15 @@ function screen.object.set_padding(self, padding)
         data.padding[self] = padding
         self:emit_signal("padding")
     end
+end
+
+--- Return the currently screen for new clients.
+-- This is exactly the same as `awful.screen.focused` exept it avoids clients
+-- being moved when Awesome is restarted. This is used by the default `rc.lua`.
+-- @tparam client c A client
+-- @treturn screen The preferred screen.
+function screen.preferred(c)
+    return capi.awesome.startup and c.screen or screen.focused()
 end
 
 --- The defaults arguments for `awful.screen.focused`


### PR DESCRIPTION
The test error will be easy enough to fix. Just disable the connect_sighnal("property::screen") in the first commit, then add a second commit to undo that and monkey-patch awful.screen.preferred to nil for the current tests, then put it back to its original value for the new tests we will need to prevent this from regressing. The connect_signal("property::screen") check is still necessary for the tests to be useful, as what they really test is that c.screen is set only once (to prevent the other use cases from regressing, again...). I don't have time for it now.