### PR TITLE
tag: Warn when the number of `awful.tag.new` layout is too small.

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -240,11 +240,20 @@ end
 -- @return A table with all created tags.
 function tag.new(names, screen, layout)
     screen = get_screen(screen or 1)
-    local tags = {}
+
+    if layout and layout[1] and #names > #layout then
+        gdebug.print_warning("The number of tags is greater than the number of layouts")
+    end
+
+    local tags, overflow = {}, false
     for id, name in ipairs(names) do
-        table.insert(tags, id, tag.add(name, {screen = screen,
-                                            layout = (layout and layout[id]) or
-                                                        layout}))
+        table.insert(tags, id, tag.add(name, {
+            screen = screen,
+            layout = (layout and layout[id]) or (overflow and layout[1] or layout)
+        }))
+
+        overflow = overflow or (layout and layout[id])
+
         -- Select the first tag.
         if id == 1 then
             tags[id].selected = true


### PR DESCRIPTION
Just a note on how not to fix this:

```
(Julien Danjou      2009-08-21) --- Create a set of tags and attach it to a screen.
(Emmanuel L-V       2016-04-11) -- @function awful.tag.new
(Julien Danjou      2009-08-21) -- @param names The tag name, in a table
(Julien Danjou      2009-08-21) -- @param screen The tag screen, or 1 if not set.
(Zsolt Udvari       2009-10-26) -- @param layout The layout or layout table to set for this tags by default.
(Julien Danjou      2009-08-21) -- @return A table with all created tags.
(Arvydas Sidorenko  2012-06-12) function tag.new(names, screen, layout)
(Uli Schlachter     2016-02-26)     screen = get_screen(screen or 1)
(Julien Danjou      2009-08-21)     local tags = {}
(Julien Danjou      2009-08-21)     for id, name in ipairs(names) do
(Arvydas Sidorenko  2012-06-12)         table.insert(tags, id, tag.add(name, {screen = screen,
(Perry Hargrave     2010-05-28)                                             layout = (layout and layout[id]) or
(Perry Hargrave     2010-05-28)                                                         layout}))
(Julien Danjou      2009-08-21)         -- Select the first tag.
(Julien Danjou      2009-08-21)         if id == 1 then
(Perry Hargrave     2010-05-28)             tags[id].selected = true
(Julien Danjou      2009-08-21)         end
(Julien Danjou      2009-08-21)     end
(Perry Hargrave     2010-05-28) 
(Julien Danjou      2009-08-21)     return tags
(Julien Danjou      2009-08-21) end
```

Note that the code has always been this way. I admit I was also a little shocked the first time I saw it and never used `awful.tag.new` (Tyrannical uses `awful.tag.add`, a saner alternative). However the current behavior needs to "keep working", of course it doesn't mean the bug cannot be fixed, but the code might be a little ugly. The best solution is simply 