### PR TITLE
Use GdkPixbuf directly from Lua

### DIFF
--- a/build-utils/lgi-check.c
+++ b/build-utils/lgi-check.c
@@ -35,7 +35,7 @@ const char commands[] =
 "        '0.8.0', require('lgi.version')))\n"
 "end\n"
 "lgi = require('lgi')\n"
-"assert(lgi.cairo, lgi.Pango, lgi.PangoCairo, lgi.GLib, lgi.Gio)\n"
+"assert(lgi.cairo, lgi.Pango, lgi.PangoCairo, lgi.GLib, lgi.Gio, lgi.GdkPixbuf)\n"
 ;
 
 int main()

--- a/draw.c
+++ b/draw.c
@@ -81,7 +81,7 @@ draw_surface_from_data(int width, int height, uint32_t *data)
  * \param buf The pixbuf
  * \return Number of items pushed on the lua stack.
  */
-static cairo_surface_t *
+cairo_surface_t *
 draw_surface_from_pixbuf(GdkPixbuf *buf)
 {
     int width = gdk_pixbuf_get_width(buf);

--- a/draw.h
+++ b/draw.h
@@ -30,6 +30,9 @@
 #include "common/array.h"
 #include "common/util.h"
 
+/* Forward definition */
+typedef struct _GdkPixbuf GdkPixbuf;
+
 typedef struct area_t area_t;
 struct area_t
 {
@@ -57,6 +60,7 @@ DO_ARRAY(cairo_surface_t *, cairo_surface, cairo_surface_array_destroy_surface)
 cairo_surface_t *draw_surface_from_data(int width, int height, uint32_t *data);
 cairo_surface_t *draw_dup_image_surface(cairo_surface_t *surface);
 cairo_surface_t *draw_load_image(lua_State *L, const char *path, GError **error);
+cairo_surface_t *draw_surface_from_pixbuf(GdkPixbuf *buf);
 
 xcb_visualtype_t *draw_find_visual(const xcb_screen_t *s, xcb_visualid_t visual);
 xcb_visualtype_t *draw_default_visual(const xcb_screen_t *s);

--- a/lib/gears/surface.lua
+++ b/lib/gears/surface.lua
@@ -8,6 +8,7 @@ local setmetatable = setmetatable
 local type = type
 local capi = { awesome = awesome }
 local cairo = require("lgi").cairo
+local GdkPixbuf = require("lgi").GdkPixbuf
 local color = nil
 local gdebug = require("gears.debug")
 local hierarchy = require("wibox.hierarchy")
@@ -36,7 +37,6 @@ end
 -- @return The loaded surface, or the replacement default
 -- @return An error message, or nil on success
 function surface.load_uncached_silently(_surface, default)
-    local file
     -- On nil, return some sane default
     if not _surface then
         return get_default(default)
@@ -47,12 +47,11 @@ function surface.load_uncached_silently(_surface, default)
     end
     -- Strings are assumed to be file names and get loaded
     if type(_surface) == "string" then
-        local err
-        file = _surface
-        _surface, err = capi.awesome.load_image(file)
-        if not _surface then
-            return get_default(default), err
+        local pixbuf, err = GdkPixbuf.Pixbuf.new_from_file(_surface)
+        if not pixbuf then
+            return get_default(default), tostring(err)
         end
+        _surface = capi.awesome.pixbuf_to_surface(pixbuf._native)
     end
     -- Everything else gets forced into a surface
     return cairo.Surface(_surface, true)

--- a/luaa.c
+++ b/luaa.c
@@ -281,6 +281,23 @@ luaA_sync(lua_State *L)
     return 0;
 }
 
+/** Translate a GdkPixbuf to a cairo image surface..
+ *
+ * @param pixbuf The pixbuf as a light user datum.
+ * @return A cairo surface as light user datum.
+ * @function pixbuf_to_surface
+ */
+static int
+luaA_pixbuf_to_surface(lua_State *L)
+{
+    GdkPixbuf *pixbuf = (GdkPixbuf *) lua_touserdata(L, 1);
+    cairo_surface_t *surface = draw_surface_from_pixbuf(pixbuf);
+
+    /* lua has to make sure to free the ref or we have a leak */
+    lua_pushlightuserdata(L, surface);
+    return 1;
+}
+
 /** Load an image from a given path.
  *
  * @param name The file name.
@@ -292,6 +309,10 @@ luaA_sync(lua_State *L)
 static int
 luaA_load_image(lua_State *L)
 {
+    /* TODO: Deprecate this function, Lua can use GdkPixbuf directly plus
+     * awesome.pixbuf_to_surface
+     */
+
     GError *error = NULL;
     const char *filename = luaL_checkstring(L, 1);
     cairo_surface_t *surface = draw_load_image(L, filename, &error);
@@ -776,6 +797,7 @@ luaA_init(xdgHandle* xdg, string_array_t *searchpath)
         { "emit_signal", luaA_awesome_emit_signal },
         { "systray", luaA_systray },
         { "load_image", luaA_load_image },
+        { "pixbuf_to_surface", luaA_pixbuf_to_surface },
         { "set_preferred_icon_size", luaA_set_preferred_icon_size },
         { "register_xproperty", luaA_register_xproperty },
         { "set_xproperty", luaA_set_xproperty },


### PR DESCRIPTION
Note that this (likely) conflicts with #2123, so should only be merged after #2123.

The diffstat for this PR is:
```
 5 files changed, 33 insertions(+), 8 deletions(-)
```
However, the following patch has this diffstat
```
 3 files changed, 53 deletions(-)
```
```diff
diff --git a/draw.c b/draw.c
index 83d3d355..c3590b58 100644
--- a/draw.c
+++ b/draw.c
@@ -171,27 +171,6 @@ draw_dup_image_surface(cairo_surface_t *surface)
     return res;
 }
 
-/** Load the specified path into a cairo surface
- * \param L Lua state
- * \param path file to load
- * \param error A place to store an error message, if needed
- * \return A cairo image surface or NULL on error.
- */
-cairo_surface_t *
-draw_load_image(lua_State *L, const char *path, GError **error)
-{
-    cairo_surface_t *ret;
-    GdkPixbuf *buf = gdk_pixbuf_new_from_file(path, error);
-
-    if (!buf)
-        /* error was set above */
-        return NULL;
-
-    ret = draw_surface_from_pixbuf(buf);
-    g_object_unref(buf);
-    return ret;
-}
-
 xcb_visualtype_t *draw_find_visual(const xcb_screen_t *s, xcb_visualid_t visual)
 {
     xcb_depth_iterator_t depth_iter = xcb_screen_allowed_depths_iterator(s);
diff --git a/draw.h b/draw.h
index 867296cf..9adc36ff 100644
--- a/draw.h
+++ b/draw.h
@@ -59,7 +59,6 @@ DO_ARRAY(cairo_surface_t *, cairo_surface, cairo_surface_array_destroy_surface)
 
 cairo_surface_t *draw_surface_from_data(int width, int height, uint32_t *data);
 cairo_surface_t *draw_dup_image_surface(cairo_surface_t *surface);
-cairo_surface_t *draw_load_image(lua_State *L, const char *path, GError **error);
 cairo_surface_t *draw_surface_from_pixbuf(GdkPixbuf *buf);
 
 xcb_visualtype_t *draw_find_visual(const xcb_screen_t *s, xcb_visualid_t visual);
diff --git a/luaa.c b/luaa.c
index 29c7ec06..d143bcdb 100644
--- a/luaa.c
+++ b/luaa.c
@@ -298,36 +298,6 @@ luaA_pixbuf_to_surface(lua_State *L)
     return 1;
 }
 
-/** Load an image from a given path.
- *
- * @param name The file name.
- * @return[1] A cairo surface as light user datum.
- * @return[2] nil
- * @treturn[2] string Error message
- * @function load_image
- */
-static int
-luaA_load_image(lua_State *L)
-{
-    /* TODO: Deprecate this function, Lua can use GdkPixbuf directly plus
-     * awesome.pixbuf_to_surface
-     */
-
-    GError *error = NULL;
-    const char *filename = luaL_checkstring(L, 1);
-    cairo_surface_t *surface = draw_load_image(L, filename, &error);
-    if (!surface) {
-        lua_pushnil(L);
-        lua_pushstring(L, error->message);
-        g_error_free(error);
-        return 2;
-    }
-
-    /* lua has to make sure to free the ref or we have a leak */
-    lua_pushlightuserdata(L, surface);
-    return 1;
-}
-
 /** Set the preferred size for client icons.
  *
  * The closest equal or bigger size is picked if present, otherwise the closest
@@ -796,7 +766,6 @@ luaA_init(xdgHandle* xdg, string_array_t *searchpath)
         { "disconnect_signal", luaA_awesome_disconnect_signal },
         { "emit_signal", luaA_awesome_emit_signal },
         { "systray", luaA_systray },
-        { "load_image", luaA_load_image },
         { "pixbuf_to_surface", luaA_pixbuf_to_surface },
         { "set_preferred_icon_size", luaA_set_preferred_icon_size },
         { "register_xproperty", luaA_register_xproperty },

```
So if one day we get rid of `load_image`, then this actually saves lines. ;-)