### PR TITLE
Naughty rewrite, part 1

### DIFF
--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -124,7 +124,7 @@ end
 -- @function awful.mouse.wibox.move
 --@tparam wibox w The wibox to move, or none to use that under the pointer
 function mouse.wibox.move(w)
-    w = w or mouse.wibox_under_pointer()
+    w = w or mouse.current_wibox
     if not w then return end
 
     if not w

--- a/lib/awful/widget/clienticon.lua
+++ b/lib/awful/widget/clienticon.lua
@@ -31,7 +31,7 @@ end
 
 function clienticon:draw(_, cr, width, height)
     local c = self._private.client
-    if not c.valid then
+    if not c or not c.valid then
         return
     end
 
@@ -52,7 +52,7 @@ end
 
 function clienticon:fit(_, width, height)
     local c = self._private.client
-    if not c.valid then
+    if not c or not c.valid then
         return 0, 0
     end
 
@@ -78,6 +78,21 @@ function clienticon:fit(_, width, height)
 
     local aspect = math.min(width / w, height / h)
     return w * aspect, h * aspect
+end
+
+--- The widget client.
+--
+-- @property client
+-- @param client
+
+function clienticon:get_client()
+    return self._private.client
+end
+
+function clienticon:set_client(c)
+    self._private.client = c
+    self:emit_signal("widget::layout_changed")
+    self:emit_signal("widget::redraw_needed")
 end
 
 --- Returns a new clienticon.

--- a/lib/awful/widget/clienticon.lua
+++ b/lib/awful/widget/clienticon.lua
@@ -80,7 +80,7 @@ function clienticon:fit(_, width, height)
     return w * aspect, h * aspect
 end
 
---- The widget client.
+--- The widget's @{client}.
 --
 -- @property client
 -- @param client

--- a/lib/gears/object.lua
+++ b/lib/gears/object.lua
@@ -56,6 +56,11 @@ function object:connect_signal(name, func)
     sig.strong[func] = true
 end
 
+-- Register a global signal receiver.
+function object:_connect_everything(callback)
+    table.insert(self._global_receivers, callback)
+end
+
 local function make_the_gc_obey(func)
     if _VERSION <= "Lua 5.1" then
         -- Lua 5.1 only has the behaviour we want if a userdata is used as the
@@ -119,6 +124,9 @@ function object:emit_signal(name, ...)
     end
     for func in pairs(sig.weak) do
         func(self, ...)
+    end
+    for _, func in ipairs(self._global_receivers) do
+        func(name, self, ...)
     end
 end
 
@@ -187,6 +195,8 @@ local function new(args)
     end
 
     ret._signals = {}
+
+    ret._global_receivers = {}
 
     local mt = {}
 

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -63,6 +63,37 @@ function wibox:find_widgets(x, y)
     return self._drawable:find_widgets(x, y)
 end
 
+--- Create a widget that reflects the current state of this wibox.
+-- @treturn widget A new widget.
+function wibox:to_widget()
+    local bw = self.border_width or beautiful.border_width or 0
+    return wibox.widget {
+        {
+            self:get_widget(),
+            margins = bw,
+            widget  = wibox.container.margin
+        },
+        bg                 = self.bg or beautiful.bg_normal or "#ffffff",
+        fg                 = self.fg or beautiful.fg_normal or "#000000",
+        shape_border_color = self.border_color or beautiful.border_color or "#000000",
+        shape_border_width = bw*2,
+        shape_clip         = true,
+        shape              = self._shape,
+        forced_width       = self:geometry().width  + 2*bw,
+        forced_height      = self:geometry().height + 2*bw,
+        widget             = wibox.container.background
+    }
+end
+
+--- Save a screenshot of the wibox to `path`.
+-- @tparam string path The path.
+-- @tparam[opt=nil] table context A widget context.
+function wibox:save_to_svg(path, context)
+    wibox.widget.draw_to_svg_file(
+        self:to_widget(), path, self:geometry().width, self:geometry().height, context
+    )
+end
+
 function wibox:_apply_shape()
     local shape = self._shape
 

--- a/lib/wibox/layout/grid.lua
+++ b/lib/wibox/layout/grid.lua
@@ -900,10 +900,14 @@ end
 -- @tparam number|nil forced_num_rows Forced number of rows (`nil` for automatic).
 -- @tparam widget ... Widgets that should be added to the layout.
 -- @function wibox.layout.grid.horizontal
-function grid.horizontal(forced_num_rows, ...)
+function grid.horizontal(forced_num_rows, widget, ...)
     local ret = new("horizontal")
     ret:set_forced_num_rows(forced_num_rows)
-    ret:add(...)
+
+    if widget then
+        ret:add(widget, ...)
+    end
+
     return ret
 end
 
@@ -914,10 +918,14 @@ end
 -- @tparam number|nil forced_num_cols Forced number of columns (`nil` for automatic).
 -- @tparam widget ... Widgets that should be added to the layout.
 -- @function wibox.layout.grid.vertical
-function grid.vertical(forced_num_cols, ...)
+function grid.vertical(forced_num_cols, widget, ...)
     local ret = new("vertical")
     ret:set_forced_num_cols(forced_num_cols)
-    ret:add(...)
+
+    if widget then
+        ret:add(widget, ...)
+    end
+
     return ret
 end
 

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -582,6 +582,37 @@ function base.make_widget_declarative(args)
     return setmetatable(w, mt)
 end
 
