### PR TITLE
travis-apidoc.sh: revert -B with git-checkout

### DIFF
--- a/build-utils/travis-apidoc.sh
+++ b/build-utils/travis-apidoc.sh
@@ -50,7 +50,7 @@ else
   BRANCH="gh-pages"
 fi
 if [ "$BRANCH" != "gh-pages" ]; then
-  git checkout -B "$BRANCH" "origin/${BRANCH}"
+  git checkout -b "$BRANCH" "origin/${BRANCH}" || git checkout -b "$BRANCH"
 fi
 
 # Use a temporary branch for the two commits, which allows for a better UI.


### PR DESCRIPTION
Reverts part of 6b8c3642b to fix:

> Cloning into 'build/apidoc'...
> fatal: Cannot update paths and switch to branch 'pr-1429' at the same
> time.
> Did you intend to checkout 'origin/pr-1429' which can not be resolved
> as commit?