### PR TITLE
rules: switchtotag: fix usage of awful.tag.viewmore

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -301,8 +301,7 @@ end
 
 function rules.delayed_properties.switchtotag(c, value)
     if not value then return end
-
-    atag.viewmore(c:tags())
+    atag.viewmore(c:tags(), c.screen)
 end
 
 function rules.extra_properties.geometry(c, _, props)


### PR DESCRIPTION
This passes in the client's screen for now.

In the long run this should get fixed via
https://github.com/awesomeWM/awesome/issues/1883, but that is more
involved.

Fixes https://github.com/awesomeWM/awesome/issues/1886.