### PR TITLE
Mixed-DPI groundwork

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -504,6 +504,28 @@ function screen.object.get_selected_tag(s)
     return screen.object.get_selected_tags(s)[1]
 end
 
+--- The screen DPI
+--
+-- For cloned displays, this reports the smallest DPI
+--
+-- @property dpi
+-- @treturn number the pixel density for the screen, in dots per inch
+function screen.object.get_dpi(s)
+    local h = s.geometry.height
+    local w = s.geometry.width
+    local mm_inch = 25.4 -- 25.4 millimeters to the inch
+    local dpi = nil
+    for _, o in pairs(s.outputs) do
+        local dpix = w*mm_inch/o.mm_width
+        local dpiy = h*mm_inch/o.mm_height
+        local dpi_avg = (dpix+dpiy)/2
+        if not dpi or dpi_avg < dpi then
+            dpi = dpi_avg
+        end
+    end
+    return dpi or 96 -- fall back to 96 if no information available
+end
+
 
 --- When the tag history changed.
 -- @signal tag::history::update

--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -103,8 +103,9 @@ local active_font
 -- @see https://developer.gnome.org/pango/stable/pango-Fonts.html#pango-font-description-from-string
 -- @tparam string|lgi.Pango.FontDescription name Font, which can be a
 --   string or a lgi.Pango.FontDescription.
+-- @tparam screen (optional) screen to get DPI information about
 -- @treturn table A table with `name`, `description` and `height`.
-local function load_font(name)
+local function load_font(name, screen)
     name = name or active_font
     if name and type(name) ~= "string" then
         if descs[name] then
@@ -113,14 +114,15 @@ local function load_font(name)
             name = name:to_string()
         end
     end
-    if fonts[name] then
-        return fonts[name]
+    local fonts_key = {name, screen}
+    if fonts[fonts_key] then
+        return fonts[fonts_key]
     end
 
     -- Load new font
     local desc = Pango.FontDescription.from_string(name)
     local ctx = PangoCairo.font_map_get_default():create_context()
-    ctx:set_resolution(beautiful.xresources.get_dpi())
+    ctx:set_resolution(beautiful.xresources.get_dpi(screen))
 
     -- Apply default values from the context (e.g. a default font size)
     desc:merge(ctx:get_font_description(), false)
@@ -136,7 +138,7 @@ local function load_font(name)
     end
 
     local font = { name = name, description = desc, height = height }
-    fonts[name] = font
+    fonts[fonts_key] = font
     descs[desc] = name
     return font
 end
@@ -174,8 +176,9 @@ end
 --- Get the height of a font.
 --
 -- @param name Name of the font
-function beautiful.get_font_height(name)
-    return load_font(name).height
+-- @param screen (optional) screen to compute height for
+function beautiful.get_font_height(name, screen)
+    return load_font(name, screen).height
 end
 
 --- Init function, should be runned at the beginning of configuration file.

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -75,8 +75,8 @@ end
 -- @treturn number DPI value.
 function xresources.get_dpi(s)
     s = get_screen(s)
-    if dpi_per_screen[s] then
-        return dpi_per_screen[s]
+    if s then
+        return dpi_per_screen[s] or s.dpi
     end
     if not xresources.dpi then
         -- Might not be present when run under unit tests

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -145,6 +145,7 @@ end
 -- @tparam[opt] integer|screen s The screen.
 -- @treturn integer Resulting size (rounded to integer).
 function xresources.apply_dpi(size, s)
+    if not size then return size end
     local scale = xresources.get_dpi(s)/96
     return round(size * scale)
 end

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -140,6 +140,9 @@ local function recalc_auto_dpi()
     end
 end
 
+screen.connect_signal("property::geometry", recalc_auto_dpi)
+screen.connect_signal("property::outputs", recalc_auto_dpi)
+
 
 --- Get global or per-screen DPI value falling back to xrdb.
 -- @tparam[opt] integer|screen s The screen.

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -64,6 +64,9 @@ function xresources.get_current_theme()
 end
 
 
+--- Store the cached or user-set per-screen DPI
+-- Values are tables with key dpi (the dpi) and set_from (user, auto, xrdb)
+-- The same is done for xresources.dpi
 local dpi_per_screen = {}
 
 local dpi_scale_rounding = nil
@@ -81,40 +84,81 @@ local function rounded_dpi(dpi)
     end
 end
 
