### PR TITLE
Stabilize awful.tooltip code coverage

### DIFF
--- a/tests/test-tooltip.lua
+++ b/tests/test-tooltip.lua
@@ -26,7 +26,9 @@ place.centered(mouse)
 local tt = nil
 
 table.insert(steps, function()
-    tt = tooltip {text = "A long tooltip", visible = true}
+    tt = tooltip {text = "short", visible = true}
+    -- This tests changing the text while the tooltip is visible
+    tt:set_text("A long tooltip")
 
     return true
 end)


### PR DESCRIPTION
For a while now we had our code coverage tools tell us that the coverage
for one line of code fluctuated. Sometimes it was being executed and
other times it was not. This is useless noise.

I think what is happening here is that the coverage depends on the order
of iteration over a table. Either the tooltip that is being created was
first made visible and then it text changed, or things happened in the
opposite order.

Fix this by doing this by explicitly changing the tooltip's text while
it is surely visible.

Signed-off-by: Uli Schlachter <psychon@znc.in>