### PR TITLE
awful.tag: handle invalid client in delayed_call

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -1387,6 +1387,9 @@ capi.client.connect_signal("property::screen", function(c)
     -- awful.rules. It is also messing up the tags before the user have a chance
     -- to set them manually.
     timer.delayed_call(function()
+        if not c.valid then
+            return
+        end
         local tags, new_tags = c:tags(), {}
 
         for _, t in ipairs(tags) do


### PR DESCRIPTION
A short-lived client (e.g. `urxvt -e false`) might be invalid already
when the delayed callback is called.

TODO:
 - [ ] test