### PR TITLE
docs/add instructions to pass args to cmake

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -19,10 +19,16 @@ After building is finished, you can either install via `make install`:
 or by auto-generating a .deb or .rpm package, for easy removal later on:
 
     make package
-    
+
     sudo dpkg -i awesome-x.y.z.deb
     # or
     sudo rpm -Uvh awesome-x.y.z.rpm
+
+NOTE: awesome uses [`cmake`](https://cmake.org) to build. In case you want to
+pass arguments to cmake, please use the `CMAKE_ARGS` environment variable. For
+instance:
+
+    CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=/opt/awesome" make
 
 ### Build dependencies
 


### PR DESCRIPTION
Adds a small note to the README for passing arguments to cmake during
the build by using the `CMAKE_ARGS` environment variable

Fixes #1316 