### PR TITLE
awesome-client: allow override of rlwrap

### DIFF
--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -12,12 +12,15 @@ if [ "$ISATTY" = 0 ]
 then
     # rlwrap provides readline functionality for "read", which is more enhanced
     # than bash's "read" itself.
-    RLWRAP=$(which rlwrap 2>/dev/null)
-    if [ "$RLWRAP" != "" ]
+    # It can be disabled/overridden using 'AWESOME_RLWRAP= awesome-client'.
+    if [ -z "${AWESOME_RLWRAP+x}" ]; then
+        AWESOME_RLWRAP="$(which rlwrap 2>/dev/null)"
+    fi
+    if [ -n "$AWESOME_RLWRAP" ]
     then
         if [ "$A_RERUN" = "" ]
         then
-            A_RERUN="no" exec $RLWRAP $0 "$@"
+            A_RERUN="no" exec $AWESOME_RLWRAP $0 "$@"
         fi
         READ_CMD="read"
     else


### PR DESCRIPTION
This is necessary when being run with a tty that has no width, which
happens when using https://github.com/metakirby5/codi.vim/ in Vim 8 (but
not Neovim), where rlwrap complains as follows:

> rlwrap: error: My terminal reports width=0 (is it emacs?) I can't
> handle this, sorry!

Then `awesome-client` can be used like this in codi.vim:

```vim
    function! s:pp_awesome_remove_spaces(line)
      return substitute(a:line, '^   ', '', 'g')
    endfunction
    let g:codi#interpreters = {
          \ 'awesome': {
          \   'bin': ['env', 'AWESOME_RLWRAP=', 'awesome-client'],
          \   'prompt': '^awesome# ',
          \   'preprocess': function('s:pp_awesome_remove_spaces')
          \ }}
```
(Requires this fix: https://github.com/metakirby5/codi.vim/pull/48)