### PR TITLE
[RFC] Add a deprecated_in variable to util.deprecate args table

### DIFF
--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -40,12 +40,12 @@ local displayed_deprecations = {}
 -- @param[opt] see The message to a new method / function to use.
 -- @tparam table args Extra arguments
 -- @tparam boolean args.raw Print the message as-is without the automatic context
--- @tparam integer args.deprecated_in Print the message only when Awesome's major version is equal to or greater than deprecated_in
+-- @tparam integer args.deprecated_in Print the message only when Awesome's
+--   version is equal to or greater than deprecated_in.
 function util.deprecate(see, args)
     args = args or {}
-    -- If args.deprecated_in is defined, only print deprecation warning after the given major version
     if args.deprecated_in then
-        local dep_ver = "v" .. tostring(args.deprecated_in) .. ".0"
+        local dep_ver = "v" .. tostring(args.deprecated_in)
         if awesome.version < dep_ver then
             return
         end

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -40,8 +40,16 @@ local displayed_deprecations = {}
 -- @param[opt] see The message to a new method / function to use.
 -- @tparam table args Extra arguments
 -- @tparam boolean args.raw Print the message as-is without the automatic context
+-- @tparam integer args.deprecated_in Print the message only when Awesome's major version is equal to or greater than deprecated_in
 function util.deprecate(see, args)
     args = args or {}
+    -- If args.deprecated_in is defined, only print deprecation warning after the given major version
+    if args.deprecated_in then
+        local dep_ver = "v" .. tostring(args.deprecated_in) .. ".0"
+        if awesome.version < dep_ver then
+            return
+        end
+    end
     local tb = debug.traceback()
     if displayed_deprecations[tb] then
         return


### PR DESCRIPTION
As referenced in #1583, @Elv13 and myself have talked about adding a `deprecated_in` variable to `util.deprecate`. This variable is to stop the deprecation message from showing until Awesome's major version is greater than or equal to the deprecated in version. This is to help prevent (visible) API breakage while updating the current major version with new functionality and movement of API around, such as current work in #1549. Currently with the updates though, Elv has agreed that keeping the `@deprecated` and `@see` tags in the documentation will be fine.
(Feel free to correct anything here, Elv)

Example with referencing the above #1549, the current work in splitting up `awful.util` into new `gears` modules is an API breakage, and without the `deprecated_in` logic will print deprecation warnings once v4.1 is released. Setting the `deprecated_in` variable to `5` will suppress the printed warning until Awesome v5.0 is released. After v5 is released the message will be printed, giving proper warning that the `awful.util` functions will be removed in the next major release. This keeps the v4 API sane without much hiccup as we clean up code and introduce new.

So with this here's a few questions:
* Do we want to make clear that the functions will be removed **specifically** in the next major release? So v5 warning, v6 is removed, so on and so forth.
* Shall we update all current `util.deprecate` functions with the `deprecated_in` variable setting it to `4` for completeness? See below.
* Is there any other arguments we want to add logic for while we're at it?

---

