### PR TITLE
Partly fix removal of systray from a wibox

### DIFF
--- a/lib/wibox/hierarchy.lua
+++ b/lib/wibox/hierarchy.lua
@@ -157,8 +157,8 @@ function hierarchy_update(self, context, widget, width, height, region, matrix_t
 
     -- Update widget counts
     self._widget_counts = {}
-    if widgets_to_count[self._widget] then
-        self._widget_counts[self._widget] = 1
+    if widgets_to_count[widget] and width > 0 and height > 0 then
+        self._widget_counts[widget] = 1
     end
     for _, h in ipairs(self._children) do
         for w, count in pairs(h._widget_counts) do

--- a/lib/wibox/hierarchy.lua
+++ b/lib/wibox/hierarchy.lua
@@ -16,6 +16,16 @@ local no_parent = base.no_parent_I_know_what_I_am_doing
 
 local hierarchy = {}
 
+local widgets_to_count = setmetatable({}, { __mode = "k" })
+
+--- Add a widget to the list of widgets for which hierarchies should count their
+-- occurrences. Note that for correct operations, the widget must not yet be
+-- visible in any hierarchy.
+-- @param widget The widget that should be counted.
+function hierarchy.count_widget(widget)
+    widgets_to_count[widget] = true
+end
+
 local function hierarchy_new(redraw_callback, layout_callback, callback_arg)
     local result = {
         _matrix = matrix.identity,
@@ -37,7 +47,8 @@ local function hierarchy_new(redraw_callback, layout_callback, callback_arg)
             height = 0
         },
         _parent = nil,
-        _children = {}
+        _children = {},
+        _widget_counts = {},
     }
 
     function result._redraw()
@@ -143,6 +154,17 @@ function hierarchy_update(self, context, widget, width, height, region, matrix_t
         width = x2 - x1,
         height = y2 - y1
     }
+
+    -- Update widget counts
+    self._widget_counts = {}
+    if widgets_to_count[self._widget] then
+        self._widget_counts[self._widget] = 1
+    end
+    for _, h in ipairs(self._children) do
+        for w, count in pairs(h._widget_counts) do
+            self._widget_counts[w] = (self._widget_counts[w] or 0) + count
+        end
+    end
 
     -- Check which part needs to be redrawn
 
@@ -258,6 +280,14 @@ end
 -- @return List of all children hierarchies.
 function hierarchy:get_children()
     return self._children
+end
+
+--- Count how often this widget is visible inside this hierarchy. This function
+-- only works with widgets registered via `count_widget`.
+-- @param widget The widget that should be counted
+-- @return The number of times that this widget is contained in this hierarchy.
+function hierarchy:get_count(widget)
+    return self._widget_counts[widget] or 0
 end
 
 --- Does the given cairo context have an empty clip (aka "no drawing possible")?

--- a/lib/wibox/widget/systray.lua
+++ b/lib/wibox/widget/systray.lua
@@ -5,6 +5,7 @@
 ---------------------------------------------------------------------------
 
 local wbase = require("wibox.widget.base")
+local drawable = require("wibox.drawable")
 local beautiful = require("beautiful")
 local gtable = require("gears.table")
 local capi = {
@@ -70,6 +71,13 @@ function systray:draw(context, cr, width, height)
     end
     capi.awesome.systray(context.wibox.drawin, math.ceil(x), math.ceil(y),
                          base, is_rotated, bg, reverse, spacing)
+end
+
+-- Private API. Does not appear in LDoc on purpose. This function is called
+-- some time after the systray is removed from some drawable. It's purpose is to
+-- really remove the systray.
+function systray:_kickout(context)
+    capi.awesome.systray(context.wibox.drawin)
 end
 
 function systray:fit(context, width, height)
@@ -170,6 +178,8 @@ local function new(revers)
             ret:emit_signal("widget::layout_changed")
         end
     end)
+
+    drawable._set_systray_widget(ret)
 
     return ret
 end

--- a/lib/wibox/widget/systray.lua
+++ b/lib/wibox/widget/systray.lua
@@ -161,7 +161,7 @@ end
 -- @function wibox.widget.systray
 
 local function new(revers)
-    local ret = wbase.make_widget()
+    local ret = wbase.make_widget(nil, nil, {enable_properties = true})
 
     gtable.crush(ret, systray, true)
 
@@ -190,6 +190,10 @@ function systray.mt:__call(...)
     end
     return instance
 end
+
+--@DOC_widget_COMMON@
+
+--@DOC_object_COMMON@
 
 return setmetatable(systray, systray.mt)
 

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -166,6 +166,12 @@ drawin_systray_kickout(drawin_t *w)
     }
 }
 
