### PR TITLE
magnifier layout: Never manage floating windows

### DIFF
--- a/lib/awful/layout/suit/magnifier.lua
+++ b/lib/awful/layout/suit/magnifier.lua
@@ -71,7 +71,7 @@ function magnifier.arrange(p)
     if focus and focus.screen ~= get_screen(p.screen) then focus = nil end
 
     -- If no window is focused or focused window is not tiled, take the first tiled one.
-    if (not focus or focus.floating) and #cls > 0 then
+    if not focus or focus.floating then
         focus = cls[1]
         fidx = 1
     end


### PR DESCRIPTION
The magnifier layout handles the currently focused client specially.
However, if the currently floating client is floating, it should not be
handled by the layout at all. A bug caused the magnifier layout to
handle a focused and floating client anyway if it was the only tiled
client.

Fix this by removing the '#cls > 0'-case. If #cls == 0, then no client
is available to be managed. Thus, cls[1] will be nil, which is fine
since, well, no client is available to be managed. This only made a
difference in the specific bug that I described above. Thus, drop this
case.

Fixes: https://github.com/awesomeWM/awesome/issues/2045
Signed-off-by: Uli Schlachter <psychon@znc.in>