+--- Create a widget from an undetermined value.
+--
+-- The value can be:
+--
+-- * A widget (in which case nothing new is created)
+-- * A declarative construct
+-- * A constructor function
+-- * A metaobject
+--
+-- If a widget cannot be deduced from the value, this function assert.
+--
+-- @param wdg A value
+-- @param[opt=nil] ... Arguments passed to the contructor (if any)
+-- @treturn A widget
+function base.make_widget_from_value(wdg, ...)
+    local is_table = type(wdg) == "table"
+    local is_function = ((not is_table) and type(wdg) == "function")
+        or (is_table and getmetatable(wdg) and getmetatable(wdg).__call)
+
+    -- Syntax sugar to allow the multiple ways to define a widget
+    if is_function then
+        wdg = wdg(...)
+    elseif is_table and not wdg.is_widget then
+        wdg = base.make_widget_declarative(wdg)
+    else
+        assert(wdg.is_widget, "The argument is not a widget")
+    end
+
+    return wdg
+end
+
 --- Create an empty widget skeleton.
 --
 -- See [Creating new widgets](../documentation/04-new-widget.md.html).

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -591,23 +591,20 @@ end
 -- * A constructor function
 -- * A metaobject
 --
--- If a widget cannot be deduced from the value, this function assert.
---
--- @param wdg A value
--- @param[opt=nil] ... Arguments passed to the contructor (if any)
--- @treturn A widget
+-- @param wdg The value.
+-- @param[opt=nil] ... Arguments passed to the contructor (if any).
+-- @treturn The new widget.
 function base.make_widget_from_value(wdg, ...)
     local is_table = type(wdg) == "table"
     local is_function = ((not is_table) and type(wdg) == "function")
         or (is_table and getmetatable(wdg) and getmetatable(wdg).__call)
 
-    -- Syntax sugar to allow the multiple ways to define a widget
     if is_function then
         wdg = wdg(...)
     elseif is_table and not wdg.is_widget then
         wdg = base.make_widget_declarative(wdg)
     else
-        assert(wdg.is_widget, "The argument is not a widget")
+        assert(wdg.is_widget, "The argument is not a function, table, or widget.")
     end
 
     return wdg

