### PR TITLE
screen.dpi: Use RandR for per-screen DPI

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -525,6 +525,18 @@ function screen.object.get_dpi(s)
         return xft_dpi
     end
 
+    -- Try to compute DPI based on outputs (use the minimum)
+    local dpi = nil
+    local geo = s.geometry
+    for _, o in pairs(s.outputs) do
+        local dpix = geo.width * mm_per_inch / o.mm_width
+        local dpiy = geo.height * mm_per_inch / o.mm_height
+        dpi = math.min(dpix, dpiy, dpi or dpix)
+    end
+    if dpi then
+        return dpi
+    end
+
     -- We have no outputs, so guess based on the size of the root window.
     if root and not fallback_dpi then
         local _, h = root.size()


### PR DESCRIPTION
This commit makes awesome automatically compute the DPI of a screen
based on its RandR outputs. If multiple outputs exist, the lowest DPI is
used.

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @blueyed This pretty much supersedes your #1204, is that okay with you?
CC @Oblomov 