### PR TITLE
Move ensure_pango_color out of awful.util to gears.color

### DIFF
--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -127,6 +127,7 @@ local beautiful = require("beautiful")
 local akey = require("awful.key")
 local debug = require('gears.debug')
 local gtable = require("gears.table")
+local gcolor = require("gears.color")
 
 local prompt = {}
 
@@ -293,8 +294,8 @@ local function prompt_text_with_cursor(args)
         text_end = util.escape(text:sub(args.cursor_pos + 1))
     end
 
-    local cursor_color = util.ensure_pango_color(args.cursor_color)
-    local text_color = util.ensure_pango_color(args.text_color)
+    local cursor_color = gcolor.ensure_pango_color(args.cursor_color)
+    local text_color = gcolor.ensure_pango_color(args.text_color)
 
     if args.highlighter then
         text_start, text_end = args.highlighter(text_start, text_end)

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -16,10 +16,9 @@ local pairs = pairs
 local type = type
 local gtable = require("gears.table")
 local string = string
-local lgi = require("lgi")
 local grect = require("gears.geometry").rectangle
 local Gio = require("lgi").Gio
-local Pango = lgi.Pango
+local gcolor = require("gears.color")
 local capi =
 {
     awesome = awesome,
@@ -102,12 +101,15 @@ function util.deprecate_class(fallback, old_name, new_name)
 end
 
 --- Get a valid color for Pango markup
+-- @deprecated ensure_pango_color
 -- @param color The color.
 -- @tparam string fallback The color to return if the first is invalid. (default: black)
 -- @treturn string color if it is valid, else fallback.
+-- @see gears.color
 function util.ensure_pango_color(color, fallback)
-    color = tostring(color)
-    return Pango.Color.parse(Pango.Color(), color) and color or fallback or "black"
+    util.deprecate("gears.color.ensure_pango_color")
+
+    return gcolor.ensure_pango_color(color, fallback)
 end
 
 --- Make i cycle.

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -21,6 +21,7 @@ local beautiful = require("beautiful")
 local fixed = require("wibox.layout.fixed")
 local surface = require("gears.surface")
 local timer = require("gears.timer")
+local gcolor = require("gears.color")
 
 local function get_screen(s)
     return s and capi.screen[s]
@@ -328,7 +329,7 @@ function taglist.taglist_label(t, args)
     if not tag.getproperty(t, "icon_only") then
         text = "<span font_desc='"..font.."'>"
         if fg_color then
-            text = text .. "<span color='" .. util.ensure_pango_color(fg_color) ..
+            text = text .. "<span color='" .. gcolor.ensure_pango_color(fg_color) ..
                 "'>" .. (util.escape(t.name) or "") .. "</span>"
         else
             text = text .. (util.escape(t.name) or "")

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -41,6 +41,7 @@ local util = require("awful.util")
 local tag = require("awful.tag")
 local flex = require("wibox.layout.flex")
 local timer = require("gears.timer")
+local gcolor = require("gears.color")
 
 local function get_screen(s)
     return s and screen[s]
@@ -204,14 +205,15 @@ local function tasklist_label(c, args, tb)
     if not args then args = {} end
     local theme = beautiful.get()
     local align = args.align or theme.tasklist_align or "left"
-    local fg_normal = util.ensure_pango_color(args.fg_normal or theme.tasklist_fg_normal or theme.fg_normal, "white")
+    local fg_normal = gcolor.ensure_pango_color(args.fg_normal or theme.tasklist_fg_normal or theme.fg_normal, "white")
     local bg_normal = args.bg_normal or theme.tasklist_bg_normal or theme.bg_normal or "#000000"
-    local fg_focus = util.ensure_pango_color(args.fg_focus or theme.tasklist_fg_focus or theme.fg_focus, fg_normal)
+    local fg_focus = gcolor.ensure_pango_color(args.fg_focus or theme.tasklist_fg_focus or theme.fg_focus, fg_normal)
     local bg_focus = args.bg_focus or theme.tasklist_bg_focus or theme.bg_focus or bg_normal
-    local fg_urgent = util.ensure_pango_color(args.fg_urgent or theme.tasklist_fg_urgent or theme.fg_urgent, fg_normal)
-    local bg_urgent = args.bg_urgent or theme.tasklist_bg_urgent or theme.bg_urgent or bg_normal
-    local fg_minimize = util.ensure_pango_color(args.fg_minimize or theme.tasklist_fg_minimize or theme.fg_minimize,
+    local fg_urgent = gcolor.ensure_pango_color(args.fg_urgent or theme.tasklist_fg_urgent or theme.fg_urgent,
                                                 fg_normal)
+    local bg_urgent = args.bg_urgent or theme.tasklist_bg_urgent or theme.bg_urgent or bg_normal
+    local fg_minimize = gcolor.ensure_pango_color(args.fg_minimize or theme.tasklist_fg_minimize or theme.fg_minimize,
+                                                  fg_normal)
     local bg_minimize = args.bg_minimize or theme.tasklist_bg_minimize or theme.bg_minimize or bg_normal
     -- FIXME v5, remove the fallback theme.bg_image_* variables, see GH#1403
     local bg_image_normal = args.bg_image_normal or theme.tasklist_bg_image_normal or theme.bg_image_normal

--- a/lib/gears/color.lua
+++ b/lib/gears/color.lua
@@ -332,6 +332,15 @@ function color.recolor_image(image, new_color)
     return image
 end
 
+--- Get a valid color for Pango markup
+-- @param color The color.
+-- @tparam string fallback The color to return if the first is invalid. (default: black)
+-- @treturn string color if it is valid, else fallback.
+function color.ensure_pango_color(check_color, fallback)
+    check_color = tostring(check_color)
+    return Pango.Color.parse(Pango.Color(), check_color) and check_color or fallback or "black"
+end
+
 function color.mt.__call(_, ...)
     return color.create_pattern(...)
 end

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -30,6 +30,7 @@ local awful = require("awful")
 local common = require("awful.widget.common")
 local theme = require("beautiful")
 local wibox = require("wibox")
+local gcolor = require("gears.color")
 
 local function get_screen(s)
     return s and capi.screen[s]
@@ -104,7 +105,7 @@ local common_args = { w = wibox.layout.fixed.horizontal(),
 -- @param c The desired text color.
 -- @return the text wrapped in a span tag.
 local function colortext(s, c)
-    return "<span color='" .. awful.util.ensure_pango_color(c) .. "'>" .. s .. "</span>"
+    return "<span color='" .. gcolor.ensure_pango_color(c) .. "'>" .. s .. "</span>"
 end
 
 --- Get how the menu item should be displayed.


### PR DESCRIPTION
For #1549.

The change to `wibox/widget/base.lua` is to prevent a cyclic require chain. Details [here](https://github.com/awesomeWM/awesome/issues/1549#issuecomment-283810356).