### PR TITLE
tests/examples/CMakeLists.txt: set env via LUA_COV_RUNNER only

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -61,12 +61,7 @@ ${TOP_SOURCE_DIR}/tests/examples/shims/?/init.lua\\;\
 ${TOP_SOURCE_DIR}/tests/examples/shims/?\\;\
 ${LUA_PATH_}")
 
-set(LUA_COV_RUNNER env -u LUA_PATH_5_1 -u LUA_PATH_5_2 -u LUA_PATH_5_3 "LUA_PATH=${LUA_PATH_}" ${LUA_COV_RUNNER})
-
-# Done in 3 variables to avoid CMake from implicitly converting into a list.
-set(ENV{LUA_PATH} "${LUA_PATH3_}${LUA_PATH2_}${LUA_PATH_}")
-
-set(ENV{AWESOME_THEMES_PATH} "${TOP_SOURCE_DIR}/themes/")
+set(LUA_COV_RUNNER env -u LUA_PATH_5_1 -u LUA_PATH_5_2 -u LUA_PATH_5_3 "LUA_PATH=${LUA_PATH_}" "AWESOME_THEMES_PATH=${TOP_SOURCE_DIR}/themes/" ${LUA_COV_RUNNER})
 
 # The documentation images directory.
 set(IMAGE_DIR "${CMAKE_BINARY_DIR}/doc/images")


### PR DESCRIPTION
LUA_COV_RUNNER is used with `add_custom_command` for the command to
generate the images, and AWESOME_THEMES_PATH should be set there.

Since LUA_COV_RUNNER is used also with `execute_process` there is no
need for `set(ENV …)` anymore.