### PR TITLE
Makefile: distclean: do not try to rm `awesome`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ install:
 
 distclean:
 	$(ECHO) -n "Cleaning up build directory…"
-	$(RM) -r $(BUILDDIR) $(TARGETS)
-	$(ECHO) " done"
+	$(RM) -r $(BUILDDIR)
 
 # Use an explicit rule to not "update" the Makefile via the implicit rule below.
 Makefile: ;


### PR DESCRIPTION
Follow-up to ec51e3f93, where we stopped creating the symlink.

[ci skip]