### PR TITLE
Fix error handling in awesome.spawn()

### DIFF
--- a/spawn.c
+++ b/spawn.c
@@ -414,11 +414,11 @@ luaA_spawn(lua_State *L)
     {
         g_strfreev(argv);
         if (error) {
-            luaA_warn(L, "spawn: parse error: %s", error->message);
+            lua_pushfstring(L, "spawn: parse error: %s", error->message);
             g_error_free(error);
         }
         else
-            luaA_warn(L, "spawn: There is nothing to execute");
+            lua_pushliteral(L, "spawn: There is nothing to execute");
         return 1;
     }
 
@@ -443,7 +443,7 @@ luaA_spawn(lua_State *L)
     g_strfreev(argv);
     if(!retval)
     {
-        luaA_warn(L, "%s", error->message);
+        lua_pushstring(L, error->message);
         g_error_free(error);
         if(context)
             sn_launcher_context_complete(context);

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -29,6 +29,9 @@ local steps = {
     error_message = spawn(" ")
     assert(string.find(error_message, 'Text was empty'), error_message)
 
+    error_message = spawn("")
+    assert(string.find(error_message, 'Text was empty'), error_message)
+
     error_message = spawn{}
     assert(string.find(error_message, 'There is nothing to execute'), error_message)
 
@@ -89,17 +92,6 @@ local steps = {
       assert(exit_snd == 42)
       return true
     end
-  end,
-  function()
-    -- Test empty command table
-    spawn{}
-    return true
-  end,
-  function()
-    -- Test empty command string
-    spawn("")
-    assert(#client.get() == 0)
-    return true
   end,
 }
 

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -10,6 +10,31 @@ local exit_yay, exit_snd = nil, nil
 -- * spawn with startup notification is covered by test-spawn-snid.lua
 
 local steps = {
+  function()
+    -- Test various error conditions. There are quite a number of them...
+    local error_message
+
+    error_message = spawn("this_does_not_exist_and_should_fail")
+    assert(string.find(error_message, 'No such file or directory'), error_message)
+
+    error_message = spawn({"this_does_not_exist_and_should_fail"})
+    assert(string.find(error_message, 'No such file or directory'), error_message)
+
+    error_message = spawn("foo '")
+    assert(string.find(error_message, 'parse error: Text ended before matching quote was found'), error_message)
+
+    error_message = spawn()
+    assert(string.find(error_message, 'No command to execute'), error_message)
+
+    error_message = spawn(" ")
+    assert(string.find(error_message, 'Text was empty'), error_message)
+
+    error_message = spawn{}
+    assert(string.find(error_message, 'There is nothing to execute'), error_message)
+
+    return true
+  end,
+
   function(count)
     if count == 1 then
       local steps_yay = 0


### PR DESCRIPTION
Commit 5e6a893 broke error handling in awesome.spawn(): Instead of
returning an error message, it would just return its last argument.

This commit fixes that, removes some not-so-helpful warnings, and adds
lots of tests for this code.

Fixes: https://github.com/awesomeWM/awesome/issues/1281
Signed-off-by: Uli Schlachter <psychon@znc.in>