### PR TITLE
Fix/porting guide code blocks

### DIFF
--- a/docs/17-porting-tips.md
+++ b/docs/17-porting-tips.md
@@ -97,7 +97,7 @@ work. Remove this section.
 The `quit` menu command must be wrapped in a function, otherwise an error
 occurs due to mismatched argument types from the v4.0 `awful.menu` library.
 
-     -- {{{ Menu
+     -- {{{ Menu
      -- Create a laucher widget and a main menu
      myawesomemenu = {
        { "manual", terminal .. " -e man awesome" },
@@ -109,7 +109,7 @@ occurs due to mismatched argument types from the v4.0 `awful.menu` library.
 
 The textclock is now part of the `wibox` library, rename it.
 
-     -- {{{ Wibar
+     -- {{{ Wibar
      -- Create a textclock widget
     -mytextclock = `awful.widget.textclock`()
     +mytextclock = `wibox.widget.textclock`()


### PR DESCRIPTION
In #1486 @Elv13 found that ldoc glitched when rendering code blocks I modified.  This PR resolves that issue and cleans up the porting guides code blocks a bit more.

I found that non-blocking-whitespace (0xa0) had the same effect on ldoc as Elv13's braille space (0x2800), but the nbsp has the same width as a space (0x32), where braille space does not.  If we'd rather have braille space, I'm happy to adjust this patch.

The first patch adds nbsp to correct #1486.  The second patch replaces the remaining braille space with nbsp, and adds nbsp to better align the code blocks.

I installed ldoc 1.4.6, reproduced the bug, and verified the patches correctly render.

Steps I used [modified for your perspective]
```
git clone git@github.com:awesomeWM/awesome.git
git fetch origin pull/1488/head:pr-1488
cd awesome
git checkout 420f6726  # PR 1486
cmake .
make ldoc
(cd doc && chromium documentation/17-porting-tips.md.html)
# review code blocks and observe missing diff columns
git checkout .
git checkout pr-1488
make ldoc
(cd doc && chromium documentation/17-porting-tips.md.html)
# review code blocks and observe all diff columns appear
```