### PR TITLE
Better obj properties

### DIFF
--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -451,6 +451,17 @@ luaA_class_index(lua_State *L)
 
     lua_class_property_t *prop = luaA_class_property_get(L, class, 2);
 
+    /* Is this the special 'data' property? This is available on all objects and
+     * thus not implemented as a lua_class_property_t.
+     */
+    if (A_STREQ(attr, "data"))
+    {
+        luaA_checkudata(L, 1, class);
+        luaA_getuservalue(L, 1);
+        lua_getfield(L, -1, "data");
+        return 1;
+    }
+
     /* Property does exist and has an index callback */
     if(prop)
     {

--- a/common/luaobject.h
+++ b/common/luaobject.h
@@ -173,6 +173,8 @@ int luaA_object_emit_signal_simple(lua_State *);
         lua_newtable(L);                                                       \
         lua_newtable(L);                                                       \
         lua_setmetatable(L, -2);                                               \
+        lua_newtable(L);                                                       \
+        lua_setfield(L, -2, "data");                                           \
         luaA_setuservalue(L, -2);                                              \
         lua_pushvalue(L, -1);                                                  \
         luaA_class_emit_signal(L, &(lua_class), "new", 1);                     \

--- a/lib/gears/object/properties.lua
+++ b/lib/gears/object/properties.lua
@@ -10,22 +10,6 @@
 
 local object = {}
 
-local properties = setmetatable({}, { __mode = 'k' })
-
-local function cobj_register(cobj)
-    local fallback = {}
-
-    function fallback:rawset(_, prop, val)
-        fallback[prop] = val
-    end
-
-    function fallback:rawget(_, prop)
-        return fallback[prop]
-    end
-
-    properties[cobj] = fallback
-    return fallback
-end
 
 --- Add the missing properties handler to a CAPI object such as client/tag/screen.
 -- Valid args:
@@ -66,10 +50,8 @@ function object.capi_index_fallback(class, args)
             return args.getter_fallback(cobj, prop)
         end
 
-        local fallback = properties[cobj] or cobj_register(cobj)
-
         -- Use the fallback property table
-        return fallback[prop]
+        return cobj.data[prop]
     end
 
     local setter = args.setter or function(cobj, prop, value)
@@ -88,10 +70,8 @@ function object.capi_index_fallback(class, args)
             return
         end
 
-        local fallback = properties[cobj] or cobj_register(cobj)
-
         -- Use the fallback property table
-        fallback[prop] = value
+        cobj.data[prop] = value
 
         -- Emit the signal
         if args.auto_emit then

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -5,6 +5,7 @@ local gears_obj = require("gears.object")
 -- handlers.
 local function _shim_fake_class()
     local obj = gears_obj()
+    obj.data = {}
 
     local meta = {
         __index     = function()end,

--- a/tests/examples/shims/button.lua
+++ b/tests/examples/shims/button.lua
@@ -1,3 +1,4 @@
 return function() return {
+    data = {},
     connect_signal = function() end
 } end

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -17,6 +17,7 @@ end
 -- Create fake clients to move around
 function client.gen_fake(args)
     local ret = gears_obj()
+    ret.data = {}
     ret.type = "normal"
     ret.valid = true
     ret.size_hints = {}

--- a/tests/examples/shims/drawin.lua
+++ b/tests/examples/shims/drawin.lua
@@ -4,6 +4,7 @@ local drawin, meta = awesome._shim_fake_class()
 
 local function new_drawin(_, args)
     local ret = gears_obj()
+    ret.data = {}
 
     for k, v in pairs(args) do
         rawset(ret, k, v)

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -6,6 +6,7 @@ screen.count = 1
 
 local function create_screen(args)
     local s = gears_obj()
+    s.data = {}
 
     -- Copy the geo in case the args are mutated
     local geo = {

--- a/tests/examples/shims/tag.lua
+++ b/tests/examples/shims/tag.lua
@@ -5,6 +5,7 @@ local tag, meta = awesome._shim_fake_class()
 local function new_tag(_, args)
     local ret = gears_obj()
 
+    ret.data = {}
     ret.name = args.name or "test"
     ret.activated = true
     ret.selected = true


### PR DESCRIPTION
This adds a `.data` table to all C objects. This is just some Lua table that is not used in any way by the C code. This table is then used by `gears.object.properties` to save properties. The upshot of this is that something like the following no longer causes a memory leak (I have to admit that I did not actually test this example):
```lua
do
    local k = key{}
    k[k] = k
end
```
Edit: This is (loosely) connected to #1125.