### PR TITLE
test-current-desktop: make wait_for_current_desktop fail directly

### DIFF
--- a/tests/test-current-desktop.lua
+++ b/tests/test-current-desktop.lua
@@ -23,6 +23,7 @@ local function wait_for_current_desktop(tag)
             return true
         end
         print(string.format("Got _NET_CURRENT_DESKTOP = '%s', expected %d", value, idx))
+        return false
     end
 end
 


### PR DESCRIPTION
We should get the expected state before already.

Ref: https://github.com/awesomeWM/awesome/issues/1495#issuecomment-277098634