### PR TITLE
textclock: Detect failures from g_date_time_format

### DIFF
--- a/lib/wibox/widget/textclock.lua
+++ b/lib/wibox/widget/textclock.lua
@@ -44,7 +44,13 @@ function textclock.new(format, timeout, timezone)
     local w = textbox()
     w.force_update = textclock.force_update
     function w._private.textclock_update_cb()
-        w:set_markup(DateTime.new_now(timezone):format(format))
+        local str = DateTime.new_now(timezone):format(format)
+        if str == nil then
+            require("gears.debug").print_warning("textclock: "
+                    .. "g_date_time_format() failed for format "
+                    .. "'" .. format .. "'")
+        end
+        w:set_markup(str)
         w._timer.timeout = calc_timeout(timeout)
         w._timer:again()
         return true -- Continue the timer


### PR DESCRIPTION
If g_date_time_format() fails, it returns a NULL pointer. This change
makes the textclock detect this and print a warning. This warning
contains 'g_date_time_format()' so that people can ask their favorite
search engine for the supported formats of this function. This warning
also contains the actual format string so that all the information is
available in one place and possible bug reports hopefully include the
format string.

Reference: https://github.com/awesomeWM/awesome/issues/2118
Signed-off-by: Uli Schlachter <psychon@znc.in>