### PR TITLE
Make the output of the gears.object.signal example stable

### DIFF
--- a/tests/examples/text/gears/object/signal.lua
+++ b/tests/examples/text/gears/object/signal.lua
@@ -2,10 +2,10 @@ local gears = require("gears") --DOC_HIDE
 
 local o = gears.object{}
 
--- Add a __tostring metamethod for prettier output
-getmetatable(o).__tostring = function()
-    return "[obj]"
-end
+-- Add a __tostring metamethod for prettier output --DOC_HIDE
+getmetatable(o).__tostring = function() --DOC_HIDE
+    return "[obj]" --DOC_HIDE
+end --DOC_HIDE
 
 -- Function can be attached to signals
 local function slot(obj, a, b, c)

--- a/tests/examples/text/gears/object/signal.lua
+++ b/tests/examples/text/gears/object/signal.lua
@@ -2,6 +2,11 @@ local gears = require("gears") --DOC_HIDE
 
 local o = gears.object{}
 
+-- Add a __tostring metamethod for prettier output
+getmetatable(o).__tostring = function()
+    return "[obj]"
+end
+
 -- Function can be attached to signals
 local function slot(obj, a, b, c)
     print("In slot", obj, a, b, c)


### PR DESCRIPTION
Previously it would print a table which would include the memory
location where the table was stored. Thus, this produces a different
result on every build.

Signed-off-by: Uli Schlachter <psychon@znc.in>