### PR TITLE
Make beautiful.foo = bar work properly

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -227,6 +227,10 @@ function beautiful.mt:__index(k)
     return theme[k]
 end
 
+function beautiful.mt:__newindex(k, v)
+    theme[k] = v
+end
+
 -- Set the default font
 set_font("sans 8")
 


### PR DESCRIPTION
Without this, users would modify the beautiful table directly instead of
the theme. This made a difference for code using beautiful.get() to get
the theme.

Reference: https://github.com/awesomeWM/awesome/pull/1854
Signed-off-by: Uli Schlachter <psychon@znc.in>