### PR TITLE
Move project() call to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0.0)
+project(awesome C)
 
 # Require an out-of-source build. We generate an awesomerc.lua in the build dir
 # from the one in the source dir and this does not work otherwise.

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -6,8 +6,6 @@ set(VERSION devel)
 
 set(CODENAME "Technologic")
 
-project(${PROJECT_AWE_NAME} C)
-
 option(WITH_DBUS "build with D-BUS" ON)
 option(GENERATE_MANPAGES "generate manpages" ON)
 option(COMPRESS_MANPAGES "compress manpages" ON)


### PR DESCRIPTION
CMake "fakes" a call to "project(Project C CXX)" if it does not see a
project() call in CMakeLists.txt. Since we had this call in a different
file, this default applied. This meant that CMake unnecessarily required
a C++ compiler.

Fix/work-around this by moving the call to project() into CMakeLists.txt

Reference: https://github.com/awesomeWM/awesome/pull/1907#discussion_r125581273
Signed-off-by: Uli Schlachter <psychon@znc.in>

@blueyed This should allow you to get rid of the C++ compiler in your docker build.