### PR TITLE
[RFC] awesomeConfig.cmake: GENERATE_DOC/GENERATE_MANPAGES: default to OFF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ install:
     if [ "$BUILD_APIDOC" = "true" ] || [ "$DO_CHECKQA" = 1 ]; then
       travis_retry sudo luarocks install ldoc
       travis_retry sudo luarocks install lua-discount
+      CMAKE_ARGS+=" -D GENERATE_DOC=1"
     fi
 
   # Install dependencies for code coverage testing.
@@ -156,7 +157,7 @@ install:
       return 0
     }
 script:
-  - export CMAKE_ARGS="-DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION -DSTRICT_TESTS=true -D DO_COVERAGE=$DO_COVERAGE"
+  - export CMAKE_ARGS="$CMAKE_ARGS -DLUA_LIBRARY=${LUALIBRARY} -DLUA_INCLUDE_DIR=${LUAINCLUDE} -D OVERRIDE_VERSION=$AWESOME_VERSION -DSTRICT_TESTS=true -D DO_COVERAGE=$DO_COVERAGE"
   - |
     if [ "$EMPTY_THEME_WHILE_LOADING" = 1 ]; then
       # Break beautiful so that trying to access the theme before beautiful.init() causes an error

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,9 +171,13 @@ script:
       SOURCE_DIRECTORY="$PWD"
       mkdir "$BUILD_IN_DIR"
       cd "$BUILD_IN_DIR"
+      BUILD_DIR="$PWD"
       travis_run_in_fold "build_in_dir" cmake $CMAKE_ARGS "$SOURCE_DIRECTORY"
+    else
+      BUILD_DIR="$PWD/build"
     fi
   - travis_run_in_fold "make" make
+  - if [ "$BUILD_APIDOC" = "true" ]; then test -f "$BUILD_DIR/doc/index.html"; fi
   - |
     if [ "$TRAVIS_TEST_RESULT" = 0 ]; then
       travis_run_in_fold "make.install" sudo env PATH=$PATH make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,10 @@ if(GENERATE_MANPAGES)
     endforeach()
 
     add_custom_target(man ALL DEPENDS ${MAN_FILES})
+else()
+    add_custom_target(man false
+        COMMENT "man target not generated. Use GENERATE_MANPAGES=1 to enable it, e.g. via `cmake -D GENERATE_MANPAGES=1 build/` or `make distclean man`."
+        VERBATIM)
 endif()
 # }}}
 
@@ -302,6 +306,10 @@ if(GENERATE_DOC)
         WORKING_DIRECTORY ${AWE_DOC_DIR}
         DEPENDS ${AWE_SRCS} ${AWE_LUA_FILES} ${AWE_MD_FILES} ${BUILD_DIR}/docs/config.ld
         COMMENT "Generating API documentation${ldoc_desc_suffix}")
+else()
+    add_custom_target(ldoc false
+        COMMENT "ldoc target not generated. Use GENERATE_DOC=1 to enable it, e.g. via `cmake -D GENERATE_DOC=1 build/` or `make distclean ldoc`."
+        VERBATIM)
 endif()
 # }}}
 

--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,6 @@ distclean:
 	$(ECHO) -n "Cleaning up build directory…"
 	$(RM) -r $(BUILDDIR)
 
-# Wrapper targets to enable building man pages / doc.
-# Should do the same as the implicit target at the end.
-man: CMAKE_ARGS+=-D GENERATE_MANPAGES=1
-ldoc: CMAKE_ARGS+=-D GENERATE_DOC=1
-ldoc man: $(BUILDDIR)/Makefile
-	$(ECHO) "Running make $@ in $(BUILDDIR)…"
-	$(MAKE) -C $(BUILDDIR) $@
-
 # Use an explicit rule to not "update" the Makefile via the implicit rule below.
 Makefile: ;
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ distclean:
 	$(ECHO) -n "Cleaning up build directory…"
 	$(RM) -r $(BUILDDIR)
 
+# Wrapper targets to enable building man pages / doc.
+# Should do the same as the implicit target at the end.
+man: CMAKE_ARGS+=-D GENERATE_MANPAGES=1
+ldoc: CMAKE_ARGS+=-D GENERATE_DOC=1
+ldoc man: $(BUILDDIR)/Makefile
+	$(ECHO) "Running make $@ in $(BUILDDIR)…"
+	$(MAKE) -C $(BUILDDIR) $@
+
 # Use an explicit rule to not "update" the Makefile via the implicit rule below.
 Makefile: ;
 

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -6,10 +6,16 @@ set(VERSION devel)
 
 set(CODENAME "Human after all")
 
+string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type)
+
 option(WITH_DBUS "build with D-BUS" ON)
-option(GENERATE_MANPAGES "generate manpages" ON)
+if("${build_type}" STREQUAL "RELEASE")
+    option(GENERATE_MANPAGES "generate manpages" ON)
+else()
+    option(GENERATE_MANPAGES "generate manpages" OFF)
+endif()
 option(COMPRESS_MANPAGES "compress manpages" ON)
-option(GENERATE_DOC "generate API documentation" ON)
+option(GENERATE_DOC "generate API documentation" OFF)
 option(DO_COVERAGE "build with coverage" OFF)
 if (GENERATE_DOC AND DO_COVERAGE)
     message(STATUS "Not generating API documentation with DO_COVERAGE")


### PR DESCRIPTION
Generating documentation is slow, since it runs/configures all the
example tests, and the typical user does not care about generating the
docs when building.

Generating man pages is also rather slow, and is typically not needed.
For CMAKE_BUILD_TYPE=RELEASE generating man pages is still enabled by default.

This adds fallback `ldoc` and `man` targets to explain how to enable it,
with wrapping targets in our main Makefile.

TODO:
- [ ] mention in docs how distributions should build it to include man pages, i.e. that they should use cmake with `-D CMAKE_BUILD_TYPE=RELEASE`, or `make CMAKE_ARGS=-DCMAKE_BUILD_TYPE=RELEASE`