### PR TITLE
Add support for resizing notification icon with respect to aspect

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -759,9 +759,14 @@ function naughty.notify(args)
             iconbox = wibox.widget.imagebox()
             iconmargin = wibox.container.margin(iconbox, margin, margin, margin, margin)
             if icon_size then
-                local scaled = cairo.ImageSurface(cairo.Format.ARGB32, icon_size, icon_size)
+                local scale_factor = icon_size / math.max(icon:get_height(),
+                                                          icon:get_width())
+                local scaled =
+                    cairo.ImageSurface(cairo.Format.ARGB32,
+                                       icon:get_width() * scale_factor,
+                                       icon:get_height() * scale_factor)
                 local cr = cairo.Context(scaled)
-                cr:scale(icon_size / icon:get_height(), icon_size / icon:get_width())
+                cr:scale(scale_factor, scale_factor)
                 cr:set_source_surface(icon, 0, 0)
                 cr:paint()
                 icon = scaled

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -22,6 +22,7 @@ local screen = require("awful.screen")
 local util = require("awful.util")
 local gtable = require("gears.table")
 local gfs = require("gears.filesystem")
+local gmath = require("gears.math")
 local beautiful = require("beautiful")
 local wibox = require("wibox")
 local surface = require("gears.surface")
@@ -763,8 +764,8 @@ function naughty.notify(args)
                                                           icon:get_width())
                 local scaled =
                     cairo.ImageSurface(cairo.Format.ARGB32,
-                                       icon:get_width() * scale_factor,
-                                       icon:get_height() * scale_factor)
+                                       gmath.round(icon:get_width() * scale_factor),
+                                       gmath.round(icon:get_height() * scale_factor))
                 local cr = cairo.Context(scaled)
                 cr:scale(scale_factor, scale_factor)
                 cr:set_source_surface(icon, 0, 0)


### PR DESCRIPTION
Previously, if an icon was not exactly square, an icon size set in configuration would cause the notification to pad the icon with empty space so dimensions are equal.

Now behaviour is different: the bigger dimension of the icon is scaled to fit the icon_size value, while smaller is scaled same amount to preserve aspect.

Also, ImageSurface is now created not as a fixed size square, but with dimensions computed in similar way.

P.S. I actually don't know Lua, so feel free to educate me on mistakes that I most likely managed to make even in these 3 statements.
![illustration](https://user-images.githubusercontent.com/7015572/35760126-c7342b42-0886-11e8-8952-c705075f0210.png)
