### PR TITLE
Allow setting environment vars for spawned processes

### DIFF
--- a/spawn.c
+++ b/spawn.c
@@ -369,6 +369,48 @@ spawn_callback(gpointer user_data)
         unsetenv("DESKTOP_STARTUP_ID");
 }
 
+/** Convert a Lua table of string to a char** array.
+ * \param L The Lua VM state.
+ * \param idx The index of the table that we should parse
+ * \return The argv array.
+ */
+static gchar **
+parse_table_array(lua_State *L, int idx, GError **error)
+{
+    gchar **argv = NULL;
+    size_t i, len;
+
+    luaL_checktype(L, idx, LUA_TTABLE);
+    idx = luaA_absindex(L, idx);
+    len = luaA_rawlen(L, idx);
+
+    /* First verify that the table is sane: All integer keys must contain
+     * strings. Do this by pushing them all onto the stack.
+     */
+    for (i = 0; i < len; i++)
+    {
+        lua_rawgeti(L, idx, i+1);
+        if (lua_type(L, -1) != LUA_TSTRING)
+        {
+            g_set_error(error, G_SPAWN_ERROR, 0,
+                    "Non-string argument at table index %zd", i+1);
+            return NULL;
+        }
+    }
+
+    /* From this point on nothing can go wrong and so we can safely allocate
+     * memory.
+     */
+    argv = g_new0(gchar *, len + 1);
+    for (i = 0; i < len; i++)
+    {
+        argv[len - i - 1] = g_strdup(lua_tostring(L, -1));
+        lua_pop(L, 1);
+    }
+
+    return argv;
+}
+
 /** Parse a command line.
  * \param L The Lua VM state.
  * \param idx The index of the argument that we should parse
@@ -378,7 +420,6 @@ static gchar **
 parse_command(lua_State *L, int idx, GError **error)
 {
     gchar **argv = NULL;
-    idx = luaA_absindex(L, idx);
 
     if (lua_isstring(L, idx))
     {
@@ -388,31 +429,7 @@ parse_command(lua_State *L, int idx, GError **error)
     }
     else if (lua_istable(L, idx))
     {
-        size_t i, len = luaA_rawlen(L, idx);
-
-        /* First verify that the table is sane: All integer keys must contain
-         * strings. Do this by pushing them all onto the stack.
-         */
-        for (i = 0; i < len; i++)
-        {
-            lua_rawgeti(L, idx, i+1);
-            if (lua_type(L, -1) != LUA_TSTRING)
-            {
-                g_set_error(error, G_SPAWN_ERROR, 0,
-                        "Non-string argument at table index %zd", i+1);
-                return NULL;
-            }
-        }
-
-        /* From this point on nothing can go wrong and so we can safely allocate
-         * memory.
-         */
-        argv = g_new0(gchar *, len + 1);
-        for (i = 0; i < len; i++)
-        {
-            argv[len - i - 1] = g_strdup(lua_tostring(L, -1));
-            lua_pop(L, 1);
-        }
+        argv = parse_table_array(L, idx, error);
     }
     else
     {

--- a/spawn.c
+++ b/spawn.c
@@ -369,9 +369,9 @@ spawn_callback(gpointer user_data)
         unsetenv("DESKTOP_STARTUP_ID");
 }
 
-/** Convert a Lua table of string to a char** array.
+/** Convert a Lua table of strings to a char** array.
  * \param L The Lua VM state.
- * \param idx The index of the table that we should parse
+ * \param idx The index of the table that we should parse.
  * \return The argv array.
  */
 static gchar **
@@ -413,7 +413,7 @@ parse_table_array(lua_State *L, int idx, GError **error)
 
 /** Parse a command line.
  * \param L The Lua VM state.
- * \param idx The index of the argument that we should parse
+ * \param idx The index of the argument that we should parse.
  * \return The argv array for the new process.
  */
 static gchar **
@@ -434,7 +434,7 @@ parse_command(lua_State *L, int idx, GError **error)
     else
     {
         g_set_error_literal(error, G_SPAWN_ERROR, 0,
-                "Invalid argument to spawn(), expect string or table");
+                "Invalid argument to spawn(), expected string or table");
         return NULL;
     }
 
@@ -473,10 +473,10 @@ child_exit_callback(GPid pid, gint status, gpointer user_data)
  * @tparam[opt=false] boolean stdout Return a fd for stdout?
  * @tparam[opt=false] boolean stderr Return a fd for stderr?
  * @tparam[opt=nil] function exit_callback Function to call on process exit. The
- * function arguments will be type of exit ("exit" or "signal") and the exit
- * code / the signal number causing process termination.
+ *   function arguments will be type of exit ("exit" or "signal") and the exit
+ *   code / the signal number causing process termination.
  * @tparam[opt=nil] table cmd The environment to use for the spawned program.
- * Without this, the spawned process inherits awesome's environment.
+ *   Without this the spawned process inherits awesome's environment.
  * @treturn[1] integer Process ID if everything is OK.
  * @treturn[1] string Startup-notification ID, if `use_sn` is true.
  * @treturn[1] integer stdin, if `stdin` is true.

--- a/spawn.c
+++ b/spawn.c
@@ -457,7 +457,7 @@ child_exit_callback(GPid pid, gint status, gpointer user_data)
  * @treturn[1] integer stdin, if `stdin` is true.
  * @treturn[1] integer stdout, if `stdout` is true.
  * @treturn[1] integer stderr, if `stderr` is true.
- * @treturn[2] string An error string if an error occured.
+ * @treturn[2] string An error string if an error occurred.
  * @function spawn
  */
 int

--- a/spawn.c
+++ b/spawn.c
@@ -397,7 +397,11 @@ parse_command(lua_State *L, int idx, GError **error)
         {
             lua_rawgeti(L, idx, i+1);
             if (lua_type(L, -1) != LUA_TSTRING)
-                luaL_error(L, "Non-string argument at table index %d", i+1);
+            {
+                g_set_error(error, G_SPAWN_ERROR, 0,
+                        "Non-string argument at table index %zd", i+1);
+                return NULL;
+            }
         }
 
         /* From this point on nothing can go wrong and so we can safely allocate
@@ -412,7 +416,9 @@ parse_command(lua_State *L, int idx, GError **error)
     }
     else
     {
-        luaL_error(L, "Invalid argument to spawn(), expect string or table");
+        g_set_error_literal(error, G_SPAWN_ERROR, 0,
+                "Invalid argument to spawn(), expect string or table");
+        return NULL;
     }
 
     return argv;


### PR DESCRIPTION
See #1667 for how this happened (more or less, I'm not completely sure?!?).

Note that this PR only does the necessary changes on the C side so that an environment for spawned processes can be set. Nothing is done on the Lua side and somehow I feel that just "tacking things" onto the existing spawn API ends up being complicated. Also note that *only* the provided environment is used, so nothing else is inherited. Thus, the following snipped of code might be needed:
```lua
glib = require("lgi").GLib
local env = {}
for _, k in ipairs(glib.listenv()) do
    env[k] = glib.getenv(k)
end
```
(The above does the equivalent of lines 441 to 463 in https://github.com/bang-uin/awesome/commit/9e8ea1bce201be624999e527b9102e7bf73ad74c#diff-7d165d612dceb08d572a0ad1fb250565R441 but instead of 20 lines of codes (with memory leaks), it's just 5 (and we can be sure that there are no memory leaks))