### PR TITLE
Fix fullscreen clients with gravity != NorthWest

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -292,17 +292,10 @@ function ewmh.geometry(c, context, hints)
 
         if original_context == "fullscreen" and beautiful.fullscreen_hide_border ~= false then
             props.ignore_border_width = true
+            props.zap_border_width = true
         end
 
         aplace[context](c, props)
-
-        -- Remove the border to get a "real" fullscreen.
-        if original_context == "fullscreen" and beautiful.fullscreen_hide_border ~= false then
-            local original = repair_geometry_lock
-            repair_geometry_lock = true
-            c.border_width = 0
-            repair_geometry_lock = original
-        end
     end
 end
 

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -295,7 +295,10 @@ function ewmh.geometry(c, context, hints)
             props.zap_border_width = true
         end
 
+        local original = repair_geometry_lock
+        repair_geometry_lock = true
         aplace[context](c, props)
+        repair_geometry_lock = original
     end
 end
 

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -352,6 +352,9 @@ end
 -- @treturn The drawin's area.
 area_common = function(d, new_geo, ignore_border_width, args)
     -- The C side expect no arguments, nil isn't valid
+    if new_geo and args.zap_border_width then
+        d.border_width = 0
+    end
     local geometry = new_geo and d:geometry(new_geo) or d:geometry()
     local border = ignore_border_width and 0 or d.border_width or 0
 


### PR DESCRIPTION
Once upon a time, 4b9584fdb14fc3 already fixed this problem: We have to
set the border width to zero before applying the new geometry to the
client, because changing the border width makes the client move
according to its gravity.

Then came e54387904b16e3 and made this code use awful.placement instead
of just fullscreening the client itself (without explaining why in the
commit message!). After this commit, the border width was just ignored
and left as-is. This was then fixed in 0bf8bb6a64638dec0e (no idea which
callback the commit message refers to, the old code was basically just
c.border_width=0, c:geometry(screen_geo)). However, now the border width
was again changed after the geometry and the bug that was fixed by
4b9584fdb14fc3 was back.

This commit fixes this regression again by making sure that the border
width is set to zero before the geometry is set. This becomes slightly
more complicated, because now it is also awful.placement's job to
restore the old border width.

This is why this commit adds a new option to awful.placement so that it
sets the border width to zero after creating its memento of the old
border width.

Fixes: https://github.com/awesomeWM/awesome/issues/1607
Signed-off-by: Uli Schlachter <psychon@znc.in>


No idea how this PR related to https://github.com/awesomeWM/awesome/pull/1608, but that might be because I am not even sure what that PR tries to do. Also, I don't understand `awful.placement` and even needed some minutes just to figure out where it calls `c:geometry()`. Thus requesting review by @Elv13 to see which part of `awful.placement` I am misunderstanding that would make it possible to do this a lot nicer...