### PR TITLE
Makefile: add explicit rule for Makefile to not "update" it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ distclean:
 	$(RM) -r $(BUILDDIR) $(TARGETS)
 	$(ECHO) " done"
 
+# Use an explicit rule to not "update" the Makefile via the implicit rule below.
+Makefile: ;
+
 %: $(BUILDDIR)/Makefile
 	$(ECHO) "Running make $@ in $(BUILDDIR)…"
 	$(MAKE) -C $(BUILDDIR) $@


### PR DESCRIPTION
Typically the implicit rule below will trigger a "make -C build
Makefile" run, whenever build/Makefile is newer than our Makefile.

Ref: https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html