### PR TITLE
wibar: Fix with width and height beautiful properties

### DIFF
--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -379,7 +379,8 @@ function awfulwibar.new(arg)
 
     -- Set default size
     if position == "left" or position == "right" then
-        arg.width = arg.width or math.ceil(beautiful.get_font_height(arg.font) * 1.5)
+        arg.width = arg.width or beautiful["wibar_width"]
+            or math.ceil(beautiful.get_font_height(arg.font) * 1.5)
         if arg.height then
             has_to_stretch = false
             if arg.screen then
@@ -390,7 +391,8 @@ function awfulwibar.new(arg)
             end
         end
     else
-        arg.height = arg.height or math.ceil(beautiful.get_font_height(arg.font) * 1.5)
+        arg.height = arg.height or beautiful["wibar_height"]
+            or math.ceil(beautiful.get_font_height(arg.font) * 1.5)
         if arg.width then
             has_to_stretch = false
             if arg.screen then

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -409,7 +409,7 @@ function awfulwibar.new(arg)
     -- The C code scans the table directly, so metatable magic cannot be used.
     for _, prop in ipairs {
         "border_width", "border_color", "font", "opacity", "ontop", "cursor",
-        "height", "width", "bgimage", "bg", "fg", "type", "stretch", "shape"
+        "bgimage", "bg", "fg", "type", "stretch", "shape"
     } do
         if (arg[prop] == nil) and beautiful["wibar_"..prop] ~= nil then
             arg[prop] = beautiful["wibar_"..prop]


### PR DESCRIPTION
There was code that always set the values. The fallback was never
executed.

Fix #1824