### PR TITLE
Emit screen::arrange signal outside of arrange_lock

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -190,10 +190,10 @@ function layout.arrange(screen)
             g.y = g.y + useless_gap
             c:geometry(g)
         end
-        screen:emit_signal("arrange")
-
         arrange_lock = false
         delayed_arrange[screen] = nil
+
+        screen:emit_signal("arrange")
     end)
 end
 


### PR DESCRIPTION
This will handle changes in the layout recursively, e.g. when changing
the border_width of clients.

Ref: https://github.com/awesomeWM/awesome/issues/171#issuecomment-256146578

The patch is from Uli, but he does not want to be blamed: https://github.com/awesomeWM/awesome/issues/171#issuecomment-256150715 ;)

As for problems this might cause: should there be some "maximum recursion" guard?  Or do we have it implicitly already?