### PR TITLE
Speedup ignore enterleave

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -8,8 +8,6 @@ set(CODENAME "The Fox")
 
 project(${PROJECT_AWE_NAME} C)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 option(WITH_DBUS "build with D-BUS" ON)
 option(GENERATE_MANPAGES "generate manpages" ON)
 option(COMPRESS_MANPAGES "compress manpages" ON)

--- a/globalconf.h
+++ b/globalconf.h
@@ -55,6 +55,11 @@ typedef struct button_t button_t;
 typedef struct client_t client_t;
 typedef struct tag tag_t;
 typedef struct xproperty xproperty_t;
+struct sequence_pair {
+    xcb_void_cookie_t begin;
+    xcb_void_cookie_t end;
+};
+typedef struct sequence_pair sequence_pair_t;
 
 ARRAY_TYPE(button_t *, button)
 ARRAY_TYPE(tag_t *, tag)
@@ -62,6 +67,7 @@ ARRAY_TYPE(screen_t *, screen)
 ARRAY_TYPE(client_t *, client)
 ARRAY_TYPE(drawin_t *, drawin)
 ARRAY_TYPE(xproperty_t, xproperty)
+DO_ARRAY(sequence_pair_t, sequence_pair, DO_NOTHING)
 
 /** Main configuration structure */
 typedef struct
@@ -180,6 +186,9 @@ typedef struct
     uint32_t preferred_icon_size;
     /** Cached wallpaper information */
     cairo_surface_t *wallpaper;
+    /** List of enter/leave events to ignore */
+    sequence_pair_array_t ignore_enter_leave_events;
+    xcb_void_cookie_t pending_enter_leave_begin;
 } awesome_t;
 
 extern awesome_t globalconf;

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -297,10 +297,10 @@ static void
 drawin_map(lua_State *L, int widx)
 {
     drawin_t *drawin = luaA_checkudata(L, widx, &drawin_class);
-    /* Activate BMA */
-    client_ignore_enterleave_events();
     /* Apply any pending changes */
     drawin_apply_moveresize(drawin);
+    /* Activate BMA */
+    client_ignore_enterleave_events();
     /* Map the drawin */
     xcb_map_window(globalconf.connection, drawin->window);
     /* Deactivate BMA */

--- a/tests/test-tooltip.lua
+++ b/tests/test-tooltip.lua
@@ -93,8 +93,12 @@ table.insert(steps, function()
         x = w.x + w.width - 20 - 12.5,
         y = w.y + 125 + 12.5,
     }
+    return true
+end)
 
-    assert(tt.current_position == "top")
+-- Test that the above move had the intended effect
+table.insert(steps, function()
+    assert(tt.current_position == "top", tt.current_position)
 
     return true
 end)


### PR DESCRIPTION
This is yet another fix to #1107. According to that bug report, `client_ignore_enterleave_events()` is slow. We already reacted to that by calling this function less often. This pull request also makes that function less slow.

Unrelated to that, this also contains a commit that stops forcing `CMAKE_BUILD_TYPE` to be set to `Release`. This means that people can now actually chose a value for this variable and it means that `assert()` starts to work, because we are no longer compiled with `NDEBUG` defined. Well, it is partly related, since this adds some `assert()`s...