### PR TITLE
build-utils/dist.sh: remove "-dirty" suffix

### DIFF
--- a/build-utils/dist.sh
+++ b/build-utils/dist.sh
@@ -9,7 +9,7 @@ if [ -z "$1" ]; then
     exit 64
 fi
 
-GIT_TAG="$1"
+GIT_TAG="${1%-dirty}"
 SVERSION=$(echo "$GIT_TAG" | sed 's/^v//')
 
 date=$(git log -1 --format=%cI "$GIT_TAG")


### PR DESCRIPTION
Calling `make dist` on a dirty tree caused an error when trying to use
`git log` with the `-dirty` suffix.

This patch removes any "-dirty" suffix from the argument.

[ci skip]