### PR TITLE
.travis.yml: Enable even more assertions for Lua 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
        wget http://www.lua.org/ftp/lua-5.3.4.tar.gz -O lua.tar.gz
        tar -xvzf lua.tar.gz
        cd lua-5.3.*/src \
-        && make SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2 -DLUA_USE_APICHECK" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="/tmp/myar" liblua.so \
+        && make SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2 -DLUA_USE_APICHECK -Dlua_assert=assert" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="/tmp/myar" liblua.so \
         && cd .. \
         && sudo make INSTALL_TOP=/usr/ INSTALL_INC=${LUAINCLUDE} TO_LIB=liblua.so linux install)
     elif [[ "$LUANAME" == "luajit-2.0" ]]; then


### PR DESCRIPTION
It might be well known that test-menubar.lua fails with "cannot do calls
on non-normal thread" when run under our Lua 5.3 build with coverage
tracking enabled. This new, extra assertion catches the error earlier
and in a different way. Since more assertions means more errors caught,
let's add this.

Signed-off-by: Uli Schlachter <psychon@znc.in>