### PR TITLE
Asynchronously update the keyboard state

### DIFF
--- a/event.h
+++ b/event.h
@@ -42,9 +42,13 @@ void client_destroy_later(void);
 /* objects/screen.c */
 void screen_refresh(void);
 
+/* xkb.c */
+void xkb_refresh(void);
+
 static inline int
 awesome_refresh(void)
 {
+    xkb_refresh();
     screen_refresh();
     luaA_emit_refresh();
     drawin_refresh();

--- a/globalconf.h
+++ b/globalconf.h
@@ -186,6 +186,12 @@ typedef struct
     struct xkb_context *xkb_ctx;
     /* xkb state of dead keys on keyboard */
     struct xkb_state *xkb_state;
+    /* Do we have a pending reload? */
+    bool xkb_reload_keymap;
+    /* Do we have a pending map change? */
+    bool xkb_map_changed;
+    /* Do we have a pending group change? */
+    bool xkb_group_changed;
     /** The preferred size of client icons for this screen */
     uint32_t preferred_icon_size;
     /** Cached wallpaper information */

--- a/tests/test-keyboard-layout-changes.lua
+++ b/tests/test-keyboard-layout-changes.lua
@@ -1,0 +1,29 @@
+-- Test for bug #1494: Using xmodmap freezes awesome since it re-queries the
+-- keyboard layout many, many times. (xmodmap applies each change on its own)
+
+local runner = require("_runner")
+local spawn = require("awful.spawn")
+local GLib = require("lgi").GLib
+
+local done
+local timer = GLib.Timer()
+
+local steps = {
+    function(count)
+        if count == 1 then
+            -- POSIX allows us to use awk
+            local cmd = "awk 'BEGIN { for(i=1; i<=1000;i++) print \"keycode 107 = parenleft\" }' | xmodmap -"
+            spawn.easy_async({"sh", "-c", cmd}, function()
+                awesome.sync()
+                done = true
+            end)
+        end
+        if done then
+            -- Apply some limit on how long awesome may need to process 'things'
+            return timer:elapsed() < 5
+        end
+    end
+}
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/xkb.h
+++ b/xkb.h
@@ -26,6 +26,7 @@
 #include <lua.h>
 
 void event_handle_xkb_notify(xcb_generic_event_t* event);
+void xkb_refresh(void);
 void xkb_init(void);
 void xkb_free(void);
 


### PR DESCRIPTION
When the keyboard layout is modified via xmodmap, each single "change"
(line of input to xmodmap) causes an "the keyboard configuration
changed"-event to be sent. Awesome reacted to each of these events by
reloading the keyboard layout. Thus, awesome reloaded the keyboard
layout a lot and appeared to freeze.

Fix this by asynchronously update the keyboard state: When such an event
comes in, instead of reloading things immediately, we set a flag which
makes us update the state at the end of the main loop iteration. This
means that many events still cause only a single (or at least few)
re-quering of the layout. Thus, a lot of time is saved.

This commit removes the argument to the (undocumented!) signal
xkb::group_changed. Previously, the argument was the active group
number. Since this argument was unused and I'm lazy, I just removed it.
The alternative would be that it might be visible to Lua that some "the
active group changed"-events are dropped.

Fixes: https://github.com/awesomeWM/awesome/issues/1494
Signed-off-by: Uli Schlachter <psychon@znc.in>


P.S.: The new test takes 20 seconds here without the fix. Since the test runner does not allow a test step to take that long, the test fails. Thus, this new test is testing "is awesome finishing in the time allowed by the test runner?".