### PR TITLE
WIP: Run test-menubar.lua under lgi 0.9.2

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -395,6 +395,9 @@ end
 --- Show the menubar on the given screen.
 -- @param scr Screen.
 function menubar.show(scr)
+    scr = scr or awful.screen.focused() or 1
+    scr = get_screen(scr)
+
     if not instance then
         -- Add to each category the name of its key in all_categories
         for k, v in pairs(menubar.menu_gen.all_categories) do
@@ -425,8 +428,6 @@ function menubar.show(scr)
     end
 
     -- Set position and size
-    scr = scr or awful.screen.focused() or 1
-    scr = get_screen(scr)
     local scrgeom = scr.workarea
     local geometry = menubar.geometry
     instance.geometry = {x = geometry.x or scrgeom.x,

--- a/tests/test-menubar.lua
+++ b/tests/test-menubar.lua
@@ -10,14 +10,22 @@ function menubar.refresh(...)
     orig_refresh(...)
 end
 
+local have_atleast_lgi_092
+do
+    local ver_major, ver_minor, ver_patch = string.match(require('lgi.version'), '(%d)%.(%d)%.(%d)')
+    have_atleast_lgi_092 = tonumber(ver_major) > 0
+        or tonumber(ver_minor) > 9
+        or tonumber(ver_patch) > 1
+end
+
 -- XXX We are building Lua 5.3 with -DLUA_USE_APICHECK=1 and this catches some
--- bugs in lgi. Thus, do not run this test with Lua 5.3 until lgi is fixed.
+-- bugs in lgi. Thus, do not run this test with Lua 5.3 before lgi 0.9.2.
 -- We run into the same bug when doing code-coverage analysis, supposedly
 -- because the additional GC activity means that something which is GC-able when
 -- it should not gets collected too early.
 -- This test also sporadically errors on LuaJIT ("attempt to call a number
 -- value"). This might be a different issue, but still, disable the test.
-if _VERSION == "Lua 5.3" or debug.gethook() or jit then --luacheck: globals jit
+if (_VERSION == "Lua 5.3" or debug.gethook() or jit) and not have_atleast_lgi_092 then --luacheck: globals jit
     print("Skipping this test since it would just fail.")
     runner.run_steps { function() return true end }
     return


### PR DESCRIPTION
lgi 0.9.2 was released and this supposedly fixes the problems that test-menubar.lua runs into. I doubt that the problem that LuaJIT runs into was fixed as well, but we can at least try.

Thus, right now this PR just exists to trigger a Travis build with test-menubar.lua and the newer lgi. Hopefully, not much fails.