### PR TITLE
Use memory shorter with awful.client.shape

### DIFF
--- a/lib/awful/client/shape.lua
+++ b/lib/awful/client/shape.lua
@@ -80,6 +80,10 @@ function shape.get_transformed(c, shape_name)
         cr:pop_group_to_source()
         cr:set_operator(cairo.Operator.IN)
         cr:paint()
+
+        -- 'cr' is kept alive until Lua's GC frees it. Make sure it does not
+        -- keep the group alive since that's a large image surface.
+        cr:set_source_rgba(0, 0, 0, 0)
     end
 
     return result


### PR DESCRIPTION
To apply the shape of a client, we have to create an image and draw the
shape we want to it. Since clients can be quite large, we have to make
sure that we do not keep this image alive unnecessarily long.

The code in awful.client.shape.get_transformed() however needs another
temporary surface in case the client has its own shape and another one
was set in Lua (side note: currently the code also creates this extra
temporary surface if the client does not have its own shape; that might
be worth fixing). This temporary surface is then used as the source of a
cairo context to draw it to the image that will be used as the client's
final source.

After we are done, the temporary surface is still kept alive since it is
the current source of the cairo context. The cairo context in turn is
only freed when Lua's garbage collector collects it, which may take
quite a while.

Improve this by setting a different source to the cairo context. Thus,
it now releases the temporary surface as soon as possible and it is only
allocated for a short time.

Fixes: https://github.com/awesomeWM/awesome/issues/2050
Signed-off-by: Uli Schlachter <psychon@znc.in>