### PR TITLE
textbox: Make some screen arguments optional again

### DIFF
--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -73,7 +73,14 @@ end
 -- @treturn number The preferred width.
 -- @treturn number The preferred height.
 function textbox:get_preferred_size(s)
-    return self:get_preferred_size_at_dpi(screen[s].dpi)
+    local dpi
+    if s then
+        dpi = screen[s].dpi
+    else
+        gdebug.deprecate("textbox:get_preferred_size() requires a screen argument", {deprecated_in=5, raw=true})
+        dpi = beautiful.xresources.get_dpi()
+    end
+    return self:get_preferred_size_at_dpi(dpi)
 end
 
 --- Get the preferred height of a textbox at a given width.
@@ -83,7 +90,14 @@ end
 -- @tparam integer|screen s The screen on which the textbox will be displayed.
 -- @treturn number The needed height.
 function textbox:get_height_for_width(width, s)
-    return self:get_height_for_width_at_dpi(width, screen[s].dpi)
+    local dpi
+    if s then
+        dpi = screen[s].dpi
+    else
+        gdebug.deprecate("textbox:get_preferred_size() requires a screen argument", {deprecated_in=5, raw=true})
+        dpi = beautiful.xresources.get_dpi()
+    end
+    return self:get_height_for_width_at_dpi(width, dpi)
 end
 
 --- Get the preferred size of a textbox.


### PR DESCRIPTION
Since beautiful.xresources.get_dpi(s) allows nil as argument to query
some "global DPI", the functions to query the size of a textbox also
allowed to use nil as the screen, even though this was never documented
to work. Commit a1376557917a88 broke this by assuming a valid screen
object.

This commit makes a nil argument work again, but will cause a
deprecation warning in awesome 5.

Signed-off-by: Uli Schlachter <psychon@znc.in>