### PR TITLE
Automatically make LuaRocks modules available in awesome

### DIFF
--- a/build-utils/check_for_invalid_requires.lua
+++ b/build-utils/check_for_invalid_requires.lua
@@ -18,6 +18,9 @@ local allowed_deps = {
     gears = {
         lgi = true,
     },
+    ["gears.require_luarocks"] = {
+        ["*"] = true,
+    },
     beautiful = {
         gears = true,
         lgi = true,

--- a/build-utils/lgi-check.sh
+++ b/build-utils/lgi-check.sh
@@ -25,7 +25,7 @@ die()
 lua -e 'require("lgi")' || die
 
 # Check the version number.
-# Keep this in sync with lib/gears/surface.lua and .travis.yml (LGIVER)!
+# Keep this in sync with lib/gears/init.lua and .travis.yml (LGIVER)!
 lua -e '_, _, major_minor, patch = string.find(require("lgi.version"), "^(%d%.%d)%.(%d)");
 	if tonumber(major_minor) < 0.8 or (tonumber(major_minor) == 0.8 and tonumber(patch) < 0) then
 		error(string.format("lgi is too old, need at least version %s, got %s.",

--- a/lib/gears/init.lua
+++ b/lib/gears/init.lua
@@ -4,6 +4,8 @@
 -- @module gears
 ---------------------------------------------------------------------------
 
+local require_luarocks = require("gears.require_luarocks")
+require_luarocks.require("lgi")
 
 return
 {
@@ -22,6 +24,7 @@ return
     table = require("gears.table");
     string = require("gears.string");
     filesystem = require("gears.filesystem");
+    require_luarocks = require_luarocks;
 }
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/gears/init.lua
+++ b/lib/gears/init.lua
@@ -7,6 +7,12 @@
 local require_luarocks = require("gears.require_luarocks")
 require_luarocks.require("lgi")
 
+-- Keep this in sync with build-utils/lgi-check.sh and .travis.yml (LGIVER)!
+local ver_major, ver_minor, ver_patch = string.match(require_luarocks.require('lgi.version'), '(%d)%.(%d)%.(%d)')
+if tonumber(ver_major) <= 0 and (tonumber(ver_minor) < 8 or (tonumber(ver_minor) == 8 and tonumber(ver_patch) < 0)) then
+    error("lgi too old, need at least version 0.8.0")
+end
+
 return
 {
     color = require("gears.color");

--- a/lib/gears/require_luarocks.lua
+++ b/lib/gears/require_luarocks.lua
@@ -1,0 +1,63 @@
+---------------------------------------------------------------------------
+-- @author Uli Schlachter
+-- @copyright 2017 Uli Schlachter
+-- @module gears.require_luarocks
+---------------------------------------------------------------------------
+
+local require = require
+local io = io
+
+local require_luarocks = {}
+
+local luarocks_set_up = false
+
+--- Make sure that libraries installed through LuaRocks can be require()d.
+-- This function does the equivalent of running `luarocks path` before starting
+-- Lua. If LuaRocks is not installed, this might print an error on stderr.
+function require_luarocks.add_luarocks_path()
+    if luarocks_set_up then
+        return
+    end
+    luarocks_set_up = true
+
+    -- Run the given command and add its output to package[key]
+    local function read_and_add(command, key)
+        -- Using io.popen blocks awesome and is almost always a bad idea,
+        -- because lgi offers better alternatives. Here, we might not have lgi
+        -- yet and so we must resort to popen.
+        local out = io.popen(command)
+        if not out then
+            return
+        end
+        -- Read output and remove trailing newline
+        local result = out:read("*a"):sub(1, -2)
+        out:close()
+        if result ~= "" then
+            package[key] = package[key] .. ";" .. result
+        end
+    end
+    read_and_add("luarocks path --lr-path", "path")
+    read_and_add("luarocks path --lr-cpath", "cpath")
+end
+
+--- Try to load a module and if that fails, try to load it through LuaRocks.
+-- This function works just like Lua's normal `require` function, but calls
+-- @{add_luarocks_path} when needed.
+-- @tparam string module the name of the module to load.
+function require_luarocks.require(module)
+    if luarocks_set_up then
+        return require(module)
+    end
+    local success, result = pcall(require, module)
+    if success then
+        return result
+    end
+    io.stderr:write("Failed to require(\"" .. tostring(module) .. "\"),"
+        .. " checking if this module is available through LuaRocks\n")
+    require_luarocks.add_luarocks_path()
+    return require(module)
+end
+
+return require_luarocks
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -12,12 +12,6 @@ local color = nil
 local gdebug = require("gears.debug")
 local hierarchy = require("wibox.hierarchy")
 
--- Keep this in sync with build-utils/lgi-check.sh!
-local ver_major, ver_minor, ver_patch = string.match(require('lgi.version'), '(%d)%.(%d)%.(%d)')
-if tonumber(ver_major) <= 0 and (tonumber(ver_minor) < 8 or (tonumber(ver_minor) == 8 and tonumber(ver_patch) < 0)) then
-    error("lgi too old, need at least version 0.8.0")
-end
-
 local surface = { mt = {} }
 local surface_cache = setmetatable({}, { __mode = 'v' })
 

--- a/spec/gears/require_luarocks_spec.lua
+++ b/spec/gears/require_luarocks_spec.lua
@@ -1,0 +1,180 @@
+---------------------------------------------------------------------------
+-- @author Uli Schlachter
+-- @copyright 2017 Uli Schlachter
+---------------------------------------------------------------------------
+
+local io_mock
+
+-- Mock require(): It simply returns from require_results, or errors out if
+-- nothing found.
+local require_results = {}
+local own_require = function(module)
+    return assert(require_results[module], "tried to require " .. tostring(module))
+end
+
+local original_path, original_cpath = package.path, package.cpath
+
+describe("gears.require_luarocks", function()
+    local function load_require_luarocks()
+        -- Make sure the module is reloaded and starts in its initial state
+        package.loaded["gears.require_luarocks"] = nil
+
+        -- Replace require and io for the module with our mocks
+        local original_require = require
+        local original_io = io
+        if io_mock then
+            _G.io = io_mock
+        end
+        _G.require = own_require
+
+        local require_luarocks = original_require("gears.require_luarocks")
+
+        _G.io = original_io
+        _G.require = original_require
+
+        return require_luarocks
+    end
+
+    describe("require", function()
+        local wrote_to_stderr
+        before_each(function()
+            wrote_to_stderr = false
+            io_mock = {
+                stderr = {
+                    write = function()
+                        wrote_to_stderr = true
+                    end
+                }
+            }
+        end)
+
+        local called
+        local function mock_add_luarocks_path(require_luarocks)
+            called = false
+            require_luarocks.add_luarocks_path = function()
+                called = true
+            end
+        end
+
+        it("successful require", function()
+            local require_luarocks = load_require_luarocks()
+            mock_add_luarocks_path(require_luarocks)
+
+            local result = {}
+            require_results.foo = result
+            assert.is.equal(result, require_luarocks.require("foo"))
+            assert.is_false(called)
+            assert.is_false(wrote_to_stderr)
+        end)
+
+        it("unsuccessful require", function()
+            local require_luarocks = load_require_luarocks()
+            mock_add_luarocks_path(require_luarocks)
+
+            assert.has_error(function()
+                require_luarocks.require("bar")
+            end)
+            assert.is_true(called)
+            assert.is_true(wrote_to_stderr)
+        end)
+
+        it("successful after add_luarocks_path", function()
+            local require_luarocks = load_require_luarocks()
+
+            local result = {}
+            require_luarocks.add_luarocks_path = function()
+                require_results.baz = result
+                called = true
+            end
+            assert.is.equal(result, require_luarocks.require("baz"))
+            assert.is_true(called)
+            assert.is_true(wrote_to_stderr)
+        end)
+    end)
+
+    describe("add_luarocks_path", function()
+        -- Mock io as needed
+        local popen_results, open_count
+        before_each(function()
+            popen_results = {}
+            open_count = 0
+            io_mock = {
+                popen = function(cmd)
+                    local result = popen_results[cmd]
+                    if result == false then
+                        -- Simulate popen failing
+                        return nil
+                    end
+                    assert(result, "popen(" .. tostring(cmd) .. ") unexpected")
+                    local self
+                    open_count = open_count + 1
+                    self = {
+                        read = function(self2, arg)
+                            assert(self == self2)
+                            assert(arg == "*a", arg)
+                            return result
+                        end,
+                        close = function()
+                            open_count = open_count - 1
+                        end
+                    }
+                    return self
+                end
+            }
+        end)
+
+        after_each(function()
+            package.path = original_path
+            package.cpath = original_cpath
+        end)
+
+        it("with luarocks", function()
+            local require_luarocks = load_require_luarocks()
+
+            -- First time it is called: Should actually do something
+            popen_results["luarocks path --lr-path"] = "lr-path\n"
+            popen_results["luarocks path --lr-cpath"] = "lr-cpath\n"
+            require_luarocks.add_luarocks_path()
+
+            assert.is.equal(original_path .. ";lr-path", package.path)
+            assert.is.equal(original_cpath .. ";lr-cpath", package.cpath)
+            assert.is.equal(0, open_count)
+
+            -- Second time: Should be a no-op
+            popen_results = {}
+            require_luarocks.add_luarocks_path()
+
+            assert.is.equal(original_path .. ";lr-path", package.path)
+            assert.is.equal(original_cpath .. ";lr-cpath", package.cpath)
+            assert.is.equal(0, open_count)
+        end)
+
+        it("without luarocks", function()
+            local require_luarocks = load_require_luarocks()
+
+            -- If LuaRocks is not available: Should do nothing
+            popen_results["luarocks path --lr-path"] = ""
+            popen_results["luarocks path --lr-cpath"] = ""
+            require_luarocks.add_luarocks_path()
+
+            assert.is.equal(original_path, package.path)
+            assert.is.equal(original_cpath, package.cpath)
+            assert.is.equal(0, open_count)
+        end)
+
+        it("popen fails", function()
+            local require_luarocks = load_require_luarocks()
+
+            -- If LuaRocks is not available: Should do nothing
+            popen_results["luarocks path --lr-path"] = false
+            popen_results["luarocks path --lr-cpath"] = false
+            require_luarocks.add_luarocks_path()
+
+            assert.is.equal(original_path, package.path)
+            assert.is.equal(original_cpath, package.cpath)
+            assert.is.equal(0, open_count)
+        end)
+    end)
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The "preferred way" to use LuaRocks is to run `eval $(luarocks path --bin)`, but for a window manager this is a bit hard to do before starting it. Thus, this PR is intended to make this easier to do.

This is WIP since I did not yet actually test if this work, but I just remembered that this is actually easy to do:
In `awesomerc.lua`:
```diff
print(pcall(require, "term"))
print(pcall(require("gears").require_luarocks.require, "term"))
```
Output:
```
false	module 'term' not found:
	no field package.preload['term']
	no file '/usr/share/lua/5.3/term.lua'
	no file '/usr/share/lua/5.3/term/init.lua'
	no file '/usr/lib64/lua/5.3/term.lua'
	no file '/usr/lib64/lua/5.3/term/init.lua'
	no file './term.lua'
	no file './term/init.lua'
	no file 'lib/term.lua'
	no file 'lib/term/init.lua'
	no file '/home/psychon/awesome/tests/term.lua'
	no file '/home/psychon/awesome/tests/term/init.lua'
	no file '/home/psychon/awesome/build/awesome/term.lua'
	no file '/home/psychon/awesome/build/awesome/term/init.lua'
	no file '/etc/xdg/awesome/term.lua'
	no file '/etc/xdg/awesome/term/init.lua'
	no file '/usr/local/share/awesome/lib/term.lua'
	no file '/usr/local/share/awesome/lib/term/init.lua'
	no file '/usr/lib64/lua/5.3/term.so'
	no file '/usr/lib64/lua/5.3/loadall.so'
	no file './term.so'
	no file 'lib/term.so'
	no file '/home/psychon/awesome/tests/term.so'
	no file '/home/psychon/awesome/build/awesome/term.so'
	no file '/etc/xdg/awesome/term.so'
	no file '/usr/local/share/awesome/lib/term.so'
Failed to require("term"), checking if this module is available through LuaRocks
true	table: 0xde01d0
```
Thus, this works just as intended.

----- 

Sigh. While writing the above I looked up `eval $(luarocks path --bin)` and found it here on this page: https://github.com/luarocks/luarocks/wiki/Using-LuaRocks#Multiple_versions_using_the_LuaRocks_package_loader
If you click that link, you are told that LuaRocks make available a `luarocks.loader` package that replaces `require` so that modules found through LuaRocks are found. I tested it and it seems to work just fine. Thus, this whole PR can be replaced with:
```diff
diff --git a/awesomerc.lua b/awesomerc.lua
index 00d1b60..5f31086 100644
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -1,3 +1,7 @@
+-- If LuaRocks is installed, make sure that packages installed through it are
+-- found (e.g. lgi). If LuaRocks is not installed, do nothing.
+pcall(require, "luarocks.loader")
+
 -- @DOC_REQUIRE_SECTION@
 -- Standard awesome library
 local gears = require("gears")
```
So... what now? Opinions on the preferred approach? Can we be sure that the new patch works everywhere where the old patch worked? I can only see reasons why the new patch is better: No `popen`, so less resource intensive. It is a Lua module, so you do not get errors due to version incompatibilities (awesome running with Lua 5.2 and LuaRocks with Lua 5.3 and we mix modules for the two).

-----

CC  @hishamhm Just for your information, plus I'll continue to CC you on all LuaRocks-related things.