### PR TITLE
awful.tooltip: Set wibox.type = "tooltip"

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -580,6 +580,7 @@ function tooltip.new(args)
         fg = fg,
         bg = color.transparent,
         opacity = beautiful.tooltip_opacity or 1,
+        type = "tooltip",
     }
 
     self.textbox = textbox()


### PR DESCRIPTION
Fixes: https://github.com/awesomeWM/awesome/issues/1938
Signed-off-by: Uli Schlachter <psychon@znc.in>