### PR TITLE
Travis: failure (X) on test failure, not "!"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ install:
     travis_run_in_fold() {
       travis_fold_start "$1"
       shift
-      "$@" || return
+      "$@" || return 1
       travis_fold_end
       return 0
     }
@@ -189,15 +189,14 @@ script:
          && cmake $CMAKE_ARGS ..)
         do_codecov samples
 
-        (make check-unit-coverage \
-         && do_codecov unittests \
-         && tests/run.sh \
-         && do_codecov functionaltests \
-         && gcov $(find -name '*.o') \
-         && do_codecov_gcov c_code)
-        ret=$?
+        make check-unit-coverage
+        do_codecov unittests
+        tests/run.sh
+        do_codecov functionaltests
+        gcov $(find -name '*.o')
+        do_codecov_gcov c_code
+
         travis_fold_end
-        [ "$ret" = 0 ]
       else
         travis_run_in_fold "make.check-unit" make check-unit
         travis_run_in_fold "make.check-integration" make check-integration


### PR DESCRIPTION
Debugging/fixing different build outcomes.
    
    Build: https://travis-ci.org/awesomeWM/awesome/builds/248484247
    
    !: https://travis-ci.org/awesomeWM/awesome/jobs/248484252
        Test finished successfully
        There were 3 errors!
        make[4]: *** [CMakeFiles/check-integration] Error 1
        make[3]: *** [CMakeFiles/check-integration.dir/all] Error 2
        make[2]: *** [CMakeFiles/check-integration.dir/rule] Error 2
        make[1]: *** [check-integration] Error 2
        make: *** [check-integration] Error 2
        ++return
    
    X: https://travis-ci.org/awesomeWM/awesome/jobs/248484250
        Test finished successfully
        There were 3 errors!

- Is it the exit code (2 via make)?
- Is it the "return" via `|| return` that does not make the `make` itself fail due to `set -x` already?