### PR TITLE
Pass freedesktop hints to naughty.notify

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -51,6 +51,10 @@ notifications, e.g.
         args.text = 'prefix: ' .. args.text
         return args
     end
+  To reject a notification return `nil` from the callback.
+  If the notification is a freedesktop notification received via DBUS, you can
+  access the freedesktop hints via `args.freedesktop_hints` if any where
+  specified.
 
 @tfield table presets Notification presets.  See `config.presets`.
 

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -181,6 +181,7 @@ capi.dbus.connect_signal("org.freedesktop.Notifications",
                 if expire and expire > -1 then
                     args.timeout = expire / 1000
                 end
+                args.freedesktop_hints = hints
                 notification = naughty.notify(args)
                 return "u", notification.id
             end


### PR DESCRIPTION
If a notification was received via DBUS pass the freedesktop hints, that were received via DBUS to `args` which will be passed to naughty. That way a registered `naughty.config.notify_callback` can get access to them.

*But why?* This can be useful to add some more features on notifications, that the awesome core doesn't support, e.g. `sound` or setting the icon from `desktop-entry` if no icon was specified. Some of them might make sense to implement in the future in the core itself (e.g. falling back to the `hints.desktop-entry` icon when no icon is specified), but others will imho never make much sense in awesome itself (e.g. implementing sound for notifications or grouping notifications according to `hints.category`). This pull requests enables users to use the hints and implement that features nevertheless in their own config.