### PR TITLE
Update menubar generator to acknowledge application translations

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -261,6 +261,7 @@ end
 function utils.parse_desktop_file(file)
     local program = { show = true, file = file }
     local desktop_entry = false
+    local locale = string.sub(os.setlocale(nil), 1, 2) or "en"
 
     -- Parse the .desktop file.
     -- We are interested in [Desktop Entry] group only.
@@ -278,9 +279,12 @@ function utils.parse_desktop_file(file)
             end
 
             -- Grab the values
-            for key, value in line:gmatch("(%w+)%s*=%s*(.+)") do
+            for key, value in line:gmatch("([%w%[%]]+)%s*=%s*(.+)") do
                 if list_keys[key] then
                     program[key] = utils.parse_list(value)
+                elseif key == "Name[" .. locale .. "]" then
+                    -- Overwrite Name with a translation of the current locale.
+                    program["Name"] = utils.unescape(value)
                 else
                     program[key] = utils.unescape(value)
                 end


### PR DESCRIPTION
This patch revises the generation of the program entry list by
considering the current locale and matching against the program
name's translation, if there is one, for the designated locale.