### PR TITLE
Fix wrapper Makefile dependency on CMake outcome

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ all: check-unit $(TARGETS) ;
 $(TARGETS): cmake-build
 	ln -s -f $(BUILDDIR)/$@ $@
 
-$(BUILDDIR)/CMakeCache.txt:
+$(BUILDDIR)/Makefile:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."
 	$(ECHO)
 	mkdir -p $(BUILDDIR)
 	$(ECHO) "Running cmake…"
 	cd $(BUILDDIR) && cmake $(CMAKE_ARGS) "$(@D)" ..
 
-cmake-build: $(BUILDDIR)/CMakeCache.txt
+cmake-build: $(BUILDDIR)/Makefile
 	$(ECHO) "Building…"
 	$(MAKE) -C $(BUILDDIR)
 
@@ -36,8 +36,8 @@ distclean:
 	$(RM) -r $(BUILDDIR) $(TARGETS)
 	$(ECHO) " done"
 
-%: $(BUILDDIR)/CMakeCache.txt
-	$(ECHO) "Running make $@…"
+%: $(BUILDDIR)/Makefile
+	$(ECHO) "Running make $@ in $(BUILDDIR)…"
 	$(MAKE) -C $(BUILDDIR) $@
 
 .PHONY: cmake-build install distclean tags


### PR DESCRIPTION
If `cmake ..` in the build dir failed (e.g. because Lua could not be
found), a subsequent `make` will cause a strange error (this is in
non-quiet mode):

```
/src/awesome # make
echo "Running make Makefile…"
Running make Makefile…
make -C build Makefile
make[1]: Entering directory '/src/awesome/build'
make[1]: *** No rule to make target 'Makefile'.  Stop.
make[1]: Leaving directory '/src/awesome/build'
make: *** [Makefile:44: Makefile] Error 2
```

With `s` in `MAKEFLAGS` (at the top of our Makefile):
```
Running make check-unit…
make[1]: *** No rule to make target 'check-unit'.  Stop.
make: *** [Makefile:44: check-unit] Error 2
```

Therefore this patch looks for build/Makefile to be generated really.

Should this depend on both `CMakeCache.txt` and `Makefile`?