### PR TITLE
Add custom keys to existing groups

### DIFF
--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -227,7 +227,7 @@ function widget.new()
         local max_height_px = height - group_label_height
         local column_layouts = {}
         for _, group in ipairs(available_groups) do
-            local keys = cached_awful_keys[group] or widget_instance.additional_hotkeys[group]
+            local keys = awful.util.table.join(cached_awful_keys[group], widget_instance.additional_hotkeys[group])
             local joined_descriptions = ""
             for i, key in ipairs(keys) do
                 joined_descriptions = joined_descriptions .. key.description .. (i~=#keys and "\n" or "")


### PR DESCRIPTION
So the keydocs for the keybindings to numbered tags can be removed and put this instead:
```
hotkeys_popup.add_hotkeys({
    ["tag"]      = {{modifiers = {modkey,                   }, keys = {["#"]="view tag #(1-9)"}},
                    {modifiers = {modkey, "Control"         }, keys = {["#"]="toggle tag #(1-9)"}},
                    {modifiers = {modkey, "Shift"           }, keys = {["#"]="move client to tag #(1-9)"}},
                    {modifiers = {modkey, "Control", "Shift"}, keys = {["#"]="toggle client on tag #(1-9)"}},
    }
})
```
Otherwise, these additional hotkeys cannot be added to the `tag` group.