### PR TITLE
Fix travis package list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
   # Install build dependencies.
   # See also `apt-cache showsrc awesome | grep -E '^(Version|Build-Depends)'`.
-  - sudo apt-get install -y libcairo2-dev gtk+3.0 xmlto asciidoc libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
+  - sudo apt-get install -y libcairo2-dev gir1.2-gtk-3.0 xmlto asciidoc libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
 
   # Deps for functional tests.
   - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb


### PR DESCRIPTION
The entry "gtk+3.0" caused the following to happen:

  Note, selecting 'libcanberra-gtk3-0-dbg' for regex 'gtk+3.0'
  Note, selecting 'monodoc-gtk3.0-manual' for regex 'gtk+3.0'
  Note, selecting 'libgtk3.0-cil' for regex 'gtk+3.0'
  Note, selecting 'libavahi-ui-gtk3-0' for regex 'gtk+3.0'
  Note, selecting 'libwxgtk3.0-0-dbg' for regex 'gtk+3.0'
  Note, selecting 'libseed-gtk3-0' for regex 'gtk+3.0'
  Note, selecting 'libgtk3.0-cil-dev' for regex 'gtk+3.0'
  Note, selecting 'libcanberra-gtk3-0' for regex 'gtk+3.0'
  Note, selecting 'libinfgtk3-0.5-0' for regex 'gtk+3.0'
  Note, selecting 'libwxgtk3.0-0' for regex 'gtk+3.0'
  Note, selecting 'gir1.2-dbusmenu-gtk3-0.4' for regex 'gtk+3.0'
  Note, selecting 'libwxgtk3.0-dev' for regex 'gtk+3.0'

This was clearly not intended. Fix this by using gir1.2-gtk-3.0 instead,
which is what we actually want (GObject introspection data for GTK 3).

This pretty much reverts commit 30a527fcfd1bdc5f4dce7c662d9647dacccf7b1.

Signed-off-by: Uli Schlachter <psychon@znc.in>