### PR TITLE
Specify USES_TERMINAL for running tests/run.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ add_custom_target(check-integration
     sh -c "CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${CMAKE_SOURCE_DIR}/tests/run.sh"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
+    USES_TERMINAL
     VERBATIM)
 a_find_program(BUSTED_EXECUTABLE busted FALSE)
 if(BUSTED_EXECUTABLE)


### PR DESCRIPTION
The documentation for CMake's add_custom_command()-command says the
following for USES_TERMINAL:

  The command will be given direct access to the terminal if possible.
  With the ``Ninja`` generator, this places the command in the
  ``console`` ``pool``.

The result is that one can see the progress of tests/run.sh, because
messages appear immediately instead of delayed (instead all other
parallel steps are delayed; in practice this means luacheck output
appears only after tests/run.sh is done).

Signed-off-by: Uli Schlachter <psychon@znc.in>

I have the following `GNUmakefile` laying around in my build dir so that awesome is built with ninja (and I do not have to use `make -j10`):
```
HEADLESS=1
export HEADLESS

all: ninja-build update-symlink
	cd ninja-build && ninja

check clean package luacheck: ninja-build update-symlink
	cd ninja-build && ninja $@

ninja-build:
	mkdir ninja-build && cd ninja-build && cmake -G Ninja -DSYSCONFDIR=/etc -DCMAKE_INSTALL_PREFIX=/usr -DOVERRIDE_VERSION=9999 ..

update-symlink: ninja-build
	rm -f build
	ln -s ninja-build build

.PHONY: all check clean update-symlink
```