### PR TITLE
Speed up tests/run.sh on Travis

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -210,7 +210,7 @@ for f in $tests; do
     DISPLAY=$D "$AWESOME_CLIENT" 2>&1 < "$f"
 
     # Tail the log and quit, when awesome quits.
-    tail -n 100000 -f --pid "$awesome_pid" "$awesome_log"
+    tail -n 100000 -s 0.1 -f --pid "$awesome_pid" "$awesome_log"
 
     set +e
     wait $awesome_pid


### PR DESCRIPTION
tests/run.sh waits for awesome to exit via tail's "--pid" option. This
makes tail check once per second if the process still exists and if not,
tail will exit. However, the default of "once per second" causes lots of
wasted time for us.

This commit adds the argument "-s 0.1" to tail which makes tail check
once every 0.1 seconds. This commit changes the time that "tests/run.sh"
runs on Travis from about 60 seconds to about 35 seconds, which is a big
improvement.

Closes: https://github.com/awesomeWM/awesome/issues/1374
Signed-off-by: Uli Schlachter <psychon@znc.in>