### PR TITLE
fix beautiful.arcchart_thickness documentation

### DIFF
--- a/lib/wibox/container/arcchart.lua
+++ b/lib/wibox/container/arcchart.lua
@@ -38,7 +38,7 @@ local arcchart = { mt = {} }
 -- @tparam[opt=0] number paddings.right
 
 --- The arc thickness.
--- @beautiful beautiful.thickness
+-- @beautiful beautiful.arcchart_thickness
 -- @param number
 
 local function outline_workarea(width, height)


### PR DESCRIPTION
The arcchart_ prefix was missing.