### PR TITLE
Revert 31b8623ff6c4e6e0c and fix things properly

### DIFF
--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -60,7 +60,7 @@ local function default_template()
         bgb     = bgb,
         tbm     = tbm,
         ibm     = ibm,
-        primary = l,
+        primary = bgb,
     }
 end
 
@@ -154,7 +154,7 @@ function common.list_update(w, buttons, label, data, objects, args)
             cache.ibm:set_margins(0)
         end
 
-        w:add(cache.bgb)
+        w:add(cache.primary)
    end
 end
 


### PR DESCRIPTION
The code here has things like "if cache.bgb" which suggests that "bgb"
(great name, by the way) is supposed to be optional. However,
31b8623ff6c4e6e0c made this thing definitely not optional by making it
*the* widget that is displayed. That feels wrong.

Also, after the above commit, the ".primary" entry is no longer used,
which is at least surprising for something which is called "primary".

None of this is explicitly documented (I didn't find anything when
looking for "primary" in common.lua nor tasklist.lua; I know that there
are examples for using this, but still that doesn't say how this is
supposed to work), so I'm not quite sure how this was intended to work.
Instead, I am just proposing this commit as a better fix with the above
rational and see what feedback I get...

Signed-off-by: Uli Schlachter <psychon@znc.in>