### PR TITLE
build-utils/dist.sh: fix shellcheck warnings and add usage

### DIFF
--- a/build-utils/dist.sh
+++ b/build-utils/dist.sh
@@ -4,20 +4,23 @@
 
 set -e
 
+if [ -z "$1" ]; then
+    echo "Usage: $0 VERSION"
+    exit 64
+fi
+
 VERSION=$1
-SVERSION=`echo $1 | sed 's/^v//'`
-git archive --prefix=dist/awesome-$SVERSION/ $VERSION | tar -xf -
+SVERSION=$(echo "$VERSION" | sed 's/^v//')
+git archive --prefix "dist/awesome-$SVERSION/" "$VERSION" | tar -xf -
 cd dist
-echo -n $VERSION > awesome-$SVERSION/.version_stamp
-tar cjf awesome-$SVERSION.tar.bz2 awesome-$SVERSION
-tar cJf awesome-$SVERSION.tar.xz awesome-$SVERSION
-gpg --armor --detach-sign awesome-$SVERSION.tar.bz2
-gpg --armor --detach-sign awesome-$SVERSION.tar.xz
+printf '%s' "$VERSION" > "awesome-$SVERSION/.version_stamp"
+tar cjf "awesome-$SVERSION.tar.bz2" "awesome-$SVERSION"
+tar cJf "awesome-$SVERSION.tar.xz" "awesome-$SVERSION"
+gpg --armor --detach-sign "awesome-$SVERSION.tar.bz2"
+gpg --armor --detach-sign "awesome-$SVERSION.tar.xz"
 
 echo "Created the following files in dist/:"
-echo "awesome-$SVERSION.tar.bz2"
-echo "awesome-$SVERSION.tar.xz"
-echo "awesome-$SVERSION.tar.bz2.asc"
-echo "awesome-$SVERSION.tar.xz.asc"
+ls -l "awesome-$SVERSION.tar.bz2"     "awesome-$SVERSION.tar.xz" \
+      "awesome-$SVERSION.tar.bz2.asc" "awesome-$SVERSION.tar.xz.asc"
 
 # vim: filetype=sh:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/build-utils/dist.sh
+++ b/build-utils/dist.sh
@@ -5,17 +5,26 @@
 set -e
 
 if [ -z "$1" ]; then
-    echo "Usage: $0 VERSION"
+    echo "Usage: $0 <GIT_TAG>"
     exit 64
 fi
 
-VERSION=$1
-SVERSION=$(echo "$VERSION" | sed 's/^v//')
-git archive --prefix "dist/awesome-$SVERSION/" "$VERSION" | tar -xf -
+GIT_TAG="$1"
+SVERSION=$(echo "$GIT_TAG" | sed 's/^v//')
+
+date=$(git log -1 --format=%cI "$GIT_TAG")
+git archive --prefix "dist/awesome-$SVERSION/" "$GIT_TAG" | tar -xf -
+
 cd dist
-printf '%s' "$VERSION" > "awesome-$SVERSION/.version_stamp"
-tar cjf "awesome-$SVERSION.tar.bz2" "awesome-$SVERSION"
-tar cJf "awesome-$SVERSION.tar.xz" "awesome-$SVERSION"
+version_stamp="awesome-$SVERSION/.version_stamp"
+printf '%s' "$GIT_TAG" > "$version_stamp"
+touch --date="$date" "$version_stamp" "awesome-$SVERSION"
+
+tar cf "awesome-$SVERSION.tar" "awesome-$SVERSION"
+bzip2 -c "awesome-$SVERSION.tar" > "awesome-$SVERSION.tar.bz2"
+xz -c "awesome-$SVERSION.tar" > "awesome-$SVERSION.tar.xz"
+rm "awesome-$SVERSION.tar"
+
 gpg --armor --detach-sign "awesome-$SVERSION.tar.bz2"
 gpg --armor --detach-sign "awesome-$SVERSION.tar.xz"
 


### PR DESCRIPTION
[ci skip]