### PR TITLE
Print full RandR version in --version output

### DIFF
--- a/common/version.c
+++ b/common/version.c
@@ -54,11 +54,6 @@ eprint_version(void)
 #else
     const char *has_dbus = "✘";
 #endif
-#ifdef XCB_RANDR_GET_MONITORS
-    const char *has_RandR15 = "✔";
-#else
-    const char *has_RandR15 = "✘";
-#endif
 #ifdef HAS_EXECINFO
     const char *has_execinfo = "✔";
 #else
@@ -69,11 +64,12 @@ eprint_version(void)
            " • Compiled against %s (running with %s)\n"
            " • D-Bus support: %s\n"
            " • execinfo support: %s\n"
-           " • RandR 1.5 support: %s\n"
+           " • xcb-randr version: %d.%d\n"
            " • LGI version: %s\n",
            AWESOME_VERSION, AWESOME_RELEASE,
            LUA_RELEASE, lua_tostring(L, -2),
-           has_dbus, has_execinfo, has_RandR15,
+           has_dbus, has_execinfo,
+           XCB_RANDR_MAJOR_VERSION, XCB_RANDR_MINOR_VERSION,
            lua_tostring(L, -1));
     lua_close(L);
 


### PR DESCRIPTION
All versions of libxcb provide at least RandR 1.3 (if I remember
correctly). With version 1.5, the concept of a monitor was added. This
might make quite a difference for awesome and to help debugging bug
reports that are due to missing support for monitors, the existence of
this support was added to the --version output.

However, many people feel like they are missing out due to this, even
though the new RandR 1.5 stuff likely makes no difference for them. To
help these people, instead of having a yes/no, just print the full RandR
version. When a bug report that is due to missing monitor support shows
up, we can look up if the reporter has RandR 1.5. All other people are
no longer bothered.

Example-reference: http://stackoverflow.com/questions/41773529/no-randr-1-5-support-in-test-install-of-awesome-4-0-what-to-check
Signed-off-by: Uli Schlachter <psychon@znc.in>