### PR TITLE
Makefile: do not call check-unit by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 TARGETS=awesome
 BUILDDIR=build
 
-all: check-unit $(TARGETS) ;
+all: $(TARGETS) ;
 
 $(TARGETS): cmake-build
 


### PR DESCRIPTION
It should get run explicitly only.

As for Travis: we run it there initially (when just using `make`, and
later again - at least when using check-unit-coverage).