### PR TITLE
cmake: check (and cache) check of required modules

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -127,6 +127,7 @@ pkg_check_modules(AWESOME_COMMON_REQUIRED REQUIRED
     xcb>=1.6)
 
 set(AWESOME_DEPENDENCIES
+    glib-2.0
     glib-2.0>=2.40
     gdk-pixbuf-2.0
     cairo
@@ -136,8 +137,11 @@ set(AWESOME_DEPENDENCIES
     xcb-xtest
     xcb-xinerama
     xcb-shape
+    xcb-util
     xcb-util>=0.3.8
+    xcb-keysyms
     xcb-keysyms>=0.3.4
+    xcb-icccm
     xcb-icccm>=0.3.8
     # NOTE: it's not clear what version is required, but 1.10 works at least.
     # See https://github.com/awesomeWM/awesome/pull/149#issuecomment-94208356.
@@ -145,23 +149,14 @@ set(AWESOME_DEPENDENCIES
     xkbcommon
     xkbcommon-x11
     cairo-xcb
+    libstartup-notification-1.0
     libstartup-notification-1.0>=0.10
+    xproto
     xproto>=7.0.15
+    libxdg-basedir
     libxdg-basedir>=1.0.0
     xcb-xrm
 )
-
-# Check the deps one by one
-foreach(dependency ${AWESOME_DEPENDENCIES})
-    unset(TMP_DEP_FOUND CACHE)
-    pkg_check_modules(TMP_DEP REQUIRED ${dependency})
-
-    if(NOT TMP_DEP_FOUND)
-        message(FATAL_ERROR)
-    endif()
-endforeach()
-
-# Do it again, but this time with the CFLAGS/LDFLAGS
 pkg_check_modules(AWESOME_REQUIRED REQUIRED ${AWESOME_DEPENDENCIES})
 
 macro(a_find_library variable library)


### PR DESCRIPTION
This makes the CMake run much faster in general, and does not re-check
the dependencies every time again (since it gets cached).

There are several reports where the reference to the missing module was
not provided, and they all appear to have happened with CMake 3.6.1.

A missing "foobar" module gets reported there, but if you remove
/usr/lib/pkgconfig/libstartup-notification-1.0.pc, this does not get
reported:

    -- Checking for modules '…'
    --
    CMake Error at /tmp/cmake/share/cmake-3.6/Modules/FindPkgConfig.cmake:424 (message):
      A required package was not found

This apparently affects modules that have version requirements. After
removing that from "libstartup-notification-1.0>=0.10", it gets reported
also: "No package 'libstartup-notification-1.0' found".

The workaround is to require the package without version information
before the requirement with the version information.

This reverts https://github.com/awesomeWM/awesome/pull/1253.