### PR TITLE
Always emit property::floating when needed

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -667,17 +667,38 @@ function client.object.get_floating(c)
         if value ~= nil then
             return value
         end
-        if c.type ~= "normal"
+        return client.property.get(c, "_implicitly_floating") or false
+    end
+end
+
+-- When a client is not explicitly assigned a floating state, it might
+-- implicitly end up being floating. The following makes sure that
+-- property::floating is still emitted if this implicit floating state changes.
+
+local function update_implicitly_floating(c)
+    local explicit = client.property.get(c, "floating")
+    if explicit ~= nil then
+        return
+    end
+    local cur = client.property.get(c, "_implicitly_floating")
+    local new = c.type ~= "normal"
             or c.fullscreen
             or c.maximized_vertical
             or c.maximized_horizontal
             or c.maximized
-            or client.object.is_fixed(c) then
-            return true
-        end
-        return false
+            or client.object.is_fixed(c)
+    if cur ~= new then
+        client.property.set(c, "_implicitly_floating", new)
+        c:emit_signal("property::floating")
     end
 end
+
+capi.client.connect_signal("property::type", update_implicitly_floating)
+capi.client.connect_signal("property::fullscreen", update_implicitly_floating)
+capi.client.connect_signal("property::maximized_vertical", update_implicitly_floating)
+capi.client.connect_signal("property::maximized_horizontal", update_implicitly_floating)
+capi.client.connect_signal("property::maximized", update_implicitly_floating)
+capi.client.connect_signal("property::size_hints", update_implicitly_floating)
 
 --- Toggle the floating state of a client between 'auto' and 'true'.
 -- Use `c.floating = not c.floating`

--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -74,7 +74,41 @@ local steps = {
 
             return true
         end
-    end
+    end,
+
+    -- Test implicitly floating state: Even though a client way not explicitly
+    -- made floating, it could still end up being floating
+    function()
+        local c = client.get()[1]
+        assert(c ~= nil)
+
+        awful.client.property.set(c, "floating", nil)
+        assert(not c.floating)
+        assert(not c.maximized)
+
+        local signal_count = 0
+        c:connect_signal("property::floating", function()
+            signal_count = signal_count + 1
+        end)
+
+        c.maximized = true
+        assert(c.floating)
+        assert(signal_count == 1)
+
+        c.fullscreen = true
+        assert(c.floating)
+        assert(signal_count == 1)
+
+        c.maximized = false
+        assert(c.floating)
+        assert(signal_count == 1)
+
+        c.fullscreen = false
+        assert(c.floating == false)
+        assert(signal_count == 2)
+
+        return true
+    end,
 }
 
 local original_count, c1, c2 = 0


### PR DESCRIPTION
There are some cases where a client's floating state "silently" changes.
For example, a fullscreen client will be considered floating. However,
even though c.floating changes its value in this case, we did not emit
the property::floating signal.

Fix this by explicitly tracking the "implicitly floating" state. When
some property that influences this "implicitly floating" state changes,
we update it and if a client which was not explicitly assigned a
floating state observes a change in this value, property::floating is
emitted.

This was tested by running a terminal and two xeyes in a tag with a
tiling layout where awful.ewmh was patched so that clients do not change
their geometry when fullscreening or maximizing. It was observable that
after this patch e.g. the titlebar and the tasklist update to show the
floating state of the client which became implicitly floating due to
being maximized.

Fixes: https://github.com/awesomeWM/awesome/issues/1662
Signed-off-by: Uli Schlachter <psychon@znc.in>