### PR TITLE
Mention minimum ldoc version in the readme

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -69,7 +69,8 @@ Additionally, the following optional dependencies exist:
 - [asciidoc](http://www.methods.co.nz/asciidoc/) and
   [xmlto](https://fedorahosted.org/xmlto/) for generating man pages
 - [gzip](http://www.gzip.org/) for compressing man pages
-- [ldoc](https://stevedonovan.github.io/ldoc/) for generating the documentation
+- [ldoc >= 1.4.5](https://stevedonovan.github.io/ldoc/) for generating the
+  documentation
 - [busted](https://olivinelabs.com/busted/) for running unit tests
 - [luacheck](https://github.com/mpeterv/luacheck) for static code analysis
 - [LuaCov](https://keplerproject.github.io/luacov/) for collecting code coverage


### PR DESCRIPTION
See commit 2c741f8e1d934da32a which introduced this dependency.

Signed-off-by: Uli Schlachter <psychon@znc.in>

There I was, trying to reproduce #2026 locally and my build failed for yet another reason. :-(
Do we need some kind of LDoc version check in CMake or is this supposed to be enough?