### PR TITLE
Reply on configurerequest even if geometry is the same

### DIFF
--- a/event.c
+++ b/event.c
@@ -395,9 +395,8 @@ event_handle_configurerequest(xcb_configure_request_event_t *ev)
                 geometry.y += diff_y;
         }
 
-        if(!client_resize(c, geometry, false))
-            /* ICCCM 4.1.5 / 4.2.3, if nothing was changed, send an event saying so */
-            client_send_configure(c);
+        c->got_configure_request = true;
+        client_resize(c, geometry, false);
     }
     else if (xembed_getbywin(&globalconf.embedded, ev->window))
     {

--- a/objects/client.c
+++ b/objects/client.c
@@ -1210,8 +1210,14 @@ client_geometry_refresh(void)
 
         /* Is there anything to do? */
         if (AREA_EQUAL(geometry, c->x11_frame_geometry)
-                && AREA_EQUAL(real_geometry, c->x11_client_geometry))
+                && AREA_EQUAL(real_geometry, c->x11_client_geometry)) {
+            if (c->got_configure_request) {
+                /* ICCCM 4.1.5 / 4.2.3, if nothing was changed, send an event saying so */
+                client_send_configure(c);
+                c->got_configure_request = false;
+            }
             continue;
+        }
 
         if (!ignored_enterleave) {
             client_ignore_enterleave_events();
@@ -1230,6 +1236,7 @@ client_geometry_refresh(void)
 
         /* ICCCM 4.2.3 says something else, but Java always needs this... */
         client_send_configure(c);
+        c->got_configure_request = false;
     }
     if (ignored_enterleave)
         client_restore_enterleave_events();

--- a/objects/client.h
+++ b/objects/client.h
@@ -64,6 +64,8 @@ struct client_t
     /** Old window geometry currently configured in X11 */
     area_t x11_client_geometry;
     area_t x11_frame_geometry;
+    /** Got a configure request and have to call client_send_configure() if its ignored? */
+    bool got_configure_request;
     /** Startup ID */
     char *startup_id;
     /** True if the client is sticky */


### PR DESCRIPTION
Becuse `ConfigureRequest` are handled in async way some requests may be left without reply in case lua code disacrds new geometry. This PR makes sure such requests are replied.

Fixes https://github.com/awesomeWM/awesome/issues/1369 and https://github.com/awesomeWM/awesome/issues/1340