### PR TITLE
Fix some ldoc see

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -155,7 +155,6 @@ end
 
 --- Swap 2 tags
 -- @function tag.swap
--- @see tag.swap
 -- @param tag2 The second tag
 -- @see client.swap
 function tag.object.swap(self, tag2)

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -262,7 +262,7 @@ end
 --
 -- @deprecated awful.wibox.stretch
 -- @see awful.placement
--- @see stretch
+-- @see awful.wibar.stretch
 
 --- Create a new wibox and attach it to a screen edge.
 -- You can add also position key with value top, bottom, left or right.


### PR DESCRIPTION
So I took a look at the problems with #834 and, well, most of it is due to us abusing LDoc.

For example, we are documenting `client.get()` as a function that appears on client objects, so LDoc expect us to use `client:get` to refer to it. However, we use `client.get` and so LDoc has to find something else to link to (it picks `awful.client.dockable.get` or `awful.client.floating.get`.
Other problems are because LDoc does not really support signals. So, does `client.window` refer to the `window` property on a client object, or is it the `property::window` signal? I don't blame LDoc for getting confused here since `::` is not exactly valid Lua syntax.

Anyway, this PR handles the fixable cases that I found.

If we really, really tried, we could fix #834 completely (e.g. by using `@see client:get` instead of `@see client.get`), but I guess that's ugly as well. I'd say it is less ugly than what we have right now (the user is directed to an essentially random target by the `@see`!), but still I don't want to be guilty of creating this. And I guess less abuse of LDoc would also not be a popular proposal, because we would lose so much useful (but broken) docs...