### PR TITLE
Add some non-helpful examples

### DIFF
--- a/tests/examples/wibox/container/defaults/only_on_screen.lua
+++ b/tests/examples/wibox/container/defaults/only_on_screen.lua
@@ -1,0 +1,22 @@
+--DOC_HIDE_ALL
+local wibox = require("wibox")
+local awful = { widget = { only_on_screen = require("awful.widget.only_on_screen") } }
+
+return {
+    text   = "Before",
+    align  = "center",
+    valign = "center",
+    widget = wibox.widget.textbox,
+},
+{
+    {
+        text   = "After",
+        align  = "center",
+        valign = "center",
+        widget = wibox.widget.textbox,
+    },
+    screen = "primary",
+    widget = awful.widget.only_on_screen
+}
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/container/defaults/scroll.lua
+++ b/tests/examples/wibox/container/defaults/scroll.lua
@@ -1,0 +1,20 @@
+--DOC_HIDE_ALL
+local wibox = require("wibox")
+
+return {
+    text   = "Before",
+    align  = "center",
+    valign = "center",
+    widget = wibox.widget.textbox,
+},
+{
+    {
+        text   = "After",
+        align  = "center",
+        valign = "center",
+        widget = wibox.widget.textbox,
+    },
+    widget = wibox.container.scroll.horizontal
+}
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This makes the scroll and only_on_screen widgets appear in the widget
lists. The examples are not really helpful, but Elv13 told me to add
them. Also, only_on_screen is in awful.widget, but now something in
tests/examples/wibox/container refers to it...

Signed-off-by: Uli Schlachter <psychon@znc.in>