### PR TITLE
Sync instead of flush after setting a wallpaper

### DIFF
--- a/root.c
+++ b/root.c
@@ -136,7 +136,7 @@ root_set_wallpaper(cairo_pattern_t *pattern)
 
     result = true;
 disconnect:
-    xcb_flush(c);
+    xcb_aux_sync(c);
     xcb_disconnect(c);
     return result;
 }


### PR DESCRIPTION
When setting a wallpaper, we open a second connection to the X11 server
and create a pixmap there. This pixmap is then used as the wallpaper. We
do this so that we can use a "close down mode" called "permanent". This
means that the X11 server will not free the pixmap after we disconnect,
but keeps it allocated. Setting this close down mode is the last thing
that we do on the setup-the-wallpaper-connection before disconnecting.

However, sometimes things didn't work around. The wallpaper was missing
and trying to query it resulted in errors that basically mean "there is
no such pixmap". Thus, the symptoms say that the close down mode did not
work.

This commit is an attempt to fix this. Instead of just flushing before
closing the connection (sending all outstanding requests to the server),
this commit does a sync, which means it sends a request to the server
and waits for a reply. This guarantees that all previously requests were
handled.

The theory here is like this: We send the SetCloseDownMode-request and
then immediately disconnected. If the X11 server notices that we are
disconnected before handling the SetCloseDownMode-request, the request
would be ignored.

This theory is consistent with the symptoms above and in my local
testing this patch seems to fix things, but since the error only
appeared sporadically, I cannot be 100% sure. Still, it all seems to
make sense to me.

Fixes: https://github.com/awesomeWM/awesome/issues/1276
Signed-off-by: Uli Schlachter <psychon@znc.in>