### PR TITLE
menubar.utils: Use a protected call

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -19,6 +19,7 @@ local gio = lgi.Gio
 local glib = lgi.GLib
 local wibox = require("wibox")
 local debug = require("gears.debug")
+local protected_call = require("gears.protected_call")
 
 local utils = {}
 
@@ -288,7 +289,7 @@ function utils.parse_dir(dir_path, callback)
     gio.Async.start(function()
         local result = {}
         parser(dir_path, result)
-        callback(result)
+        protected_call.call(callback, result)
     end)()
 end
 


### PR DESCRIPTION
When awesome calls any Lua code, it does so with a protected call. This
means that any kind of Lua error should (there are exceptions) just
result in an error message being printed and everything continuing as
usual. When LGI calls Lua code, it uses a normal call. This means that
in an asynchronous context, that is, when there is no more call
generated by awesome's C code on the call stack, we must be careful,
since any error results in Awesome's unprotected error handler to be
called which restarts the WM.

menubar.utils.parse_dir() asynchronously parses a directory containing
.desktop files. This means that it is no longer in a protected call
context. Let's assume that the code itself is fine. However, the
callback that the caller provided for handling the results can be quite
arbitrary. Make sure that it is run in a protected context.

Helps-with: https://github.com/awesomeWM/awesome/issues/1173
Signed-off-by: Uli Schlachter <psychon@znc.in>