### PR TITLE
Add missing awful.widget.common require

### DIFF
--- a/lib/awful/widget/init.lua
+++ b/lib/awful/widget/init.lua
@@ -22,6 +22,7 @@ return
     only_on_screen = require("awful.widget.only_on_screen");
     clienticon = require("awful.widget.clienticon");
     calendar_popup = require("awful.widget.calendar_popup");
+    common = require("awful.widget.common");
 }
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
You currently have to require that module directly. I don't know if this was on purpose, since it's kind of helper methods for other utils, but since it has a public documentation, I would consider it API and would also make it available via `require('awful').widget.common`.