### PR TITLE
Makefile: remove `ln -s` for `awesome`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ BUILDDIR=build
 all: check-unit $(TARGETS) ;
 
 $(TARGETS): cmake-build
-	ln -s -f $(BUILDDIR)/$@ $@
 
 $(BUILDDIR)/CMakeCache.txt:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."


### PR DESCRIPTION
It does not seem to be required by tests (anymore), and fails when the
source dir is mounted read-only (which is the case for the Docker based
builds I am working on).

I think it is clearer anyway to run it as `build/awesome`.