### PR TITLE
Unescape strings when parsing desktop entries

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -188,7 +188,10 @@ function utils.unescape(s, list)
         end
 
         local segments = {}
-        local i, j = 0, 0
+        -- Starting and ending indices of the match (optional backslashes before
+        -- a semicolon)
+        local i
+        local j = 0
         while true do
             i, j = string.find(s, '\\*;', j+1)
             if not i then

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -175,11 +175,10 @@ end
 function utils.unescape(s)
     if not s then return end
 
-    -- Only return the string, not the count
-    s, _ = string.gsub(s, "\\.", function(sequence)
+    -- Ignore the second return value of string.gsub() (number replaced)
+    s = string.gsub(s, "\\.", function(sequence)
         return escape_sequences[sequence] or sequence
     end)
-
     return s
 end
 

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -190,9 +190,8 @@ end
 function utils.parse_list(s)
     if not s then return end
 
-    -- Append terminating semi-colon if not already there. Ignore whitespace
-    -- at the end
-    if not string.match(s, ';%s*$') then
+    -- Append terminating semi-colon if not already there.
+    if string.sub(s, -1) ~= ';' then
         s = s .. ';'
     end
 

--- a/spec/menubar/utils_spec.lua
+++ b/spec/menubar/utils_spec.lua
@@ -28,6 +28,8 @@ describe("menubar.utils unescape", function()
         [ [[abc;123;xyz;]] ] = { "abc", "123", "xyz" },
         -- Blank item
         [ [[abc;;123]] ] = { "abc", "", "123" },
+        -- Trailing whitespace
+        [ [[abc;123;   ]] ] = { "abc", "123", "   " },
         -- Escape semicolon
         [ [[abc\;;12\;3;\;xyz]] ] = { "abc;", "12;3", ";xyz" },
         -- Normal escapes are parsed like normal

--- a/spec/menubar/utils_spec.lua
+++ b/spec/menubar/utils_spec.lua
@@ -17,7 +17,7 @@ describe("menubar.utils unescape", function()
 
     for escaped, unescaped in pairs(single_strings) do
         it(escaped, function()
-            assert.is.equal(unescaped, utils.unescape(escaped, false))
+            assert.is.equal(unescaped, utils.unescape(escaped))
         end)
     end
 
@@ -38,7 +38,7 @@ describe("menubar.utils unescape", function()
 
     for escaped, unescaped in pairs(list_strings) do
         it(escaped, function()
-            local returned = utils.unescape(escaped, true)
+            local returned = utils.parse_list(escaped)
             assert.is.equal(#unescaped, #returned)
 
             for i = 1, #unescaped do

--- a/spec/menubar/utils_spec.lua
+++ b/spec/menubar/utils_spec.lua
@@ -1,0 +1,51 @@
+---------------------------------------------------------------------------
+-- @author Zach Peltzer
+-- @copyright 2017 Zach Peltzer
+---------------------------------------------------------------------------
+
+local utils = require("menubar.utils")
+
+describe("menubar.utils unescape", function()
+    local single_strings = {
+        [ [[\n:\r:\s:\t:\\]] ] = "\n:\r: :\t:\\",
+        -- Make sure escapes are not read recursively
+        [ [[\\s]] ] = [[\s]],
+        -- Make sure ';' is not escaped for non-list strings and other
+        -- characters are not escaped
+        [ [[ab\c\;1\23]] ] = [[ab\c\;1\23]],
+    }
+
+    for escaped, unescaped in pairs(single_strings) do
+        it(escaped, function()
+            assert.is.equal(unescaped, utils.unescape(escaped, false))
+        end)
+    end
+
+    local list_strings = {
+        -- Normal list
+        [ [[abc;123;xyz]] ] = { "abc", "123", "xyz" },
+        -- Optional terminating semicolon
+        [ [[abc;123;xyz;]] ] = { "abc", "123", "xyz" },
+        -- Blank item
+        [ [[abc;;123]] ] = { "abc", "", "123" },
+        -- Escape semicolon
+        [ [[abc\;;12\;3;\;xyz]] ] = { "abc;", "12;3", ";xyz" },
+        -- Normal escapes are parsed like normal
+        [ [[ab\c;1\s23;x\\yz]] ] = { "ab\\c", "1 23", "x\\yz" },
+        -- Escaped backslashes before semicolon
+        [ [[abc\\\;;12\\;3;xyz]] ] = { "abc\\;", "12\\", "3", "xyz" },
+    }
+
+    for escaped, unescaped in pairs(list_strings) do
+        it(escaped, function()
+            local returned = utils.unescape(escaped, true)
+            assert.is.equal(#unescaped, #returned)
+
+            for i = 1, #unescaped do
+                assert.is.equal(unescaped[i], returned[i])
+            end
+        end)
+    end
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-menubar.lua
+++ b/tests/test-menubar.lua
@@ -55,56 +55,6 @@ runner.run_steps {
         end
     end,
 
-    -- Test menubar.utils.unescape()
-    function()
-        -- Single strings
-        local single_strings = {
-            [ [[\n:\r:\s:\t:\\]] ] = "\n:\r: :\t:\\",
-            -- Make sure escapes are not read recursively
-            [ [[\\s]] ] = [[\s]],
-            -- Make sure ';' is not escaped for non-list strings and other
-            -- characters are not escaped
-            [ [[ab\c\;1\23]] ] = [[ab\c\;1\23]],
-        }
-
-        for escaped, unescaped in pairs(single_strings) do
-            if menubar.utils.unescape(escaped, false) ~= unescaped then
-                return false
-            end
-        end
-
-        -- Semicolon-separated lists of strings
-        local list_strings = {
-            -- Normal list
-            [ [[abc;123;xyz]] ] = { "abc", "123", "xyz" },
-            -- Optional terminating semicolon
-            [ [[abc;123;xyz;]] ] = { "abc", "123", "xyz" },
-            -- Blank item
-            [ [[abc;;123]] ] = { "abc", "", "123" },
-            -- Escape semicolon
-            [ [[abc\;;12\;3;\;xyz]] ] = { "abc;", "12;3", ";xyz" },
-            -- Normal escapes are parsed like normal
-            [ [[ab\c;1\s23;x\\yz]] ] = { "ab\\c", "1 23", "x\\yz" },
-            -- Escaped backslashes before semicolon
-            [ [[abc;12\\;3;xyz]] ] = { "abc", "12\\", "3", "xyz" },
-        }
-
-        for escaped, unescaped in pairs(list_strings) do
-            local returned = menubar.utils.unescape(escaped, true)
-            if #returned ~= #unescaped then
-                return false
-            end
-
-            for i = 1, #returned do
-                if returned[i] ~= unescaped[i] then
-                    return false
-                end
-            end
-        end
-
-        return true
-    end,
-
     function()
         return true
     end

--- a/tests/test-menubar.lua
+++ b/tests/test-menubar.lua
@@ -55,6 +55,56 @@ runner.run_steps {
         end
     end,
 
+    -- Test menubar.utils.unescape()
+    function()
+        -- Single strings
+        local single_strings = {
+            [ [[\n:\r:\s:\t:\\]] ] = "\n:\r: :\t:\\",
+            -- Make sure escapes are not read recursively
+            [ [[\\s]] ] = [[\s]],
+            -- Make sure ';' is not escaped for non-list strings and other
+            -- characters are not escaped
+            [ [[ab\c\;1\23]] ] = [[ab\c\;1\23]],
+        }
+
+        for escaped, unescaped in pairs(single_strings) do
+            if menubar.utils.unescape(escaped, false) ~= unescaped then
+                return false
+            end
+        end
+
+        -- Semicolon-separated lists of strings
+        local list_strings = {
+            -- Normal list
+            [ [[abc;123;xyz]] ] = { "abc", "123", "xyz" },
+            -- Optional terminating semicolon
+            [ [[abc;123;xyz;]] ] = { "abc", "123", "xyz" },
+            -- Blank item
+            [ [[abc;;123]] ] = { "abc", "", "123" },
+            -- Escape semicolon
+            [ [[abc\;;12\;3;\;xyz]] ] = { "abc;", "12;3", ";xyz" },
+            -- Normal escapes are parsed like normal
+            [ [[ab\c;1\s23;x\\yz]] ] = { "ab\\c", "1 23", "x\\yz" },
+            -- Escaped backslashes before semicolon
+            [ [[abc;12\\;3;xyz]] ] = { "abc", "12\\", "3", "xyz" },
+        }
+
+        for escaped, unescaped in pairs(list_strings) do
+            local returned = menubar.utils.unescape(escaped, true)
+            if #returned ~= #unescaped then
+                return false
+            end
+
+            for i = 1, #returned do
+                if returned[i] ~= unescaped[i] then
+                    return false
+                end
+            end
+        end
+
+        return true
+    end,
+
     function()
         return true
     end


### PR DESCRIPTION
This is based of the [spec](https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s03.html) and works with all of my desktop files (including those created by wine).