### PR TITLE
Treat max client as single client for gaps

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -164,8 +164,15 @@ function layout.parameters(t, screen)
         gap_single_client = t.gap_single_client
     end
 
-    local min_clients       = gap_single_client and 1 or 2
-    local useless_gap       = t and (#clients >= min_clients and t.gap or 0) or 0
+    local useless_gap = 0
+    if t then
+        local skip_gap = layout.get(screen).skip_gap or function(nclients)
+            return nclients < 2
+        end
+        if gap_single_client or not skip_gap(#clients, t) then
+            useless_gap = t.gap
+        end
+    end
 
     p.workarea = screen:get_bounding_geometry {
         honor_padding  = true,

--- a/lib/awful/layout/suit/corner.lua
+++ b/lib/awful/layout/suit/corner.lua
@@ -163,13 +163,18 @@ end
 local corner = {}
 corner.row_privileged = false
 
+function corner.skip_gap(nclients, t)
+    return nclients == 1 and t.master_fill_policy == "expand"
+end
+
 --- Corner layout.
 -- Display master client in a corner of the screen, and slaves in one
 -- column and one row around the master.
 -- @clientlayout awful.layout.suit.corner.nw
 corner.nw = {
         name = "cornernw",
-        arrange = function (p) return do_corner(p, "NW") end
+        arrange = function (p) return do_corner(p, "NW") end,
+        skip_gap = corner.skip_gap
     }
 
 --- Corner layout.
@@ -178,7 +183,8 @@ corner.nw = {
 -- @clientlayout awful.layout.suit.corner.ne
 corner.ne = {
         name = "cornerne",
-        arrange = function (p) return do_corner(p, "NE") end
+        arrange = function (p) return do_corner(p, "NE") end,
+        skip_gap = corner.skip_gap
     }
 
 --- Corner layout.
@@ -187,7 +193,8 @@ corner.ne = {
 -- @clientlayout awful.layout.suit.corner.sw
 corner.sw = {
         name = "cornersw",
-        arrange = function (p) return do_corner(p, "SW") end
+        arrange = function (p) return do_corner(p, "SW") end,
+        skip_gap = corner.skip_gap
     }
 
 --- Corner layout.
@@ -196,7 +203,8 @@ corner.sw = {
 -- @clientlayout awful.layout.suit.corner.se
 corner.se = {
         name = "cornerse",
-        arrange = function (p) return do_corner(p, "SE") end
+        arrange = function (p) return do_corner(p, "SE") end,
+        skip_gap = corner.skip_gap
     }
 
 return corner

--- a/lib/awful/layout/suit/max.lua
+++ b/lib/awful/layout/suit/max.lua
@@ -47,11 +47,15 @@ max.name = "max"
 function max.arrange(p)
     return fmax(p, false)
 end
+function max.skip_gap(nclients, t) -- luacheck: no unused args
+    return true
+end
 
 --- Fullscreen layout.
 -- @clientlayout awful.layout.suit.max.fullscreen
 max.fullscreen = {}
 max.fullscreen.name = "fullscreen"
+max.fullscreen.skip_gap = max.skip_gap
 function max.fullscreen.arrange(p)
     return fmax(p, true)
 end

--- a/lib/awful/layout/suit/tile.lua
+++ b/lib/awful/layout/suit/tile.lua
@@ -296,12 +296,17 @@ local function do_tile(param, orientation)
 
 end
 
+function tile.skip_gap(nclients, t)
+    return nclients == 1 and t.master_fill_policy == "expand"
+end
+
 --- The main tile algo, on the right.
 -- @param screen The screen number to tile.
 -- @clientlayout awful.layout.suit.tile.right
 tile.right = {}
 tile.right.name = "tile"
 tile.right.arrange = do_tile
+tile.right.skip_gap = tile.skip_gap
 function tile.right.mouse_resize_handler(c, corner, x, y)
     return mouse_resize_handler(c, corner, x, y)
 end
@@ -311,6 +316,7 @@ end
 -- @clientlayout awful.layout.suit.tile.left
 tile.left = {}
 tile.left.name = "tileleft"
+tile.left.skip_gap = tile.skip_gap
 function tile.left.arrange(p)
     return do_tile(p, "left")
 end
@@ -323,6 +329,7 @@ end
 -- @clientlayout awful.layout.suit.tile.bottom
 tile.bottom = {}
 tile.bottom.name = "tilebottom"
+tile.bottom.skip_gap = tile.skip_gap
 function tile.bottom.arrange(p)
     return do_tile(p, "bottom")
 end
@@ -335,6 +342,7 @@ end
 -- @clientlayout awful.layout.suit.tile.top
 tile.top = {}
 tile.top.name = "tiletop"
+tile.top.skip_gap = tile.skip_gap
 function tile.top.arrange(p)
     return do_tile(p, "top")
 end


### PR DESCRIPTION
When gap_single_client is set to 'false', no gap is used when only one client is shown in a tag. Since the max layout only ever shows one client at a time it makes sense to apply this setting for this layout regardless of the actual number of clients in that tag.
