### PR TITLE
Move filesystem functions out of awful.util into new gears.filesystem

### DIFF
--- a/docs/07-my-first-awesome.md
+++ b/docs/07-my-first-awesome.md
@@ -71,7 +71,7 @@ Awesome has four themes you can choose from: *default*, *sky*, *xresources*, and
 To change the theme, open your rc.lua and edit this line near the beginning of
 the file:
 
-    beautiful.init(awful.util.getdir("config") .. "/themes/default/theme.lua")
+    beautiful.init(gears.filesystem.get_dir("config") .. "/themes/default/theme.lua")
 
 For this tutorial we will stick with the default theme.
 

--- a/docs/sample_theme.lua
+++ b/docs/sample_theme.lua
@@ -15,11 +15,11 @@ require("sample_files")(
 -- `~/.config/awesome/mytheme.lua`
 -- and replace:
 --
---    beautiful.init(awful.util.get_themes_dir() .. "default/theme.lua")
+--    beautiful.init(gears.filesystem.get_themes_dir() .. "default/theme.lua")
 --
 -- with
 --
---    beautiful.init(awful.util.getdir("config") .. "mytheme.lua")
+--    beautiful.init(gears.filesystem.get_dir("config") .. "mytheme.lua")
 --
 -- in your `rc.lua`.
 --

--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -129,6 +129,7 @@ local debug = require('gears.debug')
 local gtable = require("gears.table")
 local gcolor = require("gears.color")
 local gstring = require("gears.string")
+local gfs = require("gears.filesystem")
 
 local prompt = {}
 
@@ -216,7 +217,7 @@ local function history_save(id)
             for d in id:gmatch(".-/") do
                 i = i + #d
             end
-            util.mkdir(id:sub(1, i - 1))
+            gfs.mkdir(id:sub(1, i - 1))
             f = assert(io.open(id, "w"))
         end
         for i = 1, math.min(#data.history[id].table, data.history[id].max) do

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -18,8 +18,8 @@ local gtable = require("gears.table")
 local string = string
 local gstring = require("gears.string")
 local grect = require("gears.geometry").rectangle
-local Gio = require("lgi").Gio
 local gcolor = require("gears.color")
+local gfs = require("gears.filesystem")
 local capi =
 {
     awesome = awesome,
@@ -126,10 +126,14 @@ function util.cycle(t, i)
 end
 
 --- Create a directory
+-- @deprecated mkdir
 -- @param dir The directory.
 -- @return mkdir return code
+-- @see gears.filesystem
 function util.mkdir(dir)
-    return os.execute("mkdir -p " .. dir)
+    util.deprecate("gears.filesystem.mkdir", {deprecated_in=5})
+
+    return gfs.mkdir(dir)
 end
 
 --- Eval Lua code.
@@ -188,55 +192,77 @@ function util.restart()
 end
 
 --- Get the config home according to the XDG basedir specification.
+-- @deprecated get_xdg_config_home
 -- @return the config home (XDG_CONFIG_HOME) with a slash at the end.
+-- @see gears.filesystem
 function util.get_xdg_config_home()
-    return (os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config") .. "/"
+    util.deprecate("gears.filesystem.get_xdg_config_home", {deprecated_in=5})
+
+    return gfs.get_xdg_config_home()
 end
 
 --- Get the cache home according to the XDG basedir specification.
+-- @deprecated get_xdg_cache_home
 -- @return the cache home (XDG_CACHE_HOME) with a slash at the end.
+-- @see gears.filesystem
 function util.get_xdg_cache_home()
-    return (os.getenv("XDG_CACHE_HOME") or os.getenv("HOME") .. "/.cache") .. "/"
+    util.deprecate("gears.filesystem.get_xdg_cache_home", {deprecated_in=5})
+
+    return gfs.get_xdg_cache_home()
 end
 
 --- Get the path to the user's config dir.
 -- This is the directory containing the configuration file ("rc.lua").
+-- @deprecated get_configuration_dir
 -- @return A string with the requested path with a slash at the end.
+-- @see gears.filesystem
 function util.get_configuration_dir()
-    return capi.awesome.conffile:match(".*/") or "./"
+    util.deprecate("gears.filesystem.get_configuration_dir", {deprecated_in=5})
+
+    return gfs.get_configuration_dir()
 end
 
 --- Get the path to a directory that should be used for caching data.
+-- @deprecated get_cache_dir
 -- @return A string with the requested path with a slash at the end.
+-- @see gears.filesystem
 function util.get_cache_dir()
-    return util.get_xdg_cache_home() .. "awesome/"
+    util.deprecate("gears.filesystem.get_cache_dir", {deprecated_in=5})
+
+    return gfs.get_cache_dir()
 end
 
 --- Get the path to the directory where themes are installed.
+-- @deprecated get_themes_dir
 -- @return A string with the requested path with a slash at the end.
+-- @see gears.filesystem
 function util.get_themes_dir()
-    return (os.getenv('AWESOME_THEMES_PATH') or awesome.themes_path) .. "/"
+    util.deprecate("gears.filesystem.get_themes_dir", {deprecated_in=5})
+
+    return gfs.get_themes_dir()
 end
 
 --- Get the path to the directory where our icons are installed.
+-- @deprecated get_awesome_icon_dir
 -- @return A string with the requested path with a slash at the end.
+-- @see gears.filesystem
 function util.get_awesome_icon_dir()
-    return (os.getenv('AWESOME_ICON_PATH') or awesome.icon_path) .. "/"
+    util.deprecate("gears.filesystem.get_awesome_icon_dir", {deprecated_in=5})
+
+    return gfs.get_awesome_icon_dir()
 end
 
 --- Get the user's config or cache dir.
 -- It first checks XDG_CONFIG_HOME / XDG_CACHE_HOME, but then goes with the
 -- default paths.
+-- @deprecated getdir
 -- @param d The directory to get (either "config" or "cache").
 -- @return A string containing the requested path.
+-- @see gears.filesystem
 function util.getdir(d)
-    if d == "config" then
-        -- No idea why this is what is returned, I recommend everyone to use
-        -- get_configuration_dir() instead
-        return util.get_xdg_config_home() .. "awesome/"
-    elseif d == "cache" then
-        return util.get_cache_dir()
-    end
+    util.deprecate("gears.filesystem.get_dir", {deprecated_in=5})
+
+    return gfs.get_dir(d)
 end
 
 --- Search for an icon and return the full path.
@@ -256,13 +282,13 @@ function util.geticonpath(iconname, exts, dirs, size)
         local icon
         for _, e in pairs(exts) do
             icon = d .. iconname .. '.' .. e
-            if util.file_readable(icon) then
+            if gfs.file_readable(icon) then
                 return icon
             end
             if size then
                 for _, t in pairs(icontypes) do
                     icon = string.format("%s%ux%u/%s/%s.%s", d, size, size, t, iconname, e)
-                    if util.file_readable(icon) then
+                    if gfs.file_readable(icon) then
                         return icon
                     end
                 end
@@ -271,33 +297,37 @@ function util.geticonpath(iconname, exts, dirs, size)
     end
 end
 
---- Check if a file exists, is not readable and not a directory.
+--- Check if a file exists, is readable and not a directory.
+-- @deprecated file_readable
 -- @param filename The file path.
 -- @return True if file exists and is readable.
+-- @see gears.filesystem
 function util.file_readable(filename)
-    local gfile = Gio.File.new_for_path(filename)
-    local gfileinfo = gfile:query_info("standard::type,access::can-read",
-                                       Gio.FileQueryInfoFlags.NONE)
-    return gfileinfo and gfileinfo:get_file_type() ~= "DIRECTORY" and
-        gfileinfo:get_attribute_boolean("access::can-read")
+    util.deprecate("gears.filesystem.file_readable", {deprecated_in=5})
+
+    return gfs.file_readable(filename)
 end
 
 --- Check if a path exists, is readable and is a directory.
+-- @deprecated dir_readable
 -- @tparam string path The directory path.
 -- @treturn boolean True if dir exists and is readable.
+-- @see gears.filesystem
 function util.dir_readable(path)
-    local gfile = Gio.File.new_for_path(path)
-    local gfileinfo = gfile:query_info("standard::type,access::can-read",
-                                       Gio.FileQueryInfoFlags.NONE)
-    return gfileinfo and gfileinfo:get_file_type() == "DIRECTORY" and
-        gfileinfo:get_attribute_boolean("access::can-read")
+    util.deprecate("gears.filesystem.dir_readable", {deprecated_in=5})
+
+    return gfs.dir_readable(path)
 end
 
 --- Check if a path is a directory.
+-- @deprecated is_dir
 -- @tparam string path
 -- @treturn bool True if path exists and is a directory.
+-- @see gears.filesystem
 function util.is_dir(path)
-    return Gio.File.new_for_path(path):query_file_type({}) == "DIRECTORY"
+    util.deprecate("gears.filesystem.is_dir", {deprecated_in=5})
+
+    return gfs.is_dir(path)
 end
 
 --- Return all subsets of a specific set.

--- a/lib/awful/widget/prompt.lua
+++ b/lib/awful/widget/prompt.lua
@@ -21,7 +21,7 @@
 local setmetatable = setmetatable
 
 local completion = require("awful.completion")
-local util = require("awful.util")
+local gfs = require("gears.filesystem")
 local spawn = require("awful.spawn")
 local prompt = require("awful.prompt")
 local beautiful = require("beautiful")
@@ -39,7 +39,7 @@ local function run(promptbox)
         prompt              = promptbox.prompt,
         textbox             = promptbox.widget,
         completion_callback = completion.shell,
-        history_path        = util.get_cache_dir() .. "/history",
+        history_path        = gfs.get_cache_dir() .. "/history",
         exe_callback        = function (...)
             promptbox:spawn_and_handle_error(...)
         end,

--- a/lib/gears/filesystem.lua
+++ b/lib/gears/filesystem.lua
@@ -1,0 +1,109 @@
+---------------------------------------------------------------------------
+--- Filesystem module for gears
+--
+-- @module gears.filesystem
+---------------------------------------------------------------------------
+
+-- Grab environment we need
+local Gio = require("lgi").Gio
+
+local filesystem = {}
+
+--- Create a directory
+-- @tparam string dir The directory.
+-- @return (true, nil) on success, (false, err) on failure
+function filesystem.mkdir(dir)
+	local gfile = Gio.File.new_for_path(dir)
+	local success, err = gfile:make_directory_with_parents()
+	if success then
+		return true
+	end
+	if err.domain == Gio.IOErrorEnum and err.code == "EXISTS" then
+		-- Direcotry already exists, let this count as success
+		return true
+	end
+	return false, err
+end
+
+--- Check if a file exists, is readable and not a directory.
+-- @tparam string filename The file path.
+-- @treturn boolean True if file exists and is readable.
+function filesystem.file_readable(filename)
+    local gfile = Gio.File.new_for_path(filename)
+    local gfileinfo = gfile:query_info("standard::type,access::can-read",
+                                       Gio.FileQueryInfoFlags.NONE)
+    return gfileinfo and gfileinfo:get_file_type() ~= "DIRECTORY" and
+        gfileinfo:get_attribute_boolean("access::can-read")
+end
+
+--- Check if a path exists, is readable and a directory.
+-- @tparam string path The directory path.
+-- @treturn boolean True if path exists and is readable.
+function filesystem.dir_readable(path)
+    local gfile = Gio.File.new_for_path(path)
+    local gfileinfo = gfile:query_info("standard::type,access::can-read",
+                                       Gio.FileQueryInfoFlags.NONE)
+    return gfileinfo and gfileinfo:get_file_type() == "DIRECTORY" and
+        gfileinfo:get_attribute_boolean("access::can-read")
+end
+
+--- Check if a path is a directory.
+-- @tparam string path The directory path
+-- @treturn boolean True if path exists and is a directory.
+function filesystem.is_dir(path)
+    return Gio.File.new_for_path(path):query_file_type({}) == "DIRECTORY"
+end
+
+--- Get the config home according to the XDG basedir specification.
+-- @return the config home (XDG_CONFIG_HOME) with a slash at the end.
+function filesystem.get_xdg_config_home()
+    return (os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config") .. "/"
+end
+
+--- Get the cache home according to the XDG basedir specification.
+-- @return the cache home (XDG_CACHE_HOME) with a slash at the end.
+function filesystem.get_xdg_cache_home()
+    return (os.getenv("XDG_CACHE_HOME") or os.getenv("HOME") .. "/.cache") .. "/"
+end
+
+--- Get the path to the user's config dir.
+-- This is the directory containing the configuration file ("rc.lua").
+-- @return A string with the requested path with a slash at the end.
+function filesystem.get_configuration_dir()
+    return awesome.conffile:match(".*/") or "./"
+end
+
+--- Get the path to a directory that should be used for caching data.
+-- @return A string with the requested path with a slash at the end.
+function filesystem.get_cache_dir()
+    return filesystem.get_xdg_cache_home() .. "awesome/"
+end
+
+--- Get the path to the directory where themes are installed.
+-- @return A string with the requested path with a slash at the end.
+function filesystem.get_themes_dir()
+    return (os.getenv('AWESOME_THEMES_PATH') or awesome.themes_path) .. "/"
+end
+
+--- Get the path to the directory where our icons are installed.
+-- @return A string with the requested path with a slash at the end.
+function filesystem.get_awesome_icon_dir()
+    return (os.getenv('AWESOME_ICON_PATH') or awesome.icon_path) .. "/"
+end
+
+--- Get the user's config or cache dir.
+-- It first checks XDG_CONFIG_HOME / XDG_CACHE_HOME, but then goes with the
+-- default paths.
+-- @param d The directory to get (either "config" or "cache").
+-- @return A string containing the requested path.
+function filesystem.get_dir(d)
+    if d == "config" then
+        -- No idea why this is what is returned, I recommend everyone to use
+        -- get_configuration_dir() instead
+        return filesystem.get_xdg_config_home() .. "awesome/"
+    elseif d == "cache" then
+        return filesystem.get_cache_dir()
+    end
+end
+
+return filesystem

--- a/lib/gears/init.lua
+++ b/lib/gears/init.lua
@@ -21,6 +21,7 @@ return
     math = require("gears.math");
     table = require("gears.table");
     string = require("gears.string");
+    filesystem = require("gears.filesystem");
 }
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/menubar/icon_theme.lua
+++ b/lib/menubar/icon_theme.lua
@@ -11,7 +11,7 @@
 --  http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-0.12.html
 
 local beautiful = require("beautiful")
-local awful_util = require("awful.util")
+local gfs = require("gears.filesystem")
 local GLib = require("lgi").GLib
 local index_theme = require("menubar.index_theme")
 
@@ -25,18 +25,18 @@ local get_pragmatic_base_directories = function()
     local dirs = {}
 
     local dir = GLib.build_filenamev({GLib.get_home_dir(), ".icons"})
-    if awful_util.dir_readable(dir) then
+    if gfs.dir_readable(dir) then
         table.insert(dirs, dir)
     end
 
     dir = GLib.build_filenamev({GLib.get_user_data_dir(), "icons"})
-    if awful_util.dir_readable(dir) then
+    if gfs.dir_readable(dir) then
         table.insert(dirs, dir)
     end
 
     for _, v in ipairs(GLib.get_system_data_dirs()) do
         dir = GLib.build_filenamev({v, "icons"})
-        if awful_util.dir_readable(dir) then
+        if gfs.dir_readable(dir) then
             table.insert(dirs, dir)
         end
     end
@@ -44,7 +44,7 @@ local get_pragmatic_base_directories = function()
     local need_usr_share_pixmaps = true
     for _, v in ipairs(GLib.get_system_data_dirs()) do
         dir = GLib.build_filenamev({v, "pixmaps"})
-        if awful_util.dir_readable(dir) then
+        if gfs.dir_readable(dir) then
             table.insert(dirs, dir)
         end
         if dir == "/usr/share/pixmaps" then
@@ -53,7 +53,7 @@ local get_pragmatic_base_directories = function()
     end
 
     dir = "/usr/share/pixmaps"
-    if need_usr_share_pixmaps and awful_util.dir_readable(dir) then
+    if need_usr_share_pixmaps and gfs.dir_readable(dir) then
         table.insert(dirs, dir)
     end
 
@@ -65,7 +65,7 @@ local get_default_icon_theme_name = function()
     for _, dir in ipairs(get_pragmatic_base_directories()) do
         for _, icon_theme_name in ipairs(icon_theme_names) do
             local filename = string.format("%s/%s/index.theme", dir, icon_theme_name)
-            if awful_util.file_readable(filename) then
+            if gfs.file_readable(filename) then
                 return icon_theme_name
             end
         end
@@ -152,7 +152,7 @@ local lookup_icon = function(self, icon_name, icon_size)
                     local filename = string.format("%s/%s/%s/%s.%s",
                                                    basedir, self.icon_theme_name, subdir,
                                                    icon_name, ext)
-                    if awful_util.file_readable(filename) then
+                    if gfs.file_readable(filename) then
                         return filename
                     else
                         checked_already[filename] = true
@@ -173,7 +173,7 @@ local lookup_icon = function(self, icon_name, icon_size)
                                                    basedir, self.icon_theme_name, subdir,
                                                    icon_name, ext)
                     if not checked_already[filename] then
-                        if awful_util.file_readable(filename) then
+                        if gfs.file_readable(filename) then
                             closest_filename = filename
                             minimal_size = dist
                         end
@@ -209,7 +209,7 @@ local lookup_fallback_icon = function(self, icon_name)
             local filename = string.format("%s/%s.%s",
                                            dir,
                                            icon_name, ext)
-            if awful_util.file_readable(filename) then
+            if gfs.file_readable(filename) then
                 return filename
             end
         end

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -27,6 +27,7 @@ local capi = {
 }
 local gmath = require("gears.math")
 local awful = require("awful")
+local gfs = require("gears.filesystem")
 local common = require("awful.widget.common")
 local theme = require("beautiful")
 local wibox = require("wibox")
@@ -128,7 +129,7 @@ local function load_count_table()
         return instance.count_table
     end
     instance.count_table = {}
-    local count_file_name = awful.util.getdir("cache") .. "/menu_count_file"
+    local count_file_name = gfs.get_dir("cache") .. "/menu_count_file"
     local count_file = io.open (count_file_name, "r")
     if count_file then
         for line in count_file:lines() do
@@ -144,7 +145,7 @@ end
 
 local function write_count_table(count_table)
     count_table = count_table or instance.count_table
-    local count_file_name = awful.util.getdir("cache") .. "/menu_count_file"
+    local count_file_name = gfs.get_dir("cache") .. "/menu_count_file"
     local count_file = io.open (count_file_name, "w")
     for name, count in pairs(count_table) do
         local str = string.format("%s;%d\n", name, count)
@@ -434,7 +435,7 @@ function menubar.show(scr)
         prompt              = "Run: ",
         textbox             = instance.prompt.widget,
         completion_callback = awful.completion.shell,
-        history_path        = awful.util.get_cache_dir() .. "/history_menu",
+        history_path        = gfs.get_cache_dir() .. "/history_menu",
         done_callback       = menubar.hide,
         changed_callback    = function(query)
             instance.query = query

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -13,6 +13,7 @@ local ipairs = ipairs
 local string = string
 local screen = screen
 local awful_util = require("awful.util")
+local gfs = require("gears.filesystem")
 local theme = require("beautiful")
 local lgi = require("lgi")
 local gio = lgi.Gio
@@ -77,7 +78,7 @@ local icon_lookup_path = nil
 local function get_icon_lookup_path()
     if not icon_lookup_path then
         local add_if_readable = function(t, path)
-            if awful_util.dir_readable(path) then
+            if gfs.dir_readable(path) then
                 table.insert(t, path)
             end
         end
@@ -90,7 +91,7 @@ local function get_icon_lookup_path()
                                                      '.icons'}))
         for _,dir in ipairs(paths) do
             local icons_dir = glib.build_filenamev({dir, 'icons'})
