### PR TITLE
Fix #1321 and #1459 and #171 and #1320 and #1456

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -49,9 +49,9 @@ ewmh_client_update_hints(lua_State *L)
         state[i++] = _NET_WM_STATE_MODAL;
     if(c->fullscreen)
         state[i++] = _NET_WM_STATE_FULLSCREEN;
-    if(c->maximized_vertical)
+    if(c->maximized_vertical || c->maximized)
         state[i++] = _NET_WM_STATE_MAXIMIZED_VERT;
-    if(c->maximized_horizontal)
+    if(c->maximized_horizontal || c->maximized)
         state[i++] = _NET_WM_STATE_MAXIMIZED_HORZ;
     if(c->sticky)
         state[i++] = _NET_WM_STATE_STICKY;
@@ -220,6 +220,7 @@ ewmh_init_lua(void)
     luaA_class_connect_signal(L, &client_class, "property::fullscreen" , ewmh_client_update_hints);
     luaA_class_connect_signal(L, &client_class, "property::maximized_horizontal" , ewmh_client_update_hints);
     luaA_class_connect_signal(L, &client_class, "property::maximized_vertical" , ewmh_client_update_hints);
+    luaA_class_connect_signal(L, &client_class, "property::maximized" , ewmh_client_update_hints);
     luaA_class_connect_signal(L, &client_class, "property::sticky" , ewmh_client_update_hints);
     luaA_class_connect_signal(L, &client_class, "property::skip_taskbar" , ewmh_client_update_hints);
     luaA_class_connect_signal(L, &client_class, "property::above" , ewmh_client_update_hints);

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -138,6 +138,7 @@ function client.tiled(s, stacked)
     for _, c in pairs(clients) do
         if not client.object.get_floating(c)
             and not c.fullscreen
+            and not c.maximized
             and not c.maximized_vertical
             and not c.maximized_horizontal then
             table.insert(tclients, c)
@@ -668,6 +669,7 @@ function client.object.get_floating(c)
             or c.fullscreen
             or c.maximized_vertical
             or c.maximized_horizontal
+            or c.maximized
             or client.object.is_fixed(c) then
             return true
         end

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -13,11 +13,16 @@ local util = require("awful.util")
 local aclient = require("awful.client")
 local aplace = require("awful.placement")
 local asuit = require("awful.layout.suit")
+local beautiful = require("beautiful")
 
 local ewmh = {
     generic_activate_filters    = {},
     contextual_activate_filters = {},
 }
+
+--- Honor the screen padding when maximizing.
+-- @beautiful beautiful.maximized_honor_padding
+-- @tparam[opt=true] boolean maximized_honor_padding
 
 --- The list of all registered generic request::activate (focus stealing)
 -- filters. If a filter is added to only one context, it will be in
@@ -274,6 +279,10 @@ function ewmh.geometry(c, context, hints)
 
         if props.honor_workarea == nil then
             props.honor_workarea = honor_default
+        end
+
+        if props.honor_padding == nil and props.honor_workarea and context:match("maximize") then
+            props.honor_padding = beautiful.maximized_honor_padding ~= false
         end
 
         aplace[context](c, props)

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -224,6 +224,7 @@ end
 local context_mapper = {
     maximized_vertical   = "maximize_vertically",
     maximized_horizontal = "maximize_horizontally",
+    maximized            = "maximize",
     fullscreen           = "maximize"
 }
 

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -24,6 +24,10 @@ local ewmh = {
 -- @beautiful beautiful.maximized_honor_padding
 -- @tparam[opt=true] boolean maximized_honor_padding
 
+--- Hide the border on fullscreen clients.
+-- @beautiful beautiful.fullscreen_hide_border
+-- @tparam[opt=true] boolean fullscreen_hide_border
+
 --- The list of all registered generic request::activate (focus stealing)
 -- filters. If a filter is added to only one context, it will be in
 -- `ewmh.contextual_activate_filters`["context_name"].
@@ -285,7 +289,19 @@ function ewmh.geometry(c, context, hints)
             props.honor_padding = beautiful.maximized_honor_padding ~= false
         end
 
+        if original_context == "fullscreen" and beautiful.fullscreen_hide_border ~= false then
+            props.ignore_border_width = true
+        end
+
         aplace[context](c, props)
+
+        -- Remove the border to get a "real" fullscreen.
+        if original_context == "fullscreen" and beautiful.fullscreen_hide_border ~= false then
+            local original = repair_geometry_lock
+            repair_geometry_lock = true
+            c.border_width = 0
+            repair_geometry_lock = original
+        end
     end
 end
 

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -45,10 +45,10 @@ local function geometry_change(window)
     -- Fix up the geometry in case this window needs to cover the whole screen.
     local bw = window.border_width or 0
     local g = window.screen.workarea
-    if window.maximized_vertical then
+    if window.maximized_vertical or window.maximized then
         window:geometry { height = g.height - 2*bw, y = g.y }
     end
-    if window.maximized_horizontal then
+    if window.maximized_horizontal or window.maximized then
         window:geometry { width = g.width - 2*bw, x = g.x }
     end
     if window.fullscreen then

--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -82,6 +82,7 @@ function mouse.client.move(c, snap, finished_cb) --luacheck: no unused args
 
     if not c
         or c.fullscreen
+        or c.maximized
         or c.type == "desktop"
         or c.type == "splash"
         or c.type == "dock" then
@@ -189,6 +190,7 @@ function mouse.client.resize(c, corner, args)
     if not c then return end
 
     if c.fullscreen
+        or c.maximized
         or c.type == "desktop"
         or c.type == "splash"
         or c.type == "dock" then

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -930,7 +930,7 @@ function placement.under_mouse(d, args)
     ngeo.x = math.floor(m_coords.x - ngeo.width  / 2)
     ngeo.y = math.floor(m_coords.y - ngeo.height / 2)
 
-    local bw = d.border_width or 0
+    local bw    = (not args.ignore_border_width) and d.border_width or 0
     ngeo.width  = ngeo.width  - 2*bw
     ngeo.height = ngeo.height - 2*bw
 
@@ -1034,7 +1034,7 @@ function placement.resize_to_mouse(d, args)
         pts.x_only and ngeo.y + ngeo.height or math.max(p2.y, p1.y)
     )
 
