### PR TITLE
Move table functions out of awful.util into new gears.table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,12 @@ install:
 
   # Determine custom version.
   - export AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)"
-  - 'if [ "$TRAVIS_PULL_REQUEST" != false ]; then AWESOME_VERSION="v9999-PR${TRAVIS_PULL_REQUEST}"; fi'
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" != false ] && [ "$TEST_PREV_COMMITS" = 1 ]; then
+      AWESOME_VERSION="${AWESOME_VERSION}-PR${TRAVIS_PULL_REQUEST}"
+    elif [ "$TRAVIS_PULL_REQUEST" != false ]; then
+      AWESOME_VERSION="v9999-PR${TRAVIS_PULL_REQUEST}";
+    fi
   # function for codecov support
   - if [ "$DO_COVERAGE" = "codecov" ]; then travis_retry wget -O /tmp/codecov-bash https://codecov.io/bash; fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ install:
 
   # Determine custom version.
   - export AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)"
-  - 'if [ "$TRAVIS_PULL_REQUEST" != false ]; then AWESOME_VERSION="${AWESOME_VERSION}-PR${TRAVIS_PULL_REQUEST}"; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != false ]; then AWESOME_VERSION="v9999-PR${TRAVIS_PULL_REQUEST}"; fi'
   # function for codecov support
   - if [ "$DO_COVERAGE" = "codecov" ]; then travis_retry wget -O /tmp/codecov-bash https://codecov.io/bash; fi
   - |

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -13,9 +13,8 @@ local load = loadstring or load -- luacheck: globals loadstring (compatibility w
 local loadfile = loadfile
 local debug = debug
 local pairs = pairs
-local ipairs = ipairs
 local type = type
-local rtable = table
+local gtable = require("gears.table")
 local string = string
 local lgi = require("lgi")
 local grect = require("gears.geometry").rectangle
@@ -324,43 +323,29 @@ end
 
 --- Join all tables given as parameters.
 -- This will iterate all tables and insert all their keys into a new table.
+-- @deprecated util.table.join
 -- @param args A list of tables to join
 -- @return A new table containing all keys from the arguments.
+-- @see gears.table
 function util.table.join(...)
-    local ret = {}
-    for _, t in pairs({...}) do
-        if t then
-            for k, v in pairs(t) do
-                if type(k) == "number" then
-                    rtable.insert(ret, v)
-                else
-                    ret[k] = v
-                end
-            end
-        end
-    end
-    return ret
+    util.deprecate("gears.table.join", {deprecated_in=5})
+
+    return gtable.join(...)
 end
 
 --- Override elements in the first table by the one in the second.
 --
 -- Note that this method doesn't copy entries found in `__index`.
+-- @deprecated util.table.crush
 -- @tparam table t the table to be overriden
 -- @tparam table set the table used to override members of `t`
 -- @tparam[opt=false] boolean raw Use rawset (avoid the metatable)
 -- @treturn table t (for convenience)
+-- @see gears.table
 function util.table.crush(t, set, raw)
-    if raw then
-        for k, v in pairs(set) do
-            rawset(t, k, v)
-        end
-    else
-        for k, v in pairs(set) do
-            t[k] = v
-        end
-    end
+    util.deprecate("gears.table.crush", {deprecated_in=5})
 
-    return t
+    return gtable.crush(t, set, raw)
 end
 
 --- Pack all elements with an integer key into a new table
@@ -370,36 +355,26 @@ end
 --
 -- This function remove any non numeric keys from the value set
 --
+-- @deprecated util.table.from_sparse
 -- @tparam table t A potentially sparse table
 -- @treturn table A packed table with all numeric keys
+-- @see gears.table
 function util.table.from_sparse(t)
-    local keys= {}
-    for k in pairs(t) do
-        if type(k) == "number" then
-            keys[#keys+1] = k
-        end
-    end
+    util.deprecate("gears.table.from_sparse", {deprecated_in=5})
 
-    table.sort(keys)
-
-    local ret = {}
-    for _,v in ipairs(keys) do
-        ret[#ret+1] = t[v]
-    end
-
-    return ret
+    return gtable.from_sparse(t)
 end
 
 --- Check if a table has an item and return its key.
+-- @deprecated util.table.hasitem
 -- @param t The table.
 -- @param item The item to look for in values of the table.
 -- @return The key were the item is found, or nil if not found.
+-- @see gears.table
 function util.table.hasitem(t, item)
-    for k, v in pairs(t) do
-        if v == item then
-            return k
-        end
-    end
+    util.deprecate("gears.table.hasitem", {deprecated_in=5})
+
+    return gtable.hasitem(t, item)
 end
 
 --- Split a string into multiple lines
@@ -430,105 +405,78 @@ function util.linecount(text)
 end
 
 --- Get a sorted table with all integer keys from a table
+-- @deprecated util.table.keys
 -- @param t the table for which the keys to get
 -- @return A table with keys
+-- @see gears.table
 function util.table.keys(t)
-    local keys = { }
-    for k, _ in pairs(t) do
-        rtable.insert(keys, k)
-    end
-    rtable.sort(keys, function (a, b)
-        return type(a) == type(b) and a < b or false
-    end)
-    return keys
+    util.deprecate("gears.table.keys", {deprecated_in=5})
+
+    return gtable.keys(t)
 end
 
 --- Filter a tables keys for certain content types
+-- @deprecated util.table.keys_filter
 -- @param t The table to retrieve the keys for
 -- @param ... the types to look for
 -- @return A filtered table with keys
+-- @see gears.table
 function util.table.keys_filter(t, ...)
-    local keys = util.table.keys(t)
-    local keys_filtered = { }
-    for _, k in pairs(keys) do
-        for _, et in pairs({...}) do
-            if type(t[k]) == et then
-                rtable.insert(keys_filtered, k)
-                break
-            end
-        end
-    end
-    return keys_filtered
+    util.deprecate("gears.table.keys_filter", {deprecated_in=5})
+
+    return gtable.keys_filter(t, ...)
 end
 
 --- Reverse a table
+-- @deprecated util.table.reverse
 -- @param t the table to reverse
 -- @return the reversed table
+-- @see gears.table
 function util.table.reverse(t)
-    local tr = { }
-    -- reverse all elements with integer keys
-    for _, v in ipairs(t) do
-        rtable.insert(tr, 1, v)
-    end
-    -- add the remaining elements
-    for k, v in pairs(t) do
-        if type(k) ~= "number" then
-            tr[k] = v
-        end
-    end
-    return tr
+    util.deprecate("gears.table.reverse", {deprecated_in=5})
+
+    return gtable.reverse(t)
 end
 
 --- Clone a table
+-- @deprecated util.table.clone
 -- @param t the table to clone
 -- @param deep Create a deep clone? (default: true)
 -- @return a clone of t
+-- @see gears.table
 function util.table.clone(t, deep)
-    deep = deep == nil and true or deep
-    local c = { }
-    for k, v in pairs(t) do
-        if deep and type(v) == "table" then
-            c[k] = util.table.clone(v)
-        else
-            c[k] = v
-        end
-    end
-    return c
+    util.deprecate("gears.table.clone", {deprecated_in=5})
+
+    return gtable.clone(t, deep)
 end
 
 ---
 -- Returns an iterator to cycle through, starting from the first element or the
 -- given index, all elements of a table that match a given criteria.
 --
+-- @deprecated util.table.iterate
 -- @param t      the table to iterate
 -- @param filter a function that returns true to indicate a positive match
 -- @param start  what index to start iterating from.  Default is 1 (=> start of
 -- the table)
+-- @see gears.table
 function util.table.iterate(t, filter, start)
-    local count  = 0
-    local index  = start or 1
-    local length = #t
+    util.deprecate("gears.table.iterate", {deprecated_in=5})
 
-    return function ()
-        while count < length do
-            local item = t[index]
-            index = gmath.cycle(#t, index + 1)
-            count = count + 1
-            if filter(item) then return item end
-        end
-    end
+    return gtable.iterate(t, filter, start)
 end
 
 
 --- Merge items from the one table to another one
+-- @deprecated util.table.merge
 -- @tparam table t the container table
 -- @tparam table set the mixin table
 -- @treturn table Return `t` for convenience
+-- @see gears.table
 function util.table.merge(t, set)
-    for _, v in ipairs(set) do
-        table.insert(t, v)
-    end
-    return t
+    util.deprecate("gears.table.merge", {deprecated_in=5})
+
+    return gtable.merge(t, set)
 end
 
 

--- a/lib/gears/init.lua
+++ b/lib/gears/init.lua
@@ -19,6 +19,7 @@ return
     protected_call = require("gears.protected_call");
     geometry = require("gears.geometry");
     math = require("gears.math");
+    table = require("gears.table");
 }
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/gears/table.lua
+++ b/lib/gears/table.lua
@@ -1,0 +1,216 @@
+---------------------------------------------------------------------------
+--- Table module for gears
+--
+-- @module gears.table
+---------------------------------------------------------------------------
+
+
+local rtable = table
+
+local gmath = require("gears.math")
+local gtable = {}
+
+--- Join all tables given as parameters.
+-- This will iterate all tables and insert all their keys into a new table.
+-- @class function
+-- @name join
+-- @param args A list of tables to join
+-- @return A new table containing all keys from the arguments.
+function gtable.join(...)
+    local ret = {}
+    for _, t in pairs({...}) do
+        if t then
+            for k, v in pairs(t) do
+                if type(k) == "number" then
+                    rtable.insert(ret, v)
+                else
+                    ret[k] = v
+                end
+            end
+        end
+    end
+    return ret
+end
+
+--- Override elements in the first table by the one in the second.
+--
+-- Note that this method doesn't copy entries found in `__index`.
+-- @class function
+-- @name crush
+-- @tparam table t the table to be overriden
+-- @tparam table set the table used to override members of `t`
+-- @tparam[opt=false] boolean raw Use rawset (avoid the metatable)
+-- @treturn table t (for convenience)
+function gtable.crush(t, set, raw)
+    if raw then
+        for k, v in pairs(set) do
+            rawset(t, k, v)
+        end
+    else
+        for k, v in pairs(set) do
+            t[k] = v
+        end
+    end
+
+    return t
+end
+
+--- Pack all elements with an integer key into a new table
+-- While both lua and luajit implement __len over sparse
+-- table, the standard define it as an implementation
+-- detail.
+--
+-- This function remove any non numeric keys from the value set
+--
+-- @class function
+-- @name from_sparse
+-- @tparam table t A potentially sparse table
+-- @treturn table A packed table with all numeric keys
+function gtable.from_sparse(t)
+    local keys= {}
+    for k in pairs(t) do
+        if type(k) == "number" then
+            keys[#keys+1] = k
+        end
+    end
+
+    table.sort(keys)
+
+    local ret = {}
+    for _,v in ipairs(keys) do
+        ret[#ret+1] = t[v]
+    end
+
+    return ret
+end
+
+--- Check if a table has an item and return its key.
+-- @class function
+-- @name hasitem
+-- @param t The table.
+-- @param item The item to look for in values of the table.
+-- @return The key were the item is found, or nil if not found.
+function gtable.hasitem(t, item)
+    for k, v in pairs(t) do
+        if v == item then
+            return k
+        end
+    end
+end
+
+--- Get a sorted table with all integer keys from a table
+-- @class function
+-- @name keys
+-- @param t the table for which the keys to get
+-- @return A table with keys
+function gtable.keys(t)
+    local keys = { }
+    for k, _ in pairs(t) do
+        rtable.insert(keys, k)
+    end
+    rtable.sort(keys, function (a, b)
+        return type(a) == type(b) and a < b or false
+    end)
+    return keys
+end
+
+--- Filter a tables keys for certain content types
+-- @class function
+-- @name keys_filter
+-- @param t The table to retrieve the keys for
+-- @param ... the types to look for
+-- @return A filtered table with keys
+function gtable.keys_filter(t, ...)
+    local keys = gtable.keys(t)
+    local keys_filtered = { }
+    for _, k in pairs(keys) do
+        for _, et in pairs({...}) do
+            if type(t[k]) == et then
+                rtable.insert(keys_filtered, k)
+                break
+            end
+        end
+    end
+    return keys_filtered
+end
+
+--- Reverse a table
+-- @class function
+-- @name reverse
+-- @param t the table to reverse
+-- @return the reversed table
+function gtable.reverse(t)
+    local tr = { }
+    -- reverse all elements with integer keys
+    for _, v in ipairs(t) do
+        rtable.insert(tr, 1, v)
+    end
+    -- add the remaining elements
+    for k, v in pairs(t) do
+        if type(k) ~= "number" then
+            tr[k] = v
+        end
+    end
+    return tr
+end
+
+--- Clone a table
+-- @class function
+-- @name clone
+-- @param t the table to clone
+-- @param deep Create a deep clone? (default: true)
+-- @return a clone of t
+function gtable.clone(t, deep)
+    deep = deep == nil and true or deep
+    local c = { }
+    for k, v in pairs(t) do
+        if deep and type(v) == "table" then
+            c[k] = gtable.clone(v)
+        else
+            c[k] = v
+        end
+    end
+    return c
+end
+
+---
+-- Returns an iterator to cycle through, starting from the first element or the
+-- given index, all elements of a table that match a given criteria.
+--
+-- @class function
+-- @name iterate
+-- @param t      the table to iterate
+-- @param filter a function that returns true to indicate a positive match
+-- @param start  what index to start iterating from.  Default is 1 (=> start of
+-- the table)
+function gtable.iterate(t, filter, start)
+    local count  = 0
+    local index  = start or 1
+    local length = #t
+
+    return function ()
+        while count < length do
+            local item = t[index]
+            index = gmath.cycle(#t, index + 1)
+            count = count + 1
+            if filter(item) then return item end
+        end
+    end
+end
+
+
+--- Merge items from the one table to another one
+-- @class function
+-- @name merge
+-- @tparam table t the container table
+-- @tparam table set the mixin table
+-- @treturn table Return `t` for convenience
+function gtable.merge(t, set)
+    for _, v in ipairs(set) do
+        table.insert(t, v)
+    end
+    return t
+end
+
+
+return gtable


### PR DESCRIPTION
For #1549.

This leaves the old functions there with deprecation warnings while redirecting to the new gears functions.

Note: I did not include `util.subsets` in this move. While it does deal specifically with tables I feel it's more a mathematics function than a table function.