### PR TITLE
Ignore warnings from ldoc by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ include_directories(
     ${AWESOME_REQUIRED_INCLUDE_DIRS}
     ${AWESOME_OPTIONAL_INCLUDE_DIRS})
 
+set(CHECK_TARGETS check-integration)
+
 set(AWE_CONF_FILE_DEFAULT ${BUILD_DIR}/awesomerc.lua)
 set(AWE_CONF_FILE rc.lua)
 
@@ -272,17 +274,24 @@ if(GENERATE_DOC)
     # Copy the aliases to the build directory
     file(COPY ${SOURCE_DIR}/docs/aliases DESTINATION ${BUILD_DIR}/docs)
 
-    # Run ldoc and make it fail if any warnings are generated. The
-    # redirection-magic swaps stdout and stderr and awk exits with a non-zero
-    # status if it sees at least one line of input.
-    # All together, this fails as soon as ldoc prints on stderr.
     add_custom_target(ldoc ALL
-        COMMAND ${LDOC_EXECUTABLE} . 3>&1 1>&2 2>&3 | awk "{ fail=1 \; print } END { exit fail }"
+        COMMAND ${LDOC_EXECUTABLE} .
         WORKING_DIRECTORY ${AWE_DOC_DIR}
         DEPENDS ${AWE_LUA_FILES} ${AWE_MD_FILES} ${BUILD_DIR}/docs/06-appearance.md
         ${BUILD_DIR}/docs/05-awesomerc.md
     )
 
+    # Run ldoc and make it fail if any warnings are generated. The
+    # redirection-magic swaps stdout and stderr and awk exits with a non-zero
+    # status if it sees at least one line of input.
+    # All together, this fails as soon as ldoc prints on stderr.
+    add_custom_target(check-ldoc-warnings
+        COMMAND ${LDOC_EXECUTABLE} . 3>&1 1>&2 2>&3 | awk "{ fail=1 \; print } END { exit fail }"
+        WORKING_DIRECTORY ${AWE_DOC_DIR}
+        DEPENDS ${AWE_LUA_FILES} ${AWE_MD_FILES} ${BUILD_DIR}/docs/06-appearance.md
+        ${BUILD_DIR}/docs/05-awesomerc.md
+    )
+    list(APPEND CHECK_TARGETS check-ldoc-warnings)
 endif()
 # }}}
 
@@ -365,7 +374,6 @@ endif()
 # }}}
 
 # {{{ Tests
-set(CHECK_TARGETS check-integration)
 add_custom_target(check-integration
     sh -c "CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${CMAKE_SOURCE_DIR}/tests/run.sh"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,12 @@ if(GENERATE_DOC)
 
     file(GLOB_RECURSE AWE_LUA_FILES ${BUILD_DIR}/lib/*.lua)
     file(GLOB_RECURSE AWE_MD_FILES ${AWE_DOC_DIR}/*.md)
+    file(GLOB_RECURSE AWE_MD_LUA_FILES RELATIVE "${SOURCE_DIR}/docs" docs/*.md.lua)
+    foreach(file ${AWE_MD_LUA_FILES})
+        # Remove .lua file extensions
+        string(REPLACE ".lua" "" file ${file})
+        list(APPEND AWE_MD_FILES "${AWE_DOC_DIR}/${file}")
+    endforeach()
 
     # Copy the images to the build directory
     file(COPY ${SOURCE_DIR}/docs/images DESTINATION ${BUILD_DIR}/doc)
@@ -277,8 +283,7 @@ if(GENERATE_DOC)
     add_custom_target(ldoc ALL
         COMMAND ${LDOC_EXECUTABLE} .
         WORKING_DIRECTORY ${AWE_DOC_DIR}
-        DEPENDS ${AWE_LUA_FILES} ${AWE_MD_FILES} ${BUILD_DIR}/docs/06-appearance.md
-        ${BUILD_DIR}/docs/05-awesomerc.md
+        DEPENDS ${AWE_LUA_FILES} ${AWE_MD_FILES}
     )
 
     # Run ldoc and make it fail if any warnings are generated. The
@@ -288,8 +293,7 @@ if(GENERATE_DOC)
     add_custom_target(check-ldoc-warnings
         COMMAND ${LDOC_EXECUTABLE} . 3>&1 1>&2 2>&3 | awk "{ fail=1 \; print } END { exit fail }"
         WORKING_DIRECTORY ${AWE_DOC_DIR}
-        DEPENDS ${AWE_LUA_FILES} ${AWE_MD_FILES} ${BUILD_DIR}/docs/06-appearance.md
-        ${BUILD_DIR}/docs/05-awesomerc.md
+        DEPENDS ${AWE_LUA_FILES} ${AWE_MD_FILES}
     )
     list(APPEND CHECK_TARGETS check-ldoc-warnings)
 endif()


### PR DESCRIPTION
A while ago, we made errors from ldoc fatal by default. Then a new ldoc
release appeared and caused problems for all of our users, because
awesome failed to work.

This patch reverts the previous fix so that we ignore ldoc warnings by
default again. However, to catch ldoc warnings on Travis, another
ldoc-building-target is added that fails on warnings. This new target is
included in our "check" target.

Helps-with: https://github.com/awesomeWM/awesome/issues/1098
Signed-off-by: Uli Schlachter <psychon@znc.in>