### PR TITLE
Travis: fix travis_run_in_fold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,10 +130,9 @@ install:
     travis_run_in_fold() {
       travis_fold_start "$1"
       shift
-      "$@"
-      local result="$?"
+      "$@" || return
       travis_fold_end
-      return $result
+      return 0
     }
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION -DSTRICT_TESTS=true"


### PR DESCRIPTION
It seems that when running travis_fold_end in case of a failure the
Travis job will be marked as "errored", but not "failed".

Ref: https://github.com/awesomeWM/awesome/pull/1516#issuecomment-277448575