### PR TITLE
Add support for debugging signals

### DIFF
--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -287,13 +287,22 @@ luaA_object_emit_signal(lua_State *L, int oud,
         int nbfunc = sigfound->sigfuncs.len;
         luaL_checkstack(L, nbfunc + nargs + 2, "too much signal");
 
-        const char *objname = lua_tostring(L, oud_abs);
-        debug("Emitting signal '%s' on %s (%d funcs)", name, objname, nbfunc);
+        /* if( name != "refresh" ) { */
+            const char *objname = lua_tostring(L, oud_abs);
+            debug("Emitting signal '%s' on %s (%d funcs)", name, objname, nbfunc);
+            luaA_dumpstack(L);
+        /* } */
 
         /* Push all functions and then execute, because this list can change
          * while executing funcs. */
         foreach(func, sigfound->sigfuncs)
             luaA_object_push_item(L, oud_abs, *func);
+
+        /* lua_pushvalue(L, oud_abs); */
+        /* lua_class = luaA_class_get(L, oud_abs); */
+        /* luaA_object_tostring_idx(L, oud_abs); */
+        /* const char *objname = lua_tostring(L, -1); */
+        /* lua_pop(L, 1); */
 
         for(int i = 0; i < nbfunc; i++)
         {

--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -242,6 +242,7 @@ signal_object_emit(lua_State *L, signal_array_t *arr, const char *name, int narg
         foreach(func, sigfound->sigfuncs)
             luaA_object_push(L, *func);
 
+        debug("Emitting class signal '%s' (%d funcs)", name, nbfunc);
         for(int i = 0; i < nbfunc; i++)
         {
             /* push all args */
@@ -285,6 +286,10 @@ luaA_object_emit_signal(lua_State *L, int oud,
     {
         int nbfunc = sigfound->sigfuncs.len;
         luaL_checkstack(L, nbfunc + nargs + 2, "too much signal");
+
+        const char *objname = lua_tostring(L, oud_abs);
+        debug("Emitting signal '%s' on %s (%d funcs)", name, objname, nbfunc);
+
         /* Push all functions and then execute, because this list can change
          * while executing funcs. */
         foreach(func, sigfound->sigfuncs)

--- a/common/util.c
+++ b/common/util.c
@@ -73,6 +73,19 @@ _warn(int line, const char *fct, const char *fmt, ...)
     fprintf(stderr, "\n");
 }
 
+/** Print debug message on stderr.
+ */
+void
+_debug(int line, const char *fct, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "D: awesome: %s:%d: ", fct, line);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, "\n");
+}
+
 /** \brief safe limited strcpy.
  *
  * Copies at most min(<tt>n-1</tt>, \c l) characters from \c src into \c dst,

--- a/common/util.h
+++ b/common/util.h
@@ -321,6 +321,12 @@ void _warn(int, const char *, const char *, ...)
 
 const char *a_current_time_str(void);
 
+#define debug(string, ...) _debug(__LINE__, \
+                                 __FUNCTION__, \
+                                 string, ## __VA_ARGS__)
+void _debug(int, const char *, const char *, ...)
+    __attribute__ ((format(printf, 3, 4)));
+
 void a_exec(const char *);
 
 #endif

--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -223,6 +223,7 @@ end
 local delayed_calls = {}
 capi.awesome.connect_signal("refresh", function()
     for _, callback in ipairs(delayed_calls) do
+        print("D: awesome: delayed_call: " .. tostring(callback[1]))
         protected_call(unpack(callback))
     end
     delayed_calls = {}


### PR DESCRIPTION
This is #129, rebased.

Re-opening (which could not be done for the initial PR), since I've used this to debug some 100% CPU loop in awesome's `refresh`.

I think we should provide a way to easily enable this somehow.

There has not been much discussion/review on https://github.com/awesomeWM/awesome/pull/129, but please look at it before reviewing.