### PR TITLE
Automatically make LuaRocks modules available in awesome

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -1,3 +1,7 @@
+-- If LuaRocks is installed, make sure that packages installed through it are
+-- found (e.g. lgi). If LuaRocks is not installed, do nothing.
+pcall(require, "luarocks.loader")
+
 -- @DOC_REQUIRE_SECTION@
 -- Standard awesome library
 local gears = require("gears")


### PR DESCRIPTION
Running eval $(luarocks path --bin) before running awesome is not all
that easy. It's a lot easier to do the equivalent for this in rc.lua.
Plus, if LuaRocks is not installed, this will silently do nothing.

This supersedes #1860. I guess this version is better...?