### PR TITLE
menubar: Produce better errors for broken .desktop files

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -305,9 +305,13 @@ function utils.parse_dir(dir_path, callback)
                 local file_child = enum:get_child(info)
                 if file_type == 'REGULAR' then
                     local path = file_child:get_path()
-                    local program = path and utils.parse_desktop_file(path)
-                    if program then
-                        table.insert(programs, program)
+                    if path then
+                        local success, program = pcall(utils.parse_desktop_file, path)
+                        if not success then
+                            gdebug.print_error("Error while reading '" .. path .. "': " .. program)
+                        elseif program then
+                            table.insert(programs, program)
+                        end
                     end
                 elseif file_type == 'DIRECTORY' then
                     parser(file_child, programs)


### PR DESCRIPTION
This now runs parse_desktop_file in a protected context so that a single
broken desktop file does not break the whole menubar.

Also, the error message that is produced when a Lua error occurs now
also includes the file name of the .desktop file which we attempted to
parse. This should help quite a lot in debugging.

Related-to: https://github.com/awesomeWM/awesome/issues/1880
Signed-off-by: Uli Schlachter <psychon@znc.in>