For point 2, here's the current grep for all `deprecate(` in `lib/*`:
```
$ grep -r 'deprecate(' lib/*
lib/awful/init.lua:    util.deprecate("gears.timer")
lib/awful/init.lua:   util.deprecate("awful.spawn")
lib/awful/init.lua:   util.deprecate("awful.spawn.with_shell")
lib/awful/init.lua:    util.deprecate("Use io.popen() directly or look at awful.spawn.easy_async() "
lib/awful/util.lua:function util.deprecate(see, args)
lib/awful/util.lua:        util.deprecate(message, {raw = true})
lib/awful/util.lua:        util.deprecate(message, {raw = true})
lib/awful/util.lua:        util.deprecate(message, {raw = true})
lib/awful/util.lua:    util.deprecate("gears.geometry.rectangle.get_in_direction")
lib/awful/tag.lua:    util.deprecate("Use t.index = new_index instead of awful.tag.move")
lib/awful/tag.lua:    util.deprecate("Use t:swap(tag2) instead of awful.tag.swap")
lib/awful/tag.lua:    util.deprecate("Use t:delete(fallback_tag) instead of awful.tag.delete")
lib/awful/tag.lua:    util.deprecate("Use s.tags instead of awful.tag.gettags")
lib/awful/tag.lua:    util.deprecate("Use t.screen = s instead of awful.tag.setscreen(t, s)")
lib/awful/tag.lua:    util.deprecate("Use t.screen instead of awful.tag.getscreen(t)")
lib/awful/tag.lua:    util.deprecate("Use s.selected_tags instead of awful.tag.selectedlist")
lib/awful/tag.lua:    util.deprecate("Use s.selected_tag instead of awful.tag.selected")
lib/awful/tag.lua:    util.deprecate("Use t.master_width_factor = mwfact instead of awful.tag.setmwfact")
lib/awful/tag.lua:    util.deprecate("Use t.master_width_factor instead of awful.tag.getmwfact")
lib/awful/tag.lua:    util.deprecate("Use t.layout = layout instead of awful.tag.setlayout")
lib/awful/tag.lua:    util.deprecate("Use t.volatile = volatile instead of awful.tag.setvolatile")
lib/awful/tag.lua:    util.deprecate("Use t.volatile instead of awful.tag.getvolatile")
lib/awful/tag.lua:    util.deprecate("Use t.gap = useless_gap instead of awful.tag.setgap")
lib/awful/tag.lua:    util.deprecate("Use t.gap instead of awful.tag.getgap")
lib/awful/tag.lua:    util.deprecate("Use t.master_fill_policy = policy instead of awful.tag.setmfpol")
lib/awful/tag.lua:    util.deprecate("Use t.master_fill_policy instead of awful.tag.getmfpol")
lib/awful/tag.lua:    util.deprecate("Use t.master_count = nmaster instead of awful.tag.setnmaster")
lib/awful/tag.lua:    util.deprecate("Use t.master_count instead of awful.tag.setnmaster")
lib/awful/tag.lua:    util.deprecate("Use t.icon = icon instead of awful.tag.seticon")
lib/awful/tag.lua:    util.deprecate("Use t.icon instead of awful.tag.geticon")
lib/awful/tag.lua:    util.deprecate("Use t.column_count = new_index instead of awful.tag.setncol")
lib/awful/tag.lua:    util.deprecate("Use t.column_count instead of awful.tag.getncol")
lib/awful/tag.lua:    util.deprecate("Use t.index instead of awful.tag.getidx")
lib/awful/tag.lua:    util.deprecate("Use t:view_only() instead of awful.tag.viewonly")
lib/awful/tag.lua:    util.deprecate("Use c:to_selected_tags() instead of awful.tag.selectedlist")
lib/awful/placement.lua:        util.deprecate(
lib/awful/prompt.lua:        util.deprecate(string.format(
lib/awful/wibar.lua:    util.deprecate("Use wb:get_position() instead of awful.wibar.get_position")
lib/awful/wibar.lua:    util.deprecate("Use wb:set_position(position) instead of awful.wibar.set_position")
lib/awful/wibar.lua:    util.deprecate("awful.wibar.attach is deprecated, use the 'attach' property"..
lib/awful/wibar.lua:        util.deprecate("awful.wibar.align(wb, 'center' is deprecated, use 'centered'")
lib/awful/wibar.lua:        util.deprecate("awful.wibar.align 'screen' argument is deprecated")
lib/awful/client.lua:    util.deprecate("Use c:jump_to(merge) instead of awful.client.jumpto")
lib/awful/client.lua:    util.deprecate("Use c:relative_move(x, y, w, h) instead of awful.client.moveresize")
lib/awful/client.lua:    util.deprecate("Use c:move_to_tag(target) instead of awful.client.movetotag")
lib/awful/client.lua:    util.deprecate("Use c:toggle_tag(target) instead of awful.client.toggletag")
lib/awful/client.lua:    util.deprecate("Use c:move_to_screen(s) instead of awful.client.movetoscreen")
lib/awful/client.lua:    util.deprecate("Use c.marked = true instead of awful.client.mark")
lib/awful/client.lua:    util.deprecate("Use c.marked = false instead of awful.client.unmark")
lib/awful/client.lua:    util.deprecate("Use c.marked instead of awful.client.ismarked")
lib/awful/client.lua:    util.deprecate("Use c.marked = not c.marked instead of awful.client.togglemarked")
lib/awful/client.lua:    util.deprecate("Use c.floating = true instead of awful.client.floating.set")
lib/awful/client.lua:    util.deprecate("Use c.is_fixed instead of awful.client.isfixed")
lib/awful/client.lua:    util.deprecate("Use c.floating instead of awful.client.floating.get")
lib/awful/client.lua:    util.deprecate("Use c.dockable instead of awful.client.dockable.get")
lib/awful/client.lua:    util.deprecate("Use c.dockable = value instead of awful.client.dockable.set")
lib/awful/client.lua:    util.deprecate("Use c:get_transient_for_matching(matcher) instead of"..
lib/awful/client.lua:    util.deprecate("Use c:is_transient_for(c2) instead of"..
lib/awful/screen.lua:    util.deprecate("Use s:get_square_distance(x, y) instead of awful.screen.getdistance_sq")
lib/awful/screen.lua:    util.deprecate("Use _screen.padding = value instead of awful.screen.padding")
lib/awful/mouse/init.lua:    util.deprecate("Use mouse.current_client instead of awful.mouse.client_under_pointer()")
lib/awful/mouse/init.lua:        util.deprecate("The mouse.client.move `finished_cb` argument is no longer"..
lib/awful/mouse/init.lua:    util.deprecate("Use awful.mouse.snap.drag_to_tag_enabled = true instead "..
lib/awful/mouse/init.lua:    util.deprecate(
lib/gears/object.lua:    require("awful.util").deprecate("Use signals without explicitly adding them. This is now done implicitly.")
lib/menubar/utils.lua:    awful_util.deprecate("Use 'width, _ = textbox:get_preferred_size(s)' directly.")
lib/wibox/widget/progressbar.lua:    util.deprecate("Use a `wibox.container.constraint` widget or `forced_height`")
lib/wibox/widget/progressbar.lua:    util.deprecate("Use a `wibox.container.constraint` widget or `forced_width`")
lib/wibox/widget/progressbar.lua:    util.deprecate("Use a `wibox.container.rotate` widget")
```