### PR TITLE
Move the wibar:remove() call outside of the loop over all wiboxes.

### DIFF
--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -359,10 +359,14 @@ function awfulwibar.new(arg)
 end
 
 capi.screen.connect_signal("removed", function(s)
+    local wibars = {}
     for _, wibar in ipairs(wiboxes) do
         if wibar._screen == s then
-            wibar:remove()
+            table.insert(wibars, wibar)
         end
+    end
+    for _, wibar in ipairs(wibars) do
+        wibar:remove()
     end
 end)
 


### PR DESCRIPTION
Removing a wibar mid-loop will corrupt the indexing of the for loop and can cause other wibars from being removed.

Resolves #1498.