### PR TITLE
tests: improve coverage with integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -213,8 +213,8 @@ script:
       travis_run_in_fold "make.check-qa" make check-qa
     fi
   - |
-    set -e
     if [ "$TEST_PREV_COMMITS" = 1 ] && ! [ "$TRAVIS_PULL_REQUEST" = false ]; then
+      set -e
       # Check each commit separately (to make git-bisect less annoying).
       # Fix Travis' commit range (https://github.com/travis-ci/travis-ci/issues/4596).
       commit_range="${TRAVIS_COMMIT_RANGE/.../..}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,14 +388,14 @@ add_executable(test-gravity tests/test-gravity.c)
 target_link_libraries(test-gravity
     ${AWESOME_COMMON_REQUIRED_LDFLAGS} ${AWESOME_REQUIRED_LDFLAGS})
 add_custom_target(check-integration
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' DO_COVERAGE=${DO_COVERAGE} ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
     DEPENDS ${PROJECT_AWE_NAME}
     USES_TERMINAL)
 add_dependencies(check-integration test-gravity)
 add_custom_target(check-themes
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' DO_COVERAGE=${DO_COVERAGE} ./tests/themes/run.sh
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ./tests/themes/run.sh
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Testing themes"
     USES_TERMINAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,14 +388,14 @@ add_executable(test-gravity tests/test-gravity.c)
 target_link_libraries(test-gravity
     ${AWESOME_COMMON_REQUIRED_LDFLAGS} ${AWESOME_REQUIRED_LDFLAGS})
 add_custom_target(check-integration
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' DO_COVERAGE=${DO_COVERAGE} ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
     DEPENDS ${PROJECT_AWE_NAME}
     USES_TERMINAL)
 add_dependencies(check-integration test-gravity)
 add_custom_target(check-themes
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ./tests/themes/run.sh
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' DO_COVERAGE=${DO_COVERAGE} ./tests/themes/run.sh
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Testing themes"
     USES_TERMINAL

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -198,6 +198,7 @@ fi
 
 # Start awesome.
 start_awesome() {
+    cd "$build_dir"
     # Kill awesome after $timeout_stale seconds (e.g. for errors during test setup).
     # SOURCE_DIRECTORY is used by .luacov.
     DISPLAY="$D" SOURCE_DIRECTORY="$source_dir" \
@@ -225,7 +226,6 @@ errors=()
 # Seconds after when awesome gets killed.
 timeout_stale=30
 
-cd "$build_dir"
 for f in $tests; do
     echo "== Running $f =="
     (( ++count_tests ))
@@ -233,15 +233,17 @@ for f in $tests; do
     start_awesome
 
     if [ ! -r "$f" ]; then
-        if [ -r "$source_dir/$f" ]; then
-            f="$source_dir/$f"
-        elif [ -r "$source_dir/${f#tests/}" ]; then
-            f="$source_dir/${f#tests/}"
+        if [ -r "${f#tests/}" ]; then
+            f=${f#tests/}
         else
             echo "===> ERROR $f is not readable! <==="
             errors+=("$f is not readable.")
             continue
         fi
+    fi
+    # Make the filename absolute if it is not.
+    if [ "$f#/" = "$f" ]; then
+        f="$source_dir/$f"
     fi
 
     # Execute the test file in awesome.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -191,7 +191,8 @@ if [ -n "$DO_COVERAGE" ] && [ "$DO_COVERAGE" != 0 ]; then
     if [ -f "${RC_FILE}.in" ]; then
         RC_FILE="${RC_FILE}.in"
     fi
-    sed "1 s~^~require('luacov.runner')(); \0~" "$RC_FILE" > "$tmp_files/awesomerc.lua"
+    sed "1 s~^~require('luacov.runner')('$source_dir/.luacov'); \0~" \
+        "$RC_FILE" > "$tmp_files/awesomerc.lua"
     RC_FILE=$tmp_files/awesomerc.lua
 fi
 

--- a/tests/themes/run.sh
+++ b/tests/themes/run.sh
@@ -41,5 +41,5 @@ for theme_file in themes/*/theme.lua; do
     AWESOME_RC_FILE="$config_file" \
         AWESOME_THEMES_PATH="$build_dir/themes" \
         AWESOME_ICON_PATH="$PWD/icons" \
-        "$source_dir/tests/run.sh" themes/tests.lua
+        "$source_dir/tests/run.sh" "$source_dir/tests/themes/tests.lua"
 done


### PR DESCRIPTION
- install luacov.runner in tests/_runner.lua.
- use Lua's `dofile` to execute the test files, which will give us
  coverage for them.