### PR TITLE
completion: Show command prior to directory

### DIFF
--- a/lib/awful/completion.lua
+++ b/lib/awful/completion.lua
@@ -9,6 +9,8 @@
 -- @module awful.completion
 ---------------------------------------------------------------------------
 
+local gfs = require("gears.filesystem")
+
 -- Grab environment we need
 local io = io
 local os = os

--- a/lib/awful/completion.lua
+++ b/lib/awful/completion.lua
@@ -160,7 +160,7 @@ function completion.shell(command, cur_pos, ncomp, shell)
         while true do
             local line = c:read("*line")
             if not line then break end
-            if gfs.is_dir(line) then
+            if str_starts(line, "./") and gfs.is_dir(line) then
                 line = line .. "/"
             end
             table.insert(output, bash_escape(line))

--- a/lib/awful/completion.lua
+++ b/lib/awful/completion.lua
@@ -79,6 +79,10 @@ function completion.shell(command, cur_pos, ncomp, shell)
     local i = 1
     local comptype = "file"
 
+    local function str_starts(str, start)
+        return string.sub(str, 1, string.len(start)) == start
+    end
+
     -- do nothing if we are on a letter, i.e. not at len + 1 or on a space
     if cur_pos ~= #command + 1 and command:sub(cur_pos, cur_pos) ~= " " then
         return command, cur_pos

--- a/lib/awful/completion.lua
+++ b/lib/awful/completion.lua
@@ -160,7 +160,7 @@ function completion.shell(command, cur_pos, ncomp, shell)
         while true do
             local line = c:read("*line")
             if not line then break end
-            if os.execute("test -d " .. string.format('%q', line)) == 0 then
+            if gfs.is_dir(line) then
                 line = line .. "/"
             end
             table.insert(output, bash_escape(line))

--- a/lib/gears/filesystem.lua
+++ b/lib/gears/filesystem.lua
@@ -53,6 +53,17 @@ function filesystem.file_readable(filename)
         gfileinfo:get_attribute_boolean("access::can-read")
 end
 
