### PR TITLE
gears.surface.widget_to_*: Ignore repaints

### DIFF
--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -210,15 +210,9 @@ end
 local function no_op() end
 
 local function run_in_hierarchy(self, cr, width, height)
-
-    local function redraw(h)
-        h:draw({dpi=96}, cr)
-    end
-
-    local h = hierarchy.new({dpi=96}, self, width, height, redraw, no_op, {})
-
-    redraw(h)
-
+    local context = {dpi=96}
+    local h = hierarchy.new(context, self, width, height, no_op, no_op, {})
+    h:draw(context, cr)
     return h
 end
 


### PR DESCRIPTION
For some reason, the code here tried to handle widget::redraw_needed
signals even though it should apparently/obviously only produce a
current snapshot of the widget's look.

Fix this by just removing the redraw code.

While here, also factor out the widget context table into a local
variable and re-use it for the initial layout and for the later draw.

Signed-off-by: Uli Schlachter <psychon@znc.in>