-            if awful_util.dir_readable(icons_dir) then
+            if gfs.dir_readable(icons_dir) then
                 if icon_theme then
                     add_if_readable(icon_theme_paths,
                                     glib.build_filenamev({icons_dir,
@@ -130,11 +131,11 @@ function utils.lookup_icon_uncached(icon_file)
     if icon_file:sub(1, 1) == '/' and is_format_supported(icon_file) then
         -- If the path to the icon is absolute and its format is
         -- supported, do not perform a lookup.
-        return awful_util.file_readable(icon_file) and icon_file or nil
+        return gfs.file_readable(icon_file) and icon_file or nil
     else
         for _, directory in ipairs(get_icon_lookup_path()) do
             if is_format_supported(icon_file) and
-                    awful_util.file_readable(directory .. "/" .. icon_file) then
+                    gfs.file_readable(directory .. "/" .. icon_file) then
                 return directory .. "/" .. icon_file
             else
                 -- Icon is probably specified without path and format,
@@ -142,7 +143,7 @@ function utils.lookup_icon_uncached(icon_file)
                 -- it and see if such file exists.
                 for _, format in ipairs(icon_formats) do
                     local possible_file = directory .. "/" .. icon_file .. "." .. format
-                    if awful_util.file_readable(possible_file) then
+                    if gfs.file_readable(possible_file) then
                         return possible_file
                     end
                 end

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -21,6 +21,7 @@ local button = require("awful.button")
 local screen = require("awful.screen")
 local util = require("awful.util")
 local gtable = require("gears.table")
+local gfs = require("gears.filesystem")
 local bt = require("beautiful")
 local wibox = require("wibox")
 local surface = require("gears.surface")
@@ -648,7 +649,7 @@ function naughty.notify(args)
             icon = string.gsub(icon, "%%(%x%x)", function(x) return string.char(tonumber(x, 16)) end )
         end
         -- try to guess icon if the provided one is non-existent/readable
-        if type(icon) == "string" and not util.file_readable(icon) then
+        if type(icon) == "string" and not gfs.file_readable(icon) then
             icon = util.geticonpath(icon, naughty.config.icon_formats, naughty.config.icon_dirs, icon_size) or icon
         end
 

--- a/tests/examples/wibox/awidget/prompt/hooks.lua
+++ b/tests/examples/wibox/awidget/prompt/hooks.lua
@@ -4,6 +4,7 @@ local awful     = { prompt = require("awful.prompt"),--DOC_HIDE
                     util   = require("awful.util"), --DOC_HIDE
                     spawn  = function () end } --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
+local gfs       = require("gears.filesystem") --DOC_HIDE
 
     local atextbox = wibox.widget.textbox()
 
@@ -53,7 +54,7 @@ local beautiful = require( "beautiful" ) --DOC_HIDE
         prompt        = "<b>Run: </b>",
         hooks         = hooks,
         textbox       = atextbox,
-        history_path  = awful.util.getdir("cache") .. "/history",
+        history_path  = gfs.get_dir("cache") .. "/history",
         done_callback = clear,
     }
 

--- a/tests/examples/wibox/awidget/prompt/keypress.lua
+++ b/tests/examples/wibox/awidget/prompt/keypress.lua
@@ -4,6 +4,7 @@ local awful     = { prompt = require("awful.prompt"),--DOC_HIDE
                     util   = require("awful.util"),--DOC_HIDE
                     screen = require("awful.screen")}--DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
+local gfs       = require("gears.filesystem") --DOC_HIDE
 local naughty   = {} --DOC_HIDE
 
     local atextbox = wibox.widget.textbox()
@@ -23,7 +24,7 @@ local naughty   = {} --DOC_HIDE
             end
         end,
         textbox              = atextbox,
-        history_path         = awful.util.getdir("cache") .. "/history",
+        history_path         = gfs.get_dir("cache") .. "/history",
     }
 
 parent:add( wibox.widget {    --DOC_HIDE

--- a/tests/examples/wibox/awidget/prompt/vilike.lua
+++ b/tests/examples/wibox/awidget/prompt/vilike.lua
@@ -3,6 +3,7 @@ local wibox     = require( "wibox"     ) --DOC_HIDE
 local awful     = { prompt = require("awful.prompt"),--DOC_HIDE
                     util   = require("awful.util")}--DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
+local gfs       = require("gears.filesystem") --DOC_HIDE
 local terminal  = "xterm"  --DOC_HIDE
 
     local atextbox = wibox.widget.textbox()
@@ -43,7 +44,7 @@ local terminal  = "xterm"  --DOC_HIDE
             end},
         },
         textbox      = atextbox,
-        history_path = awful.util.getdir('cache') .. '/history',
+        history_path = gfs.get_dir('cache') .. '/history',
         exe_callback = function(cmd) awful.spawn(cmd) end
     }
 

