### PR TITLE
Fix awful.tag.object.get_gap_single_client

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -862,9 +862,15 @@ function tag.object.set_gap_single_client(t, gap_single_client)
 end
 
 function tag.object.get_gap_single_client(t)
-    return tag.getproperty(t, "gap_single_client")
-        or beautiful.gap_single_client
-        or defaults.gap_single_client
+    local val = tag.getproperty(t, "gap_single_client")
+    if val ~= nil then
+        return val
+    end
+    val = beautiful.gap_single_client
+    if val ~= nil then
+        return val
+    end
+    return defaults.gap_single_client
 end
 
 --- Get the spacing between clients.

--- a/tests/test-tag-gap-single-client.lua
+++ b/tests/test-tag-gap-single-client.lua
@@ -1,0 +1,20 @@
+local beautiful = require("beautiful")
+local runner = require("_runner")
+
+local t = screen.primary.tags[1]
+assert(t)
+
+-- The default should be true
+assert(t.gap_single_client == true, tostring(t.gap_single_client))
+
+-- Beautiful should override the default
+beautiful.gap_single_client = false
+assert(t.gap_single_client == false, tostring(t.gap_single_client))
+
+-- Tag-specific properties should override beautiful
+t.gap_single_client = true
+assert(t.gap_single_client == true, tostring(t.gap_single_client))
+
+runner.run_steps({ function() return true end })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The usual "a or b"-trick to simulate C's ?:-operator does not work when
"false" is a valid value. Fix the code to handle this correctly and add
a short unit test which would have caught this problem.

Signed-off-by: Uli Schlachter <psychon@znc.in>