### PR TITLE
Remove deprecated calls in tests

### DIFF
--- a/lib/awful/widget/clienticon.lua
+++ b/lib/awful/widget/clienticon.lua
@@ -5,7 +5,7 @@
 
 local base = require("wibox.widget.base")
 local surface = require("gears.surface")
-local util = require("awful.util")
+local gtable = require("gears.table")
 
 local clienticon = {}
 local instances = setmetatable({}, { __mode = "k" })
@@ -87,7 +87,7 @@ end
 local function new(c)
     local ret = base.make_widget(nil, nil, {enable_properties = true})
 
-    util.table.crush(ret, clienticon, true)
+    gtable.crush(ret, clienticon, true)
 
     ret._private.client = c
 

--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -33,19 +33,19 @@ local steps = {
             -- awful.client.jumpto(c)
             -- assert(client.focus == c)
 
-            -- Test moveresize
+            -- Test relative_move
             c.size_hints_honor = false
             c:geometry {x=0,y=0,width=50,height=50}
             c:relative_move( 100, 100, 50, 50 )
             for _,v in pairs(c:geometry()) do
                 assert(v == 100)
             end
-            awful.client.moveresize(-25, -25, -25, -25, c )
+            c:relative_move(-25, -25, -25, -25)
             for _,v in pairs(c:geometry()) do
                 assert(v == 75)
             end
 
-            -- Test movetotag
+            -- Test move_to_tag
 
             local t  = mouse.screen.tags[1]
             local t2 = mouse.screen.tags[2]
@@ -54,22 +54,22 @@ local steps = {
             assert(c:tags()[1] == t)
             c:move_to_tag(t2)
             assert(c:tags()[1] == t2)
-            awful.client.movetotag(t, c)
+            c:move_to_tag(t)
             assert(c:tags()[1] == t)
 
-            -- Test toggletag
+            -- Test toggle_tag
 
             c:tags{t}
             c:toggle_tag(t2)
             assert(c:tags()[1] == t2 or c:tags()[2] == t2)
-            awful.client.toggletag(t2, c)
+            c:toggle_tag(t2)
             assert(c:tags()[1] == t and c:tags()[1] ~= t2 and c:tags()[2] == nil)
 
             -- Test floating
             assert(c.floating ~= nil and type(c.floating) == "boolean")
             c.floating = true
-            assert(awful.client.floating.get(c))
-            awful.client.floating.set(c, false)
+            assert(c.floating)
+            c.floating = false
             assert(not c.floating)
 
             return true

--- a/tests/test-awful-screen.lua
+++ b/tests/test-awful-screen.lua
@@ -27,12 +27,12 @@ local steps = {
             end
             assert(counter == 4)
 
-            awful.screen.padding(s, {
-                                 left   = 1337,
-                                 right  = 1337,
-                                 top    = 1337,
-                                 bottom = 1337,
-                             })
+            s.padding = {
+                            left   = 1337,
+                            right  = 1337,
+                            top    = 1337,
+                            bottom = 1337,
+                        }
             counter = 0
             for _, v in pairs(s.padding) do
                 assert(v == 1337)
@@ -41,7 +41,7 @@ local steps = {
             assert(counter == 4)
 
             counter = 0
-            for _, v in pairs(awful.screen.padding(s)) do
+            for _, v in pairs(s.padding) do
                 assert(v == 1337)
                 counter = counter + 1
             end
@@ -49,8 +49,6 @@ local steps = {
 
             -- Test square distance
             assert(s:get_square_distance(9999, 9999))
-            assert(s:get_square_distance(9999, 9999)
-                       == awful.screen.getdistance_sq(s, 9999, 9999))
 
             -- Test count
             counter = 0

--- a/tests/test-awful-tag.lua
+++ b/tests/test-awful-tag.lua
@@ -40,7 +40,7 @@ local steps = {
 
             check_order()
 
-            awful.tag.move(5, tags[7])
+            tags[7].index = 5
             assert(tags[7].index == 5)
 
             check_order()
@@ -54,7 +54,7 @@ local steps = {
 
             check_order()
 
-            awful.tag.swap(tags[1], tags[3])
+            tags[3]:swap(tags[1])
 
             assert(tags[3].index == 3)
             assert(tags[1].index == 1)


### PR DESCRIPTION
Cleans up deprecated messages when running `tests/run.sh`