### PR TITLE
Add timezone option for textclock widget

### DIFF
--- a/lib/wibox/widget/textclock.lua
+++ b/lib/wibox/widget/textclock.lua
@@ -10,7 +10,9 @@ local setmetatable = setmetatable
 local os = os
 local textbox = require("wibox.widget.textbox")
 local timer = require("gears.timer")
-local DateTime = require("lgi").GLib.DateTime
+local glib = require("lgi").GLib
+local DateTime = glib.DateTime
+local TimeZone = glib.TimeZone
 
 local textclock = { mt = {} }
 
@@ -24,16 +26,18 @@ end
 --
 -- @tparam[opt=" %a %b %d, %H:%M "] string format The time format.
 -- @tparam[opt=60] number timeout How often update the time (in seconds).
+-- @tparam[opt] string timezone The timezone to display, or localtime if nil.
 -- @treturn table A textbox widget.
 -- @function wibox.widget.textclock
-function textclock.new(format, timeout)
+function textclock.new(format, timeout, timezone)
     format = format or " %a %b %d, %H:%M "
     timeout = timeout or 60
+    timezone = timezone and TimeZone.new(timezone) or TimeZone.new_local()
 
     local w = textbox()
     local t
     function w._private.textclock_update_cb()
-        w:set_markup(DateTime.new_now_local():format(format))
+        w:set_markup(DateTime.new_now(timezone):format(format))
         t.timeout = calc_timeout(timeout)
         t:again()
         return true -- Continue the timer

--- a/lib/wibox/widget/textclock.lua
+++ b/lib/wibox/widget/textclock.lua
@@ -26,7 +26,9 @@ end
 --
 -- @tparam[opt=" %a %b %d, %H:%M "] string format The time format.
 -- @tparam[opt=60] number timeout How often update the time (in seconds).
--- @tparam[opt] string timezone The timezone to display, or localtime if nil.
+-- @tparam[opt=local timezone] string timezone The timezone to use,
+--   e.g. "Z" for UTC, "±hh:mm" or "Europe/Amsterdam". See
+--   https://developer.gnome.org/glib/stable/glib-GTimeZone.html#g-time-zone-new.
 -- @treturn table A textbox widget.
 -- @function wibox.widget.textclock
 function textclock.new(format, timeout, timezone)


### PR DESCRIPTION
This pull request replaces https://github.com/awesomeWM/awesome/pull/1742 with code from a [comment](https://github.com/awesomeWM/awesome/pull/1742#issuecomment-295765755) by @psychon support any timezone instead of just UTC.

In awesome 3.x textclock widget used `os.date` which allowed you to start the format with `!` to use UTC time. In 4.x it now uses `GLib.DateTime` which has its own function to get the time in UTC.

This change adds a third parameter "timezone" to the textclock widget that is
optional. Defaults to local timezone if nil.
