### PR TITLE
Fix some leaks

### DIFF
--- a/lib/awful/client/shape.lua
+++ b/lib/awful/client/shape.lua
@@ -51,6 +51,8 @@ function shape.get_transformed(c, shape_name)
         cr:set_source_surface(shape_img, border + l, border + t)
         cr:rectangle(border + l, border + t, geom.width - l - r, geom.height - t - b)
         cr:fill()
+
+        shape_img:finish()
     end
 
     if _shape then

--- a/lib/awful/mouse/snap.lua
+++ b/lib/awful/mouse/snap.lua
@@ -66,6 +66,7 @@ local function show_placeholder(geo)
     cr:stroke()
 
     placeholder_w.shape_bounding = img._native
+    img:finish()
 
     placeholder_w.visible = true
 end

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -137,6 +137,7 @@ local function apply_shape(self)
     s(cr, w, h, unpack(self._private.shape_args or {}))
     cr:fill()
     wb.shape_bounding = img._native
+    img:finish()
 
     -- The wibox background uses ARGB32 border so tooltip anti-aliasing works
     -- when an external compositor is used. This will look better than

--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -204,6 +204,7 @@ function surface.apply_shape_bounding(draw, shape, ...)
   cr:fill()
 
   draw.shape_bounding = img._native
+  img:finish()
 end
 
 local function no_op() end

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -272,7 +272,7 @@ local function new(args)
         __newindex = function(self, k,v)
             if rawget(self, "set_"..k) then
                 self["set_"..k](self, v)
-            elseif w[k] ~= nil or force_forward[k] then
+            elseif force_forward[k] or w[k] ~= nil then
                 w[k] = v
             else
                 rawset(self, k, v)


### PR DESCRIPTION
Well... "leaks" is a bit strong. None of these were really leaks. Instead this is about either doing an operation in a way that uses less memory, or freeing memory faster instead of waiting for the GC to come and to its job (which can take quite long since the GC doesn't know about the real memory usage of image surfaces).

Related to #1958.