### PR TITLE
Update deprecated table calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,12 @@ install:
 
   # Determine custom version.
   - export AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)"
-  - 'if [ "$TRAVIS_PULL_REQUEST" != false ]; then AWESOME_VERSION="v9999-PR${TRAVIS_PULL_REQUEST}"; fi'
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" != false ] && [ "$TEST_PREV_COMMITS" = 1 ]; then
+      AWESOME_VERSION="${AWESOME_VERSION}-PR${TRAVIS_PULL_REQUEST}"
+    elif [ "$TRAVIS_PULL_REQUEST" != false ]; then
+      AWESOME_VERSION="v9999-PR${TRAVIS_PULL_REQUEST}";
+    fi
   # function for codecov support
   - if [ "$DO_COVERAGE" = "codecov" ]; then travis_retry wget -O /tmp/codecov-bash https://codecov.io/bash; fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ install:
 
   # Determine custom version.
   - export AWESOME_VERSION="${TRAVIS_BRANCH}-g$(git rev-parse --short HEAD)"
-  - 'if [ "$TRAVIS_PULL_REQUEST" != false ]; then AWESOME_VERSION="${AWESOME_VERSION}-PR${TRAVIS_PULL_REQUEST}"; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != false ]; then AWESOME_VERSION="v9999-PR${TRAVIS_PULL_REQUEST}"; fi'
   # function for codecov support
   - if [ "$DO_COVERAGE" = "codecov" ]; then travis_retry wget -O /tmp/codecov-bash https://codecov.io/bash; fi
   - |

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -127,7 +127,7 @@ mytextclock = wibox.widget.textclock()
 
 -- Create a wibox for each screen and add it
 -- @TAGLIST_BUTTON@
