### PR TITLE
Fix unbalanced Lua stack operation

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -783,6 +783,7 @@ luaA_loadrc(const char *confpath, bool run)
         const char *err = lua_tostring(L, -1);
         luaA_startup_error(err);
         fprintf(stderr, "%s\n", err);
+        lua_pop(L, 1);
         return false;
     }
 


### PR DESCRIPTION
Add a single "do" to the beginning of the config. This causes a parsing
error ("'end' expected") and then another warning saying "something was
left on the Lua stack.

Fix this by popping the error message where we need to do so.

Signed-off-by: Uli Schlachter <psychon@znc.in>