### PR TITLE
Drop our use of iconv

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -160,43 +160,6 @@ endforeach()
 # Do it again, but this time with the CFLAGS/LDFLAGS
 pkg_check_modules(AWESOME_REQUIRED REQUIRED ${AWESOME_DEPENDENCIES})
 
-# On Mac OS X and FreeBSD, the executable of Awesome has to be linked against libiconv
-# explicitly.  Unfortunately, libiconv doesn't have its pkg-config file,
-# and CMake doesn't provide a module for looking up the library.  Thus, we
-# have to do everything for ourselves...
-if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-    if(NOT DEFINED AWESOME_ICONV_SEARCH_PATHS)
-        set(AWESOME_ICONV_SEARCH_PATHS /opt/local /opt /usr/local /usr)
-    endif()
-
-    if(NOT DEFINED AWESOME_ICONV_INCLUDE_DIR)
-        find_path(AWESOME_ICONV_INCLUDE_DIR
-                  iconv.h
-                  PATHS ${AWESOME_ICONV_SEARCH_PATHS}
-                  PATH_SUFFIXES include
-                  NO_CMAKE_SYSTEM_PATH)
-    endif()
-
-    if(NOT DEFINED AWESOME_ICONV_LIBRARY_PATH)
-        get_filename_component(AWESOME_ICONV_BASE_DIRECTORY ${AWESOME_ICONV_INCLUDE_DIR} DIRECTORY)
-        find_library(AWESOME_ICONV_LIBRARY_PATH
-                     NAMES iconv
-                     HINTS ${AWESOME_ICONV_BASE_DIRECTORY}
-                     PATH_SUFFIXES lib)
-    endif()
-
-    if(NOT DEFINED AWESOME_ICONV_LIBRARY_PATH)
-        message(FATAL_ERROR "Looking for iconv library - not found.")
-    else()
-        message(STATUS "Looking for iconv library - found: ${AWESOME_ICONV_LIBRARY_PATH}")
-    endif()
-
-    set(AWESOME_REQUIRED_LDFLAGS
-        ${AWESOME_REQUIRED_LDFLAGS} ${AWESOME_ICONV_LIBRARY_PATH})
-    set(AWESOME_REQUIRED_INCLUDE_DIRS
-        ${AWESOME_REQUIRED_INCLUDE_DIRS} ${AWESOME_ICONV_INCLUDE_DIR})
-endif(APPLE OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-
 macro(a_find_library variable library)
     find_library(${variable} ${library})
     if(NOT ${variable})

--- a/draw.h
+++ b/draw.h
@@ -47,29 +47,6 @@ struct area_t
 #define AREA_EQUAL(a, b) ((a).x == (b).x && (a).y == (b).y && \
         (a).width == (b).width && (a).height == (b).height)
 
-bool draw_iso2utf8(const char *, size_t, char **, ssize_t *);
-
-/** Convert a string to UTF-8.
- * \param str The string to convert.
- * \param len The string length.
- * \param dest The destination string that will be allocated.
- * \param dlen The destination string length allocated, can be NULL.
- * \return True if the conversion happened, false otherwise. In both case, dest
- * and dlen will have value and dest have to be free().
- */
-static inline bool
-a_iso2utf8(const char *str, ssize_t len, char **dest, ssize_t *dlen)
-{
-    if(draw_iso2utf8(str, len, dest, dlen))
-        return true;
-
-    *dest = a_strdup(str);
-    if(dlen)
-        *dlen = len;
-
-    return false;
-}
-
 static inline void
 cairo_surface_array_destroy_surface(cairo_surface_t **s)
 {

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -366,7 +366,7 @@ is_client_tagged(client_t *c, tag_t *t)
     return false;
 }
 
-/** Get the index of the tag with focused client or first selected 
+/** Get the index of the tag with focused client or first selected
  * \return Its index
  */
 int
@@ -475,10 +475,9 @@ LUA_OBJECT_EXPORT_PROPERTY(tag, tag_t, activated, lua_pushboolean)
 static int
 luaA_tag_set_name(lua_State *L, tag_t *tag)
 {
-    size_t len;
-    const char *buf = luaL_checklstring(L, -1, &len);
+    const char *buf = luaL_checkstring(L, -1);
     p_delete(&tag->name);
-    a_iso2utf8(buf, len, &tag->name, NULL);
+    tag->name = a_strdup(buf);
     luaA_object_emit_signal(L, -3, "property::name", 0);
     ewmh_update_net_desktop_names();
     return 0;


### PR DESCRIPTION
We were only using this for tag names. This means we are assuming that
everything is UTF8, but tag names are provided in the local locale and
need to be translated into UTF8? That makes no sense, so just drop this.

Fixes: https://github.com/awesomeWM/awesome/issues/1753
Signed-off-by: Uli Schlachter <psychon@znc.in>