### PR TITLE
awful.rules: Handle non-existing tags

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -292,7 +292,13 @@ local force_ignore = {
 function rules.high_priority_properties.tag(c, value, props)
     if value then
         if type(value) == "string" then
+            local name = value
             value = atag.find_by_name(c.screen, value)
+            if not value then
+                require("gears.debug").print_error("awful.rules-rule specified "
+                    .. "tag = '" .. name .. "', but no such tag exists")
+                return
+            end
         end
 
         -- In case the tag has been forced to another screen, move the client


### PR DESCRIPTION
If a tag is specified by name, but no such tags exist, awful.rules would
cause an error (attempt to index a nil value). Fix this and add a test
for this case.

Fixes: https://github.com/awesomeWM/awesome/issues/2087
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----
Note that this only fixes the error in #2087. I am not sure if we want to do "fallback to `awful.tag.find_by_name(nil, value)`". @Elv13 ?