### PR TITLE
Travis: fix gcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ install:
       if [ "$DO_COVERAGE" = "codecov" ]; then
         test -f build/luacov.stats.out || { echo 'build/luacov.stats.out does not exist.'; return 1; }
         luacov || return 1
-        travis_retry bash /tmp/codecov-bash -X coveragepy -c -F "$1" || return 1
+        travis_retry bash /tmp/codecov-bash -X gcov -X coveragepy -c -F "$1" || return 1
         rm build/luacov.stats.out
       fi
       return 0
@@ -197,7 +197,6 @@ script:
         do_codecov unittests
         tests/run.sh
         do_codecov functionaltests
-        gcov $(find -name '*.o')
         do_codecov_gcov c_code
 
         travis_fold_end


### PR DESCRIPTION
codecov-bash runs it by default already, therefore we do not not have to
do so manually before do_codecov_gcov.
And with `do_codecov` itself, it gets disabled using `-X gcov`.