### PR TITLE
CMakeLists.txt: remove check-unit from ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ list(APPEND CHECK_QA_TARGETS check-requires)
 a_find_program(BUSTED_EXECUTABLE busted FALSE)
 if(BUSTED_EXECUTABLE)
     # Keep the arguments in sync with the version below!
-    add_custom_target(check-unit ALL
+    add_custom_target(check-unit
         ${BUSTED_EXECUTABLE} "--helper=${CMAKE_SOURCE_DIR}/spec/preload.lua"
         "--lpath=lib/?.lua;lib/?/init.lua;spec/?.lua"
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 TARGETS=awesome
 BUILDDIR=build
 
-all: $(TARGETS) ;
+all: check-unit $(TARGETS) ;
 
 $(TARGETS): cmake-build
 	ln -s -f $(BUILDDIR)/$@ $@


### PR DESCRIPTION
This makes "make install" not run the unit tests (again).

Instead "check-unit" is added to the top-level wrapper Makefile to be
run for its "all" task.

Ref: https://github.com/awesomeWM/awesome/issues/1427