### PR TITLE
Input shape support

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -661,6 +661,16 @@ main(int argc, char **argv)
     /* check for shape extension */
     query = xcb_get_extension_data(globalconf.connection, &xcb_shape_id);
     globalconf.have_shape = query && query->present;
+    if (globalconf.have_shape)
+    {
+        xcb_shape_query_version_reply_t *reply =
+            xcb_shape_query_version_reply(globalconf.connection,
+                    xcb_shape_query_version_unchecked(globalconf.connection),
+                    NULL);
+        globalconf.have_input_shape = reply && (reply->major_version > 1 ||
+                (reply->major_version == 1 && reply->minor_version >= 1));
+        p_delete(&reply);
+    }
 
     event_init();
 

--- a/docs/common/wibox.ldoc
+++ b/docs/common/wibox.ldoc
@@ -161,6 +161,15 @@
 -- @property shape_clip
 -- @param surface._native
 
+--- The wibox's input shape as a (native) cairo surface.
+--
+-- **Signal:**
+--
+--  * *property::shape_input*
+--
+-- @property shape_input
+-- @param surface._native
+
 --- Get or set mouse buttons bindings to a wibox.
 --
 -- @param buttons_table A table of buttons objects, or nothing.

--- a/globalconf.h
+++ b/globalconf.h
@@ -106,6 +106,8 @@ typedef struct
     bool have_xtest;
     /** Check for SHAPE extension */
     bool have_shape;
+    /** Check for SHAPE extension with input shape support */
+    bool have_input_shape;
     /** Check for XKB extension */
     bool have_xkb;
     uint8_t event_base_shape;

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -288,6 +288,7 @@ end
 -- @tparam wibox.widget arg.widget The widget that the wibox displays.
 -- @param arg.shape_bounding The wibox’s bounding shape as a (native) cairo surface.
 -- @param arg.shape_clip The wibox’s clip shape as a (native) cairo surface.
+-- @param arg.shape_input The wibox’s input shape as a (native) cairo surface.
 -- @tparam color arg.bg The background of the wibox.
 -- @tparam surface arg.bgimage The background image of the drawable.
 -- @tparam color arg.fg The foreground (text) of the wibox.

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -31,6 +31,7 @@ wibox.hierarchy = require("wibox.hierarchy")
 local force_forward = {
     shape_bounding = true,
     shape_clip = true,
+    shape_input = true,
 }
 
 --@DOC_wibox_COMMON@
@@ -120,6 +121,7 @@ local function setup_signals(_wibox)
     clone_signal("property::geometry")
     clone_signal("property::shape_bounding")
     clone_signal("property::shape_clip")
+    clone_signal("property::shape_input")
 
     obj = _wibox._drawable
     clone_signal("button::press")
@@ -147,6 +149,7 @@ end
 -- @tparam wibox.widget args.widget The widget that the wibox displays.
 -- @param args.shape_bounding The wibox’s bounding shape as a (native) cairo surface.
 -- @param args.shape_clip The wibox’s clip shape as a (native) cairo surface.
+-- @param args.shape_input The wibox’s input shape as a (native) cairo surface.
 -- @tparam color args.bg The background of the wibox.
 -- @tparam surface args.bgimage The background image of the drawable.
 -- @tparam color args.fg The foreground (text) of the wibox.

