### PR TITLE
Re-add documentation of xproperty API

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -21,9 +21,19 @@
 
 /** awesome core API
  *
+ * Additionally to the classes described here, one can also use X properties as
+ * described in @{xproperties}.
+ *
  * @author Julien Danjou &lt;julien@danjou.info&gt;
  * @copyright 2008-2009 Julien Danjou
  * @module awesome
+ */
+
+/** Register a new xproperty.
+ *
+ * @tparam string name The name of the X11 property.
+ * @tparam string type One of "string", "number" or "boolean".
+ * @function register_xproperty
  */
 
 #define _GNU_SOURCE


### PR DESCRIPTION
The documentation for awesome.register_xproperty, awesome.get_xproperty
and awesome.set_xproperty were lost in commit 26f15a13f3c78babf1. This
commit adds them back.

Fixes: https://github.com/awesomeWM/awesome/issues/1817
Signed-off-by: Uli Schlachter <psychon@znc.in>