### PR TITLE
Fix client shape handling

### DIFF
--- a/lib/awful/client/shape.lua
+++ b/lib/awful/client/shape.lua
@@ -87,48 +87,8 @@ end
 -- @function awful.client.shape.update.all
 -- @client c The client to act on
 function shape.update.all(c)
-    local shape_fun = c._shape
-
-    if not shape_fun then
-        c.shape_bounding = nil
-        c.shape_clip = nil
-        shape.update.bounding(c)
-        shape.update.clip(c)
-        return
-    end
-
-    local geo = c:geometry()
-    local bw = c.border_width
-
-    -- First handle the bounding shape (things including the border)
-    local img = cairo.ImageSurface(cairo.Format.A1, geo.width + 2*bw, geo.height + 2*bw)
-    local cr = cairo.Context(img)
-
-    -- We just draw the shape in its full size
-    shape_fun(cr, geo.width + 2*bw, geo.height + 2*bw)
-    cr:set_operator(cairo.Operator.SOURCE)
-    cr:fill()
-    c.shape_bounding = img._native
-    img:finish()
-
-    -- Now handle the clip shape (things excluding the border)
-    img = cairo.ImageSurface(cairo.Format.A1, geo.width, geo.height)
-    cr = cairo.Context(img)
-
-    -- We give the shape the same arguments as for the bounding shape and draw
-    -- it in its full size (the translate is to compensate for the smaller
-    -- surface)
-    cr:translate(-bw, -bw)
-    shape_fun(cr, geo.width + 2*bw, geo.height + 2*bw)
-    cr:set_operator(cairo.Operator.SOURCE)
-    cr:fill_preserve()
-    -- Now we remove an area of width 'bw' again around the shape (We use 2*bw
-    -- since half of that is on the outside and only half on the inside)
-    cr:set_source_rgba(0, 0, 0, 0)
-    cr:set_line_width(2*bw)
-    cr:stroke()
-    c.shape_clip = img._native
-    img:finish()
+    shape.update.bounding(c)
+    shape.update.clip(c)
 end
 
 --- Update a client's bounding shape from the shape the client set itself.


### PR DESCRIPTION
The functions awful.client.shape.update.bounding and .clip handle both
the client's shape and the shape set by Lua. However,
awful.client.shape.update.all only handles the shape set by Lua and
ignores the client's own shape. This can easily be noticed with xeyes.
When update.all ran last and you move around xeyes, the wallpaper behind
it is moved along, because it is not actually outside of the window.

Fix this by partly reverting 1a5f6b7ad208e1a and having update.all just
call the other two functions again.

Signed-off-by: Uli Schlachter <psychon@znc.in>

With the following patch (border width is changed delayed'ly because this causes `update.all` to be caused) I get the following result before my patch:
![shapes](https://cloud.githubusercontent.com/assets/89482/22616296/eff19092-eaaa-11e6-8ae3-19bc7e19a33f.png)
and this is the result afterwards:
![shapes-after](https://cloud.githubusercontent.com/assets/89482/22616298/f709262e-eaaa-11e6-8496-a4c2ee4890c9.png)
I opened a terminal and started xeyes from there. I waited for the border width to be changed and then moved xeyes over the terminal.

It can be seen that the "part around the eyes" is not actually transparent before this patch, but is transparent afterwards. Also, it can be seen that the arrow shape is not the best choice here, but since it is much more obvious than rounded corners, I like it for testing. ;-)

Edit: Whoops, forgot the changes to the default config that I used for the screenshots:
```diff
diff --git a/awesomerc.lua b/awesomerc.lua
index 0c7fd0178..6a4101d75 100644
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -449,12 +449,17 @@ awful.rules.rules = {
       properties = { border_width = beautiful.border_width,
                      border_color = beautiful.border_normal,
                      focus = awful.client.focus.filter,
+                     shape = function() return gears.shape.arrow end,
                      raise = true,
                      keys = clientkeys,
                      buttons = clientbuttons,
                      screen = awful.screen.preferred,
                      placement = awful.placement.no_overlap+awful.placement.no_offscreen
-     }
+     }, callback = function(c)
+         gears.timer.start_new(3, function()
+             c.border_width = 15
+         end)
+     end
     },
 
     -- @DOC_FLOATING_RULE@
```