### PR TITLE
Add naughty presets `ok`, `warn` and `info`.

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -93,7 +93,22 @@ naughty.config.presets = {
         bg = "#ff0000",
         fg = "#ffffff",
         timeout = 0,
-    }
+    },
+    ok = {
+        bg = "#00bb00",
+        fg = "#ffffff",
+        timeout = 5,
+    },
+    info = {
+        bg = "#0000ff",
+        fg = "#ffffff",
+        timeout = 5,
+    },
+    warn = {
+        bg = "#ffaa00",
+        fg = "#000000",
+        timeout = 10,
+    },
 }
 
 --- Defaults for `naughty.notify`.


### PR DESCRIPTION
Inspired by [Bootstrap's Alerts](http://getbootstrap.com/components/#alerts), I decided to make three extra presets for naughty's system:

* **ok** - Notification of success or sanity. 5 second timeout.
* **warn** - Notification of unwanted state, but not critical. 10 second timeout.
* **info** - Notification the user should be aware of, but unimportant. 5 second timeout.

![screenshot](https://cloud.githubusercontent.com/assets/2819326/23334920/1c36a78c-fb5e-11e6-92ea-603aa1f16be9.png)
