### PR TITLE
Fix maximize again

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -364,11 +364,27 @@ function ewmh.merge_maximization(c, context, hints)
     end
 end
 
+--- Allow the client to move itself.
+--
+-- This is the default geometry request handler when the context is `ewmh`.
+--
+-- @signalhandler awful.ewmh.client_geometry_requests
+-- @tparam client c The client
+-- @tparam string context The context
+-- @tparam[opt={}] table hints The hints to pass to the handler
+function ewmh.client_geometry_requests(c, context, hints)
+    if context == "ewmh" and hints then
+        c:geometry(hints)
+    end
+end
+
+
 client.connect_signal("request::activate", ewmh.activate)
 client.connect_signal("request::tag", ewmh.tag)
 client.connect_signal("request::urgent", ewmh.urgent)
 client.connect_signal("request::geometry", ewmh.geometry)
 client.connect_signal("request::geometry", ewmh.merge_maximization)
+client.connect_signal("request::geometry", ewmh.client_geometry_requests)
 client.connect_signal("property::border_width", repair_geometry)
 client.connect_signal("property::screen", repair_geometry)
 screen.connect_signal("property::workarea", function(s)

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -9,6 +9,7 @@
 local client = client
 local screen = screen
 local ipairs = ipairs
+local timer = require("gears.timer")
 local gtable = require("gears.table")
 local aclient = require("awful.client")
 local aplace = require("awful.placement")
@@ -247,10 +248,6 @@ local context_mapper = {
 function ewmh.geometry(c, context, hints)
     local layout = c.screen.selected_tag and c.screen.selected_tag.layout or nil
 
-    --TODO handle `client_maximize_horizontal` and `client_maximize_vertical`
-    -- so the clients can request being maximized. Currently they can set the
-    -- atom, but it is ignored.
-
     -- Setting the geometry will not work unless the client is floating.
     if (not c.floating) and (not layout == asuit.floating) then
         return
@@ -306,10 +303,72 @@ function ewmh.geometry(c, context, hints)
     end
 end
 
+--- Merge the 2 requests sent by clients wanting to be maximized.
+--
+-- The X clients set 2 flags (atoms) when they want to be maximized. This caused
+-- 2 request::geometry to be sent. This code gives some time for them to arrive
+-- and send a new `request::geometry` (through the property change) with the
+-- combined state.
+--
+-- @signalhandler awful.ewmh.merge_maximization
+-- @tparam client c The client
+-- @tparam string context The context
+-- @tparam[opt={}] table hints The hints to pass to the handler
+function ewmh.merge_maximization(c, context, hints)
+    if context ~= "client_maximize_horizontal" and context ~= "client_maximize_vertical" then
+        return
+    end
+
+    if not c._delay_maximization then
+        c._delay_maximization = function()
+            -- This ignores unlikely corner cases like mismatching toggles.
+            -- That's likely to be an accident anyway.
+            if c._delayed_max_h and c._delayed_max_v then
+                c.maximized = c._delayed_max_h or c._delayed_max_v
+            elseif c._delayed_max_h then
+                c.maximized_horizontal = c._delayed_max_h
+            elseif c._delayed_max_v then
+                c.maximized_vertical = c._delayed_max_v
+            end
+        end
+
+        timer {
+            timeout     = 1/60,
+            autostart   = true,
+            single_shot = true,
+            callback    = function()
+                if not c.valid then return end
+
+                c._delay_maximization(c)
+                c._delay_maximization = nil
+                c._delayed_max_h = nil
+                c._delayed_max_v = nil
+            end
+        }
+    end
+
+    local function get_value(suffix, long_suffix)
+        if hints.toggle and c["_delayed_max_"..suffix] ~= nil then
+            return not c["_delayed_max_"..suffix]
+        elseif hints.toggle then
+            return not c["maximized_"..long_suffix]
+        else
+            return hints.status
+        end
+    end
+
+    if context == "client_maximize_horizontal" then
+        c._delayed_max_h = get_value("h", "horizontal")
+    elseif context == "client_maximize_vertical" then
+        c._delayed_max_v = get_value("v", "vertical")
+    end
+end
+
 client.connect_signal("request::activate", ewmh.activate)
 client.connect_signal("request::tag", ewmh.tag)
 client.connect_signal("request::urgent", ewmh.urgent)
 client.connect_signal("request::geometry", ewmh.geometry)
+client.connect_signal("request::geometry", ewmh.merge_maximization)
 client.connect_signal("property::border_width", repair_geometry)
 client.connect_signal("property::screen", repair_geometry)
 screen.connect_signal("property::workarea", function(s)

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -247,6 +247,10 @@ local context_mapper = {
 function ewmh.geometry(c, context, hints)
     local layout = c.screen.selected_tag and c.screen.selected_tag.layout or nil
 
+    --TODO handle `client_maximize_horizontal` and `client_maximize_vertical`
+    -- so the clients can request being maximized. Currently they can set the
+    -- atom, but it is ignored.
+
     -- Setting the geometry will not work unless the client is floating.
     if (not c.floating) and (not layout == asuit.floating) then
         return

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -40,6 +40,11 @@ local function open_window(class, title, options)
     if options.maximize_after then
         window:maximize()
     end
+    if options.resize_after_width and options.resize_after_height then
+       window:resize(
+           tonumber(options.resize_after_width), tonumber(options.resize_after_height)
+       )
+    end
 end
 
 local function parse_options(options)
@@ -136,10 +141,20 @@ return function(class, title, sn_rules, callback, resize_increment, args)
     if args.maximize_after then
         options = options .. "maximize_after,"
     end
+    if args.resize then
+        options = table.concat {
+            options,
+            "resize_after_width=",
+            args.resize.height, ",",
+            "resize_after_height=",
+            args.resize.width, ","
+        }
+    end
     if args.gravity then
         assert(type(args.gravity)=="number","Use `lgi.Gdk.Gravity.NORTH_WEST`")
         options = options .. "gravity=" .. args.gravity .. ","
     end
+
     local data = class .. "\n" .. title .. "\n" .. options .. "\n"
     local success, msg = pipe:write_all(data)
     assert(success, tostring(msg))

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -32,8 +32,14 @@ local function open_window(class, title, options)
         }
         window:set_geometry_hints(nil, geom, Gdk.WindowHints.RESIZE_INC)
     end
+    if options.maximize_before then
+        window:maximize()
+    end
     window:set_wmclass(class, class)
     window:show_all()
+    if options.maximize_after then
+        window:maximize()
+    end
 end
 
 local function parse_options(options)
@@ -123,6 +129,12 @@ return function(class, title, sn_rules, callback, resize_increment, args)
     end
     if resize_increment then
         options = options .. "resize_increment,"
+    end
+    if args.maximize_before then
+        options = options .. "maximize_before,"
+    end
+    if args.maximize_after then
+        options = options .. "maximize_after,"
     end
     if args.gravity then
         assert(type(args.gravity)=="number","Use `lgi.Gdk.Gravity.NORTH_WEST`")

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -12,6 +12,17 @@ end
 
 local original_geo = nil
 
+local counter = 0
+
+local function geometry_handler(c, context, hints)
+    hints = hints or {}
+    assert(type(c) == "client")
+    assert(type(context) == "string")
+    assert(type(hints.toggle) == "boolean")
+    assert(type(hints.status) == "boolean")
+    counter = counter + 1
+end
+
 local steps = {
     function(count)
         if count == 1 then
@@ -141,6 +152,72 @@ local steps = {
 
         assert(geo_to_str(original_geo) == geo_to_str(new_geo),
             geo_to_str(original_geo) .. " == " .. geo_to_str(new_geo))
+
+        c:kill()
+
+        return true
+    end,
+    -- Now, start some clients maximized
+    function()
+        if #client.get() > 0 then return end
+
+        test_client(nil,nil,nil,nil,nil,{maximize_before=true})
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        if not c then return end
+
+        assert(not c.maximized_horizontal)
+        assert(not c.maximized_vertical)
+        assert(c.maximized)
+
+        c:kill()
+
+        return true
+    end,
+    function()
+        if #client.get() > 0 then return end
+
+        test_client(nil,nil,nil,nil,nil,{maximize_after=true})
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        if not c then return end
+
+        assert(not c.maximized_horizontal)
+        assert(not c.maximized_vertical)
+
+        -- It might happen in the second try
+        if not c.maximized then return end
+
+        c:kill()
+
+        return true
+    end,
+    function()
+        if #client.get() > 0 then return end
+
+        -- Remove the default handler and replace it with a testing one
+        -- **WARNING**, add test **BEFORE** this function if you want them
+        -- to be relevant.
+        client.disconnect_signal("request::geometry", awful.ewmh.geometry)
+        client.disconnect_signal("request::geometry", awful.ewmh.merge_maximization)
+        client.connect_signal("request::geometry", geometry_handler)
+
+        test_client(nil,nil,nil,nil,nil,{maximize_after=true})
+
+        return true
+    end,
+    function()
+        local c = client.get()[1]
+
+        if not c or counter ~= 2 then return end
 
         return true
     end

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -203,8 +203,28 @@ local steps = {
     function()
         if #client.get() > 0 then return end
 
-        -- Remove the default handler and replace it with a testing one
-        -- **WARNING**, add test **BEFORE** this function if you want them
+        -- Test if resizing requests work
+        test_client(nil,nil,nil,nil,nil,{resize={width=400, height=400}})
+
+        return true
+    end,
+    function()
+        if #client.get() ~= 1 then return end
+
+        local c = client.get()[1]
+        local _, size = c:titlebar_top()
+
+        if c.width ~= 400 or c.height ~= 400+size then return end
+
+        c:kill()
+
+        return true
+    end,
+    function()
+        if #client.get() > 0 then return end
+
+        -- Remove the default handler and replace it with a testing one.
+        -- **WARNING**: add tests **BEFORE** this function if you want them
         -- to be relevant.
         client.disconnect_signal("request::geometry", awful.ewmh.geometry)
         client.disconnect_signal("request::geometry", awful.ewmh.merge_maximization)


### PR DESCRIPTION
Fix 2 bugs, introduce a lesser one.

Prevent `max_h` and `max_v` to be set by the atoms and bypass the safeguards. <s>Also starts to ignore requests *from the clients* after `manage` has been called.</s> There is some `request::geometry` signals if the user want to honor them, but it's their problem, not mine.