### PR TITLE
Makefile: add busted tests as target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ distclean:
 	$(RM) -r $(BUILDDIR) $(TARGETS)
 	$(ECHO) " done"
 
+BUSTED_TESTS:=$(wildcard spec/**/*.lua)
+$(BUSTED_TESTS):
+	busted --lpath="lib/?.lua;lib/?/init.lua;spec/?.lua" \
+	  --helper spec/preload.lua $@
+.PHONY: $(BUSTED_TESTS)
+
 %: $(BUILDDIR)/CMakeCache.txt
 	$(ECHO) "Running make $@…"
 	$(MAKE) -C $(BUILDDIR) $@


### PR DESCRIPTION
TODO: I is bad to trigger the "wildcard" expansion on every Makefile use
probably.  Suggestions?

TODO:
- [ ] I've expected this to work with Zsh's completion,, but it does not. Need to investigate.