### PR TITLE
Tests: check-integration: error on warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,7 @@ add_executable(test-gravity tests/test-gravity.c)
 target_link_libraries(test-gravity
     ${AWESOME_COMMON_REQUIRED_LDFLAGS} ${AWESOME_REQUIRED_LDFLAGS})
 add_custom_target(check-integration
-    sh -c "CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${CMAKE_SOURCE_DIR}/tests/run.sh"
+    sh -c "CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${CMAKE_SOURCE_DIR}/tests/run.sh -W"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
     USES_TERMINAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,11 +395,10 @@ add_executable(test-gravity tests/test-gravity.c)
 target_link_libraries(test-gravity
     ${AWESOME_COMMON_REQUIRED_LDFLAGS} ${AWESOME_REQUIRED_LDFLAGS})
 add_custom_target(check-integration
-    sh -c "CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${CMAKE_SOURCE_DIR}/tests/run.sh -W"
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
-    USES_TERMINAL
-    VERBATIM)
+    USES_TERMINAL)
 add_dependencies(check-integration test-gravity)
 add_custom_target(check-themes
     ${CMAKE_SOURCE_DIR}/tests/themes/run.sh

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,13 +19,17 @@ export HOME=/dev/null
 usage() {
     cat >&2 <<EOF
 Usage: $0 [-W] [testfile]...
+  -v: verbose mode
   -W: warnings become errors
   -h: show this help
 EOF
     exit "$1"
 }
-while getopts Wh opt; do
+fail_on_warning=
+verbose=${VERBOSE:-0}
+while getopts vWh opt; do
     case $opt in
+        v) verbose=1 ;;
         W) fail_on_warning=1 ;;
         h) usage 0 ;;
         *) usage 64 ;;
@@ -33,8 +37,7 @@ while getopts Wh opt; do
 done
 shift $((OPTIND-1))
 
-VERBOSE=${VERBOSE-0}
-if [ "$VERBOSE" = 1 ]; then
+if [[ $verbose ]]; then
     set -x
 fi
 
@@ -119,9 +122,7 @@ awesome_log=$tmp_files/_awesome_test.log
 echo "awesome_log: $awesome_log"
 
 wait_until_success() {
-    if [ "$VERBOSE" = 1 ]; then
-        set +x
-    fi
+    if [[ $verbose ]]; then set +x; fi
     wait_count=60  # 60*0.05s => 3s.
     while true; do
         set +e
@@ -144,9 +145,7 @@ wait_until_success() {
         fi
         sleep 0.05
     done
-    if [ "$VERBOSE" = 1 ]; then
-        set -x
-    fi
+    if [[ $verbose ]]; then set -x; fi
 }
 
 # Wait for DISPLAY to be available, and setup xrdb,

--- a/tests/themes/run.sh
+++ b/tests/themes/run.sh
@@ -15,12 +15,12 @@ tests_dir="$(dirname -- "$0")/.."
 
 config_file="$build_dir/test-themes-awesomerc.lua"
 
-for theme in themes/*/theme.lua; do
-  echo "== Testing $theme =="
-  theme=${theme%/*}
-  theme=${theme##*/}
+for theme_file in themes/*/theme.lua; do
+  echo "==== Testing theme: $theme_file ===="
+  theme_name=${theme_file%/*}
+  theme_name=${theme_name##*/}
 
-  sed "s~default/theme~$theme/theme~g" "awesomerc.lua" > "$config_file"
+  sed "s~default/theme~$theme_name/theme~g" "awesomerc.lua" > "$config_file"
 
   # Set CMAKE_BINARY_DIR for out-of-tree builds.
   CMAKE_BINARY_DIR="$PWD" \


### PR DESCRIPTION
Does it make sense to have the `-W` option, or should we just adjust the pattern always?