### PR TITLE
beautiful: Reset theme when theme loading fails

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -196,6 +196,7 @@ function beautiful.init(config)
 
             if theme.font then set_font(theme.font) end
         else
+            theme = {}
             return gears_debug.print_error("beautiful: error loading theme file " .. config)
         end
     else


### PR DESCRIPTION
Commit c50d62749bbf added an empty table as a default theme. However,
when loading the actual theme fails, we will end up with theme having
value nil. This commit fixes this by reverting back to an empty table.

Fixes: https://github.com/awesomeWM/awesome/issues/1417
Signed-off-by: Uli Schlachter <psychon@znc.in>

(Yes, I actually reproduced the problem by calling `beautiful.init()` with a non-existent file name; after this patch things work better (awesome actually manages to start))