### PR TITLE
naughty get_offset() bug fix and some notification object change

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -546,7 +546,7 @@ function naughty.notify(args)
         beautiful.notification_margin
     local opacity = args.opacity or preset.opacity or
         beautiful.notification_opacity
-    local notification = { screen = s, destroy_cb = destroy_cb, timeout = timeout }
+    local notification = { screen = s, destroy_cb = destroy_cb, timeout = timeout, actions = actions }
 
     -- replace notification if needed
     if args.replaces_id then
@@ -583,6 +583,7 @@ function naughty.notify(args)
             die(naughty.notificationClosedReason.dismissedByUser)
         end
     end
+    notification.run = run
 
     local hover_destroy = function ()
         if hover_timeout == 0 then

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -274,7 +274,7 @@ local function get_offset(s, position, idx, width, height)
     if position:match("left") then
         v.x = ws.x + naughty.config.padding
     elseif position:match("middle") then
-        v.x = (ws.width / 2) - (width / 2)
+        v.x = ws.x + (ws.width / 2) - (width / 2)
     else
         v.x = ws.x + ws.width - (width + naughty.config.padding)
     end


### PR DESCRIPTION
get_offset() function returned incorrect values for multi-monitor configurations and notification position set to "*_middle". 

Also i think it's a good idea to save actions and run function into notificaiton object, so users can call this actions from keyboard shortcuts (like in dunst).