### PR TITLE
Let env find bash

### DIFF
--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Use bash's pipefail option to get errors during failure in a command
 # pipeline.  This is useful to get notified about an error from dbus-send


### PR DESCRIPTION

> Applications should note that the standard PATH to the shell cannot be assumed to be either /bin/sh or /usr/bin/sh, and should be determined by interrogation of the PATH returned by getconf PATH, ensuring that the returned pathname is an absolute pathname and not a shell built-in.

POSIX and SUS both say the same thing about this. This will also fix awesome-client on *BSD.