+--- Compute the global DPI from the core protocol information
+local function set_global_dpi()
+    xresources.dpi = nil
+    -- Might not be present when run under unit tests
+    if awesome and awesome.xrdb_get_value then
+        local xft_dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi"))
+        if xft_dpi then
+            xresources.dpi = {
+                dpi = xft_dpi,
+                set_from = 'xrdb'
+            }
+        end
+    end
+    -- Following Keith Packard's whitepaper on Xft,
+    -- https://keithp.com/~keithp/talks/xtc2001/paper/xft.html#sec-editing
+    -- the proper fallback for Xft.dpi is the vertical DPI reported by
+    -- the X server. This will generally be 96 on Xorg, unless the user
+    -- has configured it differently
+    if not xresources.dpi then
+        if root then
+            local mm_to_inch = 25.4
+            local _, h = root.size()
+            local _, hmm = root.size_mm()
+            if hmm ~= 0 then
+                xresources.dpi = {
+                    dpi = rounded_dpi(h*mm_to_inch/hmm),
+                    set_from = 'auto'
+                }
+            end
+        end
+    end
+    -- ultimate fallback
+    if not xresources.dpi then
+        xresources.dpi = { dpi = 96, set_from = 'auto' }
+    end
+end
+
+
+--- Recompute autodetected DPI values
+--
+-- This function should be invoked whenever automatically-compued DPI might have
+-- changed (e.g. RANDR signal, or DPI-rounding function changes)
+local function recalc_auto_dpi()
+    if xresources.dpi and xresources.dpi.set_from == 'auto' then
+        set_global_dpi()
+    end
+    for s, dpi in pairs(dpi_per_screen) do
+        if dpi.set_from == 'auto' then
+            dpi_per_screen[s] = {
+                dpi = rounded_dpi(s.dpi),
+                set_from = 'auto'
+            }
+        end
+    end
+end
+
+
 --- Get global or per-screen DPI value falling back to xrdb.
 -- @tparam[opt] integer|screen s The screen.
 -- @treturn number DPI value.
 function xresources.get_dpi(s)
     s = get_screen(s)
     if s then
-        return dpi_per_screen[s] or rounded_dpi(s.dpi)
+        if not dpi_per_screen[s] then
+            dpi_per_screen[s] = {
+                dpi = rounded_dpi(s.dpi),
+                set_from = 'auto'
+            }
+        end
+        return dpi_per_screen[s].dpi
     end
     if not xresources.dpi then
-        -- Might not be present when run under unit tests
-        if awesome and awesome.xrdb_get_value then
-            xresources.dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi"))
-        end
-        -- Following Keith Packard's whitepaper on Xft,
-        -- https://keithp.com/~keithp/talks/xtc2001/paper/xft.html#sec-editing
-        -- the proper fallback for Xft.dpi is the vertical DPI reported by
-        -- the X server. This will generally be 96 on Xorg, unless the user
-        -- has configured it differently
-        if not xresources.dpi then
-            if root then
-                local mm_to_inch = 25.4
-                local _, h = root.size()
-                local _, hmm = root.size_mm()
-                if hmm ~= 0 then
-                    xresources.dpi = rounded_dpi(h*mm_to_inch/hmm)
-                end
-            end
-        end
-        -- ultimate fallback
-        if not xresources.dpi then
-            xresources.dpi = 96
-        end
+        set_global_dpi()
     end
-    return xresources.dpi
+    return xresources.dpi.dpi
 end
 
 
@@ -123,10 +167,11 @@ end
 -- @tparam[opt] integer s Screen.
 function xresources.set_dpi(dpi, s)
     s = get_screen(s)
+    local dpi_spec = { dpi = dpi, set_from = 'user' }
     if not s then
-        xresources.dpi = dpi
+        xresources.dpi = dpi_spec
     else
-        dpi_per_screen[s] = dpi
+        dpi_per_screen[s] = dpi_spec
     end
 end
 
@@ -137,6 +182,7 @@ end
 -- @tparam function a function to be applied to the DPI scaling factor
 function xresources.set_dpi_rounding(func)
     dpi_scale_rounding = func
+    recalc_auto_dpi()
 end
 
 


### PR DESCRIPTION
Some more groundwork to improve support for mixed-DPI setups.

It pre-computes the per-screen DPI, while still allowing overrides, it allows choosing a rounding method for the used DPI, and font loading now allows an associated screen, to be used for height computation.

(Some of these make more sense view in terms of the subsequent fixes spread around the lib part, the work is pushed to my `mixed-dpi` branch, but still needs a more thorough review.)