### PR TITLE
Move awful.util.deprecate and awful.util.deprecate_class to gears.debug

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -7,7 +7,7 @@
 ---------------------------------------------------------------------------
 
 -- Grab environment we need
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 local spawn = require("awful.spawn")
 local set_shape = require("awful.client.shape").update.all
 local object = require("gears.object")
@@ -70,7 +70,7 @@ client.focus = require("awful.client.focus")
 --   If it is a function, it will be called with the client and its first
 --   tag as arguments.
 function client.jumpto(c, merge)
-    util.deprecate("Use c:jump_to(merge) instead of awful.client.jumpto")
+    gdebug.deprecate("Use c:jump_to(merge) instead of awful.client.jumpto", {deprecated_in=4})
     client.object.jump_to(c, merge)
 end
 
@@ -317,7 +317,7 @@ end
 -- @client[opt] c The client, otherwise focused one is used.
 -- @see client.relative_move
 function client.moveresize(x, y, w, h, c)
-    util.deprecate("Use c:relative_move(x, y, w, h) instead of awful.client.moveresize")
+    gdebug.deprecate("Use c:relative_move(x, y, w, h) instead of awful.client.moveresize", {deprecated_in=4})
     client.object.relative_move(c or capi.client.focus, x, y, w, h)
 end
 
@@ -343,7 +343,7 @@ end
 -- @client[opt] c The client to move, otherwise the focused one is used.
 -- @see client.move_to_tag
 function client.movetotag(target, c)
-    util.deprecate("Use c:move_to_tag(target) instead of awful.client.movetotag")
+    gdebug.deprecate("Use c:move_to_tag(target) instead of awful.client.movetotag", {deprecated_in=4})
     client.object.move_to_tag(c or capi.client.focus, target)
 end
 
@@ -368,7 +368,7 @@ end
 -- @client[opt] c The client to toggle, otherwise the focused one is used.
 -- @see client.toggle_tag
 function client.toggletag(target, c)
-    util.deprecate("Use c:toggle_tag(target) instead of awful.client.toggletag")
+    gdebug.deprecate("Use c:toggle_tag(target) instead of awful.client.toggletag", {deprecated_in=4})
     client.object.toggle_tag(c or capi.client.focus, target)
 end
 
@@ -404,7 +404,7 @@ end
 -- @see screen
 -- @see client.move_to_screen
 function client.movetoscreen(c, s)
-    util.deprecate("Use c:move_to_screen(s) instead of awful.client.movetoscreen")
+    gdebug.deprecate("Use c:move_to_screen(s) instead of awful.client.movetoscreen", {deprecated_in=4})
     client.object.move_to_screen(c or capi.client.focus, s)
 end
 
@@ -506,7 +506,7 @@ end
 -- @deprecated awful.client.mark
 -- @client c The client to mark, the focused one if not specified.
 function client.mark(c)
-    util.deprecate("Use c.marked = true instead of awful.client.mark")
+    gdebug.deprecate("Use c.marked = true instead of awful.client.mark", {deprecated_in=4})
     client.object.set_marked(c or capi.client.focus, true)
 end
 
@@ -514,7 +514,7 @@ end
 -- @deprecated awful.client.unmark
 -- @client c The client to unmark, or the focused one if not specified.
 function client.unmark(c)
-    util.deprecate("Use c.marked = false instead of awful.client.unmark")
+    gdebug.deprecate("Use c.marked = false instead of awful.client.unmark", {deprecated_in=4})
     client.object.set_marked(c or capi.client.focus, false)
 end
 
@@ -522,7 +522,7 @@ end
 -- @deprecated awful.client.ismarked
 -- @client c The client to check, or the focused one otherwise.
 function client.ismarked(c)
-    util.deprecate("Use c.marked instead of awful.client.ismarked")
+    gdebug.deprecate("Use c.marked instead of awful.client.ismarked", {deprecated_in=4})
     return client.object.get_marked(c or capi.client.focus)
 end
 
@@ -530,7 +530,7 @@ end
 -- @deprecated awful.client.togglemarked
 -- @client c The client to toggle mark.
 function client.togglemarked(c)
-    util.deprecate("Use c.marked = not c.marked instead of awful.client.togglemarked")
+    gdebug.deprecate("Use c.marked = not c.marked instead of awful.client.togglemarked", {deprecated_in=4})
     c = c or capi.client.focus
     if c then
         c.marked = not c.marked
@@ -559,7 +559,7 @@ end
 -- @client c A client.
 -- @param s True or false.
 function client.floating.set(c, s)
-    util.deprecate("Use c.floating = true instead of awful.client.floating.set")
+    gdebug.deprecate("Use c.floating = true instead of awful.client.floating.set", {deprecated_in=4})
     client.object.set_floating(c, s)
 end
 
@@ -603,7 +603,7 @@ capi.client.connect_signal("property::geometry", store_floating_geometry)
 -- @see is_fixed
 -- @see size_hints_honor
 function client.isfixed(c)
-    util.deprecate("Use c.is_fixed instead of awful.client.isfixed")
+    gdebug.deprecate("Use c.is_fixed instead of awful.client.isfixed", {deprecated_in=4})
     c = c or capi.client.focus
     return client.object.is_fixed(c)
 end
@@ -642,7 +642,7 @@ end
 -- did not set them manually. For example, windows with a type different than
 -- normal.
 function client.floating.get(c)
-    util.deprecate("Use c.floating instead of awful.client.floating.get")
+    gdebug.deprecate("Use c.floating instead of awful.client.floating.get", {deprecated_in=4})
     return client.object.get_floating(c)
 end
 
@@ -935,7 +935,7 @@ end
 -- @treturn bool
 -- @deprecated awful.client.dockable.get
 function client.dockable.get(c)
-    util.deprecate("Use c.dockable instead of awful.client.dockable.get")
+    gdebug.deprecate("Use c.dockable instead of awful.client.dockable.get", {deprecated_in=4})
     return client.object.get_dockable(c)
 end
 
