### PR TITLE
Make keyboardlayout widget more robust

### DIFF
--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -115,12 +115,15 @@ keyboardlayout.xkeyboard_country_code = {
 
 -- Callback for updating current layout.
 local function update_status (self)
-    self._current = awesome.xkb_get_layout_group();
+    self._current = awesome.xkb_get_layout_group()
     local text = ""
-    if (#self._layout > 0) then
+    if #self._layout > 0 then
         -- Please note that the group number reported by xkb_get_layout_group
         -- is lower by one than the group numbers reported by xkb_get_group_names.
-        text = (" " .. self._layout[self._current+1] .. " ")
+        local name = self._layout[self._current+1]
+        if name then
+            text = " " .. name .. " "
+        end
     end
     self.widget:set_text(text)
 end


### PR DESCRIPTION
I am not sure what exactly goes on in the below bug report, so this will
just paper over the problem. I still think that this patch is a good
idea even when it is not a proper fix, since keyboard layouts are
complicated and so this code should be robust and hard to break.

Fixes: https://github.com/awesomeWM/awesome/issues/1933
Signed-off-by: Uli Schlachter <psychon@znc.in>