### PR TITLE
menubar: Fix missing exe_callback in args table

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -444,6 +444,7 @@ function menubar.show(scr)
     awful.prompt.run(setmetatable({
         prompt              = "Run: ",
         textbox             = instance.prompt.widget,
+        exe_callback        = function() end,
         completion_callback = awful.completion.shell,
         history_path        = awful.util.get_cache_dir() .. "/history_menu",
         done_callback       = menubar.hide,


### PR DESCRIPTION
In https://github.com/awesomeWM/awesome/commit/07f3a178fa3de7dc0de0b5c39661dcaf4ed75d0b the `exe_callback` argument was left out, but at [lib/awful/prompt.lua#L367](https://github.com/awesomeWM/awesome/blob/master/lib/awful/prompt.lua#L367) it is checked for existence, and in this case it causes `prompt.run` to return before actually showing the prompt.