### PR TITLE
Move gears.surface.widget_to_svg to wibox.widget.draw_to_svg_file (and widget_to_surface to draw_to_image_surface)

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -105,7 +105,6 @@ file = {
         '../lib/awful/startup_notification.lua',
         '../lib/gears/init.lua',
         '../lib/wibox/layout/init.lua',
-        '../lib/wibox/widget/init.lua',
         '../lib/wibox/container/init.lua',
 
         -- Ignore some parts of the widget library

--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -218,6 +218,7 @@ end
 --- Create an SVG file with this widget content.
 -- This is dynamic, so the SVG will be updated along with the widget content.
 -- because of this, the painting may happen hover multiple event loop cycles.
+-- @deprecated wibox.widget.draw_to_svg_file
 -- @tparam widget widget A widget
 -- @tparam string path The output file path
 -- @tparam number width The surface width
@@ -225,6 +226,8 @@ end
 -- @return The cairo surface
 -- @return The hierarchy
 function surface.widget_to_svg(widget, path, width, height)
+    gdebug.deprecate("Use wibox.widget.draw_to_svg_file instead of "..
+        "gears.surface.render_to_svg", {deprecated_in=5})
     local img = cairo.SvgSurface.create(path, width, height)
     local cr = cairo.Context(img)
 
@@ -234,6 +237,7 @@ end
 --- Create a cairo surface with this widget content.
 -- This is dynamic, so the SVG will be updated along with the widget content.
 -- because of this, the painting may happen hover multiple event loop cycles.
+-- @deprecated wibox.widget.draw_to_image_surface
 -- @tparam widget widget A widget
 -- @tparam number width The surface width
 -- @tparam number height The surface height
@@ -241,6 +245,8 @@ end
 -- @return The cairo surface
 -- @return The hierarchy
 function surface.widget_to_surface(widget, width, height, format)
+    gdebug.deprecate("Use wibox.widget.draw_to_image_surface instead of "..
+        "gears.surface.render_to_surface", {deprecated_in=5})
     local img = cairo.ImageSurface(format or cairo.Format.ARGB32, width, height)
     local cr = cairo.Context(img)
 

--- a/lib/wibox/widget/init.lua
+++ b/lib/wibox/widget/init.lua
@@ -3,10 +3,12 @@
 -- @copyright 2010 Uli Schlachter
 -- @classmod wibox.widget
 ---------------------------------------------------------------------------
-local base = require("wibox.widget.base")
 
-return setmetatable({
-    base = base;
+local cairo = require("lgi").cairo
+local hierarchy = require("wibox.hierarchy")
+
+local widget = {
+    base = require("wibox.widget.base");
     textbox = require("wibox.widget.textbox");
     imagebox = require("wibox.widget.imagebox");
     background = require("wibox.widget.background");
@@ -17,6 +19,56 @@ return setmetatable({
     checkbox = require("wibox.widget.checkbox");
     piechart = require("wibox.widget.piechart");
     slider = require("wibox.widget.slider");
-}, {__call = function(_, args) return base.make_widget_declarative(args) end})
+}
+
+setmetatable(widget, {
+    __call = function(_, args)
+        return widget.base.make_widget_declarative(args)
+    end
+})
+
+--- Draw a widget directly to a given cairo context.
+-- This function creates a temporary `wibox.hierarchy` instance and uses that to
+-- draw the given widget once to the given cairo context.
+-- @tparam widget wdg A widget to draw
+-- @tparam cairo_context cr The cairo context to draw the widget on
+-- @tparam number width The width of the widget
+-- @tparam number height The height of the widget
+-- @tparam[opt={dpi=96}] table context The context information to give to the widget.
+function widget.draw_to_cairo_context(wdg, cr, width, height, context)
+    local function no_op() end
+    context = context or {dpi=96}
+    local h = hierarchy.new(context, wdg, width, height, no_op, no_op, {})
+    h:draw(context, cr)
+end
+
+--- Create an SVG file showing this widget.
+-- @tparam widget wdg A widget
+-- @tparam string path The output file path
+-- @tparam number width The surface width
+-- @tparam number height The surface height
+-- @tparam[opt={dpi=96}] table context The context information to give to the widget.
+function widget.draw_to_svg_file(wdg, path, width, height, context)
+    local img = cairo.SvgSurface.create(path, width, height)
+    local cr = cairo.Context(img)
+    widget.draw_to_cairo_context(wdg, cr, width, height, context)
+    img:finish()
+end
+
+--- Create a cairo image surface showing this widget.
+-- @tparam widget wdg A widget
+-- @tparam number width The surface width
+-- @tparam number height The surface height
+-- @param[opt=cairo.Format.ARGB32] format The surface format
+-- @tparam[opt={dpi=96}] table context The context information to give to the widget.
+-- @return The cairo surface
+function widget.draw_to_image_surface(wdg, width, height, format, context)
+    local img = cairo.ImageSurface(format or cairo.Format.ARGB32, width, height)
+    local cr = cairo.Context(img)
+    widget.draw_to_cairo_context(wdg, cr, width, height, context)
+    return img
+end
+
+return widget
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/container/defaults/template.lua
+++ b/tests/examples/wibox/container/defaults/template.lua
@@ -3,7 +3,6 @@ require("_common_template")(...)
 
 local beautiful = require( "beautiful"     )
 local wibox     = require( "wibox"         )
-local surface   = require( "gears.surface" )
 local shape     = require( "gears.shape"   )
 
 -- Let the test request a size and file format
@@ -72,7 +71,6 @@ end
 local f_w, f_h = container:fit({dpi=96}, 9999, 9999)
 
 -- Save to the output file
-local img = surface.widget_to_svg(container, image_path..".svg", f_w, f_h)
-img:finish()
+wibox.widget.draw_to_svg_file(container, image_path..".svg", f_w, f_h)
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/layout/template.lua
+++ b/tests/examples/wibox/layout/template.lua
@@ -2,7 +2,6 @@ local file_path, image_path = ...
 require("_common_template")(...)
 
 local wibox     = require( "wibox"         )
-local surface   = require( "gears.surface" )
 local color     = require( "gears.color"   )
 local beautiful = require( "beautiful"     )
 local unpack    = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
@@ -99,7 +98,6 @@ for _ = 1, 10 do
 end
 
 -- Save to the output file
-local img = surface["widget_to_svg"](widget, image_path..".svg", w or 200, h or 30)
-img:finish()
+wibox.widget.draw_to_svg_file(widget, image_path..".svg", w or 200, h or 30)
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
(This was specifically not pushed to my clone so that @awesome-robot hopefully tells us that this does not change the generated docs)

Edit: The intention of this is to eventually get rid of the dependency `gears.surface -> wibox.hierarchy`, which is not really allowed, but currently we have an exception for it.