### PR TITLE
Fix doc: get_clients methods belong to screen, not to client

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -341,7 +341,7 @@ end
 --
 -- This is used by `screen.clients` internally (with `stacked=true`).
 --
--- @function client:get_clients
+-- @function screen:get_clients
 -- @tparam[opt=true] boolean stacked Use stacking order? (top to bottom)
 -- @treturn table The clients list.
 function screen.object.get_clients(s, stacked)
@@ -388,7 +388,7 @@ end
 --
 -- This is used by `all_clients` internally (with `stacked=true`).
 --
--- @function client:get_all_clients
+-- @function screen:get_all_clients
 -- @tparam[opt=true] boolean stacked Use stacking order? (top to bottom)
 -- @treturn table The clients list.
 function screen.object.get_all_clients(s, stacked)
@@ -410,7 +410,7 @@ end
 --
 -- This is used by `tiles_clients` internally (with `stacked=true`).
 --
--- @function client:get_tiled_clients
+-- @function screen:get_tiled_clients
 -- @tparam[opt=true] boolean stacked Use stacking order? (top to bottom)
 -- @treturn table The clients list.
 function screen.object.get_tiled_clients(s, stacked)


### PR DESCRIPTION
The three `get_[|all_|tiled_]clients()` methods are incorrectly attributed to `client` although they belong to `screen`.