### PR TITLE
Provide better error message for unknown screen names

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1029,6 +1029,7 @@ luaA_screen_module_index(lua_State *L)
             foreach(output, (*screen)->outputs)
                 if(A_STREQ(output->name, name))
                     return luaA_object_push(L, *screen);
+        luaL_error(L, "Unknown screen output name: %s", name);
     }
 
     return luaA_object_push(L, luaA_checkscreen(L, 2));


### PR DESCRIPTION
The screen object can be indexed by strings to find a screen via some
RANDR output name. However, if a string is used which does not
correspond to a known output, the code just falls through to a function
which will complain "string provided, userdata expected".

This commit provides a slightly more useful error message instead.

Signed-off-by: Uli Schlachter <psychon@znc.in>