### PR TITLE
tags: specify layout in add_tag doc snippet

### DIFF
--- a/objects/tag.c
+++ b/objects/tag.c
@@ -111,7 +111,9 @@
  * Create a new tag at the end of the list
  *
  *    local function add_tag()
- *        awful.tag.add("NewTag",{screen= awful.screen.focused() }):view_only()
+ *        awful.tag.add("NewTag", {
+ *            screen = awful.screen.focused(),
+ *            layout = awful.layout.suit.floating }):view_only()
  *    end
  *
  * Rename the current tag


### PR DESCRIPTION
Adding a tag without layout causes errors while using the tag. For
example resizing with mouse causes indexing a null error.