### PR TITLE
Add pointless naughty.lua and beautiful.lua files

### DIFF
--- a/lib/beautiful.lua
+++ b/lib/beautiful.lua
@@ -1,0 +1,7 @@
+-- Work-around for broken systems which are updated by overwriting the awesome
+-- installation. This would not remove beautiful.lua from older awesome versions
+-- and thus breakage follows.
+-- The work-around is to use a pointless beautiful.lua file.
+return require("beautiful.init")
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/naughty.lua
+++ b/lib/naughty.lua
@@ -1,0 +1,7 @@
+-- Work-around for broken systems which are updated by overwriting the awesome
+-- installation. This would not remove naughty.lua from older awesome versions
+-- and thus breakage follows.
+-- The work-around is to use a pointless naughty.lua file.
+return require("naughty.init")
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
People who use a plain "make install" to install awesome will likely
also use the same approach to update their installation. However, this
does not actually work, because in awesome 3.5 there are beautiful.lua
and naughty.lua. These modules have since been split up into multiple
files and we now have beauitful/init.lua and naughty/init.lua instead.
The result is that the newer awesome will use some code from an older
version of awesome.

This commit has a work-around for this: We add "empty" beautiful.lua and
naughty.lua files whose only purpose is to load the real file. These
"empty" files will then overwrite files from an older installation and
everything works.

Sadly, this bad hack will have to be kept around forever and in the
future we will only have more instances of it. I would like to just say
people to fix their system, but apparently this should be worked around
instead.

Fixes: https://github.com/awesomeWM/awesome/issues/244
Signed-off-by: Uli Schlachter <psychon@znc.in>