### PR TITLE
Makefile: fix invoking cmake in the build dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ $(BUILDDIR)/Makefile:
 	$(ECHO)
 	mkdir -p $(BUILDDIR)
 	$(ECHO) "Running cmake…"
-	cd $(BUILDDIR) && cmake $(CMAKE_ARGS) "$(@D)" ..
+	cd $(BUILDDIR) && cmake $(CMAKE_ARGS) "$(CURDIR)"
 
 cmake-build: $(BUILDDIR)/Makefile
 	$(ECHO) "Building…"


### PR DESCRIPTION
`"(@D)"` is the dir of the target, i.e. "build" for BUILDDIR=build,
which results in calling `cmake build ..`.

cmake appears to ignore the "build" in this case, and works the same way
without it.

Instead of ".." this patch uses `$(CURDIR)`, which is the absolute path
to the source dir, which is relevant in case `BUILDDIR` is not just a
direct subdirectory.