### PR TITLE
Introduce signal_array_getbyname

### DIFF
--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -230,8 +230,7 @@ luaA_object_disconnect_signal_from_stack(lua_State *L, int oud,
 void
 signal_object_emit(lua_State *L, signal_array_t *arr, const char *name, int nargs)
 {
-    signal_t *sigfound = signal_array_getbyid(arr,
-                                              a_strhash((const unsigned char *) name));
+    signal_t *sigfound = signal_array_getbyname(arr, name);
 
     if(sigfound)
     {
@@ -279,8 +278,7 @@ luaA_object_emit_signal(lua_State *L, int oud,
         luaA_warn(L, "Trying to emit signal '%s' on invalid object", name);
         return;
     }
-    signal_t *sigfound = signal_array_getbyid(&obj->signals,
-                                              a_strhash((const unsigned char *) name));
+    signal_t *sigfound = signal_array_getbyname(&obj->signals, name);
     if(sigfound)
     {
         int nbfunc = sigfound->sigfuncs.len;

--- a/common/signal.h
+++ b/common/signal.h
@@ -91,8 +91,7 @@ signal_connect(signal_array_t *arr, const char *name, const void *ref)
 static inline bool
 signal_disconnect(signal_array_t *arr, const char *name, const void *ref)
 {
-    signal_t *sigfound = signal_array_getbyid(arr,
-                                              a_strhash((const unsigned char *) name));
+    signal_t *sigfound = signal_array_getbyname(arr, name);
     if(sigfound)
     {
         foreach(func, sigfound->sigfuncs)

--- a/common/signal.h
+++ b/common/signal.h
@@ -54,6 +54,13 @@ signal_array_getbyid(signal_array_t *arr, unsigned long id)
     return signal_array_lookup(arr, &sig);
 }
 
+static inline signal_t *
+signal_array_getbyname(signal_array_t *arr, const char *name)
+{
+    signal_t sig = { .id = a_strhash((const unsigned char *) NONULL(name)) };
+    return signal_array_lookup(arr, &sig);
+}
+
 /** Connect a signal inside a signal array.
  * You are in charge of reference counting.
  * \param arr The signal array.

--- a/dbus.c
+++ b/dbus.c
@@ -411,16 +411,14 @@ a_dbus_process_request(DBusConnection *dbus_connection, DBusMessage *msg)
 
     if(dbus_message_get_no_reply(msg))
     {
-        signal_t *sigfound = signal_array_getbyid(&dbus_signals,
-                                                  a_strhash((const unsigned char *) NONULL(interface)));
+        signal_t *sigfound = signal_array_getbyname(&dbus_signals, interface);
         /* emit signals */
         if(sigfound)
             signal_object_emit(L, &dbus_signals, NONULL(interface), nargs);
     }
     else
     {
-        signal_t *sig = signal_array_getbyid(&dbus_signals,
-                                             a_strhash((const unsigned char *) NONULL(interface)));
+        signal_t *sig = signal_array_getbyname(&dbus_signals, interface);
         if(sig)
         {
             /* there can be only ONE handler to send reply */
@@ -763,8 +761,7 @@ luaA_dbus_connect_signal(lua_State *L)
 {
     const char *name = luaL_checkstring(L, 1);
     luaA_checkfunction(L, 2);
-    signal_t *sig = signal_array_getbyid(&dbus_signals,
-                                         a_strhash((const unsigned char *) name));
+    signal_t *sig = signal_array_getbyname(&dbus_signals, name);
     if(sig) {
         luaA_warn(L, "cannot add signal %s on D-Bus, already existing", name);
         lua_pushnil(L);

--- a/spawn.c
+++ b/spawn.c
@@ -107,8 +107,7 @@ spawn_monitor_timeout(gpointer sequence)
 {
     if(spawn_sequence_remove(sequence))
     {
-         signal_t *sig = signal_array_getbyid(&global_signals,
-                                              a_strhash((const unsigned char *) "spawn::timeout"));
+         signal_t *sig = signal_array_getbyname(&global_signals, "spawn::timeout");
          if(sig)
          {
              /* send a timeout signal */
@@ -215,8 +214,7 @@ spawn_monitor_event(SnMonitorEvent *event, void *data)
     }
 
     /* send the signal */
-    signal_t *sig = signal_array_getbyid(&global_signals,
-                                         a_strhash((const unsigned char *) event_type_str));
+    signal_t *sig = signal_array_getbyname(&global_signals, event_type_str);
 
     if(sig)
     {


### PR DESCRIPTION
This commit changes basically nothing, but pulls the details of the used hash function into `common.signal`, instead of "bleeding it out" into all callers.
Related to #1074.