### PR TITLE
Check for xdgInitHandle() failures

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -585,7 +585,8 @@ main(int argc, char **argv)
         }
 
     /* Get XDG basedir data */
-    xdgInitHandle(&xdg);
+    if(!xdgInitHandle(&xdg))
+        fatal("Function xdgInitHandle() failed, is $HOME unset?");
 
     /* add XDG_CONFIG_DIR as include path */
     const char * const *xdgconfigdirs = xdgSearchableConfigDirectories(&xdg);


### PR DESCRIPTION
Before this, running "env -i ./awesome" resulted in a segfault. This was
because xdgInitHandle() failed and the following
xdgSearchableConfigDirectories() followed a NULL pointer.

After this commit, awesome fails with an error message.

Signed-off-by: Uli Schlachter <psychon@znc.in>