### PR TITLE
Fix docs/07-my-first-awesome.md

### DIFF
--- a/docs/07-my-first-awesome.md
+++ b/docs/07-my-first-awesome.md
@@ -87,7 +87,7 @@ user name):
 Your desktop background image is handled in your theme file. To change it, edit
 this line in your theme file:
 
-    theme.wallpaper = "/usr/share/awesome/themes/default/background.png"
+    beautiful.get().wallpaper = "/usr/share/awesome/themes/default/background.png"
 
 ## Personalize your layouts
 


### PR DESCRIPTION
In awesome 3.5, the default themes set a global variable called "theme".
This was, I think, not intentional and we changed this when luacheck
found this issue. However, the "my first awesome" document from the old
wiki made use of this fact and so many people were using this hack. This
commit fixes our copy of "my first awesome".

Signed-off-by: Uli Schlachter <psychon@znc.in>