### PR TITLE
Remove obsolete entries from check_for_invalid_requires.lua

### DIFF
--- a/build-utils/check_for_invalid_requires.lua
+++ b/build-utils/check_for_invalid_requires.lua
@@ -48,11 +48,6 @@ local allowed_deps = {
         wibox = true,
     },
     -- TODO: Get rid of these
-    ["beautiful.xresources"] = { ["awful.util"] = true },
-    ["gears.object"]         = { ["awful.util"] = true },
-    ["wibox.container"]      = { ["awful.util"] = true },
-    ["wibox.layout"]         = { ["awful.util"] = true },
-    ["wibox.widget"]         = { ["awful.util"] = true },
     ["gears.surface"]        = { ["wibox.hierarchy"] = true },
 }
 

--- a/lib/wibox/layout/align.lua
+++ b/lib/wibox/layout/align.lua
@@ -10,6 +10,7 @@ local table = table
 local pairs = pairs
 local type = type
 local floor = math.floor
+local gtable = require("gears.table")
 local base = require("wibox.widget.base")
 
 local align = {}
@@ -185,9 +186,7 @@ end
 -- @property children
 
 function align:get_children()
-    error("This function does not work and also did not work before this error() was added") -- TODO: fix
-    -- TODO: There never was awful.util.from_sparse
-    --return util.from_sparse {self._private.first, self._private.second, self._private.third}
+    return gtable.from_sparse {self._private.first, self._private.second, self._private.third}
 end
 
 function align:set_children(children)

--- a/lib/wibox/layout/align.lua
+++ b/lib/wibox/layout/align.lua
@@ -10,7 +10,6 @@ local table = table
 local pairs = pairs
 local type = type
 local floor = math.floor
-local util = require("awful.util")
 local base = require("wibox.widget.base")
 
 local align = {}
@@ -186,7 +185,9 @@ end
 -- @property children
 
 function align:get_children()
-    return util.from_sparse {self._private.first, self._private.second, self._private.third}
+    error("This function does not work and also did not work before this error() was added") -- TODO: fix
+    -- TODO: There never was awful.util.from_sparse
+    --return util.from_sparse {self._private.first, self._private.second, self._private.third}
 end
 
 function align:set_children(children)


### PR DESCRIPTION
Most of the entries that are marked as "TODO: Get rid of these" were
handled. wibox.layout.align:get_children() never worked (it always
called a non-existent function), so we can easily fix this entry without
introducing a regression.

I opened https://github.com/awesomeWM/awesome/issues/1672 to track the
underlying problem behind the broken :get_children() function (which is
missing test coverage).

Signed-off-by: Uli Schlachter <psychon@znc.in>