### PR TITLE
tests/run.sh: Use dbus-send directly with low timeouts

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -187,7 +187,8 @@ start_awesome() {
     cd - >/dev/null
 
     # Wait until the interface for awesome-client is ready (D-Bus interface).
-    wait_until_success "wait for awesome startup via awesome-client" "DISPLAY=$D '$AWESOME_CLIENT' 'return 1' 2>&1"
+    # Do this with dbus-send so that we can specify a low --reply-timeout
+    wait_until_success "wait for awesome startup via awesome-client" "dbus-send --reply-timeout=100 --dest=org.naquadah.awesome.awful --print-reply / org.naquadah.awesome.awful.Remote.Eval 'string:return 1' 2>&1"
 }
 
 # Count errors.


### PR DESCRIPTION
run.sh waits for awesome's startup to be done by having awesome execute "return
1" via its dbus interface. However, by default dbus has a 25 second timeout
before it fails a dbus-send invocation. This defeats the purpose of this
exercise.

So instead of using awesome-client, this commit makes the code use dbus-send
directly and specifies a relative low reply timeout (which should still be
plenty so that this doesn't erroneously fail).

This hopefully supersedes #822.