### PR TITLE
Sort list of files used in generated table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
     - LUA=5.2 LUANAME=lua5.2 DO_COVERAGE=coveralls
     # Lua 5.3 isn't available in Ubuntu Trusty, so some magic below installs it.
-    - LUA=5.3 LUANAME=lua5.3 LUALIBRARY=/usr/lib/liblua.so DO_COVERAGE=codecov
+    - LUA=5.3 LUANAME=lua5.3 LUALIBRARY=/usr/lib/liblua.so DO_COVERAGE=codecov EXPORT_SDE=true
     # luajit: installed from source.
     - LUA=5.1 LUANAME=luajit-2.0 LUALIBRARY=/usr/lib/libluajit-5.1.so LUAROCKS_ARGS=--lua-suffix=jit-2.0.5 TEST_PREV_COMMITS=1
     # Note: luarocks does not work with Lua 5.0.
@@ -156,6 +156,7 @@ install:
     }
 script:
   - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION -DSTRICT_TESTS=true -D DO_COVERAGE=$DO_COVERAGE"
+  - if [ "$EXPORT_SDE" = "true" ]; then export SOURCE_DATE_EPOCH=$(date -u -r docs/89-NEWS.md +%s); fi
   - |
     if [ "$EMPTY_THEME_WHILE_LOADING" = 1 ]; then
       # Break beautiful so that trying to access the theme before beautiful.init() causes an error

--- a/docs/06-appearance.md.lua
+++ b/docs/06-appearance.md.lua
@@ -95,6 +95,7 @@ local function get_link(file, element)
 end
 
 local all_files = get_all_files("./lib/", "lua")
+table.sort(all_files)
 
 local beautiful_vars = {}
 

--- a/tests/examples/shims/_date.lua
+++ b/tests/examples/shims/_date.lua
@@ -1,0 +1,11 @@
+local source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
+if source_date_epoch then
+    local old_osdate = os.date
+    os.date = function(format, timestamp) -- luacheck: ignore
+        if timestamp then
+            return old_osdate(format, timestamp)
+        end
+        format = "!" .. format
+        return old_osdate(format, source_date_epoch)
+    end
+end

--- a/tests/examples/wibox/widget/calendar/fn_embed_cell.lua
+++ b/tests/examples/wibox/widget/calendar/fn_embed_cell.lua
@@ -3,6 +3,7 @@ local wibox     = require("wibox") --DOC_HIDE
 local gears     = require("gears") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("monospace 10") --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/font.lua
+++ b/tests/examples/wibox/widget/calendar/font.lua
@@ -2,6 +2,7 @@ local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("sans 12") --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/long_weekdays.lua
+++ b/tests/examples/wibox/widget/calendar/long_weekdays.lua
@@ -2,6 +2,7 @@ local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("monospace 10") --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/month.lua
+++ b/tests/examples/wibox/widget/calendar/month.lua
@@ -2,6 +2,7 @@ local parent    = ... --DOC_HIDE_ALL
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("monospace 10") --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/start_sunday.lua
+++ b/tests/examples/wibox/widget/calendar/start_sunday.lua
@@ -2,6 +2,7 @@ local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("monospace 10") --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/week_numbers.lua
+++ b/tests/examples/wibox/widget/calendar/week_numbers.lua
@@ -2,6 +2,7 @@ local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("monospace 10") --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/year.lua
+++ b/tests/examples/wibox/widget/calendar/year.lua
@@ -2,6 +2,7 @@ local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("monospace 10") --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/calendar.lua
+++ b/tests/examples/wibox/widget/defaults/calendar.lua
@@ -2,6 +2,7 @@ local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE
 local Pango     = require("lgi").Pango --DOC_HIDE
+require("_date") --DOC_HIDE
 
 -- Beautiful fake get_font --DOC_HIDE
 local f = Pango.FontDescription.from_string("monospace 10") --DOC_HIDE


### PR DESCRIPTION
File order depends on file system, kernel version etc...
To build the documentation reproducibly, the file list used for generating the table needs to be sorted.