### PR TITLE
Fix short flicker when new clients appear

### DIFF
--- a/event.h
+++ b/event.h
@@ -46,10 +46,10 @@ awesome_refresh(void)
 {
     screen_refresh();
     luaA_emit_refresh();
-    banning_refresh();
-    stack_refresh();
     drawin_refresh();
     client_refresh();
+    banning_refresh();
+    stack_refresh();
     return xcb_flush(globalconf.connection);
 }
 


### PR DESCRIPTION
We are doing more and more things lazily in the C code. The newest
addition is lazily configuring clients, which means that geometry
changes are only applied later.

However, this caused a short flicker when a new client appears: We were
first making the client visible and then moving it to its "proper"
position.

Since unbanning is also done lazily, we just have to change the order in
which we apply these operations to fix this.

Signed-off-by: Uli Schlachter <psychon@znc.in>