### PR TITLE
menubar.icon_theme: Never use nil as icon theme name

### DIFF
--- a/lib/menubar/icon_theme.lua
+++ b/lib/menubar/icon_theme.lua
@@ -70,7 +70,7 @@ local get_default_icon_theme_name = function()
             end
         end
     end
-    return nil
+    return "hicolor"
 end
 
 local icon_theme = { mt = {} }


### PR DESCRIPTION
The return value for this function is used as an index in a table and
Lua does not like nil as an index.

The function that actually looks for icons, find_icon_theme() already
falls back to "hicolor" if it does not find anything via the current
theme, so fix this issue by just falling back to "hicolor" here as well.

Fixes: https://github.com/awesomeWM/awesome/issues/1819
Signed-off-by: Uli Schlachter <psychon@znc.in>