### PR TITLE
Re-arrange the magnifier layout on focus changes

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -269,6 +269,12 @@ capi.tag.connect_signal("tagged", arrange_tag)
 capi.screen.connect_signal("property::workarea", layout.arrange)
 capi.screen.connect_signal("padding", layout.arrange)
 
+capi.client.connect_signal("focus", function(c)
+    local screen = c.screen
+    if layout.get(screen).need_focus_update then
+        layout.arrange(screen)
+    end
+end)
 capi.client.connect_signal("raised", function(c) layout.arrange(c.screen) end)
 capi.client.connect_signal("lowered", function(c) layout.arrange(c.screen) end)
 capi.client.connect_signal("list", function()

--- a/lib/awful/layout/suit/magnifier.lua
+++ b/lib/awful/layout/suit/magnifier.lua
@@ -146,6 +146,10 @@ end
 
 magnifier.name = "magnifier"
 
+-- This layout handles the currently focused client specially and needs to be
+-- called again when the focus changes.
+magnifier.need_focus_update = true
+
 return magnifier
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Just re-arranging on every focus change would cause useless/needless
re-arranges (which have no effect except to waste CPU time). Thus, this
adds a special (undocumented) flag on layouts that makes sure that a
rearrange occurs when the focus changes.

Fixes: https://github.com/awesomeWM/awesome/issues/1799
Signed-off-by: Uli Schlachter <psychon@znc.in>