### PR TITLE
layoutbox: Update when a tag's screen changes

### DIFF
--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -48,6 +48,13 @@ function layoutbox.new(screen)
         boxes = setmetatable({}, { __mode = "kv" })
         capi.tag.connect_signal("property::selected", update_from_tag)
         capi.tag.connect_signal("property::layout", update_from_tag)
+        capi.tag.connect_signal("property::screen", function()
+            for s, w in pairs(boxes) do
+                if s.valid then
+                    update(w, s)
+                end
+            end
+        end)
         layoutbox.boxes = boxes
     end
 


### PR DESCRIPTION
In theory it would be enough to only update the old and new screen of
the tag whose screen changed. However, we cannot easily get the old
screen, so just update all layoutboxes.

Fixes: https://github.com/awesomeWM/awesome/issues/1503
Signed-off-by: Uli Schlachter <psychon@znc.in>