--- a/lib/wibox/widget/init.lua
+++ b/lib/wibox/widget/init.lua
@@ -20,6 +20,7 @@ local widget = {
     piechart = require("wibox.widget.piechart");
     slider = require("wibox.widget.slider");
     calendar = require("wibox.widget.calendar");
+    separator = require("wibox.widget.separator");
 }
 
 setmetatable(widget, {

--- a/lib/wibox/widget/separator.lua
+++ b/lib/wibox/widget/separator.lua
@@ -1,0 +1,192 @@
+---------------------------------------------------------------------------
+-- A flexible separator widget.
+--
+-- By default, this widget display a simple line, but can be extended by themes
+-- (or directly) to display much more complex visuals.
+--
+-- This widget is mainly intended to be used alongside the `spacing_widget`
+-- property supported by various layouts such as:
+--
+-- * `wibox.layout.fixed`
+-- * `wibox.layout.flex`
+-- * `wibox.layout.ratio`
+--
+-- When used with these layouts, it is also possible to provide custom clipping
+-- functions. This is useful when the layout has overlapping widgets (negative
+-- spacing).
+--
+--@DOC_wibox_widget_defaults_separator_EXAMPLE@
+--
+-- @author Emmanuel Lepage Vallee &lt;elv1313@gmail.com&gt;
+-- @copyright 2014, 2017 Emmanuel Lepage Vallee
+-- @classmod wibox.widget.separator
+---------------------------------------------------------------------------
+local beautiful = require( "beautiful"         )
+local base      = require( "wibox.widget.base" )
+local color     = require( "gears.color"       )
+local gtable    = require( "gears.table"       )
+
+local separator = {}
+
+--- The separator orientation.
+--
+-- The valid values are:
+--
+-- * *vertical*: From top to bottom (default)
+-- * *horizontal*: From left to right
+--
+--@DOC_wibox_widget_separator_orientation_EXAMPLE@
+--
+-- @property orientation
+-- @param string
+
+--- The separator thickness.
+--
+-- This is used by the default line separator, but ignored when a shape is used.
+--
+-- @property thickness
+-- @param number
+
+--- The separator reflection.
+--
+-- When a shape or a custom drawing function is used, the default shape assume
+-- left to right. When this property is set to anything else, the shape will be
+-- rotated on one axis or another.
+--
+-- This is the same as `wibox.container.mirror`, but need to exist on the widget
+-- level because it affects other properties such as the layout clipping.
+--
+-- @property reflection
+-- @tparam table reflection
+-- @tparam[opt=false] boolean reflection.horizontal
+-- @tparam[opt=false] boolean reflection.vertical
+
+--- The separator shape.
+--
+--@DOC_wibox_widget_separator_shape_EXAMPLE@
+--
+-- @property shape
+-- @tparam function shape A valid shape function
+-- @see gears.shape
+
+--- The relative percentage covered by the bar.
+-- @property span_ratio
+-- @tparam[opt=1] number A number between 0 and 1
+
+--- The separator color.
+-- @property color
+-- @param string
+-- @see gears.color
+
+--- The separator border color.
+--
+--@DOC_wibox_widget_separator_border_color_EXAMPLE@
+--
+-- @property border_color
+-- @param string
+-- @see gears.color
+
+--- The separator border width.
+-- @property border_width
+-- @param number
+
+local function draw_shape(self, _, cr, width, height, shape)
+    local bw = self._private.border_width or 0
+
+    cr:translate(bw/2,bw/2)
+
+    shape(cr, width-bw, height-bw)
+
+    if bw == 0 then
+        cr:fill()
+    elseif self._private.border_color then
+        cr:fill_preserve()
+        cr:set_source(color(self._private.border_color))
+        cr:set_line_width(bw)
+        cr:stroke()
+    end
+end
+
+local function draw_line(self, _, cr, width, height)
+    local thickness = self._private.thickness or beautiful.separator_thickness or 1
+
+    local orientation = self._private.orientation or (
+        width > height and "horizontal" or "vertical"
+    )
+
+    local span_ratio = self._private.span_ratio or 1
+
+    if orientation == "horizontal" then
+        local w = width*span_ratio
+        cr:rectangle((width-w)/2, height/2 - thickness/2, w, thickness)
+    else
+        local h = height*span_ratio
+        cr:rectangle(width/2 - thickness/2, (height-h)/2, thickness, h)
+    end
+
+    cr:fill()
+end
+
+local function draw(self, _, cr, width, height)
+    -- In case there is a specialized
+    local draw_custom = self._private.draw or beautiful.separator_draw
+    if draw_custom then
+        return draw_custom(self, _, cr, width, height)
+    end
+
+    local col = self._private.color or beautiful.separator_color
+
+    if col then
+        cr:set_source(color(col))
+    end
+
+    local s = self._private.shape or beautiful.separator_shape
+
+    if s then
+        draw_shape(self, _, cr, width, height, s)
+    else
+        draw_line(self, _, cr, width, height)
+    end
+end
+
+local function fit(_, _, width, height)
+    return width, height
+end
+
+for _, prop in ipairs {"orientation", "color", "thickness", "span_ratio",
+                       "border_width", "border_color", "shape" } do
+    separator["set_"..prop] = function(self, value)
+        self._private[prop] = value
+        self:emit_signal("property::"..prop)
+        if prop == "data_list" then
+            self:emit_signal("property::data")
+        end
+        self:emit_signal("widget::redraw_needed")
+    end
+    separator["get_"..prop] = function(self)
+        return self._private[prop] or beautiful["piechart_"..prop]
+    end
+end
+
+local function new(args)
+
+    local ret = base.make_widget(nil, nil, {
+        enable_properties = true,
+    })
+
+    gtable.crush(ret, separator, true)
+
+    gtable.crush(ret, args or {})
+
+    rawset(ret, "fit" , fit )
+    rawset(ret, "draw", draw)
+
+    return ret
+end
+
+--@DOC_widget_COMMON@
+
+--@DOC_object_COMMON@
+
+return setmetatable(separator, { __call = function(_, ...) return new(...) end })
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/wibox/widget/separator.lua
+++ b/lib/wibox/widget/separator.lua
@@ -28,9 +28,9 @@ local gtable    = require( "gears.table"       )
 
 local separator = {}
 
---- The separator orientation.
+--- The separator's orientation.
 --
--- The valid values are:
+-- Valid values are:
 --
 -- * *vertical*: From top to bottom (default)
 -- * *horizontal*: From left to right
@@ -40,18 +40,19 @@ local separator = {}
 -- @property orientation
 -- @param string
 
---- The separator thickness.
+--- The separator's thickness.
 --
 -- This is used by the default line separator, but ignored when a shape is used.
 --
 -- @property thickness
 -- @param number
 
---- The separator reflection.
+--- The separator's reflection.
 --
--- When a shape or a custom drawing function is used, the default shape assume
--- left to right. When this property is set to anything else, the shape will be
--- rotated on one axis or another.
+-- When a shape or a custom drawing function is used, the default shape assumes
+-- this to go from left to right.
+-- When this property is set to anything else, the shape will be rotated on one
+-- axis or another.
 --
 -- This is the same as `wibox.container.mirror`, but need to exist on the widget
 -- level because it affects other properties such as the layout clipping.
@@ -61,7 +62,7 @@ local separator = {}
 -- @tparam[opt=false] boolean reflection.horizontal
 -- @tparam[opt=false] boolean reflection.vertical
 
---- The separator shape.
+--- The separator's shape.
 --
 --@DOC_wibox_widget_separator_shape_EXAMPLE@
 --
@@ -71,14 +72,14 @@ local separator = {}
 
 --- The relative percentage covered by the bar.
 -- @property span_ratio
--- @tparam[opt=1] number A number between 0 and 1
+-- @tparam[opt=1] number A number between 0 and 1.
 
---- The separator color.
+--- The separator's color.
 -- @property color
 -- @param string
 -- @see gears.color
 
---- The separator border color.
+--- The separator's border color.
 --
 --@DOC_wibox_widget_separator_border_color_EXAMPLE@
 --
@@ -86,14 +87,14 @@ local separator = {}
 -- @param string
 -- @see gears.color
 
---- The separator border width.
+--- The separator's border width.
 -- @property border_width
 -- @param number
 
 local function draw_shape(self, _, cr, width, height, shape)
     local bw = self._private.border_width or 0
 
-    cr:translate(bw/2,bw/2)
+    cr:translate(bw/2, bw/2)
 
     shape(cr, width-bw, height-bw)
 
@@ -128,7 +129,7 @@ local function draw_line(self, _, cr, width, height)
 end
 
 local function draw(self, _, cr, width, height)
-    -- In case there is a specialized
+    -- In case there is a specialized.
     local draw_custom = self._private.draw or beautiful.separator_draw
     if draw_custom then
         return draw_custom(self, _, cr, width, height)
@@ -169,18 +170,13 @@ for _, prop in ipairs {"orientation", "color", "thickness", "span_ratio",
 end
 
 local function new(args)
-
     local ret = base.make_widget(nil, nil, {
         enable_properties = true,
     })
-
     gtable.crush(ret, separator, true)
-
     gtable.crush(ret, args or {})
-
     rawset(ret, "fit" , fit )
     rawset(ret, "draw", draw)
-
     return ret
 end
 

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -238,6 +238,25 @@ drawin_refresh(void)
     }
 }
 
+/** Get all drawins into a table.
+ * @treturn table A table with drawins.
+ * @function get
+ */
+static int
+luaA_drawin_get(lua_State *L)
+{
+    int i = 1;
+
+    lua_newtable(L);
+
+    foreach(c, globalconf.drawins) {
+        luaA_object_push(L, *c);
+        lua_rawseti(L, -2, i++);
+    }
+
+    return 1;
+}
+
 /** Move and/or resize a drawin
  * \param L The Lua VM state.
  * \param udx The index of the drawin.
@@ -746,6 +765,7 @@ drawin_class_setup(lua_State *L)
     static const struct luaL_Reg drawin_methods[] =
     {
         LUA_CLASS_METHODS(drawin)
+        { "get", luaA_drawin_get },
         { "__call", luaA_drawin_new },
         { NULL, NULL }
     };

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -63,7 +63,6 @@ ${TOP_SOURCE_DIR}/tests/examples/shims/?;"
 # Done in 3 variables to avoid CMake from implicitly converting into a list.
 set(ENV{LUA_PATH} "${LUA_PATH3_}${LUA_PATH2_}${LUA_PATH_}")
 
-# Set Awesome theme directory variable
 set(ENV{AWESOME_THEMES_PATH} "${TOP_SOURCE_DIR}/themes/")
 
 # Unset environment variables that would get in the way of evaluating LUA_PATH.

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -63,6 +63,9 @@ ${TOP_SOURCE_DIR}/tests/examples/shims/?;"
 # Done in 3 variables to avoid CMake from implicitly converting into a list.
 set(ENV{LUA_PATH} "${LUA_PATH3_}${LUA_PATH2_}${LUA_PATH_}")
 
+# Set Awesome theme directory variable
+set(ENV{AWESOME_THEMES_PATH} "${TOP_SOURCE_DIR}/themes/")
+
 # Unset environment variables that would get in the way of evaluating LUA_PATH.
 unset(ENV{LUA_PATH_5_1})
 unset(ENV{LUA_PATH_5_2})

--- a/tests/examples/awful/notification/corner.lua
+++ b/tests/examples/awful/notification/corner.lua
@@ -1,0 +1,20 @@
+--DOC_HIDE_ALL
+local naughty = require("naughty") --DOC_HIDE
+
+for _, pos in ipairs {
+    "top_left",
+    "top_middle",
+    "top_right",
+    "bottom_left",
+    "bottom_middle",
+    "bottom_right",
+} do
+    naughty.notify {
+        title    = pos,
+        position = pos,
+        text     = "",
+    }
+end
+
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/awful/template.lua
+++ b/tests/examples/awful/template.lua
@@ -5,9 +5,11 @@ local cairo      = require("lgi").cairo
 local pango      = require("lgi").Pango
 local pangocairo = require("lgi").PangoCairo
 
-local color     = require( "gears.color" )
-local shape     = require( "gears.shape" )
-local beautiful = require( "beautiful"   )
+local color     = require( "gears.color"    )
+local shape     = require( "gears.shape"    )
+local beautiful = require( "beautiful"      )
+local wibox     = require( "wibox"          )
+local titlebar  = require( "awful.titlebar" )
 
 -- Run the test
 local args = loadfile(file_path)() or {}
@@ -19,16 +21,6 @@ local cr  = cairo.Context(img)
 
 local pango_crx = pangocairo.font_map_get_default():create_context()
 local pl = pango.Layout.new(pango_crx)
-
--- Draw some text inside of the geometry
-local function draw_label(geo, text)
-    cr:save()
-    cr:set_source(color(beautiful.fg_normal))
-    cr:translate(geo.x, geo.y)
-    pl.text = text
-    cr:show_layout(pl)
-    cr:restore()
-end
 
 -- Draw a mouse cursor at [x,y]
 local function draw_mouse(x, y)
@@ -66,22 +58,125 @@ end
 cr:set_line_width(beautiful.border_width)
 cr:set_source(color(beautiful.border_color))
 
+
+
+local rect = {x1 = 0 ,y1 = 0 , x2 = 0 , y2 = 0}
+
+-- Get the region with wiboxes
+for _, obj in ipairs {drawin, client} do
+    for _, d in ipairs(obj.get()) do
+        local w = d.get_wibox and d:get_wibox() or d
+        if w and w.geometry then
+            local geo = w:geometry()
+            rect.x1 = math.min(rect.x1, geo.x                                       )
+            rect.y1 = math.min(rect.y1, geo.y                                       )
+            rect.x2 = math.max(rect.x2, geo.x + geo.width  + 2*(w.border_width or 0))
+            rect.y2 = math.max(rect.y2, geo.y + geo.height + 2*(w.border_width or 0))
+        end
+    end
+end
+
+local total_area = wibox.layout {
+    forced_width  = rect.x2,
+    forced_height = rect.y2,
+    layout        = wibox.layout.manual,
+}
+
+local function wrap_titlebar(tb, width, height)
+    return wibox.widget {
+        tb.drawable.widget,
+        bg            = tb.args.bg_normal,
+        fg            = tb.args.fg_normal,
+        forced_width  = width,
+        forced_height = height,
+        widget        = wibox.container.background
+    }
+end
+
+local function client_widget(c, color, label)
+    local geo = c:geometry()
+    local bw = c.border_width or beautiful.border_width or 0
+
+    local l = wibox.layout.align.vertical()
+    l.fill_space = true
+
+    local tbs = c.titlebars or {}
+
+    local map = {
+        top    = "set_first",
+        left   = "set_first",
+        bottom = "set_third",
+        right  = "set_third",
+    }
+
+    for _, position in ipairs{"top", "bottom"} do
+        local tb = tbs[position]
+        if tb then
+            l[map[position]](l, wrap_titlebar(tb, c:geometry().width, tb.args.height or 16))
+        end
+    end
+
+    for _, position in ipairs{"left", "right"} do
+        local tb = tbs[position]
+        if tb then
+            l[map[position]](l, wrap_titlebar(tb, tb.args.width or 16, c:geometry().height))
+        end
+    end
+
+    local l2 = wibox.layout.align.horizontal()
+    l2.fill_space = true
+    l:set_second(l2)
+    l.forced_width  = c.width
+    l.forced_height = c.height
+
+    return wibox.widget {
+        {
+            {
+                l,
+                margins = bw + 1, -- +1 because the the SVG AA
+                layout  = wibox.container.margin
+            },
+            {
+                text   = label or "",
+                align  = "center",
+                valign = "center",
+                widget = wibox.widget.textbox
+            },
+            layout = wibox.layout.stack
+        },
+        shape_border_width = bw*2,
+        shape_border_color = beautiful.border_color,
+        shape_clip         = true,
+        fg                 = beautiful.fg_normal or "#000000",
+        bg                 = color,
+        forced_width       = geo.width  + 2*bw,
+        forced_height      = geo.height + 2*bw,
+        shape              = function(cr, w, h)
+            return shape.rounded_rect(cr, w, h, args.radius or 5)
+        end,
+
+        widget = wibox.container.background,
+    }
+end
+
+-- Add all wiboxes
+for _, d in ipairs(drawin.get()) do
+    local w = d.get_wibox and d:get_wibox() or nil
+    if w then
+        local geo = w:geometry()
+        total_area:add_at(w:to_widget(), {x = geo.x, y = geo.y})
+    end
+end
+
 -- Loop each clients geometry history and paint it
 for _, c in ipairs(client.get()) do
     local pgeo = nil
     for _, geo in ipairs(c._old_geo) do
         if not geo._hide then
-            cr:save()
-            cr:translate(geo.x, geo.y)
-            shape.rounded_rect(cr, geo.width, geo.height, args.radius or 5)
-            cr:stroke_preserve()
-            cr:set_source(color(c.color or geo._color or beautiful.bg_normal))
-            cr:fill()
-            cr:restore()
-
-            if geo._label then
-                draw_label(geo, geo._label)
-            end
+            total_area:add_at(
+                client_widget(c, c.color or geo._color or beautiful.bg_normal, geo._label),
+                {x=geo.x, y=geo.y}
+            )
         end
 
         -- Draw lines between the old and new corners
@@ -114,6 +209,11 @@ for _, c in ipairs(client.get()) do
         pgeo = geo
     end
 end
+
+-- Draw the wiboxes/clients on top of the screen
+wibox.widget.draw_to_cairo_context(
+    total_area, cr, screen._get_extents()
+)
 
 cr:set_source_rgba(1,0,0,1)
 cr:set_dash({1,1},1)

--- a/tests/examples/awful/template.lua
+++ b/tests/examples/awful/template.lua
@@ -3,10 +3,10 @@ require("_common_template")(...)
 
 local cairo      = require("lgi").cairo
 
-local color     = require( "gears.color"    )
-local shape     = require( "gears.shape"    )
-local beautiful = require( "beautiful"      )
-local wibox     = require( "wibox"          )
+local color     = require("gears.color")
+local shape     = require("gears.shape")
+local beautiful = require("beautiful")
+local wibox     = require("wibox")
 
 -- Run the test
 local args = loadfile(file_path)() or {}

--- a/tests/examples/naughty/actions.lua
+++ b/tests/examples/naughty/actions.lua
@@ -1,0 +1,19 @@
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+-- local naughty = require("naughty")
+
+dbus.notify_send(
+    --[[data]] {
+        member = "Notify",
+    },
+    --[[app_name]]    "Notification demo",
+    --[[replaces_id]] nil,
+    --[[icon]] "",
+    --[[title]] "You got a message!",
+    --[[text]] "This is a message from above.\nAwesomeWM is your faith.",
+    {"Accept", "Dismiss", "Forward"},
+    --[[hints]] {},
+    --[[expire]] 5
+)
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/colors.lua
+++ b/tests/examples/naughty/colors.lua
@@ -1,0 +1,19 @@
+
+local beautiful = require("beautiful") --DOC_HIDE
+
+local text = [[An <b>important</b>
+<i>notification</i>
+]]
+
+require("naughty").notify {
+    title        = "Hello world!",
+    text         = text,
+    icon         = beautiful.icon,
+    bg           = "#0000ff",
+    fg           = "#ff0000",
+    fond         = "verdana 14",
+    border_width = 1,
+    border_color = "#ff0000"
+}
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/helloworld.lua
+++ b/tests/examples/naughty/helloworld.lua
@@ -1,0 +1,18 @@
+--DOC_HIDE_ALL
+-- local naughty = require("naughty")
+
+dbus.notify_send(
+    --[[data]] {
+        member = "Notify",
+    },
+    --[[app_name]]    "Notification demo",
+    --[[replaces_id]] nil,
+    --[[icon]] "",
+    --[[title]] "Hello world!",
+    --[[text]] "The notification content",
+    --[[actions]] {},
+    --[[hints]] {},
+    --[[expire]] 5
+)
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/shape.lua
+++ b/tests/examples/naughty/shape.lua
@@ -1,0 +1,31 @@
+
+local beautiful = require("beautiful") --DOC_HIDE
+local gears     = {shape=require("gears.shape")} --DOC_HIDE
+local naughty   = require("naughty") --DOC_HIDE
+
+local text = [[An <b>important</b>
+<i>notification</i>
+]]
+
+local shapes = {
+    gears.shape.rounded_rect,
+    gears.shape.hexagon,
+    gears.shape.octogon,
+    function(cr, w, h)
+        return gears.shape.infobubble(cr, w, h, 20, 10, w/2 - 10)
+    end
+}
+
+for _, s in ipairs(shapes) do
+    naughty.notify {
+        title        = "Hello world!",
+        text         = text,
+        icon         = beautiful.icon,
+        shape        = s,
+        border_width = 3,
+        border_color = beautiful.bg_highlight,
+        margin       = 15,
+    }
+end
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/template.lua
+++ b/tests/examples/naughty/template.lua
@@ -1,0 +1,54 @@
+local file_path, image_path = ...
+require("_common_template")(...)
+local wibox = require("wibox")
+
+-- For the connections
+require("naughty")
+
+-- Create a screen
+screen[1]._resize {x = 0, width = 800, height = 600}
+
+-- Let the test request a size and file format
+loadfile(file_path)()
+
+-- Emulate the event loop for 10 iterations
+for _ = 1, 10 do
+    awesome:emit_signal("refresh")
+end
+
+local rect = {x1 = 9999 ,y1 = 9999 , x2 = 0 , y2 = 0}
+
+-- Get the region with wiboxes
+for _, d in ipairs(drawin.get()) do
+    local w = d.get_wibox and d:get_wibox() or nil
+    if w then
+        local geo = w:geometry()
+        rect.x1 = math.min(rect.x1, geo.x                                )
+        rect.y1 = math.min(rect.y1, geo.y                                )
+        rect.x2 = math.max(rect.x2, geo.x + geo.width  + 2*w.border_width)
+        rect.y2 = math.max(rect.y2, geo.y + geo.height + 2*w.border_width)
+    end
+end
+
+if rect.x1 == rect.x2 or rect.y1 == rect.y2 then return end
+
+local multi = wibox.layout {
+    forced_width  = rect.x2 - rect.x1,
+    forced_height = rect.y2 - rect.y1,
+    layout        = wibox.layout.manual
+}
+
+-- Draw all normal wiboxes
+for _, d in ipairs(drawin.get()) do
+    local w = d.get_wibox and d:get_wibox() or nil
+    if w then
+        local geo = w:geometry()
+        multi:add_at(w:to_widget(), {x = geo.x - rect.x1, y = geo.y - rect.y1})
+    end
+end
+
+wibox.widget.draw_to_svg_file(
+    multi, image_path..".svg", multi.forced_width, multi.forced_height
+)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/shims/_common_template.lua
+++ b/tests/examples/shims/_common_template.lua
@@ -7,7 +7,7 @@ return function(_, _)
 
     -- Set the global shims
     -- luacheck: globals awesome root tag screen client mouse drawin button
-    -- luacheck: globals mousegrabber keygrabber
+    -- luacheck: globals mousegrabber keygrabber dbus
     awesome      = require( "awesome"      )
     root         = require( "root"         )
     tag          = require( "tag"          )
@@ -18,6 +18,7 @@ return function(_, _)
     button       = require( "button"       )
     keygrabber   = require( "keygrabber"   )
     mousegrabber = require( "mousegrabber" )
+    dbus         = require( "dbus"         )
 
     -- Force luacheck to be silent about setting those as unused globals
     assert(awesome and root and tag and screen and client and mouse)

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -1,3 +1,6 @@
+local lgi       = require("lgi")
+local GdkPixbuf = lgi.GdkPixbuf
+local Gdk       = lgi.Gdk
 local gears_obj = require("gears.object")
 
 -- Emulate the C API classes. They differ from C API objects as connect_signal
@@ -43,6 +46,29 @@ awesome._shim_fake_class = _shim_fake_class
 awesome.startup = true
 
 function awesome.register_xproperty()
+end
+
+local init, surfaces = false, {}
+
+function awesome.load_image(file)
+    if not init then
+        Gdk.init{}
+        init = true
+    end
+
+    local _, width, height = GdkPixbuf.Pixbuf.get_file_info(file)
+
+    local pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(file, width, height)
+
+    if not pixbuf then
+        return nil, "Could not load "..file
+    end
+
+    local s = Gdk.cairo_surface_create_from_pixbuf( pixbuf, 1, nil )
+
+    table.insert(surfaces, s)
+
+    return s._native, not s and "Could not load surface from "..file or nil, s
 end
 
 -- Always show deprecated messages

--- a/tests/examples/shims/beautiful.lua
+++ b/tests/examples/shims/beautiful.lua
@@ -51,6 +51,69 @@ function module.get_font()
     return f
 end
 
+function module.get_font_height()
+    return 9
+end
+
+--------------------------------------------------------------------
+-- Import the titlebar and layouts asserts from the default theme --
+--------------------------------------------------------------------
+
+-- Its fine as long as gears doesn't depend on CAPI and $AWESOME_THEMES_PATH is set
+local themes_path = require("gears.filesystem").get_themes_dir()
+
+-- Define the image to load
+module.titlebar_close_button_normal = themes_path.."default/titlebar/close_normal.png"
+module.titlebar_close_button_focus  = themes_path.."default/titlebar/close_focus.png"
+
+module.titlebar_minimize_button_normal = themes_path.."default/titlebar/minimize_normal.png"
+module.titlebar_minimize_button_focus  = themes_path.."default/titlebar/minimize_focus.png"
+
+module.titlebar_ontop_button_normal_inactive = themes_path.."default/titlebar/ontop_normal_inactive.png"
+module.titlebar_ontop_button_focus_inactive  = themes_path.."default/titlebar/ontop_focus_inactive.png"
+module.titlebar_ontop_button_normal_active = themes_path.."default/titlebar/ontop_normal_active.png"
+module.titlebar_ontop_button_focus_active  = themes_path.."default/titlebar/ontop_focus_active.png"
+
+module.titlebar_sticky_button_normal_inactive = themes_path.."default/titlebar/sticky_normal_inactive.png"
+module.titlebar_sticky_button_focus_inactive  = themes_path.."default/titlebar/sticky_focus_inactive.png"
+module.titlebar_sticky_button_normal_active = themes_path.."default/titlebar/sticky_normal_active.png"
+module.titlebar_sticky_button_focus_active  = themes_path.."default/titlebar/sticky_focus_active.png"
+
+module.titlebar_floating_button_normal_inactive = themes_path.."default/titlebar/floating_normal_inactive.png"
+module.titlebar_floating_button_focus_inactive  = themes_path.."default/titlebar/floating_focus_inactive.png"
+module.titlebar_floating_button_normal_active = themes_path.."default/titlebar/floating_normal_active.png"
+module.titlebar_floating_button_focus_active  = themes_path.."default/titlebar/floating_focus_active.png"
+
+module.titlebar_maximized_button_normal_inactive = themes_path.."default/titlebar/maximized_normal_inactive.png"
+module.titlebar_maximized_button_focus_inactive  = themes_path.."default/titlebar/maximized_focus_inactive.png"
+module.titlebar_maximized_button_normal_active = themes_path.."default/titlebar/maximized_normal_active.png"
+module.titlebar_maximized_button_focus_active  = themes_path.."default/titlebar/maximized_focus_active.png"
+
+module.wallpaper = themes_path.."default/background.png"
+
+-- You can use your own layout icons like this:
+module.layout_fairh = themes_path.."default/layouts/fairhw.png"
+module.layout_fairv = themes_path.."default/layouts/fairvw.png"
+module.layout_floating  = themes_path.."default/layouts/floatingw.png"
+module.layout_magnifier = themes_path.."default/layouts/magnifierw.png"
+module.layout_max = themes_path.."default/layouts/maxw.png"
+module.layout_fullscreen = themes_path.."default/layouts/fullscreenw.png"
+module.layout_tilebottom = themes_path.."default/layouts/tilebottomw.png"
+module.layout_tileleft   = themes_path.."default/layouts/tileleftw.png"
+module.layout_tile = themes_path.."default/layouts/tilew.png"
+module.layout_tiletop = themes_path.."default/layouts/tiletopw.png"
+module.layout_spiral  = themes_path.."default/layouts/spiralw.png"
+module.layout_dwindle = themes_path.."default/layouts/dwindlew.png"
+module.layout_cornernw = themes_path.."default/layouts/cornernww.png"
+module.layout_cornerne = themes_path.."default/layouts/cornernew.png"
+module.layout_cornersw = themes_path.."default/layouts/cornersww.png"
+module.layout_cornerse = themes_path.."default/layouts/cornersew.png"
+
+-- Taglist
+module.taglist_bg_focus = module.bg_highlight
+module.taglist_bg_used  = module.bg_normal
+
+
 function module.get()
     return module
 end

--- a/tests/examples/shims/beautiful.lua
+++ b/tests/examples/shims/beautiful.lua
@@ -55,11 +55,11 @@ function module.get_font_height()
     return 9
 end
 
---------------------------------------------------------------------
--- Import the titlebar and layouts asserts from the default theme --
---------------------------------------------------------------------
+------------------------------------------------------------------
+-- Import the titlebar and layout assets from the default theme --
+------------------------------------------------------------------
 
--- Its fine as long as gears doesn't depend on CAPI and $AWESOME_THEMES_PATH is set
+-- It's fine as long as gears doesn't depend on CAPI and $AWESOME_THEMES_PATH is set.
 local themes_path = require("gears.filesystem").get_themes_dir()
 
 -- Define the image to load

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -14,6 +14,15 @@ end
 --     CURRENTLY UNUSED
 -- end
 
+local function titlebar_meta(c)
+    for _, position in ipairs {"top", "bottom", "left", "right" } do
+        c["titlebar_"..position] = function(size)--luacheck: no unused
+            local d = drawin{}
+            return d
+        end
+    end
+end
+
 -- Create fake clients to move around
 function client.gen_fake(args)
     local ret = gears_obj()
@@ -22,6 +31,7 @@ function client.gen_fake(args)
     ret.valid = true
     ret.size_hints = {}
     ret.border_width = 1
+    ret.icon_sizes = {{16,16}}
 
     -- Apply all properties
     for k,v in pairs(args or {}) do
@@ -71,6 +81,20 @@ function client.gen_fake(args)
         return nil
     end
 
+    function ret:get_icon(_)
+        return require("beautiful").awesome_icon
+    end
+
+    function ret:raise()
+        --TODO
+    end
+
+    function ret:lower()
+        --TODO
+    end
+
+    titlebar_meta(ret)
+
     function ret:tags(new) --FIXME
         if new then
             ret._tags = new
@@ -92,6 +116,7 @@ function client.gen_fake(args)
     -- Record the geometry
     ret._old_geo = {}
     push_geometry(ret)
+    ret._old_geo[1]._hide = args.hide_first
 
     -- Set the attributes
     ret.screen = args.screen or screen[1]

--- a/tests/examples/shims/dbus.lua
+++ b/tests/examples/shims/dbus.lua
@@ -1,0 +1,24 @@
+local dbus = awesome._shim_fake_class()
+
+function dbus.notify_send(data, appname, replaces_id, icon, title, text, actions, hints, expire)
+    dbus.emit_signal(
+        "org.freedesktop.Notifications",
+        data,
+        appname,
+        replaces_id,
+        icon,
+        title,
+        text,
+        actions,
+        hints,
+        expire
+    )
+end
+
+function dbus.request_name()
+    -- Ignore
+end
+
+return dbus
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/shims/drawin.lua
+++ b/tests/examples/shims/drawin.lua
@@ -1,19 +1,51 @@
 local gears_obj = require("gears.object")
 
 local drawin, meta = awesome._shim_fake_class()
+local drawins = setmetatable({}, {__mode="v"})
 
 local function new_drawin(_, args)
     local ret = gears_obj()
     ret.data = {drawable = gears_obj()}
 
-    for k, v in pairs(args) do
-        rawset(ret, k, v)
+    ret.x=0
+    ret.y=0
+    ret.width=1
+    ret.height=1
+
+    ret.geometry = function(_, new)
+        new = new or {}
+        ret.x      = new.x      or ret.x
+        ret.y      = new.y      or ret.y
+        ret.width  = new.width  or ret.width
+        ret.height = new.height or ret.height
+        return {
+            x      = ret.x,
+            y      = ret.y,
+            width  = ret.width,
+            height = ret.height
+        }
     end
 
-    return setmetatable(ret, {
+    for _, k in pairs{ "buttons", "struts", "get_xproperty", "set_xproperty" } do
+        ret[k] = function() end
+    end
+
+    local md = setmetatable(ret, {
                         __index     = function(...) return meta.__index(...) end,
                         __newindex = function(...) return meta.__newindex(...) end
                     })
+
+    for k, v in pairs(args) do
+        ret[k] = v
+    end
+
+    table.insert(drawins, md)
+
+    return md
+end
+
+function drawin.get()
+    return drawins
 end
 
 return setmetatable(drawin, {

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -7,6 +7,7 @@ screen.count = 1
 local function create_screen(args)
     local s = gears_obj()
     s.data = {}
+    s.valid = true
 
     -- Copy the geo in case the args are mutated
     local geo = {
@@ -53,7 +54,10 @@ local screens = {}
 function screen._add_screen(args)
     local s = create_screen(args)
     table.insert(screens, s)
-    s.index = #screens
+
+    -- Skip the metatable or it will have side effects
+    rawset(s, "index", #screens)
+
     screen[#screen+1] = s
     screen[s] = s
 end
@@ -94,8 +98,23 @@ function screen._setup_grid(w, h, rows, args)
     end
 end
 
+local function iter_scr(_, _, s)
+    if not s then
+        assert(screen[1])
+        return screen[1], 1
+    end
+
+    local i = s.index
+
+    if i +1  < #screen then
+        return screen[i+1], i+1
+    end
+end
+
 screen._add_screen {width=320, height=240}
 
-return screen
+return setmetatable(screen, {
+    __call = iter_scr
+})
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/layout/template.lua
+++ b/tests/examples/wibox/layout/template.lua
@@ -7,7 +7,7 @@ local beautiful = require( "beautiful"     )
 local unpack    = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 
 -- Create a generic rectangle widget to show layout disposition
-local function generic_widget(text, col)
+local function generic_widget(text, col, margins)
     return wibox.widget {
         {
             {
@@ -30,7 +30,7 @@ local function generic_widget(text, col)
             } or nil,
             widget = wibox.layout.stack
         },
-        margins = 5,
+        margins = margins or 5,
         set_text = function(self, text2)
             self:get_children_by_id("text")[1]:set_text(text2)
         end,

--- a/tests/examples/wibox/widget/defaults/separator.lua
+++ b/tests/examples/wibox/widget/defaults/separator.lua
@@ -1,0 +1,13 @@
+local parent    = ... --DOC_HIDE
+local wibox     = require( "wibox"     ) --DOC_HIDE
+
+parent:add( --DOC_HIDE
+
+wibox.widget {
+    forced_height = 20, --DOC_HIDE
+    forced_width  = 100, --DOC_HIDE
+    widget = wibox.widget.separator
+}
+
+) --DOC_HIDE
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/separator/border_color.lua
+++ b/tests/examples/wibox/widget/separator/border_color.lua
@@ -1,0 +1,18 @@
+local parent    = ... --DOC_HIDE
+local wibox     = require("wibox") --DOC_HIDE
+local gears     = {shape = require("gears.shape")}--DOC_HIDE
+local beautiful = require("beautiful")--DOC_HIDE
+
+parent:add( --DOC_HIDE
+wibox.widget {
+    shape        = gears.shape.circle,
+    color        = "#00000000",
+    border_width = 1,
+    border_color = beautiful.bg_normal,
+    widget       = wibox.widget.separator,
+    forced_height = 20, --DOC_HIDE
+    forced_width  = 20, --DOC_HIDE
+}
+) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/separator/orientation.lua
+++ b/tests/examples/wibox/widget/separator/orientation.lua
@@ -1,0 +1,36 @@
+local parent = ... --DOC_HIDE_ALL
+local wibox  = require("wibox")
+
+parent:add(
+wibox.widget {
+    {
+        {
+            markup = "<b>orientation</b> = <i>horizontal</i>",
+            widget = wibox.widget.textbox
+        },
+        {
+            orientation = "horizontal",
+            widget = wibox.widget.separator,
+        },
+        forced_width = 200,
+        layout = wibox.layout.fixed.vertical
+    },
+    {
+        {
+            markup = "<b>orientation</b> = <i>vertical</i>",
+            widget = wibox.widget.textbox
+        },
+        {
+            orientation = "vertical",
+            widget = wibox.widget.separator,
+        },
+        forced_width = 200,
+        layout = wibox.layout.fixed.vertical
+    },
+    forced_height = 30,
+    forced_width = 400,
+    layout = wibox.layout.fixed.horizontal
+}
+)
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/separator/shape.lua
+++ b/tests/examples/wibox/widget/separator/shape.lua
@@ -1,0 +1,23 @@
+local parent    = ... --DOC_HIDE
+local wibox     = require("wibox") --DOC_HIDE
+local gears     = {shape = require("gears.shape")}--DOC_HIDE
+
+local wdgs = { --DOC_HIDE
+    forced_height = 30, --DOC_HIDE
+    forced_width  = 30*4, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+} --DOC_HIDE
+
+
+for _, s in ipairs { "losange" ,"circle", "isosceles_triangle", "cross" } do
+    local w = wibox.widget {
+        shape  = gears.shape[s],
+        widget = wibox.widget.separator,
+    }
+    table.insert(wdgs, w) --DOC_HIDE
+end
+
+parent:add( wibox.layout(wdgs)) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
So, this is it. I am mostly done with the new implementation. This pull request is almost unrelated, but has some commits that are necessary at some point for future parts of this pull request series.

* Part 1: This pull request, all the unrelated commits (16 commits)
* Part 2: Improve `wibox.layout` spacing (3 commits)
* Part 3: Add an `awful.popup` widget (2 commits, fix #1683)
* Part 4: Refactor `awful.widget.common` to make it externally extensible (3 commits)
* Part 5: The `naughty` rewrite/refactoring (~10 commits or one huge commit if squashed)
* Part 6: Add new notification widgets and use them in `rc.lua` (7 commits, fix #1874, #1862)

(I dropped the `tests/examples` rewrite from this series since the recent CI improvements introduced by @blueyed make it tolerable for little while longer)

Why all those changes:

The old notification system is a black box and it's very hard to change its behavior/look without forking the whole module (as @mindeunix and @timroes figured out). The `taglist` and `tasklist` also have the same issue. This pull request also adds more documentation and code examples around the `wiboxes` derived widgets.

The goal of the new system is to be as easy to customize as the titlebar and wibars are in the current `rc.lua`.

This pull request:

 * Add a simple `separator` widget. It will make sense in part 2, but had no dependencies, so I decided to put it in this PR
 * Update some images templates to support wiboxes and use more "real" code instead of shims
 * Allow to turn wibox into widgets (for testing and examples)
 * Improve the shims to cover a larger part of CAPI
 * Improve `gears.object` signal system to behave like the CAPI version
 * Add some minimal tests to `naughty` before f**cking everything up again.
