### PR TITLE
build: Fix make install when ldoc is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ set(AWESOME_C_FLAGS
 mark_as_advanced(AWESOME_C_FLAGS)
 target_compile_options(${PROJECT_AWE_NAME} PRIVATE ${AWESOME_C_FLAGS})
 
+# Make sure awesomerc.lua is generated
+add_dependencies(${PROJECT_AWE_NAME} generate_awesomerc)
+
 # Linux w/ GCC requires -rdynamic to get backtrace to fully work.
 #
 # For "historical reasons", CMake adds the option to the linker flags

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -351,6 +351,10 @@ add_custom_command(
         ${BUILD_DIR}/awesomerc.lua
 )
 
+# Create a target for the auto-generated awesomerc.lua
+add_custom_target(generate_awesomerc DEPENDS ${BUILD_DIR}/awesomerc.lua)
+
+
 #}}}
 
 # {{{ Copy additional files


### PR DESCRIPTION
When ldoc is missing, nothing does depend on `awesomerc.lua` (apparently, `install()` isn't smart enough to update the dependency graph). So it wasn't generated... This PR make the dependency explicit. Sorry about missing that earlier.

Fix #1131