### PR TITLE
tests: fix test-menubar for when there are no desktop files

### DIFF
--- a/tests/test-menubar.lua
+++ b/tests/test-menubar.lua
@@ -3,6 +3,12 @@
 local runner = require("_runner")
 local menubar = require("menubar")
 
+local menubar_refreshed = false
+
+function menubar.refresh(scr)
+    menubar_refreshed = scr or true
+end
+
 -- XXX We are building Lua 5.3 with -DLUA_USE_APICHECK=1 and this catches some
 -- bugs in lgi. Thus, do not run this test with Lua 5.3 until lgi is fixed.
 -- We run into the same bug when doing code-coverage analysis, supposedly
@@ -41,7 +47,7 @@ runner.run_steps {
         end
 
         -- Test that the async population of the menubar is done
-        if #menubar.menu_entries > 0 then
+        if menubar_refreshed then
             menubar.hide()
             awesome.sync()
             return true

--- a/tests/test-menubar.lua
+++ b/tests/test-menubar.lua
@@ -4,9 +4,10 @@ local runner = require("_runner")
 local menubar = require("menubar")
 
 local menubar_refreshed = false
-
-function menubar.refresh(scr)
-    menubar_refreshed = scr or true
+local orig_refresh = menubar.refresh
+function menubar.refresh(...)
+    menubar_refreshed = true
+    orig_refresh(...)
 end
 
 -- XXX We are building Lua 5.3 with -DLUA_USE_APICHECK=1 and this catches some


### PR DESCRIPTION
This happens with Docker based tests, where no (relevant) .desktop files are installed.