### PR TITLE
default config: add Pinentry to floating windows

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -482,6 +482,7 @@ awful.rules.rules = {
         instance = {
           "DTA",  -- Firefox addon DownThemAll.
           "copyq",  -- Includes session name in class.
+          "pinentry",
         },
         class = {
           "Arandr",
@@ -490,7 +491,6 @@ awful.rules.rules = {
           "MessageWin",  -- kalarm.
           "Sxiv",
           "Wpa_gui",
-          "pinentry",
           "veromix",
           "xtightvncviewer"},
 

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -486,6 +486,7 @@ awful.rules.rules = {
         },
         class = {
           "Arandr",
+          "Blueman-manager",
           "Gpick",
           "Kruler",
           "MessageWin",  -- kalarm.
@@ -499,6 +500,7 @@ awful.rules.rules = {
         },
         role = {
           "AlarmWindow",  -- Thunderbird's calendar.
+          "ConfigManager",  -- Thunderbird's about:config.
           "pop-up",       -- e.g. Google Chrome's (detached) Developer Tools.
         }
       }, properties = { floating = true }},


### PR DESCRIPTION
We have class "pinentry" there already, but it seems to have changed to
"Pinentry"?!

pinentry 1.0.0-1, gnupg 2.1.23-1