### PR TITLE
KeyboardLayout widget: Add EurKey

### DIFF
--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -46,6 +46,7 @@ keyboardlayout.xkeyboard_country_code = {
     ["epo"] = true,   -- Esperanto
     ["es"] = true,    -- Spain
     ["et"] = true,    -- Ethiopia
+    ["eu"] = true,    -- EurKey
     ["fi"] = true,    -- Finland
     ["fo"] = true,    -- Faroe Islands
     ["fr"] = true,    -- France


### PR DESCRIPTION
Fixes eurkey keyboard layout not being shown in widget (either keeping old layout indicator or not showing any at all).

Also, switching to eurkey with a button combination, e.g. after using
setxkbmap -layout "eu,de" -option "grp:shift_caps_toggle"
caused the error message
"Oops, an error happened!
/usr/share/awesome/lib/awful/widget/keyboardlayout.lua:124: attempt to concatenate a nil value (field '?')