### PR TITLE
tests: Fix awful.screen tests

### DIFF
--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -79,6 +79,9 @@ end
 
 local has_error
 
+-- Disable awful.screen.preferred(c)
+awful.rules.rules[1].properties.screen = nil
+
 table.insert(steps, function()
     -- Make sure there is no extra callbacks that causes double screen changes
     -- (regress #1028 #1052)


### PR DESCRIPTION
To ensure that some features such as SNID rules work, we need
to ensure that the screen isn't set by other code paths. Only
a single algorithm can be executed for the screen. As soon
as many algorithms are executed on events such as "manage", it
will most likely regress again.

This commit make sure of that by disabling the default normal source
of c.screen. After that, any other c.screen changes can be
considered bugs.