### PR TITLE
Corrected selected check in awful.tag.set_screen()

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -475,7 +475,7 @@ end
 function tag.object.set_screen(t, s)
 
     s = get_screen(s or ascreen.focused())
-    local sel = tag.selected
+    local sel = t.selected
     local old_screen = get_screen(tag.getproperty(t, "screen"))
 
     if s == old_screen then return end


### PR DESCRIPTION
Previously it would check if the awful.tag.selected function existed,
and not whether the tag was actually selected.