### PR TITLE
menubar: consider XDG_HOME_DIR and XDG_DATA_DIRS

### DIFF
--- a/lib/gears/filesystem.lua
+++ b/lib/gears/filesystem.lua
@@ -6,6 +6,8 @@
 
 -- Grab environment we need
 local Gio = require("lgi").Gio
+local gstring = require("gears.string")
+local gtable = require("gears.table")
 
 local filesystem = {}
 
@@ -64,6 +66,21 @@ end
 -- @return the cache home (XDG_CACHE_HOME) with a slash at the end.
 function filesystem.get_xdg_cache_home()
     return (os.getenv("XDG_CACHE_HOME") or os.getenv("HOME") .. "/.cache") .. "/"
+end
+
+--- Get the data home according to the XDG basedir specification.
+-- @treturn string the data home (XDG_DATA_HOME) with a slash at the end.
+function filesystem.get_xdg_data_home()
+    return (os.getenv("XDG_DATA_HOME") or os.getenv("HOME") .. "/.local/share") .. "/"
+end
+
+--- Get the data dirs according to the XDG basedir specification.
+-- @treturn table the data dirs (XDG_DATA_DIRS) with a slash at the end of each entry.
+function filesystem.get_xdg_data_dirs()
+    local xdg_data_dirs = os.getenv("XDG_DATA_DIRS") or "/usr/share:/usr/local/share"
+    return gtable.map(
+        function(dir) return dir .. "/" end,
+        gstring.split(xdg_data_dirs, ":"))
 end
 
 --- Get the path to the user's config dir.

--- a/lib/gears/string.lua
+++ b/lib/gears/string.lua
@@ -86,7 +86,7 @@ function gstring.query_to_pattern(q)
 end
 
 --- Split separates a string containing a delimiter into the list of
--- substrings between that delimiter.    
+-- substrings between that delimiter.
 -- @class function
 -- @name split
 -- @tparam string str String to be splitted

--- a/lib/gears/string.lua
+++ b/lib/gears/string.lua
@@ -84,4 +84,26 @@ function gstring.query_to_pattern(q)
                     end)
     return s
 end
+
+--- Split separates a string containing a delimiter into the list of
+-- substrings between that delimiter.    
+-- @class function
+-- @name split
+-- @tparam string str String to be splitted
+-- @tparam string delimiter Character where the string will be splitted
+-- @treturn table list of the substrings
+function gstring.split(str, delimiter)
+    local pattern = "(.-)" .. delimiter .. "()"
+    local result = {}
+    local n = 0
+    local lastPos = 0
+    for part, pos in string.gmatch(str, pattern) do
+        n = n + 1
+        result[n] = part
+        lastPos = pos
+    end
+    result[n + 1] = string.sub(str, lastPos)
+    return result
+end
+
 return gstring

--- a/lib/gears/table.lua
+++ b/lib/gears/table.lua
@@ -212,5 +212,20 @@ function gtable.merge(t, set)
     return t
 end
 
+--- Map a function to a table. The function is applied to each value
+-- on the table, returning a table of the results.
+-- @class function
+-- @name map
+-- @tparam function f the function to be applied to each value on the table
+-- @tparam table tbl the container table whose values will be operated on
+-- @treturn table Return a table of the results
+function gtable.map(f, tbl)
+    local t = {}
+    for k,v in pairs(tbl) do
+        t[k] = f(v)
+    end
+    return t
+end
+
 
 return gtable

--- a/lib/menubar/menu_gen.lua
+++ b/lib/menubar/menu_gen.lua
@@ -7,6 +7,8 @@
 ---------------------------------------------------------------------------
 
 -- Grab environment
+local gtable = require("gears.table")
+local gfilesystem = require("gears.filesystem")
 local utils = require("menubar.utils")
 local icon_theme = require("menubar.icon_theme")
 local pairs = pairs
@@ -18,14 +20,16 @@ local menu_gen = {}
 
 -- Options section
 
-local data_dir = os.getenv("XDG_DATA_HOME")
-if not data_dir then
-    data_dir = os.getenv("HOME") .. '/.local/share'
+--- Get the path to the directories where XDG menu applications are installed.
+local function get_xdg_menu_dirs()
+    local dirs = gfilesystem.get_xdg_data_dirs()
+    table.insert(dirs, 1, gfilesystem.get_xdg_data_home())
+    return gtable.map(function(dir) return dir .. 'applications/' end, dirs)
 end
 
 --- Specifies all directories where menubar should look for .desktop
 -- files. The search is recursive.
-menu_gen.all_menu_dirs = { data_dir .. '/applications/', '/usr/share/applications/', '/usr/local/share/applications/' }
+menu_gen.all_menu_dirs = get_xdg_menu_dirs()
 
 --- Specify the mapping of .desktop Categories section to the
 -- categories in the menubar. If "use" flag is set to false then any of


### PR DESCRIPTION
The freedesktop specifications let desktop files to be stored in
different directories indicated by the environment variables
XDG_DATA_HOME and XDG_DATA_DIRS. Only use the default value for these
variables if the variables are not defined.

This is important for systmes like NixOS which does not follow the LFS
and installs files differently.