--- a/objects/client.c
+++ b/objects/client.c
@@ -670,6 +670,17 @@
  */
 
 /**
+ * The client's input shape as set by awesome as a (native) cairo surface.
+ *
+ * **Signal:**
+ *
+ *  * *property::shape\_input*
+ *
+ * @property shape_input
+ * @param surface
+ */
+
+/**
  * The client's bounding shape as set by the program as a (native) cairo surface.
  *
  * **Signal:**
@@ -3271,6 +3282,41 @@ luaA_client_set_shape_clip(lua_State *L, client_t *c)
     return 0;
 }
 
+/** Get the client's frame window input shape.
+ * \param L The Lua VM state.
+ * \param client The client object.
+ * \return The number of elements pushed on stack.
+ */
+static int
+luaA_client_get_shape_input(lua_State *L, client_t *c)
+{
+    cairo_surface_t *surf = xwindow_get_shape(c->frame_window, XCB_SHAPE_SK_INPUT);
+    if (!surf)
+        return 0;
+    /* lua has to make sure to free the ref or we have a leak */
+    lua_pushlightuserdata(L, surf);
+    return 1;
+}
+
+/** Set the client's frame window input shape.
+ * \param L The Lua VM state.
+ * \param client The client object.
+ * \return The number of elements pushed on stack.
+ */
+static int
+luaA_client_set_shape_input(lua_State *L, client_t *c)
+{
+    cairo_surface_t *surf = NULL;
+    if(!lua_isnil(L, -1))
+        surf = (cairo_surface_t *)lua_touserdata(L, -1);
+    xwindow_set_shape(c->frame_window,
+            c->geometry.width + (c->border_width * 2),
+            c->geometry.height + (c->border_width * 2),
+            XCB_SHAPE_SK_INPUT, surf, -c->border_width);
+    luaA_object_emit_signal(L, -3, "property::shape_input", 0);
+    return 0;
+}
+
 /** Get or set keys bindings for a client.
  *
  * @param keys_table An array of key bindings objects, or nothing.
@@ -3518,6 +3564,10 @@ client_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_client_set_shape_clip,
                             (lua_class_propfunc_t) luaA_client_get_shape_clip,
                             (lua_class_propfunc_t) luaA_client_set_shape_clip);
+    luaA_class_add_property(&client_class, "shape_input",
+                            (lua_class_propfunc_t) luaA_client_set_shape_input,
+                            (lua_class_propfunc_t) luaA_client_get_shape_input,
+                            (lua_class_propfunc_t) luaA_client_set_shape_input);
     luaA_class_add_property(&client_class, "startup_id",
                             NULL,
                             (lua_class_propfunc_t) luaA_client_get_startup_id,

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -63,6 +63,7 @@
  * @field window The X window id.
  * @field shape_bounding The drawin's bounding shape as a (native) cairo surface.
  * @field shape_clip The drawin's clip shape as a (native) cairo surface.
+ * @field shape_input The drawin's input shape as a (native) cairo surface.
  * @table drawin
  */
 
@@ -76,6 +77,10 @@
 
 /**
  * @signal property::shape_clip
+ */
+
+/**
+ * @signal property::shape_input
  */
 
 /**
@@ -690,6 +695,45 @@ luaA_drawin_set_shape_clip(lua_State *L, drawin_t *drawin)
     return 0;
 }
 
+/** Get the drawin's input shape.
+ * \param L The Lua VM state.
+ * \param drawin The drawin object.
+ * \return The number of elements pushed on stack.
+ */
+static int
+luaA_drawin_get_shape_input(lua_State *L, drawin_t *drawin)
+{
+    cairo_surface_t *surf = xwindow_get_shape(drawin->window, XCB_SHAPE_SK_INPUT);
+    if (!surf)
+        return 0;
+    /* lua has to make sure to free the ref or we have a leak */
+    lua_pushlightuserdata(L, surf);
+    return 1;
+}
+
+/** Set the drawin's input shape.
+ * \param L The Lua VM state.
+ * \param drawin The drawin object.
+ * \return The number of elements pushed on stack.
+ */
+static int
+luaA_drawin_set_shape_input(lua_State *L, drawin_t *drawin)
+{
+    cairo_surface_t *surf = NULL;
+    if(!lua_isnil(L, -1))
+        surf = (cairo_surface_t *)lua_touserdata(L, -1);
+
+    /* The drawin might have been resized to a larger size. Apply that. */
+    drawin_apply_moveresize(drawin);
+
+    xwindow_set_shape(drawin->window,
+            drawin->geometry.width + 2*drawin->border_width,
+            drawin->geometry.height + 2*drawin->border_width,
+            XCB_SHAPE_SK_INPUT, surf, -drawin->border_width);
+    luaA_object_emit_signal(L, -3, "property::shape_input", 0);
+    return 0;
+}
+
 void
 drawin_class_setup(lua_State *L)
 {
@@ -758,6 +802,10 @@ drawin_class_setup(lua_State *L)
                             (lua_class_propfunc_t) luaA_drawin_set_shape_clip,
                             (lua_class_propfunc_t) luaA_drawin_get_shape_clip,
                             (lua_class_propfunc_t) luaA_drawin_set_shape_clip);
+    luaA_class_add_property(&drawin_class, "shape_input",
+                            (lua_class_propfunc_t) luaA_drawin_set_shape_input,
+                            (lua_class_propfunc_t) luaA_drawin_get_shape_input,
+                            (lua_class_propfunc_t) luaA_drawin_set_shape_input);
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This adds input shape support on drawins and clients to the C code (and touches some Lua docs to add it where needed). The input shape allows (as I understand it, I have to admit that I did not actually test this) to make parts of a window click-through. So if you have a compositing manager running, have parts of a drawin fully transparent and set the input shape correctly, you can actually interact with whatever is below.