### PR TITLE
awful.widget.watch: return timer too

### DIFF
--- a/lib/awful/widget/watch.lua
+++ b/lib/awful/widget/watch.lua
@@ -62,7 +62,8 @@ local watch = { mt = {} }
 --
 -- @param[opt=wibox.widget.textbox()] base_widget Base widget.
 --
--- @return The widget used by this watch
+-- @return The widget used by this watch.
+-- @return Its gears.timer.
 function watch.new(command, timeout, callback, base_widget)
     timeout = timeout or 5
     base_widget = base_widget or textbox()
@@ -79,7 +80,7 @@ function watch.new(command, timeout, callback, base_widget)
     end)
     t:start()
     t:emit_signal("timeout")
-    return base_widget
+    return base_widget, t
 end
 
 function watch.mt.__call(_, ...)


### PR DESCRIPTION
It would be useful to be able to control the widget timer too. 

For instance, when you want to pause the watcher because you don't need it for some time.

If there is already an easy way to get every `gears.timer` connected to a widget, you can close this PR.