### PR TITLE
change module to class when documention links to a class description

### DIFF
--- a/docs/aliases/awful_client.lua
+++ b/docs/aliases/awful_client.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------
---- This module documentation has been merged with the `client` module.
+--- This module documentation has been merged with the `client` class.
 --
 -- @module awful.client
 ---------------------------------------------------------------------------

--- a/docs/aliases/awful_mouse.lua
+++ b/docs/aliases/awful_mouse.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------
---- This module documentation has been merged with the `mouse` module.
+--- This module documentation has been merged with the `mouse` class.
 --
 -- @module awful.mouse
 ---------------------------------------------------------------------------

--- a/docs/aliases/awful_screen.lua
+++ b/docs/aliases/awful_screen.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------
---- This module documentation has been merged with the `screen` module.
+--- This module documentation has been merged with the `screen` class.
 --
 -- @module awful.screen
 ---------------------------------------------------------------------------

--- a/docs/aliases/awful_tag.lua
+++ b/docs/aliases/awful_tag.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------
---- This module documentation has been merged with the `tag` module.
+--- This module documentation has been merged with the `tag` class.
 --
 -- @module awful.tag
 ---------------------------------------------------------------------------


### PR DESCRIPTION
The links in the changed luadocs link to classes, not to other modules.