### PR TITLE
Some changes to fullscreen tests

### DIFF
--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -16,6 +16,9 @@ local function open_window(class, title, options)
         default_height = 100,
         title          = title
     }
+    if options.gravity then
+        window:set_gravity(tonumber(options.gravity))
+    end
     if options.snid and options.snid ~= "" then
         window:set_startup_id(options.snid)
     end
@@ -106,7 +109,8 @@ local function get_snid(sn_rules, callback)
     return snid
 end
 
-return function(class, title, sn_rules, callback, resize_increment)
+return function(class, title, sn_rules, callback, resize_increment, args)
+    args  = args or {}
     class = class or "test_app"
     title = title or "Awesome test client"
 
@@ -119,6 +123,10 @@ return function(class, title, sn_rules, callback, resize_increment)
     end
     if resize_increment then
         options = options .. "resize_increment,"
+    end
+    if args.gravity then
+        assert(type(args.gravity)=="number","Use `lgi.Gdk.Gravity.NORTH_WEST`")
+        options = options .. "gravity=" .. args.gravity .. ","
     end
     local data = class .. "\n" .. title .. "\n" .. options .. "\n"
     local success, msg = pipe:write_all(data)

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -5,6 +5,11 @@ local awful = require("awful")
 local test_client = require("_client")
 local lgi = require("lgi")
 
+local function geo_to_str(g)
+    return "pos=" .. g.x .. "," .. g.y ..
+        ";size=" .. g.width .. "x" .. g.height
+end
+
 local original_geo = nil
 
 local steps = {
@@ -68,9 +73,8 @@ local steps = {
 
         local new_geo = c:geometry()
 
-        for k,v in pairs(original_geo) do
-            assert(new_geo[k] == v)
-        end
+        assert(geo_to_str(original_geo) == geo_to_str(new_geo),
+            geo_to_str(original_geo) .. " == " .. geo_to_str(new_geo))
 
         c.fullscreen = true
 
@@ -99,9 +103,8 @@ local steps = {
 
         local new_geo = c:geometry()
 
-        for k,v in pairs(original_geo) do
-            assert(new_geo[k] == v)
-        end
+        assert(geo_to_str(original_geo) == geo_to_str(new_geo),
+            geo_to_str(original_geo) .. " == " .. geo_to_str(new_geo))
 
         c.floating  = true
 
@@ -136,9 +139,8 @@ local steps = {
 
         local new_geo = c:geometry()
 
-        for k,v in pairs(original_geo) do
-            assert(new_geo[k] == v)
-        end
+        assert(geo_to_str(original_geo) == geo_to_str(new_geo),
+            geo_to_str(original_geo) .. " == " .. geo_to_str(new_geo))
 
         return true
     end

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -2,13 +2,15 @@
 
 local runner = require("_runner")
 local awful = require("awful")
+local test_client = require("_client")
+local lgi = require("lgi")
 
 local original_geo = nil
 
 local steps = {
     function(count)
         if count == 1 then
-            awful.spawn("xterm")
+            test_client(nil,nil,nil,nil,nil,{gravity=lgi.Gdk.Gravity.NORTH_WEST})
         else
             local c = client.get()[1]
             if c then


### PR DESCRIPTION
This has some commits from https://github.com/awesomeWM/awesome/pull/1748 and it tries to add the missing test case asked for in https://github.com/awesomeWM/awesome/pull/1764#pullrequestreview-36937688.

However, the following diff makes the test fail, because the client's gravity is not restored correctly. Sigh. (Yes, I tested that the following test would have caught the original issue).
```diff
diff --git a/tests/test-maximize.lua b/tests/test-maximize.lua
index 8d5aa711a..184408484 100644
--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -15,7 +15,7 @@ local original_geo = nil
 local steps = {
     function(count)
         if count == 1 then
-            test_client(nil,nil,nil,nil,nil,{gravity=lgi.Gdk.Gravity.NORTH_WEST})
+            test_client(nil,nil,nil,nil,nil,{gravity=lgi.Gdk.Gravity.STATIC}) -- todo: Test all
         else
             local c = client.get()[1]
             if c then
@@ -60,6 +60,12 @@ local steps = {
         c.border_width = test_width
 
         c.fullscreen = true
+
+        -- Test that the client covers the full screen
+        local c_geo = geo_to_str(c:geometry())
+        local s_geo = geo_to_str(c.screen.geometry)
+        assert(c_geo == s_geo, c_geo .. " == " .. s_geo)
+
         c.fullscreen = false
 
         assert(c.border_width == test_width)
```