-    local bw = d.border_width or 0
+    local bw = (not args.ignore_border_width) and d.border_width or 0
 
     for _, a in ipairs {"width", "height"} do
         ngeo[a] = ngeo[a] - 2*bw
@@ -1084,7 +1084,7 @@ function placement.align(d, args)
 
     local sgeo = get_parent_geometry(d, args)
     local dgeo = geometry_common(d, args)
-    local bw   = d.border_width or 0
+    local bw   = (not args.ignore_border_width) and d.border_width or 0
 
     local pos  = align_map[args.position](
         sgeo.width ,
@@ -1169,7 +1169,7 @@ function placement.stretch(d, args)
     local sgeo = get_parent_geometry(d, args)
     local dgeo = geometry_common(d, args)
     local ngeo = geometry_common(d, args, nil, true)
-    local bw   = d.border_width or 0
+    local bw   = (not args.ignore_border_width) and d.border_width or 0
 
     if args.direction == "left" then
         ngeo.x      = sgeo.x
@@ -1231,7 +1231,7 @@ function placement.maximize(d, args)
 
     local sgeo = get_parent_geometry(d, args)
     local ngeo = geometry_common(d, args, nil, true)
-    local bw   = d.border_width or 0
+    local bw   = (not args.ignore_border_width) and d.border_width or 0
 
     if (not args.axis) or args.axis :match "vertical" then
         ngeo.y      = sgeo.y
@@ -1308,7 +1308,7 @@ function placement.scale(d, args)
         end
     end
 
-    local bw = d.border_width or 0
+    local bw = (not args.ignore_border_width) and d.border_width or 0
     ngeo.width  = ngeo.width  - 2*bw
     ngeo.height = ngeo.height - 2*bw
 

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -1,6 +1,22 @@
 ---------------------------------------------------------------------------
 --- Apply rules to clients at startup.
 --
+-- All existing `client` properties can be used in rules. It is also possible
+-- to add random properties that will be later accessible as `c.property_name`
+-- (where `c` is a valid client object)
+--
+-- In addition to the existing properties, the following are supported:
+--
+-- * placement
+-- * honor_padding
+-- * honor_workarea
+-- * tag
+-- * new_tag
+-- * switchtotag
+-- * focus
+-- * titlebars_enabled
+-- * callback
+--
 -- @author Julien Danjou &lt;julien@danjou.info&gt;
 -- @copyright 2009 Julien Danjou
 -- @module awful.rules

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -376,7 +376,7 @@ function rules.extra_properties.placement(c, value)
     end
 end
 
-function rules.extra_properties.tags(c, value, props)
+function rules.high_priority_properties.tags(c, value, props)
     local current = c:tags()
 
     local tags, s = {}, nil

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -353,7 +353,7 @@ function rules.high_priority_properties.new_tag(c, value, props)
     return t
 end
 
-function rules.extra_properties.placement(c, value)
+function rules.extra_properties.placement(c, value, props)
     -- Avoid problems
     if awesome.startup and
       (c.size_hints.user_position or c.size_hints.program_position) then
@@ -363,8 +363,8 @@ function rules.extra_properties.placement(c, value)
     local ty = type(value)
 
     local args = {
-        honor_workarea = true,
-        honor_padding  = true
+        honor_workarea = props.honor_workarea ~= false,
+        honor_padding  = props.honor_padding ~= false
     }
 
     if ty == "function" or (ty == "table" and

--- a/lib/awful/titlebar.lua
+++ b/lib/awful/titlebar.lua
@@ -460,13 +460,11 @@ end
 -- @param c The client for which the button is wanted.
 function titlebar.widget.maximizedbutton(c)
     local widget = titlebar.widget.button(c, "maximized", function(cl)
-        return cl.maximized_horizontal or cl.maximized_vertical
+        return cl.maximized
     end, function(cl, state)
-        cl.maximized_horizontal = not state
-        cl.maximized_vertical = not state
+        cl.maximized = not state
     end)
-    c:connect_signal("property::maximized_vertical", widget.update)
-    c:connect_signal("property::maximized_horizontal", widget.update)
+    c:connect_signal("property::maximized", widget.update)
     return widget
 end
 

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -453,6 +453,7 @@ function tasklist.new(screen, filter, buttons, style, update_function, base_widg
         capi.client.connect_signal("property::floating", u)
         capi.client.connect_signal("property::maximized_horizontal", u)
         capi.client.connect_signal("property::maximized_vertical", u)
+        capi.client.connect_signal("property::maximized", u)
         capi.client.connect_signal("property::minimized", u)
         capi.client.connect_signal("property::name", u)
         capi.client.connect_signal("property::icon_name", u)

--- a/objects/client.c
+++ b/objects/client.c
@@ -1426,8 +1426,6 @@ client_manage(xcb_window_t w, xcb_get_geometry_reply_t *wgeom, xcb_get_window_at
      * (Else, reparent could cause an UnmapNotify) */
     xcb_change_window_attributes(globalconf.connection, w, XCB_CW_EVENT_MASK, select_input_val);
 
-    luaA_object_emit_signal(L, -1, "property::window", 0);
-
     /* The frame window gets the border, not the real client window */
     xcb_configure_window(globalconf.connection, w,
                          XCB_CONFIG_WINDOW_BORDER_WIDTH,
@@ -1450,15 +1448,17 @@ client_manage(xcb_window_t w, xcb_get_geometry_reply_t *wgeom, xcb_get_window_at
 
     /* Store initial geometry and emits signals so we inform that geometry have
      * been set. */
-#define HANDLE_GEOM(attr) \
-    c->geometry.attr = wgeom->attr; \
-    luaA_object_emit_signal(L, -1, "property::" #attr, 0);
-HANDLE_GEOM(x)
-HANDLE_GEOM(y)
-HANDLE_GEOM(width)
-HANDLE_GEOM(height)
-#undef HANDLE_GEOM
 
+    c->geometry.x = wgeom->x;
+    c->geometry.y = wgeom->y;
+    c->geometry.width = wgeom->width;
+    c->geometry.height = wgeom->height;
+
+    luaA_object_emit_signal(L, -1, "property::x", 0);
+    luaA_object_emit_signal(L, -1, "property::y", 0);
+    luaA_object_emit_signal(L, -1, "property::width", 0);
+    luaA_object_emit_signal(L, -1, "property::height", 0);
+    luaA_object_emit_signal(L, -1, "property::window", 0);
     luaA_object_emit_signal(L, -1, "property::geometry", 0);
 
     /* Set border width */

--- a/objects/client.h
+++ b/objects/client.h
@@ -82,6 +82,10 @@ struct client_t
     bool maximized_horizontal;
     /** True if the client is maximized vertically */
     bool maximized_vertical;
+    /** True if the client is maximized both horizontally and vertically by the
+      * the user
+      */
+    bool maximized;
     /** True if the client is above others */
     bool above;
     /** True if the client is below others */

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -82,10 +82,11 @@ local steps = {
         local bw      = c.border_width
 
         assert(c.fullscreen)
-        assert(new_geo.x-bw==sgeo.x)
-        assert(new_geo.y-bw==sgeo.y)
-        assert(new_geo.x+new_geo.width+bw==sgeo.x+sgeo.width)
-        assert(new_geo.y+new_geo.height+bw==sgeo.y+sgeo.height)
+
+        assert(new_geo.x==sgeo.x)
+        assert(new_geo.y==sgeo.y)
+        assert(new_geo.x+new_geo.width+2*bw==sgeo.x+sgeo.width)
+        assert(new_geo.y+new_geo.height+2*bw==sgeo.y+sgeo.height)
 
         c.fullscreen = false
 

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -23,6 +23,7 @@ local steps = {
         local c = client.get()[1]
         assert(not c.maximized_horizontal)
         assert(not c.maximized_vertical  )
+        assert(not c.maximized           )
         assert(not c.fullscreen          )
 
         c.maximized_horizontal = true
@@ -92,6 +93,43 @@ local steps = {
     end,
     function()
         local c = client.get()[1]
+
+        local new_geo = c:geometry()
+
+        for k,v in pairs(original_geo) do
+            assert(new_geo[k] == v)
+        end
+
+        c.floating  = true
+
+        awful.placement.centered(c)
+        original_geo = c:geometry()
+
+        c.maximized = true
+
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        local new_geo = c:geometry()
+        local sgeo    = c.screen.workarea
+
+        assert(c.maximized)
+        assert(c.floating)
+        assert(new_geo.x==sgeo.x)
+        assert(new_geo.y==sgeo.y)
+
+        c.maximized = false
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        assert(not c.maximized)
+        assert(c.floating)
 
         local new_geo = c:geometry()
 


### PR DESCRIPTION
Before: to everything twice including the request::geometry
Now: do it once

Edit: also create a real `maximized` property, spliting the state across 2 properties is a source of corner cases.

@taptap @cagelight can you test?

Fix #1320 #1321 #171 #1459 