### PR TITLE
Some assorted fixes

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -165,8 +165,7 @@ mytasklist.buttons = awful.util.table.join(
                                               awful.client.focus.byidx(-1)
                                           end))
 
-awful.screen.connect_for_each_screen(function(s)
-    -- Wallpaper
+local function set_wallpaper(s)
     if beautiful.wallpaper then
         local wallpaper = beautiful.wallpaper
         -- If wallpaper is a function, call it with the screen
@@ -175,6 +174,14 @@ awful.screen.connect_for_each_screen(function(s)
         end
         gears.wallpaper.maximized(wallpaper, s, true)
     end
+end
+
+-- Re-set wallpaper when a screen's geometry changes (e.g. different resolution)
+screen.connect_signal("property::geometry", set_wallpaper)
+
+awful.screen.connect_for_each_screen(function(s)
+    -- Wallpaper
+    set_wallpaper(s)
 
     -- Each screen has its own tag table.
     awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.layouts[1])

--- a/lib/awful/layout/suit/magnifier.lua
+++ b/lib/awful/layout/suit/magnifier.lua
@@ -62,13 +62,8 @@ function magnifier.arrange(p)
     -- Check that the focused window is on the right screen
     if focus and focus.screen ~= p.screen then focus = nil end
 
-    if not focus and #cls > 0 then
-        focus = cls[1]
-        fidx = 1
-    end
-
-    -- If focused window is not tiled, take the first one which is tiled.
-    if focus.floating then
+    -- If no window is focused or focused window is not tiled, take the first tiled one.
+    if (not focus or focus.floating) and #cls > 0 then
         focus = cls[1]
         fidx = 1
     end

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -46,9 +46,6 @@ local function get_widget_context(self)
             screen = s,
             dpi = dpi,
             drawable = self,
-            widget_at = function(_, ...)
-                self:widget_at(...)
-            end
         }
         for k, v in pairs(self._widget_context_skeleton) do
             context[k] = v

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -51,6 +51,9 @@ local function get_widget_context(self)
             context[k] = v
         end
         self._widget_context = context
+
+        -- Give widgets a chance to react to the new context
+        self._need_complete_repaint = true
     end
     return context
 end

--- a/lib/wibox/hierarchy.lua
+++ b/lib/wibox/hierarchy.lua
@@ -23,6 +23,7 @@ local function hierarchy_new(redraw_callback, layout_callback, callback_arg)
         _matrix_to_device = matrix.identity,
         _need_update = true,
         _widget = nil,
+        _context = nil,
         _redraw_callback = redraw_callback,
         _layout_callback = layout_callback,
         _callback_arg = callback_arg,
@@ -73,6 +74,7 @@ end
 local hierarchy_update
 function hierarchy_update(self, context, widget, width, height, region, matrix_to_parent, matrix_to_device)
     if (not self._need_update) and self._widget == widget and
+            self._context == context and
             self._size.width == width and self._size.height == height and
             matrix.equals(self._matrix, matrix_to_parent) and
             matrix.equals(self._matrix_to_device, matrix_to_device) then
@@ -101,6 +103,7 @@ function hierarchy_update(self, context, widget, width, height, region, matrix_t
 
     -- Save the arguments we need to save
     self._widget = widget
+    self._context = context
     self._size.width = width
     self._size.height = height
     self._matrix = matrix_to_parent

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -177,9 +177,6 @@ local function new(args)
 
     setup_signals(ret)
     ret.draw = ret._drawable.draw
-    ret.widget_at = function(_, widget, x, y, width, height)
-        return ret._drawable:widget_at(widget, x, y, width, height)
-    end
 
     -- Set the default background
     ret:set_bg(args.bg or beautiful.bg_normal)

--- a/objects/client.c
+++ b/objects/client.c
@@ -1138,7 +1138,7 @@ client_border_refresh(void)
 static void
 client_geometry_refresh(void)
 {
-    client_ignore_enterleave_events();
+    bool ignored_enterleave = false;
     foreach(_c, globalconf.clients)
     {
         client_t *c = *_c;
@@ -1164,6 +1164,11 @@ client_geometry_refresh(void)
                 && AREA_EQUAL(real_geometry, c->x11_client_geometry))
             continue;
 
+        if (!ignored_enterleave) {
+            client_ignore_enterleave_events();
+            ignored_enterleave = true;
+        }
+
         xcb_configure_window(globalconf.connection, c->frame_window,
                 XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
                 (uint32_t[]) { geometry.x, geometry.y, geometry.width, geometry.height });
@@ -1177,7 +1182,8 @@ client_geometry_refresh(void)
         /* ICCCM 4.2.3 says something else, but Java always needs this... */
         client_send_configure(c);
     }
-    client_restore_enterleave_events();
+    if (ignored_enterleave)
+        client_restore_enterleave_events();
 }
 
 void

--- a/tests/test-use-after-gc.lua
+++ b/tests/test-use-after-gc.lua
@@ -1,0 +1,31 @@
+-- Test behaviour of C objects after they were finalized
+
+local runner = require("_runner")
+
+local done
+do
+    local obj
+    local func = function()
+        assert(obj.valid == false)
+        assert(not pcall(function()
+            print(obj.visible)
+        end))
+        assert(not pcall(function()
+            obj.visible = true
+        end))
+        done = true
+    end
+    if _VERSION >= "Lua 5.2" then
+        setmetatable({}, { __gc = func })
+    else
+        local newproxy = newproxy -- luacheck: globals newproxy
+        getmetatable(newproxy(true)).__gc = func
+    end
+    obj = drawin({})
+end
+collectgarbage("collect")
+assert(done)
+
+runner.run_steps({ function() return true end })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Lots of small fixes that hopefully do not introduce any regressions. Instead of opening several PRs for all of them individually, I put all of them here.

This should close at least #1103 and #1102, should help with #982 and also fixes some issues that weren't even reported yet (assign different DPis to your screens, move a client from one screen to the other, notice that the titlebar isn't updated; however, the size of the titlebar does still not react to DPI changes...).

This conflicts with #1070. @Elv13 do we really need a `__gc` callback or should this approach of making `.valid` work on GC'd objects be enough?

Edit: Now also has a patch for #1107.