### PR TITLE
_multi_screen: Help the garbage collector

### DIFF
--- a/tests/_multi_screen.lua
+++ b/tests/_multi_screen.lua
@@ -411,7 +411,10 @@ local function add_steps(real_steps, new_steps)
     for _, dispo in ipairs(dispositions) do
         -- Cleanup
         table.insert(real_steps, function()
-            if #client.get() == 0 then return true end
+            if #client.get() == 0 then
+                collectgarbage("collect")
+                return true
+            end
 
             for _, c in ipairs(client.get()) do
                 c:kill()


### PR DESCRIPTION
Tests using _multi_screen end up with lots of screens, which also means
that they end up with lots of wiboxes, widgets and so on. Since
drawables are kept around in a weak table and are forced to redraw when
screens change, this causes slowdowns later on when we end up with lots
of drawables.

Help the garbage collector in cleaning up by giving it a slight kick in
the right moment.

Signed-off-by: Uli Schlachter <psychon@znc.in>

Via https://github.com/awesomeWM/awesome/pull/1239#discussion_r94220308.