+--- Check if a file exists, is executable and not a directory.
+-- @tparam string filename The file path.
+-- @treturn boolean True if file exists and is executable.
+function filesystem.file_executable(filename)
+    local gfile = Gio.File.new_for_path(filename)
+    local gfileinfo = gfile:query_info("standard::type,access::can-execute",
+                                       Gio.FileQueryInfoFlags.NONE)
+    return gfileinfo and gfileinfo:get_file_type() ~= "DIRECTORY" and
+        gfileinfo:get_attribute_boolean("access::can-execute")
+end
+
 --- Check if a path exists, is readable and a directory.
 -- @tparam string path The directory path.
 -- @treturn boolean True if path exists and is readable.

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -95,7 +95,18 @@ describe("awful.completion.shell", function()
     setup(function()
         test_dir = get_test_dir()
         gfs.make_directories(test_dir .. '/true')
+        Gio.File.new_for_path(test_dir .. '/true/with_file'):create(Gio.FileCreateFlags.NONE);
         gfs.make_directories(test_dir .. '/just_a_directory')
+        Gio.File.new_for_path(test_dir .. '/just_a_directory/with_file'):create(Gio.FileCreateFlags.NONE);
+        -- Chaotic order is intended!
+        gfs.make_directories(test_dir .. '/ambiguous_dir_a')
+        gfs.make_directories(test_dir .. '/ambiguous_dir_e')
+        Gio.File.new_for_path(test_dir .. '/ambiguous_dir_e/with_file'):create(Gio.FileCreateFlags.NONE);
+        gfs.make_directories(test_dir .. '/ambiguous_dir_c')
+        Gio.File.new_for_path(test_dir .. '/ambiguous_dir_c/with_file'):create(Gio.FileCreateFlags.NONE);
+        gfs.make_directories(test_dir .. '/ambiguous_dir_d')
+        gfs.make_directories(test_dir .. '/ambiguous_dir_b')
+        gfs.make_directories(test_dir .. '/ambiguous_dir_f')
         os.execute(string.format(
             'cd %s && touch localcommand && chmod +x localcommand', test_dir))
         lfs.chdir(test_dir)
@@ -103,8 +114,18 @@ describe("awful.completion.shell", function()
     end)
 
     teardown(function()
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_a'))
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_b'))
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_c/with_file'))
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_c'))
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_d'))
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_e/with_file'))
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_e'))
+        assert.True(os.remove(test_dir .. '/ambiguous_dir_f'))
+        assert.True(os.remove(test_dir .. '/just_a_directory/with_file'))
         assert.True(os.remove(test_dir .. '/just_a_directory'))
         assert.True(os.remove(test_dir .. '/localcommand'))
+        assert.True(os.remove(test_dir .. '/true/with_file'))
         assert.True(os.remove(test_dir .. '/true'))
         assert.True(os.remove(test_dir))
         remove_test_path_dir(test_path)

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -137,12 +137,12 @@ describe("awful.completion.shell", function()
 
     if has_bash then
         it("completes local file (bash)", function()
-            assert.same(shell('ls ', 4, 1, 'bash'), {'ls localcommand', 16, {'localcommand'}})
+            assert.same(shell('ls l', 5, 1, 'bash'), {'ls localcommand', 16, {'localcommand'}})
         end)
     end
     if has_zsh then
         it("completes local file (zsh)", function()
-            assert.same(shell('ls ', 4, 1, 'zsh'), {'ls localcommand', 16, {'localcommand'}})
+            assert.same(shell('ls l', 5, 1, 'zsh'), {'ls localcommand', 16, {'localcommand'}})
         end)
     end
 end)

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -6,6 +6,7 @@ end
 local gfs = require("gears.filesystem")
 local Gio = require("lgi").Gio
 local GLib = require("lgi").GLib
+local lfs = require("lfs")
 
 local has_bash = GLib.find_program_in_path("bash")
 local has_zsh = GLib.find_program_in_path("zsh")
@@ -60,12 +61,14 @@ end
 
 describe("awful.completion.shell in empty directory", function()
     local orig_popen = io.popen
+    local orig_dir = lfs.currentdir()
 
     setup(function()
         test_dir = get_test_dir()
         io.popen = function(...)  --luacheck: ignore
             return orig_popen(string.format('cd %s && ', test_dir) .. ...)
         end
+        lfs.chdir(test_dir)
         test_path = get_test_path_dir()
     end)
 
@@ -73,6 +76,7 @@ describe("awful.completion.shell in empty directory", function()
         assert.True(os.remove(test_dir))
         io.popen = orig_popen  --luacheck: ignore
         remove_test_path_dir(test_path)
+        lfs.chdir(orig_dir)
     end)
 
     if has_bash then
@@ -92,6 +96,7 @@ end)
 
 describe("awful.completion.shell", function()
     local orig_popen = io.popen
+    local orig_dir = lfs.currentdir()
 
     setup(function()
         test_dir = get_test_dir()
@@ -102,6 +107,7 @@ describe("awful.completion.shell", function()
         io.popen = function(...)  --luacheck: ignore
             return orig_popen(string.format('cd %s && ', test_dir) .. ...)
         end
+        lfs.chdir(test_dir)
         test_path = get_test_path_dir()
     end)
 
@@ -112,6 +118,7 @@ describe("awful.completion.shell", function()
         assert.True(os.remove(test_dir))
         io.popen = orig_popen  --luacheck: ignore
         remove_test_path_dir(test_path)
+        lfs.chdir(orig_dir)
     end)
 
     if has_bash then

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -60,21 +60,16 @@ local function get_test_dir()
 end
 
 describe("awful.completion.shell in empty directory", function()
-    local orig_popen = io.popen
     local orig_dir = lfs.currentdir()
 
     setup(function()
         test_dir = get_test_dir()
-        io.popen = function(...)  --luacheck: ignore
-            return orig_popen(string.format('cd %s && ', test_dir) .. ...)
-        end
         lfs.chdir(test_dir)
         test_path = get_test_path_dir()
     end)
 
     teardown(function()
         assert.True(os.remove(test_dir))
-        io.popen = orig_popen  --luacheck: ignore
         remove_test_path_dir(test_path)
         lfs.chdir(orig_dir)
     end)
@@ -95,7 +90,6 @@ describe("awful.completion.shell in empty directory", function()
 end)
 
 describe("awful.completion.shell", function()
-    local orig_popen = io.popen
     local orig_dir = lfs.currentdir()
 
     setup(function()
@@ -104,9 +98,6 @@ describe("awful.completion.shell", function()
         gfs.make_directories(test_dir .. '/just_a_directory')
         os.execute(string.format(
             'cd %s && touch localcommand && chmod +x localcommand', test_dir))
-        io.popen = function(...)  --luacheck: ignore
-            return orig_popen(string.format('cd %s && ', test_dir) .. ...)
-        end
         lfs.chdir(test_dir)
         test_path = get_test_path_dir()
     end)
@@ -116,7 +107,6 @@ describe("awful.completion.shell", function()
         assert.True(os.remove(test_dir .. '/localcommand'))
         assert.True(os.remove(test_dir .. '/true'))
         assert.True(os.remove(test_dir))
-        io.popen = orig_popen  --luacheck: ignore
         remove_test_path_dir(test_path)
         lfs.chdir(orig_dir)
     end)

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -183,6 +183,17 @@ describe("awful.completion.shell", function()
     end)
 
     if has_bash then
+        it("does not complete local directory not starting with ./ (bash)", function()
+            assert.same(shell('just_a', 7, 1, 'bash'), {'just_a', 7})
+        end)
+    end
+    if has_zsh then
+        it("does not complete local directory not starting with ./ (zsh)", function()
+            assert.same(shell('just_a', 7, 1, 'zsh'), {'just_a', 7})
+        end)
+    end
+
+    if has_bash then
         it("completes local directories starting with ./ (bash)", function()
             assert.same(shell('./just', 7, 1, 'bash'), {'./just_a_directory/', 20, {'./just_a_directory/'}})
             assert.same(shell('./t', 4, 1, 'bash'), {'./true/', 8, {'./true/'}})

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -146,6 +146,20 @@ describe("awful.completion.shell", function()
             assert.same(shell('ls l', 5, 1, 'zsh'), {'ls localcommand', 16, {'localcommand'}})
         end)
     end
+
+    if has_bash then
+        it("completes command regardless of local directory (bash)", function()
+            assert.same(shell('true', 5, 1, 'bash'), {'true', 5, {'true'}})
+        end)
+    end
+    if has_zsh then
+        it("completes command regardless of local directory (zsh)", function()
+            assert.same(shell('true', 5, 1, 'zsh'), {'true', 5, {'true'}})
+        end)
+    end
+    it("completes command regardless of local directory (nil)", function()
+        assert.same(shell('true', 5, 1, nil), {'true', 5, {'true'}})
+    end)
 end)
 
 describe("awful.completion.shell handles $SHELL", function()

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -206,6 +206,20 @@ describe("awful.completion.shell", function()
         end)
     end
     --]]
+
+    if has_bash then
+        it("correctly sorts completed items (bash)", function()
+            assert.same(shell('./ambi', 7, 1, 'bash'), {'./ambiguous_dir_a/', 19,
+            {'./ambiguous_dir_a/', './ambiguous_dir_b/', './ambiguous_dir_c/',
+            './ambiguous_dir_d/', './ambiguous_dir_e/', './ambiguous_dir_f/'}})
+        end)
+    end
+    if has_zsh then
+        it("correctly sorts completed items (zsh)", function()
+            assert.same(shell('./ambi', 7, 1, 'zsh'), {'./ambiguous_dir_c/', 19,
+            {'./ambiguous_dir_c/', './ambiguous_dir_e/'}})
+        end)
+    end
 end)
 
 describe("awful.completion.shell handles $SHELL", function()

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -181,6 +181,20 @@ describe("awful.completion.shell", function()
     it("completes command regardless of local directory (nil)", function()
         assert.same(shell('true', 5, 1, nil), {'true', 5, {'true'}})
     end)
+
+    if has_bash then
+        it("completes local directories starting with ./ (bash)", function()
+            assert.same(shell('./just', 7, 1, 'bash'), {'./just_a_directory/', 20, {'./just_a_directory/'}})
+            assert.same(shell('./t', 4, 1, 'bash'), {'./true/', 8, {'./true/'}})
+        end)
+    end
+    if has_zsh then
+        it("completes local directories starting with ./ (zsh, non-empty)", function()
+            assert.same(shell('./just', 7, 1, 'zsh'), {'./just_a_directory/', 20, {'./just_a_directory/'}})
+            assert.same(shell('./t', 4, 1, 'zsh'), {'./true/', 8, {'./true/'}})
+        end)
+    end
+    --]]
 end)
 
 describe("awful.completion.shell handles $SHELL", function()

--- a/spec/awful/completion_spec.lua
+++ b/spec/awful/completion_spec.lua
@@ -95,6 +95,8 @@ describe("awful.completion.shell", function()
 
     setup(function()
         test_dir = get_test_dir()
+        gfs.make_directories(test_dir .. '/true')
+        gfs.make_directories(test_dir .. '/just_a_directory')
         os.execute(string.format(
             'cd %s && touch localcommand && chmod +x localcommand', test_dir))
         io.popen = function(...)  --luacheck: ignore
@@ -104,7 +106,9 @@ describe("awful.completion.shell", function()
     end)
 
     teardown(function()
+        assert.True(os.remove(test_dir .. '/just_a_directory'))
         assert.True(os.remove(test_dir .. '/localcommand'))
+        assert.True(os.remove(test_dir .. '/true'))
         assert.True(os.remove(test_dir))
         io.popen = orig_popen  --luacheck: ignore
         remove_test_path_dir(test_path)


### PR DESCRIPTION
When using tab completion in the "Run:" prompt and there is a directory
with the same name as a command in the $HOME directory (or wherever
awesome was started from), then the current completion.lua would append
a slash to it and add it to the output list.

With this patch it is first tested whether there is an actual command
for the current completion item, and add it (without slash) to the
output list. Afterwards the directory test will still be executed, so
there might be an un-slashed item as well as a slashed item in the list.
This makes it possible to get completion for `foo` (which might reside
in /usr/local/bin) as well as `foo/bar` (with directory foo residing in
$HOME). The un-slashed item will be listed prior to the slashed item
since it is more common to execute commands from $PATH than from
arbitrary folders in the current working directory.