### PR TITLE
awful.screen.object.get_dpi: Ignore outputs with size 0

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -529,9 +529,12 @@ function screen.object.get_dpi(s)
     local dpi = nil
     local geo = s.geometry
     for _, o in pairs(s.outputs) do
-        local dpix = geo.width * mm_per_inch / o.mm_width
-        local dpiy = geo.height * mm_per_inch / o.mm_height
-        dpi = math.min(dpix, dpiy, dpi or dpix)
+        -- Ignore outputs with width/height 0
+        if o.mm_width ~= 0 and o.mm_height ~= 0 then
+            local dpix = geo.width * mm_per_inch / o.mm_width
+            local dpiy = geo.height * mm_per_inch / o.mm_height
+            dpi = math.min(dpix, dpiy, dpi or dpix)
+        end
     end
     if dpi then
         return dpi


### PR DESCRIPTION
For example, Xephyr reports its output with a size of 0x0. Since a
division by zero is in no one's interest, just ignore such outputs when
trying to compute the DPI value.

Thanks to @timroes for pointing this out:
https://github.com/awesomeWM/awesome/commit/c8fac753c45c14df25101ad5ea50c30b78a9e34d#commitcomment-25072296

Signed-off-by: Uli Schlachter <psychon@znc.in>