### PR TITLE
Deprecate menubar.icon_theme

### DIFF
--- a/lib/menubar/icon_theme.lua
+++ b/lib/menubar/icon_theme.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------
---- Class module for icon lookup for menubar
+--- (Deprecated) class module for icon lookup for menubar
 --
 -- @author Kazunobu Kuriyama
 -- @copyright 2015 Kazunobu Kuriyama
@@ -78,6 +78,7 @@ local icon_theme = { mt = {} }
 local index_theme_cache = {}
 
 --- Class constructor of `icon_theme`
+-- @deprecated menubar.icon_theme.new
 -- @tparam string icon_theme_name Internal name of icon theme
 -- @tparam table base_directories Paths used for lookup
 -- @treturn table An instance of the class `icon_theme`
@@ -218,6 +219,7 @@ local lookup_fallback_icon = function(self, icon_name)
 end
 
 ---  Look up an image file based on a given icon name and/or a preferable size.
+-- @deprecated menubar.icon_theme:find_icon_path
 -- @tparam string icon_name Icon name to be looked up
 -- @tparam number icon_size Prefereable icon size
 -- @treturn string Absolute path to the icon file, or nil if not found

--- a/lib/menubar/index_theme.lua
+++ b/lib/menubar/index_theme.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------
---- Class module for parsing an index.theme file
+--- (Deprecated) class module for parsing an index.theme file
 --
 -- @author Kazunobu Kuriyama
 -- @copyright 2015 Kazunobu Kuriyama
@@ -31,6 +31,7 @@ local THRESHOLD = "Threshold"
 local index_theme = { mt = {} }
 
 --- Class constructor of `index_theme`
+-- @deprecated menubar.index_theme.new
 -- @tparam table cls Metatable that will be used. Should always be `index_theme.mt`.
 -- @tparam string icon_theme_name Internal name of icon theme
 -- @tparam table base_directories Paths used for lookup
@@ -132,18 +133,21 @@ index_theme.new = function(cls, icon_theme_name, base_directories)
 end
 
 --- Table of the values of the `Directories` key
+-- @deprecated menubar.index_theme:get_subdirectories
 -- @treturn table Values of the `Directories` key
 index_theme.get_subdirectories = function(self)
     return self[DIRECTORIES]
 end
 
 --- Table of the values of the `Inherits` key
+-- @deprecated menubar.index_theme:get_inherits
 -- @treturn table Values of the `Inherits` key
 index_theme.get_inherits = function(self)
     return self[INHERITS]
 end
 
 --- Query (part of) per-directory keys of a given subdirectory name.
+-- @deprecated menubar.index_theme:get_per_directory_keys
 -- @tparam table subdirectory Icon theme's subdirectory
 -- @treturn[1] string Value of the `Type` key
 -- @treturn[2] number Value of the `Size` key

--- a/lib/menubar/menu_gen.lua
+++ b/lib/menubar/menu_gen.lua
@@ -10,7 +10,6 @@
 local gtable = require("gears.table")
 local gfilesystem = require("gears.filesystem")
 local utils = require("menubar.utils")
-local icon_theme = require("menubar.icon_theme")
 local pairs = pairs
 local ipairs = ipairs
 local table = table
@@ -59,7 +58,7 @@ menu_gen.all_categories = {
 --- Find icons for category entries.
 function menu_gen.lookup_category_icons()
     for _, v in pairs(menu_gen.all_categories) do
-        v.icon = icon_theme():find_icon_path(v.icon_name)
+        v.icon = utils.lookup_icon(v.icon_name)
     end
 end
 


### PR DESCRIPTION
The code in menubar.icon_theme naively implements the algorithm from the
base dir specification. This is a problem: On this system,
/usr/share/icons/{Adwaita,hicolor}/index.theme list 91, respectively 649
subdirectories. Since we check for three file extensions (png, svg,
xpm), this means that a failing icon lookup for the Adwaita theme checks
for (91+649)*3 = 2220 files (in practice it might be a bit better since
the directories have specific meanings, but still). That's insane.

Since we only use this code for looking up category icons anyway, just
deprecate this mess. Category icons are now looked up in the same way
that icons for individual applications are looked up.

Since menubar.init does not require("menubar.icon_theme"), this means
that menubar.icon_theme is no longer actually loaded. That's bad.

(Hopefully) Fixes: https://github.com/awesomeWM/awesome/issues/1496
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

My long-term plan would be to "reinvent the wheel" and write some module(s) for `gears` to do icon lookups. In a way that doesn't suck. Somehow...

CC @unode Can you test this PR?