### PR TITLE
Replace improperly used asserts with warnings in prompt.lua

### DIFF
--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -125,6 +125,7 @@ local keygrabber = require("awful.keygrabber")
 local util = require("awful.util")
 local beautiful = require("beautiful")
 local akey = require("awful.key")
+local debug = require('gears.debug')
 
 local prompt = {}
 
@@ -518,10 +519,10 @@ function prompt.run(args, textbox, exe_callback, completion_callback,
                 hooks[key] = hooks[key] or {}
                 hooks[key][#hooks[key]+1] = v
             else
-                assert("The hook's 3rd parameter has to be a function.")
+                debug.print_warning("The hook's 3rd parameter has to be a function.")
             end
         else
-            assert("The hook has to have 3 parameters.")
+            debug.print_warning("The hook has to have 3 parameters.")
         end
     end
 

--- a/tests/examples/wibox/awidget/prompt/hooks.lua
+++ b/tests/examples/wibox/awidget/prompt/hooks.lua
@@ -1,7 +1,8 @@
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local awful     = { prompt = require("awful.prompt"),--DOC_HIDE
-                    util   = require("awful.util")}--DOC_HIDE
+                    util   = require("awful.util"), --DOC_HIDE
+                    spawn  = function () end } --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 
     local atextbox = wibox.widget.textbox()


### PR DESCRIPTION
`assert('foo') `never fails because assert treats 'foo` like a condition, not as an error message. Replacing with warnings not to break existing configs.

Try:
`lua -e 'assert("Critical error!")'`