### PR TITLE
Add an alternative awful.tooltip example

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -18,6 +18,16 @@
 --             end,
 --         })
 --
+--     -- alternatively, you can use mouse::enter signal
+--     myclock = wibox.widget.textclock("%T", 1)
+--     myclock_t = awful.tooltip({
+--         objects = { myclock }
+--         })
+--
+--     myclock:connect_signal("mouse::enter", function()
+--             myclock_t.text = os.date("Today is %A %B %d %Y\nThe time is %T")
+--     end)
+--
 -- How to add the same tooltip to multiple objects?
 -- ---
 --


### PR DESCRIPTION
Added an awful.tooltip example that shows how to use mouse::enter signal
to update the text properties of the tooltip.

Signed-off-by: nicodebo <nico.debo@openmailbox.org>

Note: I didn't use the same args as the first exemple because they don't seem to be valid anymore and return some errors. I was not sure if I should fix or if it was in the scope of this pull request so I left it.