### PR TITLE
Collect zombies once at startup

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -636,6 +636,12 @@ main(int argc, char **argv)
         }
     }
 
+    /* Collect any zombies that we inherited. It would be nice if we also
+     * collected zombies at runtime, but that does not really work with glib.
+     */
+    while (waitpid(-1, NULL, WNOHANG) > 0) {
+    }
+
     /* register function for signals */
     g_unix_signal_add(SIGINT, exit_on_signal, NULL);
     g_unix_signal_add(SIGTERM, exit_on_signal, NULL);


### PR DESCRIPTION
When restarting awesome, the new process inherits children processes,
but does not know about them. Thus, it cannot ask glib to inform it
about the children's exit status. This means that when the children
stop, they become zombies that are sitting around for as long as awesome
runs. Over time (with many restarts), such zombies can accumulate and
e.g. fill up the process table.

We cannot do anything about this at runtime (glib doesn't allow us to
catch SIGCHLD and calling waitpid(-1,...) would mean that glib doesn't
get informed when some child that it waits for exits), but at least at
startup we can collect all already-existing zombie children.

This does not really fix the problem, but should make sure that people
who often restart awesome and who also use
awful.spawn.with_line_callback with an exit callback (I think the
problem does not occur without) do not fill up their process table over
time.

Helps-with: https://github.com/awesomeWM/awesome/issues/1193
Signed-off-by: Uli Schlachter <psychon@znc.in>