### PR TITLE
Add & use a non-fatal kind of assert()

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -319,6 +319,12 @@ void _fatal(int, const char *, const char *, ...)
 void _warn(int, const char *, const char *, ...)
     __attribute__ ((format(printf, 3, 4)));
 
+#define check(condition) do { \
+        if (!(condition)) \
+            _warn(__LINE__, __FUNCTION__, \
+                    "Checking assertion failed: " #condition); \
+    } while (0)
+
 const char *a_current_time_str(void);
 
 void a_exec(const char *);

--- a/objects/client.c
+++ b/objects/client.c
@@ -1078,7 +1078,7 @@ client_ban(client_t *c)
 void
 client_ignore_enterleave_events(void)
 {
-    assert(globalconf.pending_enter_leave_begin.sequence == 0);
+    check(globalconf.pending_enter_leave_begin.sequence == 0);
     globalconf.pending_enter_leave_begin = xcb_grab_server(globalconf.connection);
     /* If the connection is broken, we get a request with sequence number 0
      * which would then trigger an assertion in
@@ -1087,7 +1087,7 @@ client_ignore_enterleave_events(void)
     if(xcb_connection_has_error(globalconf.connection))
         fatal("X server connection broke (error %d)",
                 xcb_connection_has_error(globalconf.connection));
-    assert(globalconf.pending_enter_leave_begin.sequence != 0);
+    check(globalconf.pending_enter_leave_begin.sequence != 0);
 }
 
 void
@@ -1095,7 +1095,7 @@ client_restore_enterleave_events(void)
 {
     sequence_pair_t pair;
 
-    assert(globalconf.pending_enter_leave_begin.sequence != 0);
+    check(globalconf.pending_enter_leave_begin.sequence != 0);
     pair.begin = globalconf.pending_enter_leave_begin;
     pair.end = xcb_no_operation(globalconf.connection);
     xcb_ungrab_server(globalconf.connection);

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -566,7 +566,7 @@ screen_scan(void)
         screen_scan_xinerama(L, &globalconf.screens);
     if (globalconf.screens.len == 0)
         screen_scan_x11(L, &globalconf.screens);
-    assert(globalconf.screens.len > 0);
+    check(globalconf.screens.len > 0);
 
     screen_deduplicate(L, &globalconf.screens);
 

--- a/spawn.c
+++ b/spawn.c
@@ -351,7 +351,7 @@ child_exit_callback(GPid pid, gint status, gpointer user_data)
         lua_pushliteral(L, "exit");
         lua_pushinteger(L, WEXITSTATUS(status));
     } else {
-        assert(WIFSIGNALED(status));
+        check(WIFSIGNALED(status));
         lua_pushliteral(L, "signal");
         lua_pushinteger(L, WTERMSIG(status));
     }

--- a/xwindow.c
+++ b/xwindow.c
@@ -308,7 +308,7 @@ xwindow_get_shape(xcb_window_t win, enum xcb_shape_sk_t kind)
             height = extents->bounding_shape_extents_height;
             shaped = extents->bounding_shaped;
         } else {
-            assert(kind == XCB_SHAPE_SK_CLIP);
+            check(kind == XCB_SHAPE_SK_CLIP);
             x = extents->clip_shape_extents_x;
             y = extents->clip_shape_extents_y;
             width = extents->clip_shape_extents_width;


### PR DESCRIPTION
Aborting the process is sometimes a bit harsh for a failed assertion.
This adds a non-fatal assert() macro called "check()" and uses it in
some places where we might be able to survive the error.

Signed-off-by: Uli Schlachter <psychon@znc.in>