+void
+luaA_drawin_systray_kickout(lua_State *L)
+{
+    drawin_systray_kickout(luaA_checkudata(L, 1, &drawin_class));
+}
+
 static void
 drawin_wipe(drawin_t *w)
 {

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -47,8 +47,8 @@ struct drawin_t
 ARRAY_FUNCS(drawin_t *, drawin, DO_NOTHING)
 
 drawin_t * drawin_getbywin(xcb_window_t);
-
 void drawin_refresh_pixmap_partial(drawin_t *, int16_t, int16_t, uint16_t, uint16_t);
+void luaA_drawin_systray_kickout(lua_State *);
 
 void drawin_class_setup(lua_State *);
 

--- a/spec/wibox/hierarchy_spec.lua
+++ b/spec/wibox/hierarchy_spec.lua
@@ -259,6 +259,66 @@ describe("wibox.hierarchy", function()
             assert.is.same({ rect.x, rect.y, rect.width, rect.height }, { 4, 0, 5, 2 })
         end)
     end)
+
+    describe("widget counts", function()
+        local child, intermediate, parent
+        local unrelated
+        local context, instance
+        before_each(function()
+            local function nop() end
+            context = {}
+            child = make_widget(nil)
+            intermediate = make_widget({
+                make_child(child, 10, 20, matrix.identity)
+            })
+            parent = make_widget({
+                make_child(intermediate, 10, 20, matrix.identity)
+            })
+            unrelated = make_widget(nil)
+
+            hierarchy.count_widget(child)
+            hierarchy.count_widget(parent)
+            hierarchy.count_widget(unrelated)
+            instance = hierarchy.new(context, parent, 10, 20, nop, nop)
+        end)
+
+        it("basic counts", function()
+            local unrelated_other = make_widget(nil)
+            assert.is.equal(1, instance:get_count(child))
+            -- intermediate was not passed to hierarchy.count_widget()!
+            assert.is.equal(0, instance:get_count(intermediate))
+            assert.is.equal(1, instance:get_count(parent))
+            assert.is.equal(0, instance:get_count(unrelated))
+            assert.is.equal(0, instance:get_count(unrelated_other))
+        end)
+
+        it("after update", function()
+            -- Replace child and intermediate by just a new_child
+            local new_child = make_widget(nil)
+            parent.layout = function()
+                return { make_child(new_child, 10, 20, matrix.identity) }
+            end
+            parent:emit_signal("widget::layout_changed")
+            instance:update(context, parent, 10, 20)
+
+            assert.is.equal(0, instance:get_count(child))
+            -- new_child was not passed to hierarchy.count_widget()!
+            assert.is.equal(0, instance:get_count(new_child))
+            assert.is.equal(1, instance:get_count(parent))
+            assert.is.equal(0, instance:get_count(unrelated))
+        end)
+
+        it("collectible", function()
+            -- This test that hierarchy.count_widget() does not prevent garbage collection of the widget.
+            local weak = setmetatable({}, { __mode = "v"})
+            weak[1], weak[2], weak[3], weak[4] = child, intermediate, parent, instance
+            child, intermediate, parent, instance = nil, nil, nil, nil
+
+            assert.is.equal(4, #weak)
+            collectgarbage("collect")
+            assert.is.equal(0, #weak)
+        end)
+    end)
 end)
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/spec/wibox/hierarchy_spec.lua
+++ b/spec/wibox/hierarchy_spec.lua
@@ -272,7 +272,8 @@ describe("wibox.hierarchy", function()
                 make_child(child, 10, 20, matrix.identity)
             })
             parent = make_widget({
-                make_child(intermediate, 10, 20, matrix.identity)
+                make_child(intermediate, 10, 20, matrix.identity),
+                make_child(child, 0, 20, matrix.identity)
             })
             unrelated = make_widget(nil)
 

--- a/spec/wibox/test_utils.lua
+++ b/spec/wibox/test_utils.lua
@@ -96,6 +96,12 @@ return {
             end
         end
         w._private.widget_caches = {}
+        w:connect_signal("widget::layout_changed", function()
+            -- TODO: This is not completely correct, since our parent's caches
+            -- are not cleared. For the time being, tests just have to handle
+            -- this clearing-part themselves.
+            w._private.widget_caches = {}
+        end)
 
         return w
     end,

--- a/systray.c
+++ b/systray.c
@@ -337,7 +337,10 @@ luaA_systray(lua_State *L)
 {
     systray_register();
 
-    if(lua_gettop(L) != 0)
+    if(lua_gettop(L) == 1)
+        luaA_drawin_systray_kickout(L);
+
+    if(lua_gettop(L) > 1)
     {
         size_t bg_len;
         drawin_t *w = luaA_checkudata(L, 1, &drawin_class);


### PR DESCRIPTION
This changes the systray widget, wibox.drawable and the C code to
fix the following bug: When the systray widget is removed from a
drawable without being moved somewhere else, the systray stayed visible.
This was because the systray is not drawn by awesome, but only placed.
When the widget is no longer "drawn", it stays wherever it was placed
last.

This change works by detecting the situation when the systray is
removed. Then, the C code is specifically told to remove the systray
window from the drawable.

Note that this is only a partial fix. This change works correctly when
the widget is removed completely, because it is no longer placed by its
parent widget. However, for example, when you do
wibox.widget.systray().visible = false, the effect is just that the
systray widget gets size 0x0. This is not really visible, but as far as
this change is concerned, the widget is still part of the drawable.

[Should `wibox.hierarchy` to be changed so that it does not count widgets with width 0 or height 0?]