### PR TITLE
awful.screen.focus_bydirecttion: fix setting screen focus

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -156,7 +156,7 @@ function screen.focus_bydirection(dir, _screen)
     local target = sel:get_next_in_direction(dir)
 
     if target then
-        return target:focus()
+        return screen.focus(target)
     end
 end
 


### PR DESCRIPTION
This was broken in 9cb60b8 in PR #1597 (from myself).

focus() is not defined on the screen instance as method
but on the screen module as function.

Signed-off-by: Christoph Mertz <chris@nimel.de>