### PR TITLE
awful.tag.viewmore: use screen from tag(s)

### DIFF
--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -514,7 +514,7 @@ function menu.clients(args, item_args, filter)
             function ()
                 if not c.valid then return end
                 if not c:isvisible() then
-                    tags.viewmore(c:tags(), c.screen)
+                    tags.viewmore(c:tags())
                 end
                 c:emit_signal("request::activate", "menu.clients", {raise=true})
             end,

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -1275,17 +1275,21 @@ end
 --- View only a set of tags.
 -- @function awful.tag.viewmore
 -- @param tags A table with tags to view only.
--- @param[opt] screen The screen of the tags.
-function tag.viewmore(tags, screen)
-    screen = get_screen(screen or ascreen.focused())
-    local screen_tags = screen.tags
-    for _, _tag in ipairs(screen_tags) do
-        if not gtable.hasitem(tags, _tag) then
-            _tag.selected = false
-        end
-    end
+function tag.viewmore(tags)
+    local screens = {}
     for _, _tag in ipairs(tags) do
-        _tag.selected = true
+        screens[_tag.screen] = true
+    end
+    for screen, _ in pairs(screens) do
+        local screen_tags = screen.tags
+        for _, _tag in ipairs(screen_tags) do
+            if not gtable.hasitem(tags, _tag) then
+                _tag.selected = false
+            end
+        end
+        for _, _tag in ipairs(tags) do
+            _tag.selected = true
+        end
     end
     screen:emit_signal("tag::history::update")
 end

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -1278,7 +1278,7 @@ end
 function tag.viewmore(tags)
     local screens = {}
     for _, _tag in ipairs(tags) do
-        screens[_tag.screen] = true
+        screens[get_screen(_tag.screen)] = true
     end
     for screen, _ in pairs(screens) do
         local screen_tags = screen.tags
@@ -1290,8 +1290,8 @@ function tag.viewmore(tags)
         for _, _tag in ipairs(tags) do
             _tag.selected = true
         end
+        screen:emit_signal("tag::history::update")
     end
-    screen:emit_signal("tag::history::update")
 end
 
 --- Toggle selection of a tag

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -1274,8 +1274,9 @@ end
 
 --- View only a set of tags.
 -- @function awful.tag.viewmore
--- @param tags A table with tags to view only.
-function tag.viewmore(tags)
+-- @tparam table tags A table with tags to view only.
+-- @param ignored_screen Ignored (only kept for backward compatibility).
+function tag.viewmore(tags, ignored_screen)  -- luacheck: ignore
     local screens = {}
     for _, _tag in ipairs(tags) do
         screens[get_screen(_tag.screen)] = true

--- a/tests/test-current-desktop.lua
+++ b/tests/test-current-desktop.lua
@@ -30,11 +30,11 @@ end
 
 local steps = {
 
-    -- Set up the state we want
+    -- Setup.
     function(count)
         if count == 1 then
             test_client()
-            awful.tag.viewmore({ tags[3], tags[4], tags[5] }, s)
+            awful.tag.viewmore({ tags[3], tags[4], tags[5] })
         end
 
         c = awful.client.visible()[1]


### PR DESCRIPTION
Fixes https://github.com/awesomeWM/awesome/issues/1883.

TODO:
- [ ] add test(s) (test-awful-client.lua)
- [ ] respect screen argument if passed in ("If you do awful.tag.viewmore({screen[1].tags[1], screen[2].tags[1]}, screen[1]), I would still expect the `screen` argument to do its job")
- [ ] "At the end of the function, the client has to be tagged on a single screen no matter what"