### PR TITLE
dbus: fix nil notifications

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -421,7 +421,7 @@ function naughty.getById(id)
 end
 
 --- Increase notification ID by one
-function get_next_notification_id()
+function naughty.get_next_notification_id()
   counter = counter + 1
   return counter
 end

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -420,6 +420,12 @@ function naughty.getById(id)
     end
 end
 
+--- Increase notification ID by one
+function get_next_notification_id()
+  counter = counter + 1
+  return counter
+end
+
 --- Install expiration timer for notification object.
 -- @tparam notification notification Notification object.
 -- @tparam number timeout Time in seconds to be set as expiration timeout.

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -184,10 +184,10 @@ capi.dbus.connect_signal("org.freedesktop.Notifications",
                 args.freedesktop_hints = hints
                 notification = naughty.notify(args)
                 if notification ~= nil then
-                    return "u", core.get_next_notification_id()
+                    return "u", notification.id
                 end
             end
-            return "u", "0"
+            return "u", naughty.get_next_notification_id()
         elseif data.member == "CloseNotification" then
             local obj = naughty.getById(appname)
             if obj then

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -184,7 +184,7 @@ capi.dbus.connect_signal("org.freedesktop.Notifications",
                 args.freedesktop_hints = hints
                 notification = naughty.notify(args)
                 if notification ~= nil then
-                    return "u", notification.id
+                    return "u", core.get_next_notification_id()
                 end
             end
             return "u", "0"

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -185,8 +185,6 @@ capi.dbus.connect_signal("org.freedesktop.Notifications",
                 notification = naughty.notify(args)
                 if notification ~= nil then
                     return "u", notification.id
-                else
-                    return "u", 0
                 end
             end
             return "u", "0"

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -183,7 +183,11 @@ capi.dbus.connect_signal("org.freedesktop.Notifications",
                 end
                 args.freedesktop_hints = hints
                 notification = naughty.notify(args)
-                return "u", notification.id
+                if notification ~= nil then
+                    return "u", notification.id
+                else
+                    return "u", 0
+                end
             end
             return "u", "0"
         elseif data.member == "CloseNotification" then


### PR DESCRIPTION
when mangling notifications via naughty.config.notify_callback it is
advised (1) to return nil for rejecting a notification. The underlaying dbus
library tries to access a field of that notification table and fails.

(1) https://awesomewm.org/doc/api/libraries/naughty.html#config