--- a/themes/default/theme.lua
+++ b/themes/default/theme.lua
@@ -6,8 +6,8 @@ local theme_assets = require("beautiful.theme_assets")
 local xresources = require("beautiful.xresources")
 local dpi = xresources.apply_dpi
 
-local util = require('awful.util')
-local themes_path = util.get_themes_dir()
+local gfs = require("gears.filesystem")
+local themes_path = gfs.get_themes_dir()
 
 local theme = {}
 

--- a/themes/sky/theme.lua
+++ b/themes/sky/theme.lua
@@ -7,7 +7,7 @@
 local theme_assets = require("beautiful.theme_assets")
 local xresources = require("beautiful.xresources")
 local dpi = xresources.apply_dpi
-local themes_path = require("awful.util").get_themes_dir()
+local themes_path = require("gears.filesystem").get_themes_dir()
 
 
 -- BASICS

--- a/themes/xresources/theme.lua
+++ b/themes/xresources/theme.lua
@@ -7,8 +7,8 @@ local theme_assets = require("beautiful.theme_assets")
 local xresources = require("beautiful.xresources")
 local dpi = xresources.apply_dpi
 local xrdb = xresources.get_current_theme()
-local util = require('awful.util')
-local themes_path = util.get_themes_dir()
+local gfs = require("gears.filesystem")
+local themes_path = gfs.get_themes_dir()
 
 -- inherit default theme
 local theme = dofile(themes_path.."default/theme.lua")

--- a/themes/zenburn/theme.lua
+++ b/themes/zenburn/theme.lua
@@ -3,7 +3,7 @@
 --    By Adrian C. (anrxc)   --
 -------------------------------
 
-local themes_path = require("awful.util").get_themes_dir()
+local themes_path = require("gears.filesystem").get_themes_dir()
 
 -- {{{ Main
 local theme = {}


### PR DESCRIPTION
For #1549.

This leaves the old functions there with deprecation warnings while redirecting to the new gears functions.