### PR TITLE
import vim hotkeys from user config, not hotkeys_popup module

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -11,6 +11,8 @@ local beautiful = require("beautiful")
 local naughty = require("naughty")
 local menubar = require("menubar")
 local hotkeys_popup = require("awful.hotkeys_popup").widget
+-- Enable VIM help for hotkeys widget when client with matching name is opened:
+require("awful.hotkeys_popup.keys.vim")
 
 -- {{{ Error handling
 -- @DOC_ERROR_HANDLING@

--- a/lib/awful/hotkeys_popup/init.lua
+++ b/lib/awful/hotkeys_popup/init.lua
@@ -9,7 +9,6 @@
 
 local hotkeys_popup = {
   widget = require("awful.hotkeys_popup.widget"),
-  keys = require("awful.hotkeys_popup.keys")
 }
 hotkeys_popup.show_help = hotkeys_popup.widget.show_help
 return hotkeys_popup


### PR DESCRIPTION
i remember one of the users was complaining what they are enabled by default