### PR TITLE
gears.timer.delayed_call: copy queue for processing

### DIFF
--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -60,6 +60,7 @@ local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility
 local glib = require("lgi").GLib
 local object = require("gears.object")
 local protected_call = require("gears.protected_call")
+local gtable = require("gears.table")
 
 --- Timer objects. This type of object is useful when triggering events repeatedly.
 -- The timer will emit the "timeout" signal every N seconds, N being the timeout
@@ -227,10 +228,12 @@ end
 
 local delayed_calls = {}
 capi.awesome.connect_signal("refresh", function()
-    for _, callback in ipairs(delayed_calls) do
+    -- Copy delayed_calls before processing them, to allow for re-queueing.
+    local callbacks = gtable.clone(delayed_calls, false)
+    delayed_calls = {}
+    for _, callback in ipairs(callbacks) do
         protected_call(unpack(callback))
     end
-    delayed_calls = {}
 end)
 
 --- Call the given function at the end of the current main loop iteration

--- a/tests/test-timers.lua
+++ b/tests/test-timers.lua
@@ -1,0 +1,51 @@
+local gears = require("gears")
+
+local delayed_call
+local cb_count = 0
+
+local steps = {
+    -- Basic functionality of gears.timer.delayed_call.
+    function(_)
+        gears.timer.delayed_call(function()
+            delayed_call = true
+        end)
+        return true
+    end,
+    function(_)
+        assert(delayed_call)
+        return true
+    end,
+
+    -- gears.timer.delayed_call: re-queue function.
+    function(_)
+        local function cb()
+            cb_count = cb_count + 1
+            if cb_count < 3 then
+                gears.timer.delayed_call(function()
+                    cb()
+                end)
+            end
+        end
+
+        gears.timer.delayed_call(function()
+            cb()
+        end)
+        return true
+    end,
+    function(_)
+        assert(cb_count == 2, 'Count should be 2, but is: ' .. cb_count)
+        return true
+    end,
+    function(_)
+        assert(cb_count == 3, cb_count)
+        return true
+    end,
+    function(_)
+        assert(cb_count == 3, cb_count)
+        return true
+    end,
+}
+
+require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This allows for re-queuing a delayed call from the delayed call itself,
without causing an infinite loop.