### PR TITLE
Fix the keyboardlayout widget for a single layout

### DIFF
--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -118,7 +118,9 @@ local function update_status (self)
     self._current = awesome.xkb_get_layout_group();
     local text = ""
     if (#self._layout > 0) then
-        text = (" " .. self._layout[self._current] .. " ")
+        -- Please note that the group number reported by xkb_get_layout_group
+        -- is lower by one than the group numbers reported by xkb_get_group_names.
+        text = (" " .. self._layout[self._current+1] .. " ")
     end
     self.widget:set_text(text)
 end
@@ -238,13 +240,10 @@ local function update_layout(self)
         return
     end
     if #layouts == 1 then
-        layouts[1].group_idx = 0
+        layouts[1].group_idx = 1
     end
     for _, v in ipairs(layouts) do
-        local layout_name = self.layout_name(v)
-        -- Please note that numbers of groups reported by xkb_get_group_names
-        -- is greater by one than the real group number.
-        self._layout[v.group_idx - 1] = layout_name
+        self._layout[v.group_idx] = self.layout_name(v)
     end
     update_status(self)
 end


### PR DESCRIPTION
Currently, awful's `keyboardlayout` widget doesn't display anything for setups with a single layout in the XKB map.

This is due to the fact that in `keyboardlayout.update_layout()`, `self._layout` is assigned at index `-1` and so `#self._layout == 0` in `keyboardlayout.update_status()`.
The fix consists in working the other way around: fill `self._layout` from index `1` so that `#self._layout` returns the actual length, and adjust `self._current` by `1` when indexing `self._layout`.

This behavior seems more consistent, and I think it makes more sense for the widget to always display the current layout. The user can always disable/remove the widget if he/she only uses a single layout and doesn't want to have it displayed in the wibar.