### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/spawn.c
+++ b/spawn.c
@@ -53,6 +53,11 @@
 
 #include "spawn.h"
 
+#include <sys/param.h>
+#ifdef __FreeBSD__
+# include <sys/wait.h>
+#endif
+
 #include <unistd.h>
 #include <glib.h>
 

--- a/spawn.c
+++ b/spawn.c
@@ -53,10 +53,8 @@
 
 #include "spawn.h"
 
-#include <sys/param.h>
-#ifdef __FreeBSD__
-# include <sys/wait.h>
-#endif
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #include <unistd.h>
 #include <glib.h>


### PR DESCRIPTION
Include <sys/wait.h> on FreeBSD to fix build, it's required for
WIFEXITED and another couple of macros