### PR TITLE
screen:swap(): Avoid segfault on almost-deleted screens

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1222,6 +1222,9 @@ luaA_screen_swap(lua_State *L)
             if(ref_s && ref_swap)
                 break;
         }
+        if(!ref_s || !ref_swap)
+            return luaL_error(L, "Invalid call to screen:swap()");
+
         /* swap ! */
         *ref_s = swap;
         *ref_swap = s;


### PR DESCRIPTION
When a screen is in the process of being removed, it is still valid, but
no longer in the global list of screens (globalconf.screens). In this
time frame, trying to swap screens could cause a NULL pointer
dereference.

Fix this by throwing a Lua error in this case instead.

Fixes: https://github.com/awesomeWM/awesome/issues/2110
Signed-off-by: Uli Schlachter <psychon@znc.in>

@stloewen You don't need to connect to `added` or `removed`, `list` is all you need.