### PR TITLE
tests/examples/CMakeLists.txt: Add a project() call

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -9,6 +9,11 @@
 # where relevant. Those images are used by the documentation and help the
 # developers track user interface regressions and glitches. Finally, it also
 # helps to find broken code.
+
+if(NOT DEFINED PROJECT_NAME)
+    project(awesome-tests-examples NONE)
+endif()
+
 cmake_minimum_required(VERSION 3.0.0)
 
 # Get and update the LUA_PATH so the scripts can be executed without Awesome.


### PR DESCRIPTION
project() automatically sets the PROJECT_NAME variable. Thus, when this
CMake code is run due to being included by awesome, this commit has no
effect.

When this CMake code is run on its own, CMake will no longer check for a
C and C++ compiler.

Signed-off-by: Uli Schlachter <psychon@znc.in>

Reference: https://github.com/awesomeWM/awesome/pull/1909#issuecomment-315646440