### PR TITLE
Get rid of broken hint in the readme

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -120,10 +120,6 @@ Then in gdb set any args and run it:
     (gdb) set arg --replace
     (gdb) run
 
-Inside gdb you can use the following to print the current Lua stack traceback:
-
-    (gdb) print luaL_dostring(globalconf.L.real_L_dont_use_directly, "print(debug.traceback())")
-
 ## Reporting issues
 
 Please report any issues you may find on [our bugtracker](https://github.com/awesomeWM/awesome/issues).


### PR DESCRIPTION
luaL_dostring(L, s) is a macro that expands to
luaL_loadstring(L,s)||lua_pcall(L,0,LUA_MULTRET,0). Then,
lua_pcall(L,n,r,f) sometimes (since Lua 5.3?) is a macro that expands to
lua_pcallk(L,n,r,f,0,NULL), but can sometimes also just be a function.

Explaining all the above would make this section more complicated and
apparently no one uses this hint anyway, because no one told us yet that
this hint does not work.

Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

Since #1783 seems to need a while, here is one of its commits which is not all that much related to the rest of the changes.