### PR TITLE
Fix recursive enterleave ignore

### DIFF
--- a/banning.c
+++ b/banning.c
@@ -52,8 +52,6 @@ banning_refresh(void)
 
     globalconf.need_lazy_banning = false;
 
-    client_ignore_enterleave_events();
-
     foreach(c, globalconf.clients)
         if(client_isvisible(*c))
             client_unban(*c);
@@ -63,8 +61,6 @@ banning_refresh(void)
     foreach(c, globalconf.clients)
         if(!client_isvisible(*c))
             client_ban(*c);
-
-    client_restore_enterleave_events();
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/client.c
+++ b/objects/client.c
@@ -1059,7 +1059,9 @@ client_ban(client_t *c)
 {
     if(!c->isbanned)
     {
+        client_ignore_enterleave_events();
         xcb_unmap_window(globalconf.connection, c->frame_window);
+        client_restore_enterleave_events();
 
         c->isbanned = true;
 
@@ -2130,7 +2132,9 @@ client_unban(client_t *c)
     lua_State *L = globalconf_get_lua_State();
     if(c->isbanned)
     {
+        client_ignore_enterleave_events();
         xcb_map_window(globalconf.connection, c->frame_window);
+        client_restore_enterleave_events();
 
         c->isbanned = false;
 


### PR DESCRIPTION
Every call to client_ignore_enterleave_events() must be paired with a
following call to client_restore_enterleave_events(). In between these
two calls, no other calls to client_ignore_enterleave_events() is
allowed.

The code in banning_refresh() sometimes broke these rules. This can
happen because the code causes signals to be emitted and Lua code can do
basically anything.

Fix this by moving the calls into the called functions.

Fixes: https://github.com/awesomeWM/awesome/issues/1746
Signed-off-by: Uli Schlachter <psychon@znc.in>

(Memo to myself: Don't mention that this does not have a regression test because then someone will make me write one and I do not have the time right now)