### PR TITLE
Use only_on_screen widget in docs

### DIFF
--- a/docs/03-declarative-layout.md
+++ b/docs/03-declarative-layout.md
@@ -41,8 +41,16 @@ configurable rules.
 Code:
 
     s.mywibox : setup {
-        s == screen.primary and my_first_widget, -- Only display on primary screen
-        s.index == 2 and my_second_widget, -- Only display on screen 2
+        {
+            layout = awful.widget.only_on_screen,
+            screen = "primary", -- Only display on primary screen
+            my_first_widget,
+        },
+        {
+            layout = awful.widget.only_on_screen,
+            screen = 2, -- Only display on screen 2
+            my_second_widget,
+        },
         my_third_widget, -- Displayed on all screens
         { -- Add a background color/pattern for my_fourth_widget
               my_fourth_widget,
@@ -53,10 +61,8 @@ Code:
     }
 
 
-In this example `s == screen.primary` is an inline expression. In the default
-`rc.lua`, there is an `s` variable represent to define the current screen. Any
-Lua logic expression can be used as long as it returns a valid widget or a
-declarative layout, or `nil`.
+This examples uses the `awful.widget.only_on_screen` container to display
+widgets only on some screens.
 
 ### Composite widgets
 


### PR DESCRIPTION
This is a follow-up to 052cda939b8a5ce1. Expressions like 's.index == 2'
and 's == screen.primary' might work at first. However, they are not
dynamic: If screens are added/removed or the primary screen changes,
then the widget is not updated to follow this.

Instead, use the new awful.widget.only_on_screen container which
provides the needed dynamic behaviour.

Signed-off-by: Uli Schlachter <psychon@znc.in>

To do:

- [x] Bring back the needed trailing whitespace which my editorconfig plugin killed thanks to our `.editorconfigrc`
- [x] Actually test if the example works correctly
- [x] Mention that this is "the real fix" to https://github.com/awesomeWM/awesome/issues/1562 in the commit message
- [x] Find the time to do the above