### PR TITLE
Test that beautiful is not used too early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
     - LUA=5.2 DO_CHECKQA=1 LUANAME=lua5.2 DO_COVERAGE=coveralls
     # luajit: installed from source.
-    - LUA=5.1 LUANAME=luajit-2.0 LUALIBRARY=/usr/lib/libluajit-5.1.so LUAROCKS_ARGS=--lua-suffix=jit-2.0.4 TEST_PREV_COMMITS=1
+    - LUA=5.1 LUANAME=luajit-2.0 LUALIBRARY=/usr/lib/libluajit-5.1.so LUAROCKS_ARGS=--lua-suffix=jit-2.0.4 TEST_PREV_COMMITS=1 EMPTY_THEME_WHILE_LOADING=1
     # Note: luarocks does not work with Lua 5.0.
     - LUA=5.1 LUANAME=lua5.1 BUILD_IN_DIR=/tmp/awesome-build
     # Lua 5.2 with older lgi and screen size not divisible by 2.
@@ -138,6 +138,12 @@ install:
     }
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION -DSTRICT_TESTS=true"
+  - |
+    if [ "$EMPTY_THEME_WHILE_LOADING" = 1 ]; then
+      # Break beautiful so that trying to access the theme before beautiful.init() causes an error
+      sed -i -e 's/theme = {}/theme = setmetatable({}, { __index = function() error("May not access theme before beautiful.init()") end })/' lib/beautiful/init.lua \
+        && grep -q 'May not access' lib/beautiful/init.lua
+    fi
   - |
     set -e
     if [ -n "$BUILD_IN_DIR" ]; then

--- a/spec/preload.lua
+++ b/spec/preload.lua
@@ -3,4 +3,7 @@
 -- is not safe to reload and yet Busted manages to do this.
 require("lgi")
 
+-- "fix" some intentional beautiful breakage done by .travis.yml
+require("beautiful").init{}
+
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
For loading a theme, beautiful.init() has to be called. We do not handle
dynamic changes of the theme, so if the theme is changed after something
was already queried, this change will not apply. This also means that
before the theme is loaded, nothing useful can be returned. In fact,
code that tries to access the theme during require() will never get a
useful value from beautiful, but just nils.

To catch this, one Travis build is modified so that an error is raised
if the theme is accessed before beautiful.init() was called.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

The only reason that this is WIP is because it already catches things that do not work. Ideas what to do about it?

Edit: Here is the backtrace:
```
error: lib/beautiful/init.lua:32: May not access theme before beautiful.init():
stack traceback:
	lib/beautiful/init.lua:32: in function '__index'
	lib/beautiful/init.lua:214: in function '__index'
	lib/awful/hotkeys_popup/widget.lua:58: in function 'new'
	lib/awful/hotkeys_popup/widget.lua:463: in function 'get_default_widget'
	lib/awful/hotkeys_popup/widget.lua:480: in function 'add_hotkeys'
	lib/awful/hotkeys_popup/keys/vim.lua:171: in main chunk
	[C]: in function 'require'
	lib/awful/hotkeys_popup/keys/init.lua:11: in main chunk
	[C]: in function 'require'
	lib/awful/hotkeys_popup/init.lua:12: in main chunk
	[C]: in function 'require'
	/home/psychon/projects/awesome/awesomerc.lua:13: in main chunk
```