### PR TITLE
WIP: Setting c.maximized now also sets max_vert/horz

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -2008,7 +2008,7 @@ void
 client_set_maximized(lua_State *L, int cidx, bool s)
 {
     return client_set_maximized_common(
-        L, cidx, s, "maximized", CLIENT_MAXIMIZED_BOTH
+        L, cidx, s, "maximized", CLIENT_MAXIMIZED_BOTH | CLIENT_MAXIMIZED_H | CLIENT_MAXIMIZED_V
     );
 }
 


### PR DESCRIPTION
Today at 4 AM someone on IRC once again had the problem "Chrome is maximized, but toggling its maximization status does not change anything" (aka "Our current handling of maximized/maximized_vertical/maximized_horizontal is confusing and wrong"). Here is a minimal patch attempting to change this.
Testing done: None
Fixes: #1599 (I think...??)