@@ -978,7 +978,7 @@ end
 -- @param value True or false.
 -- @deprecated awful.client.dockable.set
 function client.dockable.set(c, value)
-    util.deprecate("Use c.dockable = value instead of awful.client.dockable.set")
+    gdebug.deprecate("Use c.dockable = value instead of awful.client.dockable.set", {deprecated_in=4})
     client.property.set(c, "dockable", value)
 end
 
@@ -1111,8 +1111,8 @@ end
 --   a matching parent client is found.
 -- @treturn client.client|nil The matching parent client or nil.
 function client.get_transient_for_matching(c, matcher)
-    util.deprecate("Use c:get_transient_for_matching(matcher) instead of"..
-        "awful.client.get_transient_for_matching")
+    gdebug.deprecate("Use c:get_transient_for_matching(matcher) instead of"..
+        "awful.client.get_transient_for_matching", {deprecated_in=4})
 
     return client.object.get_transient_for_matching(c, matcher)
 end
@@ -1140,8 +1140,8 @@ end
 -- @client c2 The parent client to check.
 -- @treturn client.client|nil The parent client or nil.
 function client.is_transient_for(c, c2)
-    util.deprecate("Use c:is_transient_for(c2) instead of"..
-        "awful.client.is_transient_for")
+    gdebug.deprecate("Use c:is_transient_for(c2) instead of"..
+        "awful.client.is_transient_for", {deprecated_in=4})
     return client.object.is_transient_for(c, c2)
 end
 

--- a/lib/awful/init.lua
+++ b/lib/awful/init.lua
@@ -9,8 +9,9 @@
 -- TODO: This is a hack for backwards-compatibility with 3.5, remove!
 local util = require("awful.util")
 local gtimer = require("gears.timer")
+local gdebug = require("gears.debug")
 function timer(...) -- luacheck: ignore
-    util.deprecate("gears.timer")
+    gdebug.deprecate("gears.timer", {deprecated_in=4})
     return gtimer(...)
 end
 
@@ -19,18 +20,18 @@ end
 local spawn = require("awful.spawn")
 
 util.spawn = function(...)
-   util.deprecate("awful.spawn")
+   gdebug.deprecate("awful.spawn", {deprecated_in=4})
    return spawn.spawn(...)
 end
 
 util.spawn_with_shell = function(...)
-   util.deprecate("awful.spawn.with_shell")
+   gdebug.deprecate("awful.spawn.with_shell", {deprecated_in=4})
    return spawn.with_shell(...)
 end
 
 util.pread = function()
-    util.deprecate("Use io.popen() directly or look at awful.spawn.easy_async() "
-            .. "for an asynchronous alternative")
+    gdebug.deprecate("Use io.popen() directly or look at awful.spawn.easy_async() "
+            .. "for an asynchronous alternative", {deprecated_in=4})
     return ""
 end
 

--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -9,7 +9,7 @@
 -- Grab environment we need
 local layout = require("awful.layout")
 local aplace = require("awful.placement")
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 local type = type
 local ipairs = ipairs
 local capi =
@@ -62,7 +62,7 @@ mouse.wibox = {}
 -- @return The client object under the pointer, if one can be found.
 -- @see current_client
 function mouse.client_under_pointer()
-    util.deprecate("Use mouse.current_client instead of awful.mouse.client_under_pointer()")
+    gdebug.deprecate("Use mouse.current_client instead of awful.mouse.client_under_pointer()", {deprecated_in=4})
 
     return mouse.object.get_current_client()
 end
@@ -74,8 +74,8 @@ end
 -- @param finished_cb Deprecated, do not use
 function mouse.client.move(c, snap, finished_cb) --luacheck: no unused args
     if finished_cb then
-        util.deprecate("The mouse.client.move `finished_cb` argument is no longer"..
-            " used, please use awful.mouse.resize.add_leave_callback(f, 'mouse.move')")
+        gdebug.deprecate("The mouse.client.move `finished_cb` argument is no longer"..
+            " used, please use awful.mouse.resize.add_leave_callback(f, 'mouse.move')", {deprecated_in=4})
     end
 
     c = c or capi.client.focus
@@ -111,8 +111,8 @@ mouse.client.dragtotag = { }
 -- @deprecated awful.mouse.client.dragtotag.border
 -- @param c The client to move
 function mouse.client.dragtotag.border(c)
-    util.deprecate("Use awful.mouse.snap.drag_to_tag_enabled = true instead "..
-        "of awful.mouse.client.dragtotag.border(c). It will now be enabled.")
+    gdebug.deprecate("Use awful.mouse.snap.drag_to_tag_enabled = true instead "..
+        "of awful.mouse.client.dragtotag.border(c). It will now be enabled.", {deprecated_in=4})
 
     -- Enable drag to border
     mouse.snap.drag_to_tag_enabled = true
@@ -159,9 +159,9 @@ end
 -- @treturn number x The horizontal position
 -- @treturn number y The vertical position
 function mouse.client.corner(c, corner)
