### PR TITLE
Dbus fixes

### DIFF
--- a/dbus.c
+++ b/dbus.c
@@ -504,9 +504,6 @@ a_dbus_process_requests_on_bus(DBusConnection *dbus_connection, GSource **source
         dbus_connection_flush(dbus_connection);
 }
 
-/** Foreword D-Bus process session requests on too the correct function.
- * \param data
- */
 static gboolean
 a_dbus_process_requests_session(gpointer data)
 {
@@ -514,9 +511,6 @@ a_dbus_process_requests_session(gpointer data)
     return TRUE;
 }
 
-/** Foreword D-Bus process system requests on too the correct function.
- * \param data
- */
 static gboolean
 a_dbus_process_requests_system(gpointer data)
 {
@@ -524,9 +518,9 @@ a_dbus_process_requests_system(gpointer data)
     return TRUE;
 }
 
-/** Attempt to request a D-Bus name
- * \param dbus_connection The application's connection to D-Bus
- * \param name The D-Bus connection name to be requested
+/** Attempt to request a D-Bus name.
+ * \param dbus_connection The application's connection to D-Bus.
+ * \param name The D-Bus connection name to be requested.
  * \return true if the name is primary owner or the name is already
  * the owner, otherwise false.
  */
@@ -663,9 +657,9 @@ a_dbus_cleanup(void)
     a_dbus_cleanup_bus(dbus_connection_system, &system_source);
 }
 
-/** Retrieve the D-Bus bus by it's name
- * \param name The name of the bus
- * \return The corresponding D-Bus connection
+/** Retrieve the D-Bus bus by its name.
+ * \param name The name of the bus.
+ * \return The corresponding D-Bus connection.
  */
 static DBusConnection *
 a_dbus_bus_getbyname(const char *name)
@@ -677,7 +671,7 @@ a_dbus_bus_getbyname(const char *name)
     return NULL;
 }
 
-/** Register a D-Bus name to receive message from.
+/** Register a D-Bus name to receive messages from.
  *
  * @param bus A string indicating if we are using system or session bus.
  * @param name A string with the name of the D-Bus name to register.

--- a/dbus.c
+++ b/dbus.c
@@ -610,7 +610,7 @@ a_dbus_connect(DBusBusType type, const char *type_name, GSourceFunc cb, GSource 
     dbus_connection = dbus_bus_get(type, &err);
     if(dbus_error_is_set(&err))
     {
-        warn("D-Bus session bus %s failed: %s", type_name, err.message);
+        warn("Could not connect to D-Bus %s bus: %s", type_name, err.message);
         dbus_connection = NULL;
         dbus_error_free(&err);
     }


### PR DESCRIPTION
Regarding the 2nd commit (fixing the warning):

When using Docker, you do not really want to setup a D-Bus system bus.

When running awesome there, you will get the following error then, which gets repeated for every integration/functional test then:

> 2017-07-01 18:21:43 W: awesome: a_dbus_connect:613: D-Bus session bus system failed: Failed to connect to socket /var/run/dbus/system_bus_socket: No such file or directory

There should be a way to silence those, and I plan to grep this out in tests/run.sh.