### PR TITLE
ewhm: fix some transient windows not movable to other screens (#1406)

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -194,7 +194,7 @@ function ewmh.tag(c, t, hints) --luacheck: no unused
     if not t and #get_valid_tags(c, c.screen) > 0 then return end
 
     if not t then
-        if c.transient_for then
+        if c.transient_for and not (hints and hints.reason == "screen") then
             c.screen = c.transient_for.screen
             if not c.sticky then
                 c:tags(c.transient_for:tags())


### PR DESCRIPTION
After the last comment in the related bug (#1406) I was not sure, if I should create a PR for this. This change fixes the bug for me and I have not yet noticed any side effects, but I use very few programs with windows on several screens.