### PR TITLE
client.c: Set WM_STATE_NORMAL before checking _NET_WM_STATE

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -1498,14 +1498,14 @@ client_manage(xcb_window_t w, xcb_get_geometry_reply_t *wgeom, xcb_get_window_at
         if ((*oc)->transient_for_window == w)
             client_find_transient_for(*oc);
 
+    /* Put the window in normal state. */
+    xwindow_set_state(c->window, XCB_ICCCM_WM_STATE_NORMAL);
+
     /* Then check clients hints */
     ewmh_client_check_hints(c);
 
     /* Push client in stack */
     stack_client_push(c);
-
-    /* Put the window in normal state. */
-    xwindow_set_state(c->window, XCB_ICCCM_WM_STATE_NORMAL);
 
     /* Request our response */
     xcb_get_property_reply_t *reply =


### PR DESCRIPTION
_NET_WM_STATE could contain _NET_WM_STATE_HIDDEN, which we interpret as
minimized. Minimized clients have WM_STATE set to WM_STATE_ICONIC, but
the code in client_manage() would later overwrite this to
WM_STATE_NORMAL.

Fix this by setting the initial WM_STATE_NORMAL by doing so before
processing _NET_WM_STATE.

Fixes: https://github.com/awesomeWM/awesome/issues/2095
Signed-off-by: Uli Schlachter <psychon@znc.in>