### PR TITLE
emit ewmh geometry requests as signals

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -246,6 +246,12 @@ local context_mapper = {
 function ewmh.geometry(c, context, hints)
     local layout = c.screen.selected_tag and c.screen.selected_tag.layout or nil
 
+    -- For dockable clients, always apply new geometry
+    if c.dockable and context == "ewmh" then
+        c:geometry(hints.geometry)
+        return
+    end
+
     -- Setting the geometry will not work unless the client is floating.
     if (not c.floating) and (not layout == asuit.floating) then
         return


### PR DESCRIPTION
This patch will emit `request::geometry` signals when clients reposition or resize themselves, instead of simply applying the new geometry straight from C. `awful.ewmh` has been tweaked to always apply geometry requests to dockable clients (allowing panels and other programs to position themselves correctly).

Further changes are probably nessecary, notably changing the provided layouts to handle the new geometry requests. Tested (somewhat) under my own configuration, and the default config.

Note: some applications expect the request to be applied (eg. firefox when it restores a session, assigning the saved position and size of its windows), and will render incorrectly if the WM does not apply the new geometry. In the scenario where the layout does not allow the client to resize itself, a simple fix would be to update the client's size with its existing geometry.

Related to #1554 - "Yes, removing `property::geometry` did cause that."

Thanks to @Elv13 for providing the rough initial patch.