### PR TITLE
Ignore MappingNotify events

### DIFF
--- a/event.c
+++ b/event.c
@@ -919,16 +919,6 @@ event_handle_clientmessage(xcb_client_message_event_t *ev)
         ewmh_process_client_message(ev);
 }
 
-/** The keymap change notify event handler.
- * \param ev The event.
- */
-static void
-event_handle_mappingnotify(xcb_mapping_notify_event_t *ev)
-{
-    /* Since we use XKB, we shouldn't get this event */
-    warn("Unexpected MappingNotify of type %d", ev->request);
-}
-
 static void
 event_handle_reparentnotify(xcb_reparent_notify_event_t *ev)
 {
@@ -1049,7 +1039,6 @@ void event_handle(xcb_generic_event_t *event)
         EVENT(XCB_KEY_PRESS, event_handle_key);
         EVENT(XCB_KEY_RELEASE, event_handle_key);
         EVENT(XCB_LEAVE_NOTIFY, event_handle_leavenotify);
-        EVENT(XCB_MAPPING_NOTIFY, event_handle_mappingnotify);
         EVENT(XCB_MAP_REQUEST, event_handle_maprequest);
         EVENT(XCB_MOTION_NOTIFY, event_handle_motionnotify);
         EVENT(XCB_PROPERTY_NOTIFY, property_handle_propertynotify);


### PR DESCRIPTION
All we do with MappingNotify events is to print a warning. This is
because the XKB protocol specification says (§12.4):

     Once a client requests XkbMapNotify events, the server stops
     sending it MappingNotify events to inform it of keyboard changes.

However, as our test-keyboard-layout-changes.lua test shows, this is not
actually what happens. Instead, we seem to be getting both XkbMapNotify
and MappingNotify events.

Thus, just drop this print-a-warning-code.

Signed-off-by: Uli Schlachter <psychon@znc.in>