### PR TITLE
awful.tooltip: border: do not default to border_width

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -146,8 +146,7 @@ local function apply_shape(self)
 
     -- Draw the border (multiply by 2, then mask the inner part to save a path)
     local bw = (self._private.border_width
-        or beautiful.tooltip_border_width
-        or beautiful.border_width or 0) * 2
+        or beautiful.tooltip_border_width or 0) * 2
 
     -- Fix anti-aliasing
     if bw > 2 and awesome.composite_manager_running then


### PR DESCRIPTION
Several themes use `dpi(2)` which is quite thick, and it is better to
use the default of 0 here, instead of `beautiful.border_width`, which is
meant for borders on clients.