### PR TITLE
Guarantee stable output from 06-appearence.md.lua

### DIFF
--- a/docs/06-appearance.md.lua
+++ b/docs/06-appearance.md.lua
@@ -8,6 +8,27 @@ local glib = require("lgi").GLib
 local name_attr = gio.FILE_ATTRIBUTE_STANDARD_NAME
 local type_attr = gio.FILE_ATTRIBUTE_STANDARD_TYPE
 
+-- Like pairs(), but iterate over keys in a sorted manner. Does not support
+-- modifying the table while iterating.
+local function sorted_pairs(t)
+    -- Collect all keys
+    local keys = {}
+    for k in pairs(t) do
+        table.insert(keys, k)
+    end
+
+    table.sort(keys)
+
+    -- return iterator function
+    local i = 0
+    return function()
+        i = i + 1
+        if keys[i] then
+            return keys[i], t[keys[i]]
+        end
+    end
+end
+
 -- Recursive file scanner
 local function get_all_files(path, ext, ret)
     ret = ret or {}
@@ -179,7 +200,7 @@ local function create_sample(entries)
         "    local theme = {}"
     }
 
-    for name, cat in pairs(categorize(entries)) do
+    for name, cat in sorted_pairs(categorize(entries)) do
         table.insert(ret, "\n    -- "..name)
         for _, v in ipairs(cat) do
             table.insert(ret, "    -- theme."..v.name.." = nil")


### PR DESCRIPTION
This function was iterating over a table with pairs() to generate output (the
sample theme file). Since pairs() does not guarantee any iteration order, this
lead to a different order each time this file was generated. This is, for
example, visible in the diffs in the generate api documentation repository.

Fix this by using a self-made iteration function which behaves like pairs(), but
guarantees an iteration order sorted by keys.

Signed-off-by: Uli Schlachter <psychon@znc.in>