### PR TITLE
Add & use a dpi property on screen objects

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -504,6 +504,40 @@ function screen.object.get_selected_tag(s)
     return screen.object.get_selected_tags(s)[1]
 end
 
+--- The number of pixels per inch of the screen.
+-- @property dpi
+-- @treturn number the DPI value.
+
+local xft_dpi, fallback_dpi
+
+function screen.object.get_dpi(s)
+    local mm_per_inch = 25.4
+
+    if s.data.dpi then
+        return s.data.dpi
+    end
+
+    -- Xft.dpi is explicit user configuration, so honor it
+    if not xft_dpi and awesome and awesome.xrdb_get_value then
+        xft_dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi")) or false
+    end
+    if xft_dpi then
+        return xft_dpi
+    end
+
+    -- We have no outputs, so guess based on the size of the root window.
+    if root and not fallback_dpi then
+        local _, h = root.size()
+        local _, hmm = root.size_mm()
+        fallback_dpi = hmm ~= 0 and h * mm_per_inch / hmm
+    end
+    return fallback_dpi or 96
+end
+
+function screen.object.set_dpi(s, dpi)
+    s.data.dpi = dpi
+end
+
 
 --- When the tag history changed.
 -- @signal tag::history::update

--- a/lib/awful/widget/calendar_popup.lua
+++ b/lib/awful/widget/calendar_popup.lua
@@ -173,7 +173,7 @@ local function get_geometry(widget, screen, position)
     local pos, s = position or "cc", screen or ascreen.focused()
     local margin = widget._calendar_margin or 0
     local wa = s.workarea
-    local width, height = widget:fit({screen=s, dpi=beautiful.xresources.get_dpi(s)}, wa.width, wa.height)
+    local width, height = widget:fit({screen=s, dpi=s.dpi}, wa.width, wa.height)
 
     width  = width  < wa.width  and width  or wa.width
     height = height < wa.height and height or wa.height

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -64,8 +64,6 @@ function xresources.get_current_theme()
 end
 
 
-local dpi_per_screen = {}
-
 local function get_screen(s)
     return s and screen[s]
 end
@@ -75,8 +73,8 @@ end
 -- @treturn number DPI value.
 function xresources.get_dpi(s)
     s = get_screen(s)
-    if dpi_per_screen[s] then
-        return dpi_per_screen[s]
+    if s then
+        return s.dpi
     end
     if not xresources.dpi then
         -- Might not be present when run under unit tests
@@ -115,7 +113,7 @@ function xresources.set_dpi(dpi, s)
     if not s then
         xresources.dpi = dpi
     else
-        dpi_per_screen[s] = dpi
+        s.dpi = dpi
     end
 end
 

--- a/lib/wibox/drawable.lua
+++ b/lib/wibox/drawable.lua
@@ -44,7 +44,7 @@ local function get_widget_context(self)
     end
 
     local context = self._widget_context
-    local dpi = beautiful.xresources.get_dpi(s)
+    local dpi = s.dpi
     if (not context) or context.screen ~= s or context.dpi ~= dpi then
         context = {
             screen = s,

--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -73,7 +73,7 @@ end
 -- @treturn number The preferred width.
 -- @treturn number The preferred height.
 function textbox:get_preferred_size(s)
-    return self:get_preferred_size_at_dpi(beautiful.xresources.get_dpi(s))
+    return self:get_preferred_size_at_dpi(screen[s].dpi)
 end
 
 --- Get the preferred height of a textbox at a given width.
@@ -83,7 +83,7 @@ end
 -- @tparam integer|screen s The screen on which the textbox will be displayed.
 -- @treturn number The needed height.
 function textbox:get_height_for_width(width, s)
-    return self:get_height_for_width_at_dpi(width, beautiful.xresources.get_dpi(s))
+    return self:get_height_for_width_at_dpi(width, screen[s].dpi)
 end
 
 --- Get the preferred size of a textbox.


### PR DESCRIPTION
Once upon a time, beautiful.xresources.get_dpi was added to query
Xft.dpi. That made sense since this queried an xresources property. Over
time, other, non-xresources-based ways to query DPI were added to this
function. Now, it makes no more sense to have this function here.

Also, recently it became possible to add new properties to C objects
from Lua code. Thus, we no longer need to have a get_dpi() function
somewhere, but can add s.dpi directly.

Thus, this commit adds s.dpi and makes everything use it. No functional
changes are intended.

Signed-off-by: Uli Schlachter <psychon@znc.in>

This came from some discussion on IRC with @Oblomov.
My ultimate goal would be to deprecate `beautiful.xresources.get_dpi`, but right now `beautiful.get_font_height` still uses it.

CC @Oblomov 