### PR TITLE
Travis: exit with 1 when check-unit-coverage fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ script:
          && cmake $CMAKE_ARGS ..)
         do_codecov samples
 
-        make check-unit-coverage
+        make check-unit-coverage || exit 1
         do_codecov unittests
         tests/run.sh
         do_codecov functionaltests


### PR DESCRIPTION
Same as done in 1cdd7ef8 already, but missed this one.