### PR TITLE
luaA_warn: Balance stack

### DIFF
--- a/luaa.h
+++ b/luaa.h
@@ -67,6 +67,7 @@ luaA_warn(lua_State *L, const char *fmt, ...)
 #if LUA_VERSION_NUM >= 502
     luaL_traceback(L, L, NULL, 2);
     fprintf(stderr, "%s\n", lua_tostring(L, -1));
+    lua_pop(L, 1);
 #endif
 }
 


### PR DESCRIPTION
In Lua 5.2 or newer, this function left a string on the Lua stack. Fix
this by popping this string.

Signed-off-by: Uli Schlachter <psychon@znc.in>