### PR TITLE
Add set/get for textclock attributes

### DIFF
--- a/lib/wibox/widget/textclock.lua
+++ b/lib/wibox/widget/textclock.lua
@@ -40,15 +40,15 @@ function textclock:get_timezone()
     return self._private.tzid
 end
 
---- Set the clock's timeout
+--- Set the clock's refresh rate
 -- @tparam number How often the clock is updated
-function textclock:set_timeout(timeout)
-    self._private.timeout = timeout or self._private.timeout
+function textclock:set_refresh(refresh)
+    self._private.refresh = refresh or self._private.refresh
     self:force_update()
 end
 
-function textclock:get_timeout()
-    return self._private.timeout
+function textclock:get_refresh()
+    return self._private.refresh
 end
 
 --- Force a textclock to update now.
@@ -65,18 +65,18 @@ end
 --- Create a textclock widget. It draws the time it is in a textbox.
 --
 -- @tparam[opt=" %a %b %d, %H:%M "] string format The time format.
--- @tparam[opt=60] number timeout How often to update the time (in seconds).
+-- @tparam[opt=60] number refresh How often to update the time (in seconds).
 -- @tparam[opt=local timezone] string timezone The timezone to use,
 --   e.g. "Z" for UTC, "±hh:mm" or "Europe/Amsterdam". See
 --   https://developer.gnome.org/glib/stable/glib-GTimeZone.html#g-time-zone-new.
 -- @treturn table A textbox widget.
 -- @function wibox.widget.textclock
-function textclock.new(format, timeout, tzid)
+function textclock.new(format, refresh, tzid)
     local w = textbox()
     xtable.crush(w, textclock, true)
 
     w._private.format = format or " %a %b %d, %H:%M "
-    w._private.timeout = timeout or 60
+    w._private.refresh = refresh or 60
     w._private.tzid = tzid
     w._private.timezone = tzid and TimeZone.new(tzid) or TimeZone.new_local()
 
@@ -88,12 +88,12 @@ function textclock.new(format, timeout, tzid)
                     .. "'" .. w._private.format .. "'")
         end
         w:set_markup(str)
-        w._timer.timeout = calc_timeout(w._private.timeout)
+        w._timer.timeout = calc_timeout(w._private.refresh)
         w._timer:again()
         return true -- Continue the timer
     end
 
-    w._timer = timer.weak_start_new(timeout, w._private.textclock_update_cb)
+    w._timer = timer.weak_start_new(refresh, w._private.textclock_update_cb)
     w:force_update()
     return w
 end

--- a/lib/wibox/widget/textclock.lua
+++ b/lib/wibox/widget/textclock.lua
@@ -10,7 +10,7 @@ local setmetatable = setmetatable
 local os = os
 local textbox = require("wibox.widget.textbox")
 local timer = require("gears.timer")
-local xtable = require("gears.table")
+local gtable = require("gears.table")
 local glib = require("lgi").GLib
 local DateTime = glib.DateTime
 local TimeZone = glib.TimeZone
@@ -18,7 +18,9 @@ local TimeZone = glib.TimeZone
 local textclock = { mt = {} }
 
 --- Set the clock's format
+-- @property format
 -- @tparam string format The new time format.  This can contain pango markup
+
 function textclock:set_format(format)
     self._private.format = format
     self:force_update()
@@ -29,7 +31,9 @@ function textclock:get_format()
 end
 
 --- Set the clock's timezone
+-- @property timezone
 -- @tparam string timezone
+
 function textclock:set_timezone(tzid)
     self._private.tzid = tzid
     self._private.timezone = tzid and TimeZone.new(tzid) or TimeZone.new_local()
@@ -41,7 +45,9 @@ function textclock:get_timezone()
 end
 
 --- Set the clock's refresh rate
--- @tparam number How often the clock is updated
+-- @property refresh
+-- @tparam number How often the clock is updated, in seconds
+
 function textclock:set_refresh(refresh)
     self._private.refresh = refresh or self._private.refresh
     self:force_update()
@@ -71,9 +77,9 @@ end
 --   https://developer.gnome.org/glib/stable/glib-GTimeZone.html#g-time-zone-new.
 -- @treturn table A textbox widget.
 -- @function wibox.widget.textclock
-function textclock.new(format, refresh, tzid)
+local function new(format, refresh, tzid)
     local w = textbox()
-    xtable.crush(w, textclock, true)
+    gtable.crush(w, textclock, true)
 
     w._private.format = format or " %a %b %d, %H:%M "
     w._private.refresh = refresh or 60
@@ -99,7 +105,7 @@ function textclock.new(format, refresh, tzid)
 end
 
 function textclock.mt:__call(...)
-    return textclock.new(...)
+    return new(...)
 end
 
 --@DOC_widget_COMMON@


### PR DESCRIPTION
It's not very pretty the way it's implemented but hey, it works.  My
reason for wanting this was to allow "declarative" construction of
clocks.

If you'd prefer it to be more "class-like", I'd be happy to change it.