### PR TITLE
tests: tests/run.sh: timeout after 30 seconds

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -224,7 +224,7 @@ fi
 count_tests=0
 errors=()
 # Seconds after when awesome gets killed.
-timeout_stale=180 # FIXME This should be no more than 60s
+timeout_stale=30
 
 for f in $tests; do
     echo "== Running $f =="


### PR DESCRIPTION
We could do even less, but 30s improves from the 120s before a lot.