-local taglist_buttons = awful.util.table.join(
+local taglist_buttons = gears.table.join(
                     awful.button({ }, 1, function(t) t:view_only() end),
                     awful.button({ modkey }, 1, function(t)
                                               if client.focus then
@@ -145,7 +145,7 @@ local taglist_buttons = awful.util.table.join(
                 )
 
 -- @TASKLIST_BUTTON@
-local tasklist_buttons = awful.util.table.join(
+local tasklist_buttons = gears.table.join(
                      awful.button({ }, 1, function (c)
                                               if c == client.focus then
                                                   c.minimized = true
@@ -199,7 +199,7 @@ awful.screen.connect_for_each_screen(function(s)
     -- Create an imagebox widget which will contains an icon indicating which layout we're using.
     -- We need one layoutbox per screen.
     s.mylayoutbox = awful.widget.layoutbox(s)
-    s.mylayoutbox:buttons(awful.util.table.join(
+    s.mylayoutbox:buttons(gears.table.join(
                            awful.button({ }, 1, function () awful.layout.inc( 1) end),
                            awful.button({ }, 3, function () awful.layout.inc(-1) end),
                            awful.button({ }, 4, function () awful.layout.inc( 1) end),
@@ -238,7 +238,7 @@ end)
 
 -- {{{ Mouse bindings
 -- @DOC_ROOT_BUTTONS@
-root.buttons(awful.util.table.join(
+root.buttons(gears.table.join(
     awful.button({ }, 3, function () mymainmenu:toggle() end),
     awful.button({ }, 4, awful.tag.viewnext),
     awful.button({ }, 5, awful.tag.viewprev)
@@ -247,7 +247,7 @@ root.buttons(awful.util.table.join(
 
 -- {{{ Key bindings
 -- @DOC_GLOBAL_KEYBINDINGS@
-globalkeys = awful.util.table.join(
+globalkeys = gears.table.join(
     awful.key({ modkey,           }, "s",      hotkeys_popup.show_help,
               {description="show help", group="awesome"}),
     awful.key({ modkey,           }, "Left",   awful.tag.viewprev,
@@ -348,7 +348,7 @@ globalkeys = awful.util.table.join(
 )
 
 -- @DOC_CLIENT_KEYBINDINGS@
-clientkeys = awful.util.table.join(
+clientkeys = gears.table.join(
     awful.key({ modkey,           }, "f",
         function (c)
             c.fullscreen = not c.fullscreen
@@ -397,7 +397,7 @@ clientkeys = awful.util.table.join(
 -- Be careful: we use keycodes to make it work on any keyboard layout.
 -- This should map on the top row of your keyboard, usually 1 to 9.
 for i = 1, 9 do
-    globalkeys = awful.util.table.join(globalkeys,
+    globalkeys = gears.table.join(globalkeys,
         -- View tag only.
         awful.key({ modkey }, "#" .. i + 9,
                   function ()
@@ -444,7 +444,7 @@ for i = 1, 9 do
 end
 
 -- @DOC_CLIENT_BUTTONS@
-clientbuttons = awful.util.table.join(
+clientbuttons = gears.table.join(
     awful.button({ }, 1, function (c) client.focus = c; c:raise() end),
     awful.button({ modkey }, 1, awful.mouse.client.move),
     awful.button({ modkey }, 3, awful.mouse.client.resize))
@@ -530,7 +530,7 @@ end)
 -- Add a titlebar if titlebars_enabled is set to true in the rules.
 client.connect_signal("request::titlebars", function(c)
     -- buttons for the titlebar
-    local buttons = awful.util.table.join(
+    local buttons = gears.table.join(
         awful.button({ }, 1, function()
             client.focus = c
             c:raise()

--- a/lib/awful/button.lua
+++ b/lib/awful/button.lua
@@ -10,7 +10,8 @@
 local setmetatable = setmetatable
 local ipairs = ipairs
 local capi = { button = button }
-local util = require("awful.util")
+local gmath = require("gears.math")
+local gtable = require("gears.table")
 
 local button = { mt = {} }
 
@@ -38,9 +39,9 @@ local ignore_modifiers = { "Lock", "Mod2" }
 -- @treturn table A table with one or several button objects.
 function button.new(mod, _button, press, release)
     local ret = {}
-    local subsets = util.subsets(ignore_modifiers)
+    local subsets = gmath.subsets(ignore_modifiers)
     for _, set in ipairs(subsets) do
-        ret[#ret + 1] = capi.button({ modifiers = util.table.join(mod, set),
+        ret[#ret + 1] = capi.button({ modifiers = gtable.join(mod, set),
                                       button = _button })
         if press then
             ret[#ret]:connect_signal("press", function(_, ...) press(...) end)

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -13,6 +13,7 @@ local set_shape = require("awful.client.shape").update.all
 local object = require("gears.object")
 local grect = require("gears.geometry").rectangle
 local gmath = require("gears.math")
+local gtable = require("gears.table")
 local pairs = pairs
 local type = type
 local ipairs = ipairs
@@ -291,7 +292,7 @@ end
 -- @legacylayout awful.client.setmaster
 -- @client c The window to set as master.
 function client.setmaster(c)
-    local cls = util.table.reverse(capi.client.get(c.screen))
+    local cls = gtable.reverse(capi.client.get(c.screen))
     for _, v in pairs(cls) do
         c:swap(v)
     end
@@ -540,7 +541,7 @@ end
 -- @function awful.client.getmarked
 -- @return A table with all marked clients.
 function client.getmarked()
-    local copy = util.table.clone(client.data.marked, false)
+    local copy = gtable.clone(client.data.marked, false)
 
     for _, v in pairs(copy) do
         client.property.set(v, "marked", false)
@@ -755,7 +756,7 @@ function client.restore(s)
         local ctags = c:tags()
         if c.minimized then
             for _, t in ipairs(tags) do
-                if util.table.hasitem(ctags, t) then
+                if gtable.hasitem(ctags, t) then
                     c.minimized = false
                     return c
                 end
@@ -1066,8 +1067,8 @@ end
 function client.iterate(filter, start, s)
     local clients = capi.client.get(s)
     local focused = capi.client.focus
-    start         = start or util.table.hasitem(clients, focused)
-    return util.table.iterate(clients, filter, start)
+    start         = start or gtable.hasitem(clients, focused)
+    return gtable.iterate(clients, filter, start)
 end
 
 --- Switch to a client matching the given condition if running, else spawn it.
@@ -1090,7 +1091,7 @@ end
 -- end);
 function client.run_or_raise(cmd, matcher, merge)
     local clients = capi.client.get()
-    local findex  = util.table.hasitem(clients, capi.client.focus) or 1
+    local findex  = gtable.hasitem(clients, capi.client.focus) or 1
     local start   = gmath.cycle(#clients, findex + 1)
 
     local c = client.iterate(matcher, start)()

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -9,7 +9,7 @@
 local client = client
 local screen = screen
 local ipairs = ipairs
-local util = require("awful.util")
+local gtable = require("gears.table")
 local aclient = require("awful.client")
 local aplace = require("awful.placement")
 local asuit = require("awful.layout.suit")
@@ -259,7 +259,7 @@ function ewmh.geometry(c, context, hints)
     -- Now, map it to something useful
     context = context_mapper[context] or context
 
-    local props = util.table.clone(hints or {}, false)
+    local props = gtable.clone(hints or {}, false)
     props.store_geometry = props.store_geometry==nil and true or props.store_geometry
 
     -- If it is a known placement function, then apply it, otherwise let

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -12,6 +12,7 @@ local capi = {
     keygrabber = keygrabber,
 }
 local awful = require("awful")
+local gtable = require("gears.table")
 local wibox = require("wibox")
 local beautiful = require("beautiful")
 local dpi = beautiful.xresources.apply_dpi
@@ -133,7 +134,7 @@ function widget.new(args)
         merge_duplicates = (
             args.merge_duplicates == nil
         ) and widget.merge_duplicates or args.merge_duplicates,
-        group_rules = args.group_rules or awful.util.table.clone(widget.group_rules),
+        group_rules = args.group_rules or gtable.clone(widget.group_rules),
         labels = args.labels or {
             Mod4="Super",
             Mod1="Alt",
@@ -322,7 +323,7 @@ function widget.new(args)
         local max_height_px = height - group_label_height
         local column_layouts = {}
         for _, group in ipairs(available_groups) do
-            local keys = awful.util.table.join(self._cached_awful_keys[group], self._additional_hotkeys[group])
+            local keys = gtable.join(self._cached_awful_keys[group], self._additional_hotkeys[group])
             local joined_descriptions = ""
             for i, key in ipairs(keys) do
                 joined_descriptions = joined_descriptions .. key.description .. (i~=#keys and "\n" or "")
@@ -447,7 +448,7 @@ function widget.new(args)
             height = height,
         })
         mywibox:set_widget(pages[1])
-        mywibox:buttons(awful.util.table.join(
+        mywibox:buttons(gtable.join(
                 awful.button({ }, 1, function () mywibox.visible=false end),
                 awful.button({ }, 3, function () mywibox.visible=false end)
         ))

--- a/lib/awful/key.lua
+++ b/lib/awful/key.lua
@@ -10,7 +10,8 @@
 local setmetatable = setmetatable
 local ipairs = ipairs
 local capi = { key = key, root = root }
-local util = require("awful.util")
+local gmath = require("gears.math")
+local gtable = require("gears.table")
 
 
 
@@ -82,9 +83,9 @@ function key.new(mod, _key, press, release, data)
         release=nil
     end
     local ret = {}
-    local subsets = util.subsets(key.ignore_modifiers)
+    local subsets = gmath.subsets(key.ignore_modifiers)
     for _, set in ipairs(subsets) do
-        ret[#ret + 1] = capi.key({ modifiers = util.table.join(mod, set),
+        ret[#ret + 1] = capi.key({ modifiers = gtable.join(mod, set),
                                    key = _key })
         if press then
             ret[#ret]:connect_signal("press", function(_, ...) press(...) end)
@@ -95,7 +96,7 @@ function key.new(mod, _key, press, release, data)
     end
 
     -- append custom userdata (like description) to a hotkey
-    data = data and util.table.clone(data) or {}
+    data = data and gtable.clone(data) or {}
     data.mod = mod
     data.key = _key
     table.insert(key.hotkeys, data)
@@ -117,7 +118,7 @@ function key.match(_key, pressed_mod, pressed_key)
     -- pressed.
     for _, m in ipairs(mod) do
         -- Has it been pressed?
-        if not util.table.hasitem(pressed_mod, m) then
+        if not gtable.hasitem(pressed_mod, m) then
             -- No, so this is failure!
             return false
         end

--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -11,6 +11,7 @@
 local wibox = require("wibox")
 local button = require("awful.button")
 local util = require("awful.util")
+local gtable = require("gears.table")
 local spawn = require("awful.spawn")
 local tags = require("awful.tag")
 local keygrabber = require("awful.keygrabber")
@@ -146,7 +147,7 @@ local function item_position(_menu, child)
     if dir == "x" then  a, b = b, a  end
 
     local in_dir, other = 0, _menu[b]
-    local num = util.table.hasitem(_menu.child, child)
+    local num = gtable.hasitem(_menu.child, child)
     if num then
         for i = 0, num - 1 do
             local item = _menu.items[i]
@@ -237,19 +238,19 @@ local function grabber(_menu, _, key, event)
     if event ~= "press" then return end
 
     local sel = _menu.sel or 0
-    if util.table.hasitem(menu.menu_keys.up, key) then
+    if gtable.hasitem(menu.menu_keys.up, key) then
         local sel_new = sel-1 < 1 and #_menu.items or sel-1
         _menu:item_enter(sel_new)
-    elseif util.table.hasitem(menu.menu_keys.down, key) then
+    elseif gtable.hasitem(menu.menu_keys.down, key) then
         local sel_new = sel+1 > #_menu.items and 1 or sel+1
         _menu:item_enter(sel_new)
-    elseif sel > 0 and util.table.hasitem(menu.menu_keys.enter, key) then
+    elseif sel > 0 and gtable.hasitem(menu.menu_keys.enter, key) then
         _menu:exec(sel)
-    elseif sel > 0 and util.table.hasitem(menu.menu_keys.exec, key) then
+    elseif sel > 0 and gtable.hasitem(menu.menu_keys.exec, key) then
         _menu:exec(sel, { exec = true })
-    elseif util.table.hasitem(menu.menu_keys.back, key) then
+    elseif gtable.hasitem(menu.menu_keys.back, key) then
         _menu:hide()
-    elseif util.table.hasitem(menu.menu_keys.close, key) then
+    elseif gtable.hasitem(menu.menu_keys.close, key) then
         menu.get_root(_menu):hide()
     else
         check_access_key(_menu, key)
@@ -433,17 +434,17 @@ function menu:add(args, index)
 
 
     -- Create bindings
-    item._background:buttons(util.table.join(
+    item._background:buttons(gtable.join(
         button({}, 3, function () self:hide() end),
         button({}, 1, function ()
-            local num = util.table.hasitem(self.items, item)
+            local num = gtable.hasitem(self.items, item)
             self:item_enter(num, { mouse = true })
             self:exec(num, { exec = true, mouse = true })
         end )))
 
 
     item._mouse = function ()
-        local num = util.table.hasitem(self.items, item)
+        local num = gtable.hasitem(self.items, item)
         self:item_enter(num, { hover = true, moue = true })
     end
     item.widget:connect_signal("mouse::enter", item._mouse)
@@ -468,7 +469,7 @@ end
 -- @param num The position in the table of the menu entry to be deleted; can be also the menu entry itself
 function menu:delete(num)
     if type(num) == "table" then
-        num = util.table.hasitem(self.items, num)
+        num = gtable.hasitem(self.items, num)
     end
     local item = self.items[num]
     if not item then return end
@@ -519,15 +520,15 @@ function menu.clients(args, item_args, filter)
             c.icon }
         if item_args then
             if type(item_args) == "function" then
-                util.table.merge(cls_t[#cls_t], item_args(c))
+                gtable.merge(cls_t[#cls_t], item_args(c))
             else
-                util.table.merge(cls_t[#cls_t], item_args)
+                gtable.merge(cls_t[#cls_t], item_args)
             end
         end
     end
     args = args or {}
     args.items = args.items or {}
-    util.table.merge(args.items, cls_t)
+    gtable.merge(args.items, cls_t)
 
     local m = menu.new(args)
     m:show(args)

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -94,6 +94,7 @@ local layout = require("awful.layout")
 local a_screen = require("awful.screen")
 local grect = require("gears.geometry").rectangle
 local util = require("awful.util")
+local gtable = require("gears.table")
 local cairo = require( "lgi" ).cairo
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 
@@ -357,7 +358,7 @@ area_common = function(d, new_geo, ignore_border_width, args)
     -- When using the placement composition along with the "pretend"
     -- option, it is necessary to keep a "virtual" geometry.
     if args and args.override_geometry then
-        geometry = util.table.clone(args.override_geometry)
+        geometry = gtable.clone(args.override_geometry)
     end
 
     geometry.width = geometry.width + 2 * border

--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -126,6 +126,7 @@ local util = require("awful.util")
 local beautiful = require("beautiful")
 local akey = require("awful.key")
 local debug = require('gears.debug')
+local gtable = require("gears.table")
 
 local prompt = {}
 
@@ -156,7 +157,7 @@ local function history_check_load(id, max)
 
         -- Read history file
         for line in f:lines() do
-            if util.table.hasitem(data.history[id].table, line) == nil then
+            if gtable.hasitem(data.history[id].table, line) == nil then
                 table.insert(data.history[id].table, line)
                 if #data.history[id].table >= data.history[id].max then
                     break
@@ -239,7 +240,7 @@ end
 -- @param command The command to add
 local function history_add(id, command)
     if data.history[id] and command ~= "" then
-        local index = util.table.hasitem(data.history[id].table, command)
+        local index = gtable.hasitem(data.history[id].table, command)
         if index == nil then
             table.insert(data.history[id].table, command)
 
@@ -593,7 +594,7 @@ function prompt.run(args, textbox, exe_callback, completion_callback,
         if hooks[key] then
             -- Remove caps and num lock
             for _, m in ipairs(modifiers) do
-                if not util.table.hasitem(akey.ignore_modifiers, m) then
+                if not gtable.hasitem(akey.ignore_modifiers, m) then
                     table.insert(filtered_modifiers, m)
                 end
             end

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -31,7 +31,7 @@ local type = type
 local ipairs = ipairs
 local pairs = pairs
 local atag = require("awful.tag")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local a_place = require("awful.placement")
 local protected_call = require("gears.protected_call")
 
@@ -352,7 +352,7 @@ function rules.high_priority_properties.new_tag(c, value, props)
     elseif ty == "table" then
         -- Assume a table of tags properties. Set the right screen, but
         -- avoid editing the original table
-        local values = value.screen and value or util.table.clone(value)
+        local values = value.screen and value or gtable.clone(value)
         values.screen = values.screen or c.screen
 
         t = atag.add(value.name or c.class or "N/A", values)
@@ -416,7 +416,7 @@ function rules.high_priority_properties.tags(c, value, props)
     if #current == 0 or (value[1] and value[1].screen ~= current[1].screen) then
         c:tags(tags)
     else
-        c:tags(util.table.merge(current, tags))
+        c:tags(gtable.merge(current, tags))
     end
 end
 

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -13,6 +13,7 @@ local beautiful = require("beautiful")
 local gmath = require("gears.math")
 local object = require("gears.object")
 local timer = require("gears.timer")
+local gtable = require("gears.table")
 local pairs = pairs
 local ipairs = ipairs
 local table = table
@@ -262,7 +263,7 @@ function tag.find_fallback(screen, invalids)
     local t = invalids or scr.selected_tags
 
     for _, v in pairs(scr.tags) do
-        if not util.table.hasitem(t, v) then return v end
+        if not gtable.hasitem(t, v) then return v end
     end
 end
 
@@ -1266,7 +1267,7 @@ function tag.viewmore(tags, screen)
     screen = get_screen(screen or ascreen.focused())
     local screen_tags = screen.tags
     for _, _tag in ipairs(screen_tags) do
-        if not util.table.hasitem(tags, _tag) then
+        if not gtable.hasitem(tags, _tag) then
             _tag.selected = false
         end
     end

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -41,7 +41,7 @@
 
 local mouse = mouse
 local timer = require("gears.timer")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local object = require("gears.object")
 local color = require("gears.color")
 local wibox = require("wibox")
@@ -558,7 +558,7 @@ function tooltip.new(args)
     end
 
     -- export functions
-    util.table.crush(self, tooltip, true)
+    gtable.crush(self, tooltip, true)
 
     -- setup the timer action only if needed
     if args.timer_function then

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -13,9 +13,8 @@ local load = loadstring or load -- luacheck: globals loadstring (compatibility w
 local loadfile = loadfile
 local debug = debug
 local pairs = pairs
-local ipairs = ipairs
 local type = type
-local rtable = table
+local gtable = require("gears.table")
 local string = string
 local lgi = require("lgi")
 local grect = require("gears.geometry").rectangle
@@ -324,43 +323,29 @@ end
 
 --- Join all tables given as parameters.
 -- This will iterate all tables and insert all their keys into a new table.
+-- @deprecated util.table.join
 -- @param args A list of tables to join
 -- @return A new table containing all keys from the arguments.
+-- @see gears.table
 function util.table.join(...)
-    local ret = {}
-    for _, t in pairs({...}) do
-        if t then
-            for k, v in pairs(t) do
-                if type(k) == "number" then
-                    rtable.insert(ret, v)
-                else
-                    ret[k] = v
-                end
-            end
-        end
-    end
-    return ret
+    util.deprecate("gears.table.join", {deprecated_in=5})
+
+    return gtable.join(...)
 end
 
 --- Override elements in the first table by the one in the second.
 --
 -- Note that this method doesn't copy entries found in `__index`.
+-- @deprecated util.table.crush
 -- @tparam table t the table to be overriden
 -- @tparam table set the table used to override members of `t`
 -- @tparam[opt=false] boolean raw Use rawset (avoid the metatable)
 -- @treturn table t (for convenience)
+-- @see gears.table
 function util.table.crush(t, set, raw)
-    if raw then
-        for k, v in pairs(set) do
-            rawset(t, k, v)
-        end
-    else
-        for k, v in pairs(set) do
-            t[k] = v
-        end
-    end
+    util.deprecate("gears.table.crush", {deprecated_in=5})
 
-    return t
+    return gtable.crush(t, set, raw)
 end
 
 --- Pack all elements with an integer key into a new table
@@ -370,36 +355,26 @@ end
 --
 -- This function remove any non numeric keys from the value set
 --
+-- @deprecated util.table.from_sparse
 -- @tparam table t A potentially sparse table
 -- @treturn table A packed table with all numeric keys
+-- @see gears.table
 function util.table.from_sparse(t)
-    local keys= {}
-    for k in pairs(t) do
-        if type(k) == "number" then
-            keys[#keys+1] = k
-        end
-    end
+    util.deprecate("gears.table.from_sparse", {deprecated_in=5})
 
-    table.sort(keys)
-
-    local ret = {}
-    for _,v in ipairs(keys) do
-        ret[#ret+1] = t[v]
-    end
-
-    return ret
+    return gtable.from_sparse(t)
 end
 
 --- Check if a table has an item and return its key.
+-- @deprecated util.table.hasitem
 -- @param t The table.
 -- @param item The item to look for in values of the table.
 -- @return The key were the item is found, or nil if not found.
+-- @see gears.table
 function util.table.hasitem(t, item)
-    for k, v in pairs(t) do
-        if v == item then
-            return k
-        end
-    end
+    util.deprecate("gears.table.hasitem", {deprecated_in=5})
+
+    return gtable.hasitem(t, item)
 end
 
 --- Split a string into multiple lines
@@ -430,105 +405,78 @@ function util.linecount(text)
 end
 
 --- Get a sorted table with all integer keys from a table
+-- @deprecated util.table.keys
 -- @param t the table for which the keys to get
 -- @return A table with keys
+-- @see gears.table
 function util.table.keys(t)
-    local keys = { }
-    for k, _ in pairs(t) do
-        rtable.insert(keys, k)
-    end
-    rtable.sort(keys, function (a, b)
-        return type(a) == type(b) and a < b or false
-    end)
-    return keys
+    util.deprecate("gears.table.keys", {deprecated_in=5})
+
+    return gtable.keys(t)
 end
 
 --- Filter a tables keys for certain content types
+-- @deprecated util.table.keys_filter
 -- @param t The table to retrieve the keys for
 -- @param ... the types to look for
 -- @return A filtered table with keys
+-- @see gears.table
 function util.table.keys_filter(t, ...)
-    local keys = util.table.keys(t)
-    local keys_filtered = { }
-    for _, k in pairs(keys) do
-        for _, et in pairs({...}) do
-            if type(t[k]) == et then
-                rtable.insert(keys_filtered, k)
-                break
-            end
-        end
-    end
-    return keys_filtered
+    util.deprecate("gears.table.keys_filter", {deprecated_in=5})
+
+    return gtable.keys_filter(t, ...)
 end
 
 --- Reverse a table
+-- @deprecated util.table.reverse
 -- @param t the table to reverse
 -- @return the reversed table
+-- @see gears.table
 function util.table.reverse(t)
-    local tr = { }
-    -- reverse all elements with integer keys
-    for _, v in ipairs(t) do
-        rtable.insert(tr, 1, v)
-    end
-    -- add the remaining elements
-    for k, v in pairs(t) do
-        if type(k) ~= "number" then
-            tr[k] = v
-        end
-    end
-    return tr
+    util.deprecate("gears.table.reverse", {deprecated_in=5})
+
+    return gtable.reverse(t)
 end
 
 --- Clone a table
+-- @deprecated util.table.clone
 -- @param t the table to clone
 -- @param deep Create a deep clone? (default: true)
 -- @return a clone of t
+-- @see gears.table
 function util.table.clone(t, deep)
-    deep = deep == nil and true or deep
-    local c = { }
-    for k, v in pairs(t) do
-        if deep and type(v) == "table" then
-            c[k] = util.table.clone(v)
-        else
-            c[k] = v
-        end
-    end
-    return c
+    util.deprecate("gears.table.clone", {deprecated_in=5})
+
+    return gtable.clone(t, deep)
 end
 
 ---
 -- Returns an iterator to cycle through, starting from the first element or the
 -- given index, all elements of a table that match a given criteria.
 --
+-- @deprecated util.table.iterate
 -- @param t      the table to iterate
 -- @param filter a function that returns true to indicate a positive match
 -- @param start  what index to start iterating from.  Default is 1 (=> start of
 -- the table)
+-- @see gears.table
 function util.table.iterate(t, filter, start)
-    local count  = 0
-    local index  = start or 1
-    local length = #t
+    util.deprecate("gears.table.iterate", {deprecated_in=5})
 
-    return function ()
-        while count < length do
-            local item = t[index]
-            index = gmath.cycle(#t, index + 1)
-            count = count + 1
-            if filter(item) then return item end
-        end
-    end
+    return gtable.iterate(t, filter, start)
 end
 
 
 --- Merge items from the one table to another one
+-- @deprecated util.table.merge
 -- @tparam table t the container table
 -- @tparam table set the mixin table
 -- @treturn table Return `t` for convenience
+-- @see gears.table
 function util.table.merge(t, set)
-    for _, v in ipairs(set) do
-        table.insert(t, v)
-    end
-    return t
+    util.deprecate("gears.table.merge", {deprecated_in=5})
+
+    return gtable.merge(t, set)
 end
 
 

--- a/lib/awful/widget/button.lua
+++ b/lib/awful/widget/button.lua
@@ -1,7 +1,7 @@
 ---------------------------------------------------------------------------
 -- A simple button widget.
 -- @usage local button = awful.widget.button()
--- button:buttons(awful.util.table.join(
+-- button:buttons(gears.table.join(
 --     button:buttons(),
 --     awful.button({}, 1, nil, function ()
 --         print("Mouse was clicked")

--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -8,7 +8,7 @@ local capi = {awesome = awesome}
 local setmetatable = setmetatable
 local textbox = require("wibox.widget.textbox")
 local button = require("awful.button")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local widget_base = require("wibox.widget.base")
 local gdebug = require("gears.debug")
 
@@ -288,7 +288,7 @@ function keyboardlayout.new()
 
     -- Mouse bindings
     self:buttons(
-        util.table.join(button({ }, 1, self.next_layout))
+        gtable.join(button({ }, 1, self.next_layout))
     )
 
     return self

--- a/lib/awful/widget/launcher.lua
+++ b/lib/awful/widget/launcher.lua
@@ -5,7 +5,7 @@
 ---------------------------------------------------------------------------
 
 local setmetatable = setmetatable
-local util = require("awful.util")
+local gtable = require("gears.table")
 local spawn = require("awful.spawn")
 local wbutton = require("awful.widget.button")
 local button = require("awful.button")
@@ -23,9 +23,9 @@ function launcher.new(args)
 
     local b
     if args.command then
-       b = util.table.join(w:buttons(), button({}, 1, nil, function () spawn(args.command) end))
+       b = gtable.join(w:buttons(), button({}, 1, nil, function () spawn(args.command) end))
     elseif args.menu then
-       b = util.table.join(w:buttons(), button({}, 1, nil, function () args.menu:toggle() end))
+       b = gtable.join(w:buttons(), button({}, 1, nil, function () args.menu:toggle() end))
     end
 
     w:buttons(b)

--- a/lib/awful/widget/only_on_screen.lua
+++ b/lib/awful/widget/only_on_screen.lua
@@ -11,7 +11,7 @@ local type = type
 local pairs = pairs
 local setmetatable = setmetatable
 local base = require("wibox.widget.base")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local capi = {
     screen = screen,
     awesome = awesome
@@ -98,7 +98,7 @@ end
 local function new(widget, s)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, only_on_screen, true)
+    gtable.crush(ret, only_on_screen, true)
 
     ret:set_widget(widget)
     ret:set_screen(s or "primary")

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -9,7 +9,7 @@
 -- Grab environment
 local awesome = awesome
 local screen = screen
-local round = require("awful.util").round
+local round = require("gears.math").round
 local gears_debug = require("gears.debug")
 
 local xresources = {}

--- a/lib/gears/init.lua
+++ b/lib/gears/init.lua
@@ -19,6 +19,7 @@ return
     protected_call = require("gears.protected_call");
     geometry = require("gears.geometry");
     math = require("gears.math");
+    table = require("gears.table");
 }
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/gears/table.lua
+++ b/lib/gears/table.lua
@@ -1,0 +1,216 @@
+---------------------------------------------------------------------------
+--- Table module for gears
+--
+-- @module gears.table
+---------------------------------------------------------------------------
+
+
+local rtable = table
+
+local gmath = require("gears.math")
+local gtable = {}
+
+--- Join all tables given as parameters.
+-- This will iterate all tables and insert all their keys into a new table.
+-- @class function
+-- @name join
+-- @param args A list of tables to join
+-- @return A new table containing all keys from the arguments.
+function gtable.join(...)
+    local ret = {}
+    for _, t in pairs({...}) do
+        if t then
+            for k, v in pairs(t) do
+                if type(k) == "number" then
+                    rtable.insert(ret, v)
+                else
+                    ret[k] = v
+                end
+            end
+        end
+    end
+    return ret
+end
+
+--- Override elements in the first table by the one in the second.
+--
+-- Note that this method doesn't copy entries found in `__index`.
+-- @class function
+-- @name crush
+-- @tparam table t the table to be overriden
+-- @tparam table set the table used to override members of `t`
+-- @tparam[opt=false] boolean raw Use rawset (avoid the metatable)
+-- @treturn table t (for convenience)
+function gtable.crush(t, set, raw)
+    if raw then
+        for k, v in pairs(set) do
+            rawset(t, k, v)
+        end
+    else
+        for k, v in pairs(set) do
+            t[k] = v
+        end
+    end
+
+    return t
+end
+
+--- Pack all elements with an integer key into a new table
+-- While both lua and luajit implement __len over sparse
+-- table, the standard define it as an implementation
+-- detail.
+--
+-- This function remove any non numeric keys from the value set
+--
+-- @class function
+-- @name from_sparse
+-- @tparam table t A potentially sparse table
+-- @treturn table A packed table with all numeric keys
+function gtable.from_sparse(t)
+    local keys= {}
+    for k in pairs(t) do
+        if type(k) == "number" then
+            keys[#keys+1] = k
+        end
+    end
+
+    table.sort(keys)
+
+    local ret = {}
+    for _,v in ipairs(keys) do
+        ret[#ret+1] = t[v]
+    end
+
+    return ret
+end
+
+--- Check if a table has an item and return its key.
+-- @class function
+-- @name hasitem
+-- @param t The table.
+-- @param item The item to look for in values of the table.
+-- @return The key were the item is found, or nil if not found.
+function gtable.hasitem(t, item)
+    for k, v in pairs(t) do
+        if v == item then
+            return k
+        end
+    end
+end
+
+--- Get a sorted table with all integer keys from a table
+-- @class function
+-- @name keys
+-- @param t the table for which the keys to get
+-- @return A table with keys
+function gtable.keys(t)
+    local keys = { }
+    for k, _ in pairs(t) do
+        rtable.insert(keys, k)
+    end
+    rtable.sort(keys, function (a, b)
+        return type(a) == type(b) and a < b or false
+    end)
+    return keys
+end
+
+--- Filter a tables keys for certain content types
+-- @class function
+-- @name keys_filter
+-- @param t The table to retrieve the keys for
+-- @param ... the types to look for
+-- @return A filtered table with keys
+function gtable.keys_filter(t, ...)
+    local keys = gtable.keys(t)
+    local keys_filtered = { }
+    for _, k in pairs(keys) do
+        for _, et in pairs({...}) do
+            if type(t[k]) == et then
+                rtable.insert(keys_filtered, k)
+                break
+            end
+        end
+    end
+    return keys_filtered
+end
+
+--- Reverse a table
+-- @class function
+-- @name reverse
+-- @param t the table to reverse
+-- @return the reversed table
+function gtable.reverse(t)
+    local tr = { }
+    -- reverse all elements with integer keys
+    for _, v in ipairs(t) do
+        rtable.insert(tr, 1, v)
+    end
+    -- add the remaining elements
+    for k, v in pairs(t) do
+        if type(k) ~= "number" then
+            tr[k] = v
+        end
+    end
+    return tr
+end
+
+--- Clone a table
+-- @class function
+-- @name clone
+-- @param t the table to clone
+-- @param deep Create a deep clone? (default: true)
+-- @return a clone of t
+function gtable.clone(t, deep)
+    deep = deep == nil and true or deep
+    local c = { }
+    for k, v in pairs(t) do
+        if deep and type(v) == "table" then
+            c[k] = gtable.clone(v)
+        else
+            c[k] = v
+        end
+    end
+    return c
+end
+
+---
+-- Returns an iterator to cycle through, starting from the first element or the
+-- given index, all elements of a table that match a given criteria.
+--
+-- @class function
+-- @name iterate
+-- @param t      the table to iterate
+-- @param filter a function that returns true to indicate a positive match
+-- @param start  what index to start iterating from.  Default is 1 (=> start of
+-- the table)
+function gtable.iterate(t, filter, start)
+    local count  = 0
+    local index  = start or 1
+    local length = #t
+
+    return function ()
+        while count < length do
+            local item = t[index]
+            index = gmath.cycle(#t, index + 1)
+            count = count + 1
+            if filter(item) then return item end
+        end
+    end
+end
+
+
+--- Merge items from the one table to another one
+-- @class function
+-- @name merge
+-- @tparam table t the container table
+-- @tparam table set the mixin table
+-- @treturn table Return `t` for convenience
+function gtable.merge(t, set)
+    for _, v in ipairs(set) do
+        table.insert(t, v)
+    end
+    return t
+end
+
+
+return gtable

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -20,6 +20,7 @@ local timer = require("gears.timer")
 local button = require("awful.button")
 local screen = require("awful.screen")
 local util = require("awful.util")
+local gtable = require("gears.table")
 local bt = require("beautiful")
 local wibox = require("wibox")
 local surface = require("gears.surface")
@@ -502,7 +503,7 @@ function naughty.notify(args)
     end
 
     -- gather variables together
-    local preset = util.table.join(naughty.config.defaults or {},
+    local preset = gtable.join(naughty.config.defaults or {},
         args.preset or naughty.config.presets.normal or {})
     local timeout = args.timeout or preset.timeout
     local icon = args.icon or preset.icon
@@ -622,7 +623,7 @@ function naughty.notify(args)
             local action_height = h + 2 * margin
             local action_width = w + 2 * margin
 
-            actionmarginbox:buttons(util.table.join(
+            actionmarginbox:buttons(gtable.join(
                 button({ }, 1, callback),
                 button({ }, 3, callback)
                 ))
@@ -745,7 +746,7 @@ function naughty.notify(args)
     notification.box:set_widget(completelayout)
 
     -- Setup the mouse events
-    layout:buttons(util.table.join(button({}, 1, nil, run),
+    layout:buttons(gtable.join(button({}, 1, nil, run),
                                    button({}, 3, nil, function()
                                         die(naughty.notificationClosedReason.dismissedByUser)
                                     end)))

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -15,7 +15,7 @@ local type = type
 local string = string
 local capi = { awesome = awesome,
                dbus = dbus }
-local util = require("awful.util")
+local gtable = require("gears.table")
 local cairo = require("lgi").cairo
 
 local schar = string.char
@@ -129,7 +129,7 @@ capi.dbus.connect_signal("org.freedesktop.Notifications",
                 if (not filter.urgency or filter.urgency == hints.urgency) and
                 (not filter.category or filter.category == hints.category) and
                 (not filter.appname or filter.appname == appname) then
-                    args.preset = util.table.join(args.preset, preset)
+                    args.preset = gtable.join(args.preset, preset)
                 end
             end
             local preset = args.preset or naughty.config.defaults

--- a/lib/wibox/container/arcchart.lua
+++ b/lib/wibox/container/arcchart.lua
@@ -13,7 +13,7 @@
 local setmetatable = setmetatable
 local base      = require("wibox.widget.base")
 local shape     = require("gears.shape"      )
-local util      = require( "awful.util"      )
+local gtable    = require( "gears.table"     )
 local color     = require( "gears.color"     )
 local beautiful = require("beautiful"        )
 
@@ -324,7 +324,7 @@ local function new(widget)
         enable_properties = true,
     })
 
-    util.table.crush(ret, arcchart)
+    gtable.crush(ret, arcchart)
 
     ret:set_widget(widget)
 

--- a/lib/wibox/container/background.lua
+++ b/lib/wibox/container/background.lua
@@ -13,7 +13,7 @@ local color = require("gears.color")
 local surface = require("gears.surface")
 local beautiful = require("beautiful")
 local cairo = require("lgi").cairo
-local util = require("awful.util")
+local gtable = require("gears.table")
 local setmetatable = setmetatable
 local type = type
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
@@ -278,7 +278,7 @@ local function new(widget, bg, shape)
         enable_properties = true,
     })
 
-    util.table.crush(ret, background, true)
+    gtable.crush(ret, background, true)
 
     ret._private.shape = shape
 

--- a/lib/wibox/container/constraint.lua
+++ b/lib/wibox/container/constraint.lua
@@ -8,7 +8,7 @@
 
 local setmetatable = setmetatable
 local base = require("wibox.widget.base")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local math = math
 
 local constraint = { mt = {} }
@@ -144,7 +144,7 @@ end
 local function new(widget, strategy, width, height)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, constraint, true)
+    gtable.crush(ret, constraint, true)
 
     ret:set_strategy(strategy or "max")
     ret:set_width(width)

--- a/lib/wibox/container/margin.lua
+++ b/lib/wibox/container/margin.lua
@@ -11,7 +11,7 @@ local setmetatable = setmetatable
 local base = require("wibox.widget.base")
 local gcolor = require("gears.color")
 local cairo = require("lgi").cairo
-local util = require("awful.util")
+local gtable = require("gears.table")
 
 local margin = { mt = {} }
 
@@ -188,7 +188,7 @@ end
 local function new(widget, left, right, top, bottom, color, draw_empty)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, margin, true)
+    gtable.crush(ret, margin, true)
 
     ret:set_left(left or 0)
     ret:set_right(right or 0)

--- a/lib/wibox/container/mirror.lua
+++ b/lib/wibox/container/mirror.lua
@@ -12,7 +12,7 @@ local ipairs = ipairs
 local setmetatable = setmetatable
 local base = require("wibox.widget.base")
 local matrix = require("gears.matrix")
-local util = require("awful.util")
+local gtable = require("gears.table")
 
 local mirror = { mt = {} }
 
@@ -118,7 +118,7 @@ local function new(widget, reflection)
     ret._private.horizontal = false
     ret._private.vertical = false
 
-    util.table.crush(ret, mirror, true)
+    gtable.crush(ret, mirror, true)
 
     ret:set_widget(widget)
     ret:set_reflection(reflection or {})

--- a/lib/wibox/container/place.lua
+++ b/lib/wibox/container/place.lua
@@ -10,7 +10,7 @@
 
 local setmetatable = setmetatable
 local base = require("wibox.widget.base")
-local util = require("awful.util")
+local gtable = require("gears.table")
 
 local place = { mt = {} }
 
@@ -181,7 +181,7 @@ end
 local function new(widget, halign, valign)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, place, true)
+    gtable.crush(ret, place, true)
 
     ret:set_widget(widget)
     ret:set_halign(halign)

--- a/lib/wibox/container/radialprogressbar.lua
+++ b/lib/wibox/container/radialprogressbar.lua
@@ -14,7 +14,7 @@
 local setmetatable = setmetatable
 local base      = require("wibox.widget.base")
 local shape     = require("gears.shape"      )
-local util      = require( "awful.util"      )
+local gtable    = require( "gears.table"     )
 local color     = require( "gears.color"     )
 local beautiful = require("beautiful"        )
 
@@ -243,7 +243,7 @@ local function new(widget)
         enable_properties = true,
     })
 
-    util.table.crush(ret, radialprogressbar)
+    gtable.crush(ret, radialprogressbar)
     ret._private.max_value = 1
     ret._private.min_value = 0
 

--- a/lib/wibox/container/rotate.lua
+++ b/lib/wibox/container/rotate.lua
@@ -13,7 +13,7 @@ local setmetatable = setmetatable
 local tostring = tostring
 local base = require("wibox.widget.base")
 local matrix = require("gears.matrix")
-local util = require("awful.util")
+local gtable = require("gears.table")
 
 local rotate = { mt = {} }
 
@@ -141,7 +141,7 @@ end
 local function new(widget, dir)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, rotate, true)
+    gtable.crush(ret, rotate, true)
 
     ret:set_widget(widget)
     ret:set_direction(dir or "north")

--- a/lib/wibox/container/scroll.lua
+++ b/lib/wibox/container/scroll.lua
@@ -27,7 +27,7 @@ local cache = require("gears.cache")
 local timer = require("gears.timer")
 local hierarchy = require("wibox.hierarchy")
 local base = require("wibox.widget.base")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local lgi = require("lgi")
 local GLib = lgi.GLib
 
@@ -403,7 +403,7 @@ local function get_layout(dir, widget, fps, speed, extra_space, expand, max_size
     ret._private.timer = GLib.Timer()
     ret._private.scroll_timer = nil
 
-    util.table.crush(ret, scroll, true)
+    gtable.crush(ret, scroll, true)
 
     ret:set_direction(dir)
     ret:set_widget(widget)

--- a/lib/wibox/layout/fixed.lua
+++ b/lib/wibox/layout/fixed.lua
@@ -10,7 +10,7 @@ local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility
 local base  = require("wibox.widget.base")
 local table = table
 local pairs = pairs
-local util = require("awful.util")
+local gtable = require("gears.table")
 
 local fixed = {}
 
@@ -272,7 +272,7 @@ end
 local function get_layout(dir, widget1, ...)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, fixed, true)
+    gtable.crush(ret, fixed, true)
 
     ret._private.dir = dir
     ret._private.widgets = {}

--- a/lib/wibox/layout/flex.lua
+++ b/lib/wibox/layout/flex.lua
@@ -12,7 +12,7 @@ local table = table
 local pairs = pairs
 local floor = math.floor
 local gmath = require("gears.math")
-local util = require("awful.util")
+local gtable = require("gears.table")
 
 local flex = {}
 
@@ -141,7 +141,7 @@ end
 local function get_layout(dir, widget1, ...)
     local ret = fixed[dir](widget1, ...)
 
-    util.table.crush(ret, flex, true)
+    gtable.crush(ret, flex, true)
 
     ret._private.fill_space = nil
 

--- a/lib/wibox/layout/grid.lua
+++ b/lib/wibox/layout/grid.lua
@@ -22,7 +22,7 @@ local table = table
 local pairs = pairs
 local ipairs = ipairs
 local math = math
-local util = require("awful.util")
+local gtable = require("gears.table")
 local base = require("wibox.widget.base")
 
 local grid = { mt = {} }
@@ -868,7 +868,7 @@ local function new(orientation)
 
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, grid, true)
+    gtable.crush(ret, grid, true)
 
     ret._private.orientation = dir
     ret._private.widgets = {}

--- a/lib/wibox/layout/ratio.lua
+++ b/lib/wibox/layout/ratio.lua
@@ -15,7 +15,7 @@ local table = table
 local pairs = pairs
 local floor = math.floor
 local gmath = require("gears.math")
-local util  = require("awful.util")
+local gtable = require("gears.table")
 
 local ratio = {}
 
@@ -294,7 +294,7 @@ end
 local function get_layout(dir, widget1, ...)
     local ret = flex[dir](widget1, ...)
 
-    util.table.crush(ret, ratio, true)
+    gtable.crush(ret, ratio, true)
 
     ret._private.fill_space = nil
 

--- a/lib/wibox/layout/stack.lua
+++ b/lib/wibox/layout/stack.lua
@@ -18,7 +18,7 @@ local base  = require("wibox.widget.base" )
 local fixed = require("wibox.layout.fixed")
 local table = table
 local pairs = pairs
-local util  = require("awful.util")
+local gtable  = require("gears.table")
 
 local stack = {mt={}}
 
@@ -128,7 +128,7 @@ end
 local function new(...)
     local ret = fixed.horizontal(...)
 
-    util.table.crush(ret, stack, true)
+    gtable.crush(ret, stack, true)
 
     return ret
 end

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -8,7 +8,7 @@ local object = require("gears.object")
 local cache = require("gears.cache")
 local matrix = require("gears.matrix")
 local protected_call = require("gears.protected_call")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local setmetatable = setmetatable
 local pairs = pairs
 local type = type
@@ -440,7 +440,7 @@ local function parse_table(t, leave_empty)
 
     -- Pack the sparse table, if the container doesn't support sparse tables.
     if not leave_empty then
-        widgets = util.table.from_sparse(widgets)
+        widgets = gtable.from_sparse(widgets)
         max = #widgets
     end
 

--- a/lib/wibox/widget/checkbox.lua
+++ b/lib/wibox/widget/checkbox.lua
@@ -15,7 +15,7 @@ local color     = require( "gears.color"       )
 local base      = require( "wibox.widget.base" )
 local beautiful = require( "beautiful"         )
 local shape     = require( "gears.shape"       )
-local util      = require( "awful.util"        )
+local gtable    = require( "gears.table"       )
 
 local checkbox = {}
 
@@ -231,7 +231,7 @@ local function new(checked, args)
         enable_properties = true,
     })
 
-    util.table.crush(ret, checkbox)
+    gtable.crush(ret, checkbox)
 
     ret._private.checked = checked
     ret._private.color = args.color and color(args.color) or nil

--- a/lib/wibox/widget/imagebox.lua
+++ b/lib/wibox/widget/imagebox.lua
@@ -8,7 +8,7 @@
 
 local base = require("wibox.widget.base")
 local surface = require("gears.surface")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local setmetatable = setmetatable
 local type = type
 local print = print
@@ -160,7 +160,7 @@ end
 local function new(image, resize_allowed, clip_shape)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, imagebox, true)
+    gtable.crush(ret, imagebox, true)
 
     if image then
         ret:set_image(image)

--- a/lib/wibox/widget/piechart.lua
+++ b/lib/wibox/widget/piechart.lua
@@ -13,7 +13,7 @@
 local color     = require( "gears.color"       )
 local base      = require( "wibox.widget.base" )
 local beautiful = require( "beautiful"         )
-local util      = require( "awful.util"        )
+local gtable    = require( "gears.table"       )
 local pie       = require( "gears.shape"       ).pie
 local unpack    = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 
@@ -224,7 +224,7 @@ local function new(data_list)
         enable_properties = true,
     })
 
-    util.table.crush(ret, piechart)
+    gtable.crush(ret, piechart)
 
     rawset(ret, "fit" , fit )
     rawset(ret, "draw", draw)

--- a/lib/wibox/widget/progressbar.lua
+++ b/lib/wibox/widget/progressbar.lua
@@ -28,6 +28,7 @@ local base = require("wibox.widget.base")
 local color = require("gears.color")
 local beautiful = require("beautiful")
 local shape = require("gears.shape")
+local gtable = require("gears.table")
 
 local progressbar = { mt = {} }
 
@@ -437,7 +438,7 @@ function progressbar.new(args)
     pbar._private.value     = 0
     pbar._private.max_value = 1
 
-    util.table.crush(pbar, progressbar, true)
+    gtable.crush(pbar, progressbar, true)
 
     return pbar
 end

--- a/lib/wibox/widget/slider.lua
+++ b/lib/wibox/widget/slider.lua
@@ -12,7 +12,7 @@
 local setmetatable = setmetatable
 local type = type
 local color = require("gears.color")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local beautiful = require("beautiful")
 local base = require("wibox.widget.base")
 local shape = require("gears.shape")
@@ -441,9 +441,9 @@ local function new(args)
         enable_properties = true,
     })
 
-    util.table.crush(ret._private, args or {})
+    gtable.crush(ret._private, args or {})
 
-    util.table.crush(ret, slider, true)
+    gtable.crush(ret, slider, true)
 
     ret:connect_signal("button::press", mouse_press)
 

--- a/lib/wibox/widget/systray.lua
+++ b/lib/wibox/widget/systray.lua
@@ -6,7 +6,7 @@
 
 local wbase = require("wibox.widget.base")
 local beautiful = require("beautiful")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local capi = {
     awesome = awesome,
     screen = screen
@@ -155,7 +155,7 @@ end
 local function new(revers)
     local ret = wbase.make_widget()
 
-    util.table.crush(ret, systray, true)
+    gtable.crush(ret, systray, true)
 
     if revers then
         ret:set_reverse(true)

--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -11,7 +11,7 @@ local base = require("wibox.widget.base")
 local gdebug = require("gears.debug")
 local beautiful = require("beautiful")
 local lgi = require("lgi")
-local util = require("awful.util")
+local gtable = require("gears.table")
 local Pango = lgi.Pango
 local PangoCairo = lgi.PangoCairo
 local setmetatable = setmetatable
@@ -263,7 +263,7 @@ end
 local function new(text, ignore_markup)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, textbox, true)
+    gtable.crush(ret, textbox, true)
 
     ret._private.dpi = -1
     ret._private.ctx = PangoCairo.font_map_get_default():create_context()

--- a/spec/awful/util_spec.lua
+++ b/spec/awful/util_spec.lua
@@ -6,46 +6,6 @@
 local util = require("awful.util")
 
 describe("awful.util", function()
-    it("table.keys_filter", function()
-        local t = { "a", 1, function() end, false}
-        assert.is.same(util.table.keys_filter(t, "number", "function"), { 2, 3 })
-    end)
-
-    it("table.reverse", function()
-        local t = { "a", "b", c = "c", "d" }
-        assert.is.same(util.table.reverse(t), { "d", "b", "a", c = "c" })
-    end)
-
-    describe("table.iterate", function()
-        it("no filter", function()
-            local t = { "a", "b", c = "c", "d" }
-            local f = util.table.iterate(t, function() return true end)
-            assert.is.equal(f(), "a")
-            assert.is.equal(f(), "b")
-            assert.is.equal(f(), "d")
-            assert.is.equal(f(), nil)
-            assert.is.equal(f(), nil)
-        end)
-
-        it("b filter", function()
-            local t = { "a", "b", c = "c", "d" }
-            local f = util.table.iterate(t, function(i) return i == "b" end)
-            assert.is.equal(f(), "b")
-            assert.is.equal(f(), nil)
-            assert.is.equal(f(), nil)
-        end)
-
-        it("with offset", function()
-            local t = { "a", "b", c = "c", "d" }
-            local f = util.table.iterate(t, function() return true end, 2)
-            assert.is.equal(f(), "b")
-            assert.is.equal(f(), "d")
-            assert.is.equal(f(), "a")
-            assert.is.equal(f(), nil)
-            assert.is.equal(f(), nil)
-        end)
-    end)
-
     describe("quote_pattern", function()
         it("text", function()
             assert.is.equal(util.quote_pattern("text"), "text")

--- a/spec/gears/table_spec.lua
+++ b/spec/gears/table_spec.lua
@@ -1,0 +1,44 @@
+
+local gtable = require("gears.table")
+
+describe("gears.table", function()
+    it("table.keys_filter", function()
+        local t = { "a", 1, function() end, false}
+        assert.is.same(gtable.keys_filter(t, "number", "function"), { 2, 3 })
+    end)
+
+    it("table.reverse", function()
+        local t = { "a", "b", c = "c", "d" }
+        assert.is.same(gtable.reverse(t), { "d", "b", "a", c = "c" })
+    end)
+
+    describe("table.iterate", function()
+        it("no filter", function()
+            local t = { "a", "b", c = "c", "d" }
+            local f = gtable.iterate(t, function() return true end)
+            assert.is.equal(f(), "a")
+            assert.is.equal(f(), "b")
+            assert.is.equal(f(), "d")
+            assert.is.equal(f(), nil)
+            assert.is.equal(f(), nil)
+        end)
+
+        it("b filter", function()
+            local t = { "a", "b", c = "c", "d" }
+            local f = gtable.iterate(t, function(i) return i == "b" end)
+            assert.is.equal(f(), "b")
+            assert.is.equal(f(), nil)
+            assert.is.equal(f(), nil)
+        end)
+
+        it("with offset", function()
+            local t = { "a", "b", c = "c", "d" }
+            local f = gtable.iterate(t, function() return true end, 2)
+            assert.is.equal(f(), "b")
+            assert.is.equal(f(), "d")
+            assert.is.equal(f(), "a")
+            assert.is.equal(f(), nil)
+            assert.is.equal(f(), nil)
+        end)
+    end)
+end)

--- a/tests/_runner.lua
+++ b/tests/_runner.lua
@@ -1,5 +1,6 @@
 local timer = require("gears.timer")
 local awful = require("awful")
+local gtable = require("gears.table")
 
 local runner = {
     quit_awesome_on_error = os.getenv('TEST_PAUSE_ON_ERRORS') ~= '1',
@@ -8,9 +9,9 @@ local runner = {
 -- Helpers.
 
 --- Add some rules to awful.rules.rules, after the defaults.
-local default_rules = awful.util.table.clone(awful.rules.rules)
+local default_rules = gtable.clone(awful.rules.rules)
 runner.add_to_default_rules = function(r)
-    awful.rules.rules = awful.util.table.clone(default_rules)
+    awful.rules.rules = gtable.clone(default_rules)
     table.insert(awful.rules.rules, r)
 end
 

--- a/tests/test-awful-layout.lua
+++ b/tests/test-awful-layout.lua
@@ -2,6 +2,7 @@
 -- it doesn't check if the layout are correct.
 
 local awful = require("awful")
+local gtable = require("gears.table")
 
 local first_layout = nil
 
@@ -113,10 +114,10 @@ for _ in ipairs(awful.layout.layouts) do
     if not first then
         first = true
     else
-        awful.util.table.merge(steps, {next_layout})
+        gtable.merge(steps, {next_layout})
     end
 
-    awful.util.table.merge(steps, common_steps)
+    gtable.merge(steps, common_steps)
 end
 
 require("_runner").run_steps(steps)

--- a/tests/test-awful-widget-button.lua
+++ b/tests/test-awful-widget-button.lua
@@ -2,6 +2,7 @@ local runner    = require( "_runner"   )
 local wibox     = require( "wibox"     )
 local awful     = require( "awful"     )
 local beautiful = require( "beautiful" )
+local gtable    = require("gears.table")
 
 local steps = {}
 
@@ -63,7 +64,7 @@ table.insert(steps, function()
     layout = w.widget
     assert(layout)
 
-    button:buttons(awful.util.table.join(
+    button:buttons(gtable.join(
         button:buttons(),
         awful.button({}, 1, nil, function ()
             button:emit_signal_recursive("test::recursive")

--- a/tests/test-current-desktop.lua
+++ b/tests/test-current-desktop.lua
@@ -3,6 +3,7 @@
 local runner = require("_runner")
 local test_client = require("_client")
 local awful = require("awful")
+local gtable = require("gears.table")
 
 local c
 local s = screen[1]
@@ -10,7 +11,7 @@ local tags = s.tags
 
 local function wait_for_current_desktop(tag)
     -- The X property has 0-based indicies
-    local idx = awful.util.table.hasitem(tags, tag) - 1
+    local idx = gtable.hasitem(tags, tag) - 1
     return function()
         local file = io.popen("xprop -notype -root _NET_CURRENT_DESKTOP")
         local result = file:read("*all")

--- a/tests/test-leak-client.lua
+++ b/tests/test-leak-client.lua
@@ -2,10 +2,11 @@
 local runner = require("_runner")
 local awful = require("awful")
 local wibox = require("wibox")
+local gtable = require("gears.table")
 
 -- "Enable" titlebars (so that the titlebar can prevent garbage collection)
 client.connect_signal("manage", function (c)
-    local buttons = awful.util.table.join(
+    local buttons = gtable.join(
         awful.button({ }, 1, function()
             client.focus = c
             c:raise()


### PR DESCRIPTION
Based on #1582 

This updates all the `awful.util.table.*` function calls to the new `gears.table.*` functions to remove all the deprecation messages that will be produced by the base PR. And one change in `awful/button.lua` for a `gears.math.subsets` call.

Quite a few removed the need to `require("awful.util")`.