### PR TITLE
Delay client frame window destruction

### DIFF
--- a/event.h
+++ b/event.h
@@ -37,6 +37,7 @@ void drawin_refresh(void);
 /* objects/client.c */
 void client_refresh(void);
 void client_focus_refresh(void);
+void client_destroy_later(void);
 
 /* objects/screen.c */
 void screen_refresh(void);
@@ -50,6 +51,7 @@ awesome_refresh(void)
     client_refresh();
     banning_refresh();
     stack_refresh();
+    client_destroy_later();
     return xcb_flush(globalconf.connection);
 }
 

--- a/globalconf.h
+++ b/globalconf.h
@@ -68,6 +68,7 @@ ARRAY_TYPE(client_t *, client)
 ARRAY_TYPE(drawin_t *, drawin)
 ARRAY_TYPE(xproperty_t, xproperty)
 DO_ARRAY(sequence_pair_t, sequence_pair, DO_NOTHING)
+DO_ARRAY(xcb_window_t, window, DO_NOTHING)
 
 /** Main configuration structure */
 typedef struct
@@ -189,6 +190,8 @@ typedef struct
     /** List of enter/leave events to ignore */
     sequence_pair_array_t ignore_enter_leave_events;
     xcb_void_cookie_t pending_enter_leave_begin;
+    /** List of windows to be destroyed later */
+    window_array_t destroy_later_windows;
 } awesome_t;
 
 extern awesome_t globalconf;


### PR DESCRIPTION
Daniel sees a short flicker of his wallpaper when he closes a client.
This happens because the window is destroyed immediately, but other
clients are re-arranged only shortly later. In the mean time, the X
server updates the display and repaints the root window (= wallpaper
becomes visible).

Work around this by delaying the destruction of frame windows to the end
of the current main loop iteration. This means that we first update the
position of all other windows and later destroy the window that was
actually closed.

Signed-off-by: Uli Schlachter <psychon@znc.in>

See #1138.