### PR TITLE
Make the piechart deterministic

### DIFF
--- a/tests/examples/wibox/widget/defaults/piechart.lua
+++ b/tests/examples/wibox/widget/defaults/piechart.lua
@@ -5,10 +5,10 @@ local beautiful = require( "beautiful" ) --DOC_HIDE
 parent:add( --DOC_HIDE
 
 wibox.widget {
-    data = {
-        ['L1'] = 100,
-        ['L2'] = 200,
-        ['L3'] = 300,
+    data_list = {
+        { 'L1', 100 },
+        { 'L2', 200 },
+        { 'L3', 300 },
     },
     border_width = 1,
     forced_height = 50, --DOC_HIDE

--- a/tests/examples/wibox/widget/piechart/border_color.lua
+++ b/tests/examples/wibox/widget/piechart/border_color.lua
@@ -8,10 +8,10 @@ parent:add(l)
 
 for _, v in ipairs {"#ff0000", "#00ff00", "#0000ff"} do
     l:add(wibox.widget {
-        data = {
-            ['L1'] = 100,
-            ['L2'] = 200,
-            ['L3'] = 300,
+        data_list = {
+            { 'L1', 100 },
+            { 'L2', 200 },
+            { 'L3', 300 },
         },
         border_width = 1,
         border_color = v,

--- a/tests/examples/wibox/widget/piechart/border_width.lua
+++ b/tests/examples/wibox/widget/piechart/border_width.lua
@@ -8,10 +8,10 @@ parent:add(l)
 
 for _, v in ipairs {0,1,3,5} do
     l:add(wibox.widget {
-        data = {
-            ['L1'] = 100,
-            ['L2'] = 200,
-            ['L3'] = 300,
+        data_list = {
+            { 'L1', 100 },
+            { 'L2', 200 },
+            { 'L3', 300 },
         },
         border_width = v,
         forced_height = 50,

--- a/tests/examples/wibox/widget/piechart/label.lua
+++ b/tests/examples/wibox/widget/piechart/label.lua
@@ -11,10 +11,10 @@ parent:add(wibox.widget {
         },
         {
             {
-                data = {
-                    ['L1'] = 100,
-                    ['L2'] = 200,
-                    ['L3'] = 300,
+                data_list = {
+                    { 'L1', 100 },
+                    { 'L2', 200 },
+                    { 'L3', 300 },
                 },
                 border_width = 1,
                 forced_height = 50,
@@ -40,10 +40,10 @@ parent:add(wibox.widget {
         },
         {
             {
-                data = {
-                    ['L1'] = 100,
-                    ['L2'] = 200,
-                    ['L3'] = 300,
+                data_list = {
+                    { 'L1', 100 },
+                    { 'L2', 200 },
+                    { 'L3', 300 },
                 },
                 border_width = 1,
                 forced_height = 50,


### PR DESCRIPTION
Previously, the API to set the data that should be displayed was
:set_data(t) where t is a table. This table has the labels to use as its
keys and the numbers as its values. With this API, it was not possible
to influence the order in which the "pie pieces" were drawn.

This commit adds and uses a new API called :set_data_list(t). Here, t is
a table with integer keys and tables as values, thus one can iterate
over this with ipairs() and the order is well-defined. The tables used
as values contain the label as their first entry and the number as their
second entry.

Fixes: https://github.com/awesomeWM/awesome/issues/1249
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

The WIP-part of this is that it makes the API a bit ugly. Can we break the API of this widget and remove the old ".data" property and replace it with what I am calling ".data_list" right now? If we can, do we want to do that?