### PR TITLE
Deprecate menubar.get()

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -388,10 +388,13 @@ end
 -- @param scr Screen.
 function menubar.show(scr)
     if not instance then
-        menubar.refresh(scr)
         -- Add to each category the name of its key in all_categories
         for k, v in pairs(menubar.menu_gen.all_categories) do
             v.key = k
+        end
+
+        if menubar.cache_entries then
+            menubar.refresh(scr)
         end
 
         instance = {

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -35,7 +35,7 @@ local function get_screen(s)
 end
 
 -- menubar
-local menubar = { mt = {}, menu_entries = {} }
+local menubar = { menu_entries = {} }
 menubar.menu_gen = require("menubar.menu_gen")
 menubar.utils = require("menubar.utils")
 local compute_text_width = menubar.utils.compute_text_width
@@ -388,9 +388,15 @@ end
 -- @param scr Screen.
 function menubar.show(scr)
     if not instance then
+        menubar.refresh(scr)
+        -- Add to each category the name of its key in all_categories
+        for k, v in pairs(menubar.menu_gen.all_categories) do
+            v.key = k
+        end
+
         instance = {
             wibox = wibox({ ontop = true }),
-            widget = menubar.get(scr),
+            widget = common_args.w,
             prompt = awful.widget.prompt(),
             query = nil,
             count_table = nil,
@@ -451,7 +457,9 @@ end
 --- Get a menubar wibox.
 -- @tparam[opt] screen scr Screen.
 -- @return menubar wibox.
+-- @deprecated If you know what this actually does, please tell us
 function menubar.get(scr)
+    awful.util.deprecate("Use menubar.show() instead", { deprecated_in = 5 })
     menubar.refresh(scr)
     -- Add to each category the name of its key in all_categories
     for k, v in pairs(menubar.menu_gen.all_categories) do
@@ -460,10 +468,11 @@ function menubar.get(scr)
     return common_args.w
 end
 
-function menubar.mt.__call(_, ...)
+local mt = {}
+function mt.__call(_, ...)
     return menubar.get(...)
 end
 
-return setmetatable(menubar, menubar.mt)
+return setmetatable(menubar, mt)
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This is a new version of https://github.com/awesomeWM/awesome/pull/1355.

Unrelated to this PR: I get the following seven times when opening the menubar:
```
2017-03-03 17:24:39 W: awful: function ? is deprecated. Use 'width, _ = textbox:get_preferred_size(s)' directly..
stack traceback:
	lib/awful/util.lua:53: in function 'deprecate'
	lib/menubar/utils.lua:297: in function <lib/menubar/utils.lua:296>
	(...tail calls...)
	lib/menubar/init.lua:184: in function 'get_current_page'
	lib/menubar/init.lua:329: in function 'menulist_update'
	lib/menubar/init.lua:429: in function 'show'
	/home/psychon/projects/awesome/awesomerc.lua:346: in function 'press'
	lib/awful/key.lua:90: in function <lib/awful/key.lua:90>
```
Known? I remember the PR which deprecated these functions was (supposed to) making sure the other code does use the deprecated code...?