### PR TITLE
Fix some deprecated calls in code and docs

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -43,7 +43,7 @@ end
 -- {{{ Variable definitions
 -- @DOC_LOAD_THEME@
 -- Themes define colours, icons, font and wallpapers.
-beautiful.init(awful.util.get_themes_dir() .. "default/theme.lua")
+beautiful.init(gears.filesystem.get_themes_dir() .. "default/theme.lua")
 
 -- @DOC_DEFAULT_APPLICATIONS@
 -- This is used later as the default terminal and editor to run.

--- a/docs/90-FAQ.md
+++ b/docs/90-FAQ.md
@@ -176,16 +176,16 @@ You can ensure no application ever starts maximized in the first rule of your
 
 ### How to move and resize floaters with the keyboard?
 
-You can use the `awful.client.moveresize` function. The following `clientkeys`
+You can use the `client:relative_move` function. The following `clientkeys`
 example will move floaters with "Mod4 + Arrow keys" and resize them with "Mod4 +
 PgUP/DN" keys:
 
-    awful.key({ modkey }, "Next",  function () awful.client.moveresize( 20,  20, -40, -40) end),
-    awful.key({ modkey }, "Prior", function () awful.client.moveresize(-20, -20,  40,  40) end),
-    awful.key({ modkey }, "Down",  function () awful.client.moveresize(  0,  20,   0,   0) end),
-    awful.key({ modkey }, "Up",    function () awful.client.moveresize(  0, -20,   0,   0) end),
-    awful.key({ modkey }, "Left",  function () awful.client.moveresize(-20,   0,   0,   0) end),
-    awful.key({ modkey }, "Right", function () awful.client.moveresize( 20,   0,   0,   0) end),
+    awful.key({ modkey }, "Next",  function (c) c:relative_move( 20,  20, -40, -40) end),
+    awful.key({ modkey }, "Prior", function (c) c:relative_move(-20, -20,  40,  40) end),
+    awful.key({ modkey }, "Down",  function (c) c:relative_move(  0,  20,   0,   0) end),
+    awful.key({ modkey }, "Up",    function (c) c:relative_move(  0, -20,   0,   0) end),
+    awful.key({ modkey }, "Left",  function (c) c:relative_move(-20,   0,   0,   0) end),
+    awful.key({ modkey }, "Right", function (c) c:relative_move( 20,   0,   0,   0) end),
 
 #### How to resize tiled clients?
 
@@ -247,7 +247,7 @@ You can use the format `#XYZ` for keycodes in your bindings. The following
 example shows a mapped multimedia/extra key, that's why the modifier is not
 present (but it could be):
 
-    awful.key({}, "#160", function () awful.util.spawn("kscreenlocker --forcelock") end),
+    awful.key({}, "#160", function () awful.spawn("kscreenlocker --forcelock") end),
 
 ### How to add a keyboard layout switcher?
 

--- a/keygrabber.c
+++ b/keygrabber.c
@@ -126,10 +126,10 @@ keygrabber_handlekpress(lua_State *L, xcb_key_press_event_t *e)
  *       keygrabber.run(function(mod, key, event)
  *         if event == "release" then return end
  *
- *         if     key == 'Up'   then awful.client.moveresize(0, 0, 0, 5, c)
- *         elseif key == 'Down' then awful.client.moveresize(0, 0, 0, -5, c)
- *         elseif key == 'Right' then awful.client.moveresize(0, 0, 5, 0, c)
- *         elseif key == 'Left'  then awful.client.moveresize(0, 0, -5, 0, c)
+ *         if     key == 'Up'   then c:relative_move(0, 0, 0, 5)
+ *         elseif key == 'Down' then c:relative_move(0, 0, 0, -5)
+ *         elseif key == 'Right' then c:relative_move(0, 0, 5, 0)
+ *         elseif key == 'Left'  then c:relative_move(0, 0, -5, 0)
  *         else   keygrabber.stop()
  *         end
  *       end)

--- a/lib/awful/keygrabber.lua
+++ b/lib/awful/keygrabber.lua
@@ -70,10 +70,10 @@ end
 --   local grabber = awful.keygrabber.run(function(mod, key, event)
 --     if event == "release" then return end
 --
---     if     key == 'Up'    then awful.client.moveresize(0, 0, 0, 5, c)
---     elseif key == 'Down'  then awful.client.moveresize(0, 0, 0, -5, c)
---     elseif key == 'Right' then awful.client.moveresize(0, 0, 5, 0, c)
---     elseif key == 'Left'  then awful.client.moveresize(0, 0, -5, 0, c)
+--     if     key == 'Up'    then c:relative_move(0, 0, 0, 5)
+--     elseif key == 'Down'  then c:relative_move(0, 0, 0, -5)
+--     elseif key == 'Right' then c:relative_move(0, 0, 5, 0)
+--     elseif key == 'Left'  then c:relative_move(0, 0, -5, 0)
 --     else   awful.keygrabber.stop(grabber)
 --     end
 --   end)

--- a/tests/_runner.lua
+++ b/tests/_runner.lua
@@ -71,7 +71,7 @@ runner.run_steps = function(steps)
             end
 
         elseif result == false then
-            io.stderr:write("Step "..step_as_string.." failed (returned false).")
+            io.stderr:write("Step "..step_as_string.." failed (returned false).\n")
             if not runner.quit_awesome_on_error then
                 io.stderr:write("Keeping awesome open...\n")
                 return


### PR DESCRIPTION
Add missing newline in test runner

---

* Missed changing `awful.util.get_themes_dir` in `rc.lua` to `gears.filesystem.get_themes_dir`
* Updating `90-FAQ` to not use deprecated calls
* Updating `keygrabber` comments to not use deprecated calls
* Add missing newline in tests `_runner`