### PR TITLE
dbus.c: fix compiler warning

### DIFF
--- a/dbus.c
+++ b/dbus.c
@@ -134,7 +134,7 @@ a_dbus_message_iter(lua_State *L, DBusMessageIter *iter)
 
                     switch(array_type)
                     {
-                      int datalen = 0;
+                      int datalen;
 #define DBUS_MSG_HANDLE_ARRAY_TYPE_NUMBER_OR_INT(type, dbustype, pusher) \
                       case dbustype: \
                         { \


### PR DESCRIPTION
    [ 57%] Building C object CMakeFiles/awesome.dir/dbus.c.o
    …/awesome/build/dbus.c: In function ‘a_dbus_message_iter’:
    …/awesome/build/dbus.c:137:27: warning: statement will never be executed [-Wswitch-unreachable]
            int datalen = 0;
                ^~~~~~~

It was changed in dd862007, but probably not intentional.