### PR TITLE
Add call_now argument to gears.timer

### DIFF
--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -30,6 +30,7 @@
 --
 --    gears.timer {
 --        timeout   = 10,
+--        call_now  = true,
 --        autostart = true,
 --        callback  = function()
 --            -- You should read it from `/sys/class/power_supply/` (on Linux)
@@ -147,6 +148,7 @@ local timer_instance_mt = {
 -- @tparam table args Arguments.
 -- @tparam number args.timeout Timeout in seconds (e.g. 1.5).
 -- @tparam[opt=false] boolean args.autostart Automatically start the timer.
+-- @tparam[opt=false] boolean args.call_now Call the callback at timer creation.
 -- @tparam[opt=nil] function args.callback Callback function to connect to the
 --  "timeout" signal.
 -- @tparam[opt=false] boolean args.single_shot Run only once then stop.
@@ -168,6 +170,9 @@ function timer.new(args)
     end
 
     if args.callback then
+        if args.call_now then
+            args.callback()
+        end
         ret:connect_signal("timeout", args.callback)
     end
 


### PR DESCRIPTION
This is a very simple patch which adds `immediate_start` boolean argument to timer creation.
This argument works as autostart, but also calls the callback at 'zero time' - at timer creation.
It is useful for stuff like watch widgets, i have below construct repeated like 4 times across my code:
```lua
local function update() ... end
update() -- first (or zeroeth) time call here!
gears.timer { timeout = 5, autostart = true, callback = update }
```
And so i couldn't inline the callback in timer creation, which would have looked like this
```lua
gears.timer {
    timeout = 5, immediate_start = true,
    callback = function() ... end
}
```
Single statement timer looks more consice for me and there is no 'N/A' (or not any) text on widgets for `timeout` seconds.