### PR TITLE
Don't call gears.wallpaper.maximized with function

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -178,8 +178,9 @@ local function set_wallpaper(s)
         -- If wallpaper is a function, call it with the screen
         if type(wallpaper) == "function" then
             wallpaper = wallpaper(s)
+        else
+            gears.wallpaper.maximized(wallpaper, s, true)
         end
-        gears.wallpaper.maximized(wallpaper, s, true)
     end
 end
 


### PR DESCRIPTION
If theme.wallpaper is a function, call it, but don't call gears.maximized.wallpaper with it.

Fixes #1749