### PR TITLE
mouse: Fix a bad refactoring

### DIFF
--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -124,7 +124,7 @@ end
 -- @function awful.mouse.wibox.move
 --@tparam wibox w The wibox to move, or none to use that under the pointer
 function mouse.wibox.move(w)
-    w = w or mouse.wibox_under_pointer()
+    w = w or mouse.current_wibox
     if not w then return end
 
     if not w


### PR DESCRIPTION
The `wibox_under_mouse` property was renamed `current_wibox` but
a call wasn't updated. (old commit I had forgotten in my stash)