### PR TITLE
fix(awful: hotkeys_popup: keys): require all modules in init.lua

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -11,8 +11,9 @@ local beautiful = require("beautiful")
 local naughty = require("naughty")
 local menubar = require("menubar")
 local hotkeys_popup = require("awful.hotkeys_popup").widget
--- Enable VIM help for hotkeys widget when client with matching name is opened:
-require("awful.hotkeys_popup.keys.vim")
+-- Enable hotkeys help widget for VIM and other apps
+-- when client with a matching name is opened:
+require("awful.hotkeys_popup.keys")
 
 -- {{{ Error handling
 -- @DOC_ERROR_HANDLING@

--- a/lib/awful/hotkeys_popup/keys/init.lua
+++ b/lib/awful/hotkeys_popup/keys/init.lua
@@ -10,6 +10,7 @@
 local keys = {
   vim = require("awful.hotkeys_popup.keys.vim"),
   firefox = require("awful.hotkeys_popup.keys.firefox"),
+  tmux = require("awful.hotkeys_popup.keys.tmux"),
   qutebrowser = require("awful.hotkeys_popup.keys.qutebrowser"),
 }
 return keys

--- a/lib/awful/hotkeys_popup/keys/init.lua
+++ b/lib/awful/hotkeys_popup/keys/init.lua
@@ -8,7 +8,9 @@
 
 
 local keys = {
-  vim = require("awful.hotkeys_popup.keys.vim")
+  vim = require("awful.hotkeys_popup.keys.vim"),
+  firefox = require("awful.hotkeys_popup.keys.firefox"),
+  qutebrowser = require("awful.hotkeys_popup.keys.qutebrowser"),
 }
 return keys
 


### PR DESCRIPTION
allows to enable all the available hotkey maps by `require("awful.hotkeys_popup.keys")`