### PR TITLE
Fix traceback in gears.protected_call

### DIFF
--- a/lib/gears/protected_call.lua
+++ b/lib/gears/protected_call.lua
@@ -13,7 +13,7 @@ local xpcall = xpcall
 local protected_call = {}
 
 local function error_handler(err)
-    gdebug.print_error(traceback("Error during a protected call: " .. tostring(err)))
+    gdebug.print_error(traceback("Error during a protected call: " .. tostring(err), 2))
 end
 
 local function handle_result(success, ...)


### PR DESCRIPTION
The traceback should not include the error handler because this is confusing.

No unit test, because I think that this cannot be easily tested. Parsing the traceback in an error message would be too ugly.