### PR TITLE
tests/_client.lua: Improve error with Gtk 2

### DIFF
--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -20,6 +20,9 @@ local function open_window(class, title, options)
         window:set_startup_id(options.snid)
     end
     if options.resize_increment then
+        -- This requires Gtk3, but fails with an obscure message with Gtk2.
+        -- Produce a better error message instead.
+        assert(tonumber(require("lgi").Gtk._version) >= 3, "Gtk 3 required, but not found")
         local geom = Gdk.Geometry {
             width_inc = 200,
             height_inc = 200,


### PR DESCRIPTION
In Gtk 2, the "first" argument to set_geometry_hints() is not optional.
However, this code does not provide any argument here. Improve the error
message in this case by checking for Gtk 3.

Reference: https://github.com/awesomeWM/awesome/issues/1495
Signed-off-by: Uli Schlachter <psychon@znc.in>