### PR TITLE
Fix awful.widget.calendar_popup documentation

### DIFF
--- a/lib/awful/widget/calendar_popup.lua
+++ b/lib/awful/widget/calendar_popup.lua
@@ -241,7 +241,7 @@ end
 --- Attach the calendar to a widget to display at a specific position.
 --
 --    local mytextclock = wibox.widget.textclock()
---    local month_calendar = calendar.month()
+--    local month_calendar = awful.widget.calendar_popup.month()
 --    month_calendar:attach(mytextclock, 'tr')
 --
 -- @param widget Widget to attach the calendar
@@ -325,6 +325,7 @@ end
 --@DOC_wibox_awidget_calendar_month_wibox_EXAMPLE@
 --
 --    local mytextclock = wibox.widget.textclock()
+--    local month_calendar = awful.widget.calendar_popup.month()
 --    month_calendar:attach( mytextclock, "tr" )
 --
 -- @tparam table args Properties of the widget
@@ -344,7 +345,7 @@ end
 -- @tparam table args.style_normal Cell style for the normal day cells (see `cell_properties`)
 -- @tparam table args.style_focus Cell style for the current day cell (see `cell_properties`)
 -- @treturn wibox A wibox containing the calendar
--- @function awful.widget.calendar.month
+-- @function awful.widget.calendar_popup.month
 function calendar_popup.month(args)
     return get_cal_wibox("month", args)
 end
@@ -380,7 +381,7 @@ end
 -- @tparam table args.style_normal Cell style for the normal day cells (see `cell_properties`)
 -- @tparam table args.style_focus Cell style for the current day cell (see `cell_properties`)
 -- @treturn wibox A wibox containing the calendar
--- @function awful.widget.calendar.year
+-- @function awful.widget.calendar_popup.year
 function calendar_popup.year(args)
     return get_cal_wibox("year", args)
 end


### PR DESCRIPTION
There were multiple things which stood out to me, as I was trying to setup a simple calendar popup for the default textclock in my rc.lua:
1. The functions in https://awesomewm.org/doc/api/classes/awful.widget.calendar_popup.html#Functions were not named correctly (calendar vs calendar_popup) which (naturally) produced an error when used as awful.widget.calendar.month() .
2. The example for calendar_popup.month() was obviously missing a line (where does the month_calendar come from?) . Resolved by copying the line from the attach-example
3. The same examples also only refer to the function as calendar.month() which should be changed to awful.widget.calendar_popup.month()
