### PR TITLE
[TEST] tests: Add a very dirty hack to break wibox for multiscreen tests

### DIFF
--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -146,6 +146,8 @@ table.insert(steps, function()
     return true
 end)
 
+
+
 local multi_screen_steps = {}
 
 -- Add a test client on each screen.
@@ -321,7 +323,9 @@ table.insert(multi_screen_steps, function()
     return true
 end)
 
-require("_multi_screen")(steps, multi_screen_steps)
+local ms = require("_multi_screen")
+ms.disable_wibox()
+ms(steps, multi_screen_steps)
 
 require("_runner").run_steps(steps)
 

--- a/tests/test-awful-tag.lua
+++ b/tests/test-awful-tag.lua
@@ -239,7 +239,9 @@ table.insert(multi_screen_steps, function()
     return true
 end)
 
-require("_multi_screen")(steps, multi_screen_steps)
+local ms = require("_multi_screen")
+ms.disable_wibox()
+ms(steps, multi_screen_steps)
 
 require("_runner").run_steps(steps)
 


### PR DESCRIPTION
This commit add an option to shim the whole wibox module when
running multi-screen tests. This is intended to lower the test
runtime when coverage is enabled.

In theory, most of that code is already covered by the
test-screen-changes suit.

It is a reaction to #1374. My issue with #1374 is that while it saves 30 seconds and is a low hanging fruit, it fixes a linear issue depending on the number of test suits. This commit is an ugly hack, but I am curious to see how well it fares in Travis. In theory, the slowdown is exponential depending on how slow the target is.

The implementation is crap, it is intended to see the effect it has on the CI time.