### PR TITLE
apidoc: improvements to its Git magic

### DIFF
--- a/build-utils/travis-apidoc.sh
+++ b/build-utils/travis-apidoc.sh
@@ -32,7 +32,7 @@ export GIT_AUTHOR_EMAIL="awesome-robot@users.noreply.github.com"
 export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
 export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
-git clone --branch gh-pages "$REPO_APIDOC" build/apidoc \
+git clone --depth 1 --branch gh-pages "$REPO_APIDOC" build/apidoc \
     2>&1 | sed "s/$GH_APIDOC_TOKEN/GH_APIDOC_TOKEN/g"
 cd build/apidoc
 
@@ -50,7 +50,7 @@ else
   BRANCH="gh-pages"
 fi
 if [ "$BRANCH" != "gh-pages" ]; then
-  git checkout -b "$BRANCH" "origin/${BRANCH}" || git checkout -b "$BRANCH"
+  git checkout -B "$BRANCH" "origin/${BRANCH}"
 fi
 
 # Use a temporary branch for the two commits, which allows for a better UI.


### PR DESCRIPTION
 - use `--depth 1` with git-clone for faster checkout/cloning
 - use `-B` with git-checkout

   > If -B is given, <new_branch> is created if it doesn’t exist;
   > otherwise, it is reset. This is the transactional equivalent of
   >
   >      $ git branch -f <branch> [<start point>]
   >      $ git checkout <branch>

Not sure about the `--depth 1` - might break it.