### PR TITLE
rules.new_tag: Fix when the tag screen doesn't match the client

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -195,7 +195,7 @@ start_awesome() {
 # Count errors.
 errors=0
 # Seconds after when awesome gets killed.
-timeout_stale=120 # FIXME This should be no more than 60s
+timeout_stale=180 # FIXME This should be no more than 60s
 
 for f in $tests; do
     echo "== Running $f =="

--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -209,6 +209,36 @@ table.insert(multi_screen_steps, function()
     return true
 end)
 
+-- Test the `new_tag` rule
+table.insert(multi_screen_steps, function()
+    for _, c in ipairs(client.get()) do
+        c:kill()
+    end
+
+    for i=1, screen.count() do
+        local s = screen[i]
+        test_client("screen"..i, nil, {
+            new_tag = {
+                name = "NEW_AT_"..i,
+                screen = s,
+            }
+        })
+    end
+
+    return true
+end)
+
+table.insert(multi_screen_steps, function()
+    if #client.get() ~= screen.count() then return end
+
+    for _, c in ipairs(client.get()) do
+        assert(#c:tags() == 1)
+        assert(c.first_tag.name == "NEW_AT_"..c.screen.index)
+    end
+
+    return true
+end)
+
 require("_multi_screen")(steps, multi_screen_steps)
 
 require("_runner").run_steps(steps)


### PR DESCRIPTION
Also add the documented `props` argument to the high priority
rules.