### PR TITLE
Travis: move usage of xresources theme to tests/run.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
     - LUA=5.2 LUANAME=lua5.2 DO_COVERAGE=coveralls
     # Lua 5.3 isn't available in Ubuntu Trusty, so some magic below installs it.
-    - LUA=5.3 LUANAME=lua5.3 LUALIBRARY=/usr/lib/liblua.so DO_COVERAGE=codecov AWESOME_THEME=xresources
+    - LUA=5.3 LUANAME=lua5.3 LUALIBRARY=/usr/lib/liblua.so DO_COVERAGE=codecov
     # luajit: installed from source.
     - LUA=5.1 LUANAME=luajit-2.0 LUALIBRARY=/usr/lib/libluajit-5.1.so LUAROCKS_ARGS=--lua-suffix=jit-2.0.5 TEST_PREV_COMMITS=1
     # Note: luarocks does not work with Lua 5.0.
@@ -148,10 +148,6 @@ install:
     }
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION -DSTRICT_TESTS=true"
-  - |
-    if [ ! -z "$AWESOME_THEME" ]; then
-      sed awesomerc.lua -i -e "s/default\/theme/$AWESOME_THEME\/theme/g"
-    fi
   - |
     if [ "$DO_COVERAGE" = "codecov" ]; then
       export CXXFLAGS="-fprofile-arcs -ftest-coverage"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -174,6 +174,9 @@ if [ -n "$DO_COVERAGE" ] && [ "$DO_COVERAGE" != 0 ]; then
     sed "1 s~^~require('luacov.runner')('$source_dir/.luacov'); \0~" \
         "$RC_FILE" > "$tmp_files/awesomerc.lua"
     RC_FILE=$tmp_files/awesomerc.lua
+
+    # Use xresources theme for more coverage.
+    sed -i 's~default/theme~xresources/theme~' "$RC_FILE"
 fi
 
 # Start awesome.


### PR DESCRIPTION
This makes the coverage more consistent, and is done like that in the
docker branch already (where a read-only filesystem is used).