-    util.deprecate(
+    gdebug.deprecate(
         "Use awful.placement.closest_corner(mouse) or awful.placement[corner](mouse)"..
-        " instead of awful.mouse.client.corner"
+        " instead of awful.mouse.client.corner", {deprecated_in=4}
     )
 
     c = c or capi.client.focus

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -93,7 +93,7 @@ local client = require("awful.client")
 local layout = require("awful.layout")
 local a_screen = require("awful.screen")
 local grect = require("gears.geometry").rectangle
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 local gtable = require("gears.table")
 local cairo = require( "lgi" ).cairo
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
@@ -951,9 +951,10 @@ end
 -- @treturn table The new geometry
 function placement.next_to_mouse(d, args)
     if type(args) == "number" then
-        util.deprecate(
+        gdebug.deprecate(
             "awful.placement.next_to_mouse offset argument is deprecated"..
-            " use awful.placement.next_to_mouse(c, {offset={x=...}})"
+            " use awful.placement.next_to_mouse(c, {offset={x=...}})",
+            {deprecated_in=4}
         )
         args = nil
     end

--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -122,10 +122,9 @@ local capi =
 }
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 local keygrabber = require("awful.keygrabber")
-local util = require("awful.util")
 local beautiful = require("beautiful")
 local akey = require("awful.key")
-local debug = require('gears.debug')
+local gdebug = require('gears.debug')
 local gtable = require("gears.table")
 local gcolor = require("gears.color")
 local gstring = require("gears.string")
@@ -479,9 +478,9 @@ function prompt.run(args, textbox, exe_callback, completion_callback,
     local hooks = {}
 
     local deprecated = function(name)
-        util.deprecate(string.format(
+        gdebug.deprecate(string.format(
             'awful.prompt.run: the argument %s is deprecated, please use args.%s instead',
-            name, name), {raw=true})
+            name, name), {raw=true, deprecated_in=4})
     end
     if textbox             then deprecated('textbox') end
     if exe_callback        then deprecated('exe_callback') end
@@ -523,10 +522,10 @@ function prompt.run(args, textbox, exe_callback, completion_callback,
                 hooks[key] = hooks[key] or {}
                 hooks[key][#hooks[key]+1] = v
             else
-                debug.print_warning("The hook's 3rd parameter has to be a function.")
+                gdebug.print_warning("The hook's 3rd parameter has to be a function.")
             end
         else
-            debug.print_warning("The hook has to have 3 parameters.")
+            gdebug.print_warning("The hook has to have 3 parameters.")
         end
     end
 

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -14,7 +14,7 @@ local capi =
     client = client,
     awesome = awesome,
 }
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 local gmath = require("gears.math")
 local object = require("gears.object")
 local grect =  require("gears.geometry").rectangle
@@ -52,7 +52,7 @@ end
 -- @return The squared distance of the screen to the provided point.
 -- @see screen.get_square_distance
 function screen.getdistance_sq(s, x, y)
-    util.deprecate("Use s:get_square_distance(x, y) instead of awful.screen.getdistance_sq")
+    gdebug.deprecate("Use s:get_square_distance(x, y) instead of awful.screen.getdistance_sq", {deprecated_in=4})
     return screen.object.get_square_distance(s, x, y)
 end
 
@@ -184,7 +184,7 @@ end
 -- @treturn table A table with left, right, top and bottom number values.
 -- @see padding
 function screen.padding(_screen, padding)
-    util.deprecate("Use _screen.padding = value instead of awful.screen.padding")
+    gdebug.deprecate("Use _screen.padding = value instead of awful.screen.padding", {deprecated_in=4})
     if padding then
         screen.object.set_padding(_screen, padding)
     end

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -7,7 +7,7 @@
 ---------------------------------------------------------------------------
 
 -- Grab environment we need
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 local ascreen = require("awful.screen")
 local beautiful = require("beautiful")
 local gmath = require("gears.math")
@@ -149,7 +149,7 @@ end
 -- selected tag is used.
 -- @see index
 function tag.move(new_index, target_tag)
-    util.deprecate("Use t.index = new_index instead of awful.tag.move")
+    gdebug.deprecate("Use t.index = new_index instead of awful.tag.move", {deprecated_in=4})
 
     target_tag = target_tag or ascreen.focused().selected_tag
     tag.object.set_index(target_tag, new_index)
@@ -182,7 +182,7 @@ end
 -- @param tag1 The first tag
 -- @param tag2 The second tag
 function tag.swap(tag1, tag2)
-    util.deprecate("Use t:swap(tag2) instead of awful.tag.swap")
+    gdebug.deprecate("Use t:swap(tag2) instead of awful.tag.swap", {deprecated_in=4})
 
     tag.object.swap(tag1, tag2)
 end
@@ -356,7 +356,7 @@ end
 -- If after deleting the tag there is no selected tag, try and restore from
 -- history or select the first tag on the screen.
 function tag.delete(target_tag, fallback_tag)
-    util.deprecate("Use t:delete(fallback_tag) instead of awful.tag.delete")
+    gdebug.deprecate("Use t:delete(fallback_tag) instead of awful.tag.delete", {deprecated_in=4})
 
     return tag.object.delete(target_tag, fallback_tag)
 end
@@ -444,7 +444,7 @@ end
 -- @return A table with all available tags
 -- @see screen.tags
 function tag.gettags(s)
-    util.deprecate("Use s.tags instead of awful.tag.gettags")
+    gdebug.deprecate("Use s.tags instead of awful.tag.gettags", {deprecated_in=4})
 
     s = get_screen(s)
 
@@ -518,7 +518,7 @@ function tag.setscreen(s, t)
         s, t = t, s
     end
 
-    util.deprecate("Use t.screen = s instead of awful.tag.setscreen(t, s)")
+    gdebug.deprecate("Use t.screen = s instead of awful.tag.setscreen(t, s)", {deprecated_in=4})
 
     tag.object.set_screen(t, s)
 end
@@ -529,7 +529,7 @@ end
 -- @param[opt] t tag object
 -- @return Screen number
 function tag.getscreen(t)
-    util.deprecate("Use t.screen instead of awful.tag.getscreen(t)")
+    gdebug.deprecate("Use t.screen instead of awful.tag.getscreen(t)", {deprecated_in=4})
 
     -- A new getter is not required
 
@@ -544,7 +544,7 @@ end
 -- @return A table with all selected tags.
 -- @see screen.selected_tags
 function tag.selectedlist(s)
-    util.deprecate("Use s.selected_tags instead of awful.tag.selectedlist")
+    gdebug.deprecate("Use s.selected_tags instead of awful.tag.selectedlist", {deprecated_in=4})
 
     s = get_screen(s or ascreen.focused())
 
@@ -556,7 +556,7 @@ end
 -- @param s Screen.
 -- @see screen.selected_tag
 function tag.selected(s)
-    util.deprecate("Use s.selected_tag instead of awful.tag.selected")
+    gdebug.deprecate("Use s.selected_tag instead of awful.tag.selected", {deprecated_in=4})
 
     s = get_screen(s or ascreen.focused())
 
@@ -610,7 +610,7 @@ end
 -- @param mwfact Master width factor.
 -- @param t The tag to modify, if null tag.selected() is used.
 function tag.setmwfact(mwfact, t)
-    util.deprecate("Use t.master_width_factor = mwfact instead of awful.tag.setmwfact")
+    gdebug.deprecate("Use t.master_width_factor = mwfact instead of awful.tag.setmwfact", {deprecated_in=4})
 
     tag.object.set_master_width_factor(t or ascreen.focused().selected_tag, mwfact)
 end
@@ -631,7 +631,7 @@ end
 -- @see master_fill_policy
 -- @param[opt] t The tag.
 function tag.getmwfact(t)
-    util.deprecate("Use t.master_width_factor instead of awful.tag.getmwfact")
+    gdebug.deprecate("Use t.master_width_factor instead of awful.tag.getmwfact", {deprecated_in=4})
 
     return tag.object.get_master_width_factor(t or ascreen.focused().selected_tag)
 end
@@ -739,7 +739,7 @@ end
 -- @param t The tag to modify
 -- @return The layout
 function tag.setlayout(layout, t)
-    util.deprecate("Use t.layout = layout instead of awful.tag.setlayout")
+    gdebug.deprecate("Use t.layout = layout instead of awful.tag.setlayout", {deprecated_in=4})
 
     return tag.object.set_layout(t, layout)
 end
@@ -773,7 +773,7 @@ end
 -- @tparam boolean volatile If the tag must be deleted when the last client is untagged
 -- @param t The tag to modify, if null tag.selected() is used.
 function tag.setvolatile(volatile, t)
-    util.deprecate("Use t.volatile = volatile instead of awful.tag.setvolatile")
+    gdebug.deprecate("Use t.volatile = volatile instead of awful.tag.setvolatile", {deprecated_in=4})
 
     tag.setproperty(t, "volatile", volatile)
 end
@@ -784,7 +784,7 @@ end
 -- @param t The tag to modify, if null tag.selected() is used.
 -- @treturn boolean If the tag will be deleted when the last client is untagged
 function tag.getvolatile(t)
-    util.deprecate("Use t.volatile instead of awful.tag.getvolatile")
+    gdebug.deprecate("Use t.volatile instead of awful.tag.getvolatile", {deprecated_in=4})
 
     return tag.getproperty(t, "volatile") or false
 end
@@ -827,7 +827,7 @@ end
 -- @param useless_gap The spacing between clients
 -- @param t The tag to modify, if null tag.selected() is used.
 function tag.setgap(useless_gap, t)
-    util.deprecate("Use t.gap = useless_gap instead of awful.tag.setgap")
+    gdebug.deprecate("Use t.gap = useless_gap instead of awful.tag.setgap", {deprecated_in=4})
 
     tag.object.set_gap(t or ascreen.focused().selected_tag, useless_gap)
 end
@@ -882,7 +882,7 @@ end
 --   return 0 for a single client.  You can override this function to change
 --   this behavior.
 function tag.getgap(t, numclients)
-    util.deprecate("Use t.gap instead of awful.tag.getgap")
+    gdebug.deprecate("Use t.gap instead of awful.tag.getgap", {deprecated_in=4})
 
     if numclients == 1 then
         return 0
@@ -932,7 +932,7 @@ end
 -- "master_width_factor" (fill only an area inside the master width factor)
 -- @tparam[opt=tag.selected()] tag t The tag to modify
 function tag.setmfpol(policy, t)
-    util.deprecate("Use t.master_fill_policy = policy instead of awful.tag.setmfpol")
+    gdebug.deprecate("Use t.master_fill_policy = policy instead of awful.tag.setmfpol", {deprecated_in=4})
 
     t = t or ascreen.focused().selected_tag
     tag.setproperty(t, "master_fill_policy", policy)
@@ -961,7 +961,7 @@ end
 -- "expand" (fill all the available workarea, default one) or
 -- "master_width_factor" (fill only an area inside the master width factor)
 function tag.getmfpol(t)
-    util.deprecate("Use t.master_fill_policy instead of awful.tag.getmfpol")
+    gdebug.deprecate("Use t.master_fill_policy instead of awful.tag.getmfpol", {deprecated_in=4})
 
     t = t or ascreen.focused().selected_tag
     return tag.getproperty(t, "master_fill_policy")
@@ -1004,7 +1004,7 @@ end
 -- @param nmaster The number of master windows.
 -- @param[opt] t The tag.
 function tag.setnmaster(nmaster, t)
-    util.deprecate("Use t.master_count = nmaster instead of awful.tag.setnmaster")
+    gdebug.deprecate("Use t.master_count = nmaster instead of awful.tag.setnmaster", {deprecated_in=4})
 
     tag.object.set_master_count(t or ascreen.focused().selected_tag, nmaster)
 end
@@ -1014,7 +1014,7 @@ end
 -- @see master_count
 -- @param[opt] t The tag.
 function tag.getnmaster(t)
-    util.deprecate("Use t.master_count instead of awful.tag.setnmaster")
+    gdebug.deprecate("Use t.master_count instead of awful.tag.setnmaster", {deprecated_in=4})
 
     t = t or ascreen.focused().selected_tag
     return tag.getproperty(t, "master_count") or 1
@@ -1066,7 +1066,7 @@ end
 -- @param icon the icon to set, either path or image object
 -- @param _tag the tag
 function tag.seticon(icon, _tag)
-    util.deprecate("Use t.icon = icon instead of awful.tag.seticon")
+    gdebug.deprecate("Use t.icon = icon instead of awful.tag.seticon", {deprecated_in=4})
 
     _tag = _tag or ascreen.focused().selected_tag
     tag.setproperty(_tag, "icon", icon)
@@ -1077,7 +1077,7 @@ end
 -- @see icon
 -- @param _tag the tag
 function tag.geticon(_tag)
-    util.deprecate("Use t.icon instead of awful.tag.geticon")
+    gdebug.deprecate("Use t.icon instead of awful.tag.geticon", {deprecated_in=4})
 
     _tag = _tag or ascreen.focused().selected_tag
     return tag.getproperty(_tag, "icon")
@@ -1118,7 +1118,7 @@ end
 -- @param ncol The number of column.
 -- @param t The tag to modify, if null tag.selected() is used.
 function tag.setncol(ncol, t)
-    util.deprecate("Use t.column_count = new_index instead of awful.tag.setncol")
+    gdebug.deprecate("Use t.column_count = new_index instead of awful.tag.setncol", {deprecated_in=4})
 
     t = t or ascreen.focused().selected_tag
     if ncol >= 1 then
@@ -1132,7 +1132,7 @@ end
 -- @see column_count
 -- @param[opt] t The tag.
 function tag.getncol(t)
-    util.deprecate("Use t.column_count instead of awful.tag.getncol")
+    gdebug.deprecate("Use t.column_count instead of awful.tag.getncol", {deprecated_in=4})
 
     t = t or ascreen.focused().selected_tag
     return tag.getproperty(t, "column_count") or 1
@@ -1212,7 +1212,7 @@ end
 -- @param query_tag The tag object to find. [selected()]
 -- @return The index of the tag, nil if the tag is not found.
 function tag.getidx(query_tag)
-    util.deprecate("Use t.index instead of awful.tag.getidx")
+    gdebug.deprecate("Use t.index instead of awful.tag.getidx", {deprecated_in=4})
 
     return tag.object.get_index(query_tag or ascreen.focused().selected_tag)
 end
@@ -1254,7 +1254,7 @@ end
 -- @see tag.view_only
 -- @param t The tag object.
 function tag.viewonly(t)
-    util.deprecate("Use t:view_only() instead of awful.tag.viewonly")
+    gdebug.deprecate("Use t:view_only() instead of awful.tag.viewonly", {deprecated_in=4})
 
     tag.object.view_only(t)
 end
@@ -1337,7 +1337,7 @@ end
 -- @deprecated awful.tag.withcurrent
 -- @param c The client to tag.
 function tag.withcurrent(c)
-    util.deprecate("Use c:to_selected_tags() instead of awful.tag.selectedlist")
+    gdebug.deprecate("Use c:to_selected_tags() instead of awful.tag.selectedlist", {deprecated_in=4})
 
     -- It can't use c:to_selected_tags() because awful.tag is loaded before
     -- awful.client

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -11,7 +11,6 @@ local os = os
 local assert = assert
 local load = loadstring or load -- luacheck: globals loadstring (compatibility with Lua 5.1)
 local loadfile = loadfile
-local debug = debug
 local pairs = pairs
 local type = type
 local gtable = require("gears.table")
@@ -25,7 +24,7 @@ local capi =
     awesome = awesome,
     mouse = mouse
 }
-local gears_debug = require("gears.debug")
+local gdebug = require("gears.debug")
 local gmath = require("gears.math")
 
 local util = {}
@@ -34,71 +33,32 @@ util.table = {}
 --- The default shell used when spawing processes.
 util.shell = os.getenv("SHELL") or "/bin/sh"
 
-local displayed_deprecations = {}
 --- Display a deprecation notice, but only once per traceback.
+-- @deprecated deprecate
 -- @param[opt] see The message to a new method / function to use.
 -- @tparam table args Extra arguments
 -- @tparam boolean args.raw Print the message as-is without the automatic context
 -- @tparam integer args.deprecated_in Print the message only when Awesome's
 --   version is equal to or greater than deprecated_in.
+-- @see gears.debug
 function util.deprecate(see, args)
-    args = args or {}
-    if args.deprecated_in then
-        local dep_ver = "v" .. tostring(args.deprecated_in)
-        if awesome.version < dep_ver then
-            return
-        end
-    end
-    local tb = debug.traceback()
-    if displayed_deprecations[tb] then
-        return
-    end
-    displayed_deprecations[tb] = true
+    gdebug.deprecate("gears.debug.deprecate", {deprecated_in=5})
 
-    -- Get function name/desc from caller.
-    local info = debug.getinfo(2, "n")
-    local funcname = info.name or "?"
-    local msg = "awful: function " .. funcname .. " is deprecated"
-    if see then
-        if args.raw then
-            msg = see
-        elseif string.sub(see, 1, 3) == 'Use' then
-            msg = msg .. ". " .. see
-        else
-            msg = msg .. ", see " .. see
-        end
-    end
-    gears_debug.print_warning(msg .. ".\n" .. tb)
+    return gdebug.deprecate(see, args)
 end
 
 --- Create a class proxy with deprecation messages.
 -- This is useful when a class has moved somewhere else.
+-- @deprecated deprecate_class
 -- @tparam table fallback The new class
 -- @tparam string old_name The old class name
 -- @tparam string new_name The new class name
 -- @treturn table A proxy class.
+-- @see gears.debug
 function util.deprecate_class(fallback, old_name, new_name)
-    local message = old_name.." has been renamed to "..new_name
+    gdebug.deprecate("gears.debug.deprecate_class", {deprecated_in=5})
 
-    local function call(_,...)
-        util.deprecate(message, {raw = true})
-
-        return fallback(...)
-    end
-
-    local function index(_, k)
-        util.deprecate(message, {raw = true})
-
-        return fallback[k]
-    end
-
-    local function newindex(_, k, v)
-        util.deprecate(message, {raw = true})
-
-        fallback[k] = v
-    end
-
-    return setmetatable({}, {__call = call, __index = index, __newindex  = newindex})
+    return gdebug.deprecate_class(fallback, old_name, new_name)
 end
 
 --- Get a valid color for Pango markup
@@ -108,7 +68,7 @@ end
 -- @treturn string color if it is valid, else fallback.
 -- @see gears.color
 function util.ensure_pango_color(color, fallback)
-    util.deprecate("gears.color.ensure_pango_color")
+    gdebug.deprecate("gears.color.ensure_pango_color", {deprecated_in=5})
 
     return gcolor.ensure_pango_color(color, fallback)
 end
@@ -120,7 +80,7 @@ end
 -- @return An integer in (1, t) or nil if t is less than or equal to zero.
 -- @see gears.math
 function util.cycle(t, i)
-    util.deprecate("gears.math.cycle", {deprecated_in=5})
+    gdebug.deprecate("gears.math.cycle", {deprecated_in=5})
 
     return gmath.cycle(t, i)
 end
@@ -149,7 +109,7 @@ end
 -- @return Escape text.
 -- @see gears.string
 function util.escape(text)
-    util.deprecate("gears.string.xml_escape", {deprecated_in=5})
+    gdebug.deprecate("gears.string.xml_escape", {deprecated_in=5})
 
     return gstring.xml_escape(text)
 end
@@ -160,7 +120,7 @@ end
 -- @return Unescaped text.
 -- @see gears.string
 function util.unescape(text)
-    util.deprecate("gears.string.xml_unescape", {deprecated_in=5})
+    gdebug.deprecate("gears.string.xml_unescape", {deprecated_in=5})
 
     return gstring.xml_unescape(text)
 end
@@ -340,7 +300,7 @@ end
 -- @return A table with all subset.
 -- @see gears.math
 function util.subsets(set)
-    util.deprecate("gears.math.subsets", {deprecated_in=5})
+    gdebug.deprecate("gears.math.subsets", {deprecated_in=5})
 
     return gmath.subsets(set)
 end
@@ -354,7 +314,7 @@ end
 -- @return The index for the rectangle in recttbl closer to cur in the given direction. nil if none found.
 -- @see gears.geometry
 function util.get_rectangle_in_direction(dir, recttbl, cur)
-    util.deprecate("gears.geometry.rectangle.get_in_direction")
+    gdebug.deprecate("gears.geometry.rectangle.get_in_direction", {deprecated_in=4})
 
     return grect.get_in_direction(dir, recttbl, cur)
 end
@@ -366,7 +326,7 @@ end
 -- @return A new table containing all keys from the arguments.
 -- @see gears.table
 function util.table.join(...)
-    util.deprecate("gears.table.join", {deprecated_in=5})
+    gdebug.deprecate("gears.table.join", {deprecated_in=5})
 
     return gtable.join(...)
 end
@@ -381,7 +341,7 @@ end
 -- @treturn table t (for convenience)
 -- @see gears.table
 function util.table.crush(t, set, raw)
-    util.deprecate("gears.table.crush", {deprecated_in=5})
+    gdebug.deprecate("gears.table.crush", {deprecated_in=5})
 
     return gtable.crush(t, set, raw)
 end
@@ -398,7 +358,7 @@ end
 -- @treturn table A packed table with all numeric keys
 -- @see gears.table
 function util.table.from_sparse(t)
-    util.deprecate("gears.table.from_sparse", {deprecated_in=5})
+    gdebug.deprecate("gears.table.from_sparse", {deprecated_in=5})
 
     return gtable.from_sparse(t)
 end
@@ -410,7 +370,7 @@ end
 -- @return The key were the item is found, or nil if not found.
 -- @see gears.table
 function util.table.hasitem(t, item)
-    util.deprecate("gears.table.hasitem", {deprecated_in=5})
+    gdebug.deprecate("gears.table.hasitem", {deprecated_in=5})
 
     return gtable.hasitem(t, item)
 end
@@ -423,7 +383,7 @@ end
 -- @return The string with lines wrapped to width.
 -- @see gears.string
 function util.linewrap(text, width, indent)
-    util.deprecate("gears.string.linewrap", {deprecated_in=5})
+    gdebug.deprecate("gears.string.linewrap", {deprecated_in=5})
 
     return gstring.linewrap(text, width, indent)
 end
@@ -434,7 +394,7 @@ end
 -- @treturn int Number of lines.
 -- @see gears.string
 function util.linecount(text)
-    util.deprecate("gears.string.linecount", {deprecated_in=5})
+    gdebug.deprecate("gears.string.linecount", {deprecated_in=5})
 
     return gstring.linecount(text)
 end
@@ -445,7 +405,7 @@ end
 -- @return A table with keys
 -- @see gears.table
 function util.table.keys(t)
-    util.deprecate("gears.table.keys", {deprecated_in=5})
+    gdebug.deprecate("gears.table.keys", {deprecated_in=5})
 
     return gtable.keys(t)
 end
@@ -457,7 +417,7 @@ end
 -- @return A filtered table with keys
 -- @see gears.table
 function util.table.keys_filter(t, ...)
-    util.deprecate("gears.table.keys_filter", {deprecated_in=5})
+    gdebug.deprecate("gears.table.keys_filter", {deprecated_in=5})
 
     return gtable.keys_filter(t, ...)
 end
@@ -468,7 +428,7 @@ end
 -- @return the reversed table
 -- @see gears.table
 function util.table.reverse(t)
-    util.deprecate("gears.table.reverse", {deprecated_in=5})
+    gdebug.deprecate("gears.table.reverse", {deprecated_in=5})
 
     return gtable.reverse(t)
 end
@@ -480,7 +440,7 @@ end
 -- @return a clone of t
 -- @see gears.table
 function util.table.clone(t, deep)
-    util.deprecate("gears.table.clone", {deprecated_in=5})
+    gdebug.deprecate("gears.table.clone", {deprecated_in=5})
 
     return gtable.clone(t, deep)
 end
@@ -496,7 +456,7 @@ end
 -- the table)
 -- @see gears.table
 function util.table.iterate(t, filter, start)
-    util.deprecate("gears.table.iterate", {deprecated_in=5})
+    gdebug.deprecate("gears.table.iterate", {deprecated_in=5})
 
     return gtable.iterate(t, filter, start)
 end
@@ -509,7 +469,7 @@ end
 -- @treturn table Return `t` for convenience
 -- @see gears.table
 function util.table.merge(t, set)
-    util.deprecate("gears.table.merge", {deprecated_in=5})
+    gdebug.deprecate("gears.table.merge", {deprecated_in=5})
 
     return gtable.merge(t, set)
 end
@@ -521,7 +481,7 @@ end
 -- @deprecated util.quote_pattern
 -- @see gears.string
 function util.quote_pattern(s)
-    util.deprecate("gears.string.quote_pattern", {deprecated_in=5})
+    gdebug.deprecate("gears.string.quote_pattern", {deprecated_in=5})
 
     return gstring.quote_pattern(s)
 end
@@ -531,7 +491,7 @@ end
 -- @deprecated util.query_to_pattern
 -- @see gears.string
 function util.query_to_pattern(q)
-    util.deprecate("gears.string.query_to_pattern", {deprecated_in=5})
+    gdebug.deprecate("gears.string.query_to_pattern", {deprecated_in=5})
 
     return gstring.query_to_pattern(q)
 end
@@ -542,7 +502,7 @@ end
 -- @treturn integer
 -- @see gears.math
 function util.round(x)
-    util.deprecate("gears.math.round", {deprecated_in=5})
+    gdebug.deprecate("gears.math.round", {deprecated_in=5})
 
     return gmath.round(x)
 end

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -20,7 +20,7 @@ local ipairs = ipairs
 local error = error
 local wibox = require("wibox")
 local beautiful = require("beautiful")
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 local placement = require("awful.placement")
 
 local function get_screen(s)
@@ -256,7 +256,7 @@ end
 -- @deprecated awful.wibar.get_position
 -- @return The wibox position.
 function awfulwibar.get_position(wb)
-    util.deprecate("Use wb:get_position() instead of awful.wibar.get_position")
+    gdebug.deprecate("Use wb:get_position() instead of awful.wibar.get_position", {deprecated_in=4})
     return get_position(wb)
 end
 
@@ -266,7 +266,7 @@ end
 -- @param screen This argument is deprecated, use wb.screen directly.
 -- @deprecated awful.wibar.set_position
 function awfulwibar.set_position(wb, position, screen) --luacheck: no unused args
-    util.deprecate("Use wb:set_position(position) instead of awful.wibar.set_position")
+    gdebug.deprecate("Use wb:set_position(position) instead of awful.wibar.set_position", {deprecated_in=4})
 
     set_position(wb, position)
 end
@@ -282,8 +282,9 @@ end
 -- @see awful.placement
 -- @deprecated awful.wibar.attach
 function awfulwibar.attach(wb, position, screen) --luacheck: no unused args
-    util.deprecate("awful.wibar.attach is deprecated, use the 'attach' property"..
-        " of awful.placement. This method doesn't do anything anymore"
+    gdebug.deprecate("awful.wibar.attach is deprecated, use the 'attach' property"..
+        " of awful.placement. This method doesn't do anything anymore",
+        {deprecated_in=4}
     )
 end
 
@@ -311,12 +312,12 @@ end
 -- @see awful.placement.align
 function awfulwibar.align(wb, align, screen) --luacheck: no unused args
     if align == "center" then
-        util.deprecate("awful.wibar.align(wb, 'center' is deprecated, use 'centered'")
+        gdebug.deprecate("awful.wibar.align(wb, 'center' is deprecated, use 'centered'", {deprecated_in=4})
         align = "centered"
     end
 
     if screen then
-        util.deprecate("awful.wibar.align 'screen' argument is deprecated")
+        gdebug.deprecate("awful.wibar.align 'screen' argument is deprecated", {deprecated_in=4})
     end
 
     if placement[align] then

--- a/lib/awful/wibox.lua
+++ b/lib/awful/wibox.lua
@@ -5,8 +5,8 @@
 -- @copyright 2016 Emmanuel Lepage Vallee
 -- @module awful.wibox
 ---------------------------------------------------------------------------
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(require("awful.wibar"), "awful.wibox", "awful.wibar")
+return gdebug.deprecate_class(require("awful.wibar"), "awful.wibox", "awful.wibar")
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/awful/widget/graph.lua
+++ b/lib/awful/widget/graph.lua
@@ -5,9 +5,9 @@
 -- @copyright 2009 Julien Danjou
 -- @classmod awful.widget.graph
 ---------------------------------------------------------------------------
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.widget.graph"),
     "awful.widget.graph",
     "wibox.widget.graph"

--- a/lib/awful/widget/progressbar.lua
+++ b/lib/awful/widget/progressbar.lua
@@ -5,9 +5,9 @@
 -- @copyright 2009 Julien Danjou
 -- @classmod awful.widget.progressbar
 ---------------------------------------------------------------------------
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.widget.progressbar"),
     "awful.widget.progressbar",
     "wibox.widget.progressbar"

--- a/lib/awful/widget/textclock.lua
+++ b/lib/awful/widget/textclock.lua
@@ -5,9 +5,9 @@
 -- @copyright 2008-2009 Julien Danjou
 -- @classmod awful.widget.textclock
 ---------------------------------------------------------------------------
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.widget.textclock"),
     "awful.widget.textclock",
     "wibox.widget.textclock"

--- a/lib/gears/object.lua
+++ b/lib/gears/object.lua
@@ -41,7 +41,8 @@ local function find_signal(obj, name)
 end
 
 function object.add_signal()
-    require("awful.util").deprecate("Use signals without explicitly adding them. This is now done implicitly.")
+    require("gears.debug").deprecate("Use signals without explicitly adding them. This is now done implicitly.",
+                                     {deprecated_in=4})
 end
 
 --- Connect to a signal.

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -12,14 +12,13 @@ local table = table
 local ipairs = ipairs
 local string = string
 local screen = screen
-local awful_util = require("awful.util")
 local gfs = require("gears.filesystem")
 local theme = require("beautiful")
 local lgi = require("lgi")
 local gio = lgi.Gio
 local glib = lgi.GLib
 local wibox = require("wibox")
-local debug = require("gears.debug")
+local gdebug = require("gears.debug")
 local protected_call = require("gears.protected_call")
 local gstring = require("gears.string")
 
@@ -259,14 +258,14 @@ function utils.parse_dir(dir_path, callback)
         local query = gio.FILE_ATTRIBUTE_STANDARD_NAME .. "," .. gio.FILE_ATTRIBUTE_STANDARD_TYPE
         local enum, err = f:async_enumerate_children(query, gio.FileQueryInfoFlags.NONE)
         if not enum then
-            debug.print_error(err)
+            gdebug.print_error(err)
             return
         end
         local files_per_call = 100 -- Actual value is not that important
         while true do
             local list, enum_err = enum:async_next_files(files_per_call)
             if enum_err then
-                debug.print_error(enum_err)
+                gdebug.print_error(enum_err)
                 return
             end
             for _, info in ipairs(list) do
@@ -296,7 +295,7 @@ function utils.parse_dir(dir_path, callback)
 end
 
 function utils.compute_textbox_width(textbox, s)
-    awful_util.deprecate("Use 'width, _ = textbox:get_preferred_size(s)' directly.")
+    gdebug.deprecate("Use 'width, _ = textbox:get_preferred_size(s)' directly.", {deprecated_in=4})
     s = screen[s or mouse.screen]
     local w, _ = textbox:get_preferred_size(s)
     return w

--- a/lib/wibox/layout/constraint.lua
+++ b/lib/wibox/layout/constraint.lua
@@ -6,9 +6,9 @@
 -- @classmod wibox.layout.constraint
 ---------------------------------------------------------------------------
 
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.container.constraint"),
     "wibox.layout.constraint",
     "wibox.container.constraint"

--- a/lib/wibox/layout/margin.lua
+++ b/lib/wibox/layout/margin.lua
@@ -6,9 +6,9 @@
 -- @classmod wibox.layout.margin
 ---------------------------------------------------------------------------
 
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.container.margin"),
     "wibox.layout.margin",
     "wibox.container.margin"

--- a/lib/wibox/layout/mirror.lua
+++ b/lib/wibox/layout/mirror.lua
@@ -6,9 +6,9 @@
 -- @classmod wibox.layout.mirror
 ---------------------------------------------------------------------------
 
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.container.mirror"),
     "wibox.layout.mirror",
     "wibox.container.mirror"

--- a/lib/wibox/layout/rotate.lua
+++ b/lib/wibox/layout/rotate.lua
@@ -6,9 +6,9 @@
 -- @classmod wibox.layout.rotate
 ---------------------------------------------------------------------------
 
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.container.rotate"),
     "wibox.layout.rotate",
     "wibox.container.rotate"

--- a/lib/wibox/layout/scroll.lua
+++ b/lib/wibox/layout/scroll.lua
@@ -5,9 +5,9 @@
 -- @copyright 2015 Uli Schlachter
 -- @classmod wibox.layout.scroll
 ---------------------------------------------------------------------------
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.container.scroll"),
     "wibox.layout.scroll",
     "wibox.container.scroll"

--- a/lib/wibox/widget/background.lua
+++ b/lib/wibox/widget/background.lua
@@ -5,9 +5,9 @@
 -- @copyright 2010 Uli Schlachter
 -- @classmod wibox.widget.background
 ---------------------------------------------------------------------------
-local util = require("awful.util")
+local gdebug = require("gears.debug")
 
-return util.deprecate_class(
+return gdebug.deprecate_class(
     require("wibox.container.background"),
     "wibox.widget.background",
     "wibox.container.background"

--- a/lib/wibox/widget/progressbar.lua
+++ b/lib/wibox/widget/progressbar.lua
@@ -23,7 +23,7 @@
 local setmetatable = setmetatable
 local ipairs = ipairs
 local math = math
-local util =  require("awful.util")
+local gdebug =  require("gears.debug")
 local base = require("wibox.widget.base")
 local color = require("gears.color")
 local beautiful = require("beautiful")
@@ -391,7 +391,7 @@ end
 -- @param height The height to set.
 -- @deprecated set_height
 function progressbar:set_height(height)
-    util.deprecate("Use a `wibox.container.constraint` widget or `forced_height`")
+    gdebug.deprecate("Use a `wibox.container.constraint` widget or `forced_height`", {deprecated_in=4})
     self:set_forced_height(height)
 end
 
@@ -401,7 +401,7 @@ end
 -- @param width The width to set.
 -- @deprecated set_width
 function progressbar:set_width(width)
-    util.deprecate("Use a `wibox.container.constraint` widget or `forced_width`")
+    gdebug.deprecate("Use a `wibox.container.constraint` widget or `forced_width`", {deprecated_in=4})
     self:set_forced_width(width)
 end
 
@@ -417,7 +417,7 @@ for _, prop in ipairs(properties) do
 end
 
 function progressbar:set_vertical(value) --luacheck: no unused_args
-    util.deprecate("Use a `wibox.container.rotate` widget")
+    gdebug.deprecate("Use a `wibox.container.rotate` widget", {deprecated_in=4})
 end
 
 


### PR DESCRIPTION
Change all awful.util function calls to gears.debug function calls

For #1549 

This leaves the old functions there with deprecation warnings while redirecting to the new gears functions.

Note: It's fun to see deprecate is deprecated. :grin: