### PR TITLE
Fix documentation of activation filter

### DIFF
--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -120,12 +120,12 @@ end
 -- * **context** (*string*) The activation context.
 -- * **hints** (*table*) Some additional hints (depending on the context)
 --
--- If the callback returns `true`, the client will be activated unless the `force`
--- hint is set. If the callback returns `false`, the activation request is
--- cancelled. If the callback returns `nil`, the previous callback will be
--- executed. This will continue until either a callback handles the request or
--- when it runs out of callbacks. In that case, the request will be granted if
--- the client is visible.
+-- If the callback returns `true`, the client will be activated. If the callback
+-- returns `false`, the activation request is cancelled unless the `force` hint is
+-- set. If the callback returns `nil`, the previous callback will be executed.
+-- This will continue until either a callback handles the request or when it runs
+-- out of callbacks. In that case, the request will be granted if the client is
+-- visible.
 --
 -- For example, to block Firefox from stealing the focus, use:
 --


### PR DESCRIPTION
Previously the `force` hint was described incorrectly. **Please verify that I have understood the code correctly.** I am not sure if the force hint is used correctly in the code because I would expect that the client gets the focus if `ret == false and hints.force`.