### PR TITLE
Some changes to our wrapper Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ $(BUILDLN):
 	test -e $(BUILDLN) || ln -s -f ${builddir} $(BUILDLN)
 
 cmake ${builddir}/CMakeCache.txt:
+	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."
+	$(ECHO)
 	mkdir -p ${builddir}
 	$(ECHO) "Running cmake…"
 	cd ${builddir} && cmake $(CMAKE_ARGS) "$(@D)" ..

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: $(TARGETS) ;
 $(TARGETS): cmake-build
 	ln -s -f $(BUILDDIR)/$@ $@
 
-cmake $(BUILDDIR)/CMakeCache.txt:
+$(BUILDDIR)/CMakeCache.txt:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."
 	$(ECHO)
 	mkdir -p $(BUILDDIR)
@@ -36,8 +36,8 @@ distclean:
 	$(RM) -r $(BUILDDIR) $(TARGETS)
 	$(ECHO) " done"
 
-%: cmake
+%: $(BUILDDIR)/CMakeCache.txt
 	$(ECHO) "Running make $@…"
 	$(MAKE) -C $(BUILDDIR) $@
 
-.PHONY: cmake-build cmake install distclean tags
+.PHONY: cmake-build install distclean tags

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-builddir=.build-$(shell hostname)-$(shell gcc -dumpmachine)-$(shell gcc -dumpversion)
-
 ifeq (,$(VERBOSE))
     MAKEFLAGS:=$(MAKEFLAGS)s
     ECHO=echo
@@ -8,42 +6,38 @@ else
 endif
 
 TARGETS=awesome
-BUILDLN=build
+BUILDDIR=build
 
-all: $(TARGETS) $(BUILDLN) ;
+all: $(TARGETS) ;
 
 $(TARGETS): cmake-build
-	ln -s -f ${builddir}/$@ $@
+	ln -s -f $(BUILDDIR)/$@ $@
 
-$(BUILDLN):
-	test -e $(BUILDLN) || ln -s -f ${builddir} $(BUILDLN)
-
-cmake ${builddir}/CMakeCache.txt:
+cmake $(BUILDDIR)/CMakeCache.txt:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."
 	$(ECHO)
-	mkdir -p ${builddir}
+	mkdir -p $(BUILDDIR)
 	$(ECHO) "Running cmake…"
-	cd ${builddir} && cmake $(CMAKE_ARGS) "$(@D)" ..
+	cd $(BUILDDIR) && cmake $(CMAKE_ARGS) "$(@D)" ..
 
-cmake-build: ${builddir}/CMakeCache.txt
+cmake-build: $(BUILDDIR)/CMakeCache.txt
 	$(ECHO) "Building…"
-	$(MAKE) -C ${builddir}
+	$(MAKE) -C $(BUILDDIR)
 
 tags:
 	git ls-files | xargs ctags
 
 install:
 	$(ECHO) "Installing…"
-	$(MAKE) -C ${builddir} install
+	$(MAKE) -C $(BUILDDIR) install
 
 distclean:
 	$(ECHO) -n "Cleaning up build directory…"
-	$(RM) -r ${builddir} $(BUILDLN) $(TARGETS)
+	$(RM) -r $(BUILDDIR) $(TARGETS)
 	$(ECHO) " done"
 
 %: cmake
 	$(ECHO) "Running make $@…"
-	$(MAKE) -C ${builddir} $@
-	$(and $(filter clean,$@),$(RM) $(BUILDLN) $(TARGETS))
+	$(MAKE) -C $(BUILDDIR) $@
 
-.PHONY: cmake-build cmake install distclean $(BUILDLN) tags
+.PHONY: cmake-build cmake install distclean tags


### PR DESCRIPTION
This turns our `Makefile` basically into a no-op and tells people to use CMake directly. People who try in-tree builds will end up having CMake overwrite this Makefile, so it might make sense to remove this completely.

My reasoning from the commit message:

>     To build awesome, just use CMake directly. This change also gets rid of
>    the phenomenon that every time the compiler version changes, a new
>    hidden build directory is created. Sometimes even the "build" symlink
>    got out of sync with the directory that the Makefile used for building.

Also, I don't know of any other CMake-using project that does something like this.

(And another commit ended up in here more or less accidentally and removes a broken recommendation from our README)

Edit: Well, of course this breaks Travis a lot. I'll fix this up, but only after I am "clear to go" and no one was a lot against this.