### PR TITLE
awful.spawn: Separate rules from callbacks

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -491,9 +491,8 @@ function rules.execute(c, props, callbacks)
     end
 end
 
-function rules.completed_with_payload_callback(c, props)
-    rules.execute(c, props, type(props.callback) == "function" and
-        {props.callback} or props.callback )
+function rules.completed_with_payload_callback(c, props, callbacks)
+    rules.execute(c, props, callbacks)
 end
 
 client.connect_signal("spawn::completed_with_payload", rules.completed_with_payload_callback)


### PR DESCRIPTION
When adding callbacks as a `callback` entry in a property, the callback
is run by `awful.rules`, because it does `c.callback =
result_of_function`. This is obviously not intended. Also, this causes
the callbacks to run twice, because the code already handled this
`callback` property specially.

Fix this by just not merging callbacks with the normal rules at all.

Fixes: https://github.com/awesomeWM/awesome/issues/1159
Signed-off-by: Uli Schlachter <psychon@znc.in>

This conflicts with #1160. You'll have to decide between this and the other PR.