### PR TITLE
Add position and size property signals

### DIFF
--- a/lib/awful/client/shape.lua
+++ b/lib/awful/client/shape.lua
@@ -85,8 +85,8 @@ end
 
 capi.client.connect_signal("property::shape_client_bounding", shape.update.bounding)
 capi.client.connect_signal("property::shape_client_clip", shape.update.clip)
-capi.client.connect_signal("property::width", shape.update.all)
-capi.client.connect_signal("property::height", shape.update.all)
+capi.client.connect_signal("property::size", shape.update.all)
+capi.client.connect_signal("property::border_width", shape.update.all)
 
 return shape
 

--- a/lib/awful/key.lua
+++ b/lib/awful/key.lua
@@ -95,7 +95,7 @@ function key.new(mod, _key, press, release, data)
     end
 
     -- append custom userdata (like description) to a hotkey
-    data = data or {}
+    data = data and util.table.clone(data) or {}
     data.mod = mod
     data.key = _key
     table.insert(key.hotkeys, data)

--- a/objects/client.c
+++ b/objects/client.c
@@ -1647,14 +1647,22 @@ client_resize_do(client_t *c, area_t geometry)
     luaA_object_push(L, c);
     if (!AREA_EQUAL(old_geometry, geometry))
         luaA_object_emit_signal(L, -1, "property::geometry", 0);
-    if (old_geometry.x != geometry.x)
-        luaA_object_emit_signal(L, -1, "property::x", 0);
-    if (old_geometry.y != geometry.y)
-        luaA_object_emit_signal(L, -1, "property::y", 0);
-    if (old_geometry.width != geometry.width)
-        luaA_object_emit_signal(L, -1, "property::width", 0);
-    if (old_geometry.height != geometry.height)
-        luaA_object_emit_signal(L, -1, "property::height", 0);
+    if (old_geometry.x != geometry.x || old_geometry.y != geometry.y)
+    {
+        luaA_object_emit_signal(L, -1, "property::position", 0);
+        if (old_geometry.x != geometry.x)
+            luaA_object_emit_signal(L, -1, "property::x", 0);
+        else
+            luaA_object_emit_signal(L, -1, "property::y", 0);
+    }
+    if (old_geometry.width != geometry.width || old_geometry.height != geometry.height)
+    {
+        luaA_object_emit_signal(L, -1, "property::size", 0);
+        if (old_geometry.width != geometry.width)
+            luaA_object_emit_signal(L, -1, "property::width", 0);
+        else
+            luaA_object_emit_signal(L, -1, "property::height", 0);
+    }
     lua_pop(L, 1);
 
     screen_client_moveto(c, new_screen, false);

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -82,6 +82,16 @@
  * @signal property::y
  */
 
+/** When the client height or width changed.
+ * @signal property::size
+ * @see client.geometry
+ */
+
+/** When the client x or y coordinate changed.
+ * @signal property::position
+ * @see client.geometry
+ */
+
 /**
  * @signal property::surface
  */

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -110,6 +110,16 @@
  * @signal property::y
  */
 
+/** When the client height or width changed.
+ * @signal property::size
+ * @see client.geometry
+ */
+
+/** When the client x or y coordinate changed.
+ * @signal property::position
+ * @see client.geometry
+ */
+
 /** Get or set mouse buttons bindings to a drawin.
  *
  * @param buttons_table A table of buttons objects, or nothing.

--- a/tests/test-awesomerc.lua
+++ b/tests/test-awesomerc.lua
@@ -4,12 +4,6 @@ local awful = require("awful")
 
 local old_c = nil
 
-local function get_callback(mod, key)
-    local inf = {}
-    awful.key(mod, key, nil, nil, inf)
-
-    return inf.execute
-end
 
 -- Get a tag and a client
 local function get_c_and_t()
@@ -42,14 +36,12 @@ local steps = {
         assert(old_c)
 
         -- Test layout
-        -- local cb = get_callback({modkey}, " ")
-        -- assert(cb)
 
         --TODO use the key once the bug is fixed
         local l = old_c.screen.selected_tag.layout
         assert(l)
 
-        -- cb()
+        --awful.key.execute({modkey}, " ")
         awful.layout.inc(1)
 
         assert(old_c.screen.selected_tag.layout ~= l)
@@ -57,7 +49,7 @@ local steps = {
         -- Test ontop
 
         assert(not old_c.ontop)
-        get_callback({modkey}, "t")()
+        awful.key.execute({modkey}, "t")
         awesome.sync()
 
         return true
@@ -75,7 +67,7 @@ local steps = {
         -- Now, test the master_width_factor
         assert(t.master_width_factor == 0.5)
 
-        get_callback({modkey}, "l")()
+        awful.key.execute({modkey}, "l")
         awesome.sync()
 
         return true
@@ -90,7 +82,7 @@ local steps = {
         -- Now, test the master_count
         assert(t.master_count == 1)
 
-        get_callback({modkey, "Shift"}, "h")()
+        awful.key.execute({modkey, "Shift"}, "h")
         awesome.sync()
 
         return true
@@ -105,8 +97,8 @@ local steps = {
         -- Now, test the column_count
         assert(t.column_count == 1)
 
-        get_callback({modkey, "Control"}, "h")()
-        get_callback({modkey, "Shift"  }, "l")()
+        awful.key.execute({modkey, "Control"}, "h")
+        awful.key.execute({modkey, "Shift"  }, "l")
         awesome.sync()
 
         return true
@@ -121,7 +113,7 @@ local steps = {
         -- Now, test the switching tag
         assert(t.index == 1)
 
-        get_callback({modkey, }, "Right")()
+        awful.key.execute({modkey, }, "Right")
         awesome.sync()
 
         return true
@@ -201,7 +193,7 @@ local steps = {
         -- tags[1] and the client history should be kept
         assert(client.focus == old_c)
 
-        --get_callback({modkey, "Shift"  }, "#"..(9+i))() --FIXME
+        --awful.key.execute({modkey, "Shift"  }, "#"..(9+i)) --FIXME
         client.focus:move_to_tag(tags[2])
 
         assert(not client.focus)


### PR DESCRIPTION
Add two new client properties: `property::size` and `property::position`.

Useful to avoid doubling signals, and to #1507 in particular.