### PR TITLE
Revert some of the indentation changes

### DIFF
--- a/lib/gears/object.lua
+++ b/lib/gears/object.lua
@@ -45,6 +45,7 @@ function object.add_signal()
 end
 
 --- Connect to a signal.
+--@DOC_text_gears_object_signal_EXAMPLE@
 -- @tparam string name The name of the signal
 -- @tparam function func The callback to call when the signal is emitted
 function object:connect_signal(name, func)

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -104,7 +104,7 @@ endfunction()
 function(escape_code path escaped_content pre_header post_header)
     file(READ ${path} path)
 
-    escape_string("${path}\n" "" escaped_code "")
+    escape_string("${path}\n" "" escaped_code " ")
 
     extract_header("${path}" example_pre_header example_post_header)
 

--- a/tests/examples/awful/placement/compose.lua
+++ b/tests/examples/awful/placement/compose.lua
@@ -2,9 +2,9 @@ screen[1]._resize {x = 175, width = 128, height = 96} --DOC_NO_USAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 local c = client.gen_fake {x = 220, y = 35, width=40, height=30} --DOC_HIDE
 
--- "right" will be replaced by "left"
-local f = (awful.placement.right + awful.placement.left)
-f(client.focus)
+    -- "right" will be replaced by "left"
+    local f = (awful.placement.right + awful.placement.left)
+    f(client.focus)
 
 local sg = screen[1].geometry--DOC_HIDE
 assert(c.x == sg.x and c.y==sg.height/2-30/2-c.border_width--DOC_HIDE

--- a/tests/examples/awful/placement/compose2.lua
+++ b/tests/examples/awful/placement/compose2.lua
@@ -2,14 +2,14 @@ screen[1]._resize {x = 175, width = 128, height = 96} --DOC_NO_USAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 local c = client.gen_fake {x = 220, y = 35, width=40, height=30} --DOC_HIDE
 
--- Simulate Windows 7 "edge snap" (also called aero snap) feature
-local axis = "vertically"
+    -- Simulate Windows 7 "edge snap" (also called aero snap) feature
+    local axis = "vertically"
 
-local f = awful.placement.scale
-+ awful.placement.left
-+ (axis and awful.placement["maximize_"..axis] or nil)
+    local f = awful.placement.scale
+        + awful.placement.left
+        + (axis and awful.placement["maximize_"..axis] or nil)
 
-local geo = f(client.focus, {honor_workarea=true, to_percent = 0.5})
+    local geo = f(client.focus, {honor_workarea=true, to_percent = 0.5})
 
 local wa = screen[1].workarea--DOC_HIDE
 assert(c.x == wa.x and geo.x == wa.x)--DOC_HIDE

--- a/tests/examples/wibox/widget/checkbox/bg.lua
+++ b/tests/examples/wibox/widget/checkbox/bg.lua
@@ -3,20 +3,19 @@ local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 
 parent:add( --DOC_HIDE
-           wibox.widget {
-               checked            = true,
-               color              = beautiful.bg_normal,
-               bg                 = "#ff00ff",
-               border_width       = 3,
-               paddings           = 4,
-               border_color       = "#0000ff",
-               check_color        = "#ff0000",
-               forced_width       = 20, --DOC_HIDE
-               forced_height      = 20, --DOC_HIDE
-               check_border_color = "#ffff00",
-               check_border_width = 1,
-               widget             = wibox.widget.checkbox
-           }
-           ) --DOC_HIDE
-
+wibox.widget {
+    checked            = true,
+    color              = beautiful.bg_normal,
+    bg                 = "#ff00ff",
+    border_width       = 3,
+    paddings           = 4,
+    border_color       = "#0000ff",
+    check_color        = "#ff0000",
+    forced_width       = 20, --DOC_HIDE
+    forced_height      = 20, --DOC_HIDE
+    check_border_color = "#ffff00",
+    check_border_width = 1,
+    widget             = wibox.widget.checkbox
+}
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/checkbox/check_shape.lua
+++ b/tests/examples/wibox/widget/checkbox/check_shape.lua
@@ -11,19 +11,18 @@ local l = wibox.widget { --DOC_HIDE
 for _, s in ipairs {"rectangle", "circle", "losange", "octogon"} do
 
     l:add( --DOC_HIDE
-          wibox.widget {
-              checked       = true,
-              color         = beautiful.bg_normal,
-              paddings      = 2,
-              forced_width  = 20, --DOC_HIDE
-              forced_height = 20, --DOC_HIDE
-              check_shape   = gears.shape[s],
-              widget        = wibox.widget.checkbox
-          }
-          ) --DOC_HIDE
+    wibox.widget {
+        checked       = true,
+        color         = beautiful.bg_normal,
+        paddings      = 2,
+        forced_width  = 20, --DOC_HIDE
+        forced_height = 20, --DOC_HIDE
+        check_shape   = gears.shape[s],
+        widget        = wibox.widget.checkbox
+    }
+    ) --DOC_HIDE
 
 end
 
 parent:add(l) --DOC_HIDE
-
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/checkbox/custom.lua
+++ b/tests/examples/wibox/widget/checkbox/custom.lua
@@ -3,33 +3,31 @@ local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 
 parent:add( --DOC_HIDE
-           wibox.widget {
-               checked       = true,
-               color         = beautiful.bg_normal,
-               paddings      = 2,
-               forced_width  = 20, --DOC_HIDE
-               forced_height = 20, --DOC_HIDE
-               check_shape   = function(cr, width, height)
-                   local rs = math.min(width, height)
-
-                   cr:move_to( 0  , 0  )
-                   cr:line_to( rs , 0  )
-                   cr:move_to( 0  , 0  )
-                   cr:line_to( 0  , rs )
-                   cr:move_to( 0  , rs )
-                   cr:line_to( rs , rs )
-                   cr:move_to( rs , 0  )
-                   cr:line_to( rs , rs )
-                   cr:move_to( 0  , 0  )
-                   cr:line_to( rs , rs )
-                   cr:move_to( 0  , rs )
-                   cr:line_to( rs , 0  )
-               end,
-               check_border_color = "#ff0000",
-               check_color        = "#00000000",
-               check_border_width = 1,
-               widget             = wibox.widget.checkbox
-           }
-           ) --DOC_HIDE
-
+    wibox.widget {
+        checked       = true,
+        color         = beautiful.bg_normal,
+        paddings      = 2,
+        forced_width  = 20, --DOC_HIDE
+        forced_height = 20, --DOC_HIDE
+        check_shape   = function(cr, width, height)
+            local rs = math.min(width, height)
+            cr:move_to( 0  , 0  )
+            cr:line_to( rs , 0  )
+            cr:move_to( 0  , 0  )
+            cr:line_to( 0  , rs )
+            cr:move_to( 0  , rs )
+            cr:line_to( rs , rs )
+            cr:move_to( rs , 0  )
+            cr:line_to( rs , rs )
+            cr:move_to( 0  , 0  )
+            cr:line_to( rs , rs )
+            cr:move_to( 0  , rs )
+            cr:line_to( rs , 0  )
+        end,
+        check_border_color = "#ff0000",
+        check_color        = "#00000000",
+        check_border_width = 1,
+        widget             = wibox.widget.checkbox
+    }
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/checkbox/shape.lua
+++ b/tests/examples/wibox/widget/checkbox/shape.lua
@@ -11,19 +11,18 @@ local l = wibox.widget { --DOC_HIDE
 for _, s in ipairs {"rectangle", "circle", "losange", "octogon"} do
 
     l:add( --DOC_HIDE
-          wibox.widget {
-              checked       = true,
-              color         = beautiful.bg_normal,
-              paddings      = 2,
-              forced_width  = 20, --DOC_HIDE
-              forced_height = 20, --DOC_HIDE
-              shape         = gears.shape[s],
-              widget        = wibox.widget.checkbox
-          }
-          ) --DOC_HIDE
+    wibox.widget {
+        checked       = true,
+        color         = beautiful.bg_normal,
+        paddings      = 2,
+        forced_width  = 20, --DOC_HIDE
+        forced_height = 20, --DOC_HIDE
+        shape         = gears.shape[s],
+        widget        = wibox.widget.checkbox
+    }
+    ) --DOC_HIDE
 
 end
 
 parent:add(l) --DOC_HIDE
-
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/checkbox.lua
+++ b/tests/examples/wibox/widget/defaults/checkbox.lua
@@ -4,30 +4,29 @@ local beautiful = require( "beautiful" ) --DOC_HIDE
 local gears     = {shape = require("gears.shape")} --DOC_HIDE
 
 parent:add( --DOC_HIDE
-           wibox.widget { --DOC_HIDE
-               wibox.widget {
-                   checked       = true,
-                   color         = beautiful.bg_normal,
-                   paddings      = 2,
-                   forced_width  = 20, --DOC_HIDE
-                   forced_height = 20, --DOC_HIDE
-                   shape         = gears.shape.circle,
-                   widget        = wibox.widget.checkbox
-               }
-               , --DOC_HIDE
-               wibox.widget { --DOC_HIDE
-                   checked       = false, --DOC_HIDE
-                   color         = beautiful.bg_normal, --DOC_HIDE
-                   paddings      = 2, --DOC_HIDE
-                   forced_width  = 20, --DOC_HIDE
-                   forced_height = 20, --DOC_HIDE
-                   shape         = gears.shape.circle, --DOC_HIDE
-                   widget        = wibox.widget.checkbox --DOC_HIDE
-               }, --DOC_HIDE
-               spacing = 4, --DOC_HIDE
-               layout = wibox.layout.fixed.horizontal --DOC_HIDE
-           } --DOC_HIDE
+    wibox.widget { --DOC_HIDE
+        wibox.widget {
+            checked       = true,
+            color         = beautiful.bg_normal,
+            paddings      = 2,
+            forced_width  = 20, --DOC_HIDE
+            forced_height = 20, --DOC_HIDE
+            shape         = gears.shape.circle,
+            widget        = wibox.widget.checkbox
+        }
+        , --DOC_HIDE
+        wibox.widget { --DOC_HIDE
+            checked       = false, --DOC_HIDE
+            color         = beautiful.bg_normal, --DOC_HIDE
+            paddings      = 2, --DOC_HIDE
+            forced_width  = 20, --DOC_HIDE
+            forced_height = 20, --DOC_HIDE
+            shape         = gears.shape.circle, --DOC_HIDE
+            widget        = wibox.widget.checkbox --DOC_HIDE
+        }, --DOC_HIDE
+        spacing = 4, --DOC_HIDE
+        layout = wibox.layout.fixed.horizontal --DOC_HIDE
+    } --DOC_HIDE
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/graph.lua
+++ b/tests/examples/wibox/widget/defaults/graph.lua
@@ -20,5 +20,4 @@ parent:add( w ) --DOC_HIDE
 for _, v in ipairs(data) do --DOC_HIDE
     w:add_value(v) --DOC_HIDE
 end --DOC_HIDE
-
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/imagebox.lua
+++ b/tests/examples/wibox/widget/defaults/imagebox.lua
@@ -4,12 +4,11 @@ local beautiful = require( "beautiful" ) --DOC_HIDE
 
 parent:add( --DOC_HIDE
 
-           wibox.widget {
-               image  = beautiful.awesome_icon,
-               resize = false,
-               widget = wibox.widget.imagebox
-           }
+wibox.widget {
+    image  = beautiful.awesome_icon,
+    resize = false,
+    widget = wibox.widget.imagebox
+}
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/piechart.lua
+++ b/tests/examples/wibox/widget/defaults/piechart.lua
@@ -4,23 +4,22 @@ local beautiful = require( "beautiful" ) --DOC_HIDE
 
 parent:add( --DOC_HIDE
 
-           wibox.widget {
-               data_list = {
-                   { 'L1', 100 },
-                   { 'L2', 200 },
-                   { 'L3', 300 },
-               },
-               border_width = 1,
-               forced_height = 50, --DOC_HIDE
-               forced_width  = 100, --DOC_HIDE
-               colors = {
-                   beautiful.bg_normal,
-                   beautiful.bg_highlight,
-                   beautiful.border_color,
-               },
-               widget = wibox.widget.piechart
-           }
+wibox.widget {
+    data_list = {
+        { 'L1', 100 },
+        { 'L2', 200 },
+        { 'L3', 300 },
+    },
+    border_width = 1,
+    forced_height = 50, --DOC_HIDE
+    forced_width  = 100, --DOC_HIDE
+    colors = {
+        beautiful.bg_normal,
+        beautiful.bg_highlight,
+        beautiful.border_color,
+    },
+    widget = wibox.widget.piechart
+}
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/progressbar.lua
+++ b/tests/examples/wibox/widget/defaults/progressbar.lua
@@ -5,17 +5,16 @@ local beautiful = require("beautiful") --DOC_HIDE
 
 parent:add( --DOC_HIDE
 
-           wibox.widget {
-               max_value     = 1,
-               value         = 0.33,
-               forced_height = 20,
-               forced_width  = 100,
-               shape         = gears.shape.rounded_bar,
-               border_width  = 2,
-               border_color  = beautiful.border_color,
-               widget        = wibox.widget.progressbar,
-           }
+wibox.widget {
+    max_value     = 1,
+    value         = 0.33,
+    forced_height = 20,
+    forced_width  = 100,
+    shape         = gears.shape.rounded_bar,
+    border_width  = 2,
+    border_color  = beautiful.border_color,
+    widget        = wibox.widget.progressbar,
+}
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/slider.lua
+++ b/tests/examples/wibox/widget/defaults/slider.lua
@@ -5,20 +5,19 @@ local gears     = {shape=require("gears.shape") } --DOC_HIDE
 
 parent:add( --DOC_HIDE
 
-           wibox.widget {
-               bar_shape           = gears.shape.rounded_rect,
-               bar_height          = 3,
-               bar_color           = beautiful.border_color,
-               handle_color        = beautiful.bg_normal,
-               handle_shape        = gears.shape.circle,
-               handle_border_color = beautiful.border_color,
-               handle_border_width = 1,
-               value               = 25,
-               widget              = wibox.widget.slider,
-               forced_height = 50, --DOC_HIDE
-               forced_width  = 100, --DOC_HIDE
-           }
+wibox.widget {
+    bar_shape           = gears.shape.rounded_rect,
+    bar_height          = 3,
+    bar_color           = beautiful.border_color,
+    handle_color        = beautiful.bg_normal,
+    handle_shape        = gears.shape.circle,
+    handle_border_color = beautiful.border_color,
+    handle_border_width = 1,
+    value               = 25,
+    widget              = wibox.widget.slider,
+    forced_height = 50, --DOC_HIDE
+    forced_width  = 100, --DOC_HIDE
+}
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/textbox.lua
+++ b/tests/examples/wibox/widget/defaults/textbox.lua
@@ -3,13 +3,12 @@ local wibox  = require("wibox") --DOC_HIDE
 
 parent:add( --DOC_HIDE
 
-           wibox.widget{
-               markup = "This <i>is</i> a <b>textbox</b>!!!",
-               align  = "center",
-               valign = "center",
-               widget = wibox.widget.textbox
-           }
+wibox.widget{
+    markup = "This <i>is</i> a <b>textbox</b>!!!",
+    align  = "center",
+    valign = "center",
+    widget = wibox.widget.textbox
+}
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/progressbar/text.lua
+++ b/tests/examples/wibox/widget/progressbar/text.lua
@@ -4,24 +4,23 @@ local beautiful = require("beautiful") --DOC_HIDE
 
 parent:add( --DOC_HIDE
 
-           wibox.widget {
-               {
-                   max_value     = 1,
-                   value         = 0.5,
-                   forced_height = 20,
-                   forced_width  = 100,
-                   paddings      = 1,
-                   border_width  = 1,
-                   border_color  = beautiful.border_color,
-                   widget        = wibox.widget.progressbar,
-               },
-               {
-                   text   = "50%",
-                   widget = wibox.widget.textbox,
-               },
-               layout = wibox.layout.stack
-           }
+wibox.widget {
+    {
+        max_value     = 1,
+        value         = 0.5,
+        forced_height = 20,
+        forced_width  = 100,
+        paddings      = 1,
+        border_width  = 1,
+        border_color  = beautiful.border_color,
+        widget        = wibox.widget.progressbar,
+    },
+    {
+        text   = "50%",
+        widget = wibox.widget.textbox,
+    },
+    layout = wibox.layout.stack
+}
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/progressbar/vertical.lua
+++ b/tests/examples/wibox/widget/progressbar/vertical.lua
@@ -3,18 +3,17 @@ local wibox  = require("wibox") --DOC_HIDE
 
 parent:add( --DOC_HIDE
 
-           wibox.widget {
-               {
-                   max_value     = 1,
-                   value         = 0.33,
-                   widget        = wibox.widget.progressbar,
-               },
-               forced_height = 100,
-               forced_width  = 20,
-               direction     = "east",
-               layout        = wibox.container.rotate,
-           }
+wibox.widget {
+    {
+        max_value     = 1,
+        value         = 0.33,
+        widget        = wibox.widget.progressbar,
+    },
+    forced_height = 100,
+    forced_width  = 20,
+    direction     = "east",
+    layout        = wibox.container.rotate,
+}
 
-           ) --DOC_HIDE
-
+) --DOC_HIDE
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The doc wasn't generated correctly anymore. The tests examples are using markdown, some spaces are required by the RFC. Also the DOC_HIDE macro doesn't count in the indentation. Plus some other spaces were also necessary. I fixed that in `CMakeLists.txt` instead of the code.

The "end of line whitespace" commit from a while ago also broke the empty line support. This is still not fixed.