### PR TITLE
Fix "make package" with RPMs

### DIFF
--- a/Packaging.cmake
+++ b/Packaging.cmake
@@ -60,6 +60,7 @@ endif(NOT CPACK_GENERATOR)
 set(CPACK_PACKAGE_NAME "awesome")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "devnull@example.com")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A tiling window manager")
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/etc/xdg;/usr/share/xsessions")
 
 if(CPACK_GENERATOR)
     include(CPack)


### PR DESCRIPTION
In contrast do dpkg, rpm tracks which package created a directory. No
idea what happens if you remove the package which owns the directory,
but another package still owns files in there. Anyway, this behaviour
produced the following problem:

    file /etc/xdg from install of awesome-[snip].x86_64 conflicts with
    file from package filesystem-3.2-37.fc24.x86_64

Fix this by telling CPack to exclude these directories from the file
list.

Fixes: https://github.com/awesomeWM/awesome/issues/1234
Signed-off-by: Uli Schlachter <psychon@znc.in>