### PR TITLE
build: Clear the cache when checking if a package is present

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -142,6 +142,7 @@ set(AWESOME_DEPENDENCIES
 
 # Check the deps one by one
 foreach(dependency ${AWESOME_DEPENDENCIES})
+    unset(TMP_DEP_FOUND CACHE)
     pkg_check_modules(TMP_DEP REQUIRED ${dependency})
 
     if(NOT TMP_DEP_FOUND)


### PR DESCRIPTION
While on Gentoo I get the right error message anyway, apparently
this isn't universal.

Fix #1356