### PR TITLE
Drawable visibility

### DIFF
--- a/lib/awful/titlebar.lua
+++ b/lib/awful/titlebar.lua
@@ -282,6 +282,7 @@ local function new(c, args)
             position = position
         }
         ret = drawable(d, context, "awful.titlebar")
+        ret:_inform_visible(true)
         local function update_colors()
             local args_ = bars[position].args
             ret:set_bg(get_color("bg", c, args_))
@@ -298,6 +299,9 @@ local function new(c, args)
         -- Update the colors when focus changes
         c:connect_signal("focus", update_colors)
         c:connect_signal("unfocus", update_colors)
+
+        -- Inform the drawable when it becomes invisible
+        c:connect_signal("unmanage", function() ret:_inform_visible(false) end)
     else
         bars[position].args = args
         ret = bars[position].drawable

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -266,6 +266,9 @@ function drawable:set_fg(c)
     self._do_complete_repaint()
 end
 
+function drawable:_inform_visible(visible)
+end
+
 local function emit_difference(name, list, skip)
     local function in_table(table, val)
         for _, v in pairs(table) do

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -429,7 +429,11 @@ function drawable.new(d, widget_context_skeleton, drawable_name)
             return
         end
         ret._need_relayout = true
-        ret:draw()
+        -- When not visible, we will be redrawn when we become visible. In the
+        -- mean-time, the layout does not matter much.
+        if ret._visible then
+            ret:draw()
+        end
     end
 
     -- Add __tostring method to metatable.

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -169,6 +169,11 @@ local function new(args)
     ret._drawable = wibox.drawable(w.drawable, { wibox = ret },
         "wibox drawable (" .. object.modulename(3) .. ")")
 
+    ret._drawable:_inform_visible(w.visible)
+    w:connect_signal("property::visible", function()
+        ret._drawable:_inform_visible(w.visible)
+    end)
+
     for k, v in pairs(wibox) do
         if type(v) == "function" then
             ret[k] = v


### PR DESCRIPTION
This adds explicit tracking of visible to `wibox.drawable` and uses that to fix a use-after-free related crash that occasionally occurred on Travis (and I think @Elv13 ran into this while developing some PR).

The downside of this is that it might add unnecessary redraws when a wibox is made visible after being hidden for a while. This might be fixable via various kinds of magic, but I'd live with it for now. (Example for such magic: Have a global variable which is initially 0 and incremented whenever the wallpaper changes; have drawables track the value of this counter when they were redrawn last; that way we can detect if the wallpaper changed while a drawable was invisible) (Another example: Have a single boolean tracking if the dirty area is empty or not to avoid redrawns when nothing changed at all)