### PR TITLE
Make fake screens permanent

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -57,6 +57,11 @@
 #include <xcb/xinerama.h>
 #include <xcb/randr.h>
 
+/* The XID that is used on fake screens. X11 guarantees that the top three bits
+ * of a valid XID are zero, so this will not clash with anything.
+ */
+#define FAKE_SCREEN_XID ((uint32_t) 0xffffffff)
+
 /** Screen is a table where indexes are screen numbers. You can use `screen[1]`
  * to get access to the first screen, etc. Alternatively, if RANDR information
  * is available, you can use output names for finding screen objects.
@@ -673,7 +678,7 @@ screen_refresh(void)
     screen_array_init(&removed_screens);
     for(int i = 0; i < globalconf.screens.len; i++) {
         screen_t *old_screen = globalconf.screens.tab[i];
-        bool found = false;
+        bool found = old_screen->xid == FAKE_SCREEN_XID;
         foreach(new_screen, new_screens)
             found |= (*new_screen)->xid == old_screen->xid;
         if(!found) {
@@ -1144,6 +1149,7 @@ luaA_screen_fake_add(lua_State *L)
     s->geometry.y = y;
     s->geometry.width = width;
     s->geometry.height = height;
+    s->xid = FAKE_SCREEN_XID;
 
     screen_added(L, s);
     luaA_class_emit_signal(L, &screen_class, "list", 0);

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -275,6 +275,7 @@ screen_add(lua_State *L, screen_array_t *screens)
     screen_t *new_screen = screen_new(L);
     luaA_object_ref(L, -1);
     screen_array_append(screens, new_screen);
+    new_screen->xid = XCB_NONE;
     return new_screen;
 }
 


### PR DESCRIPTION
Before this, screen_scan() made sure that awesome's information about
available screens conforms to what the X11 server reports. Since fake
screens are, well, fake, this meant that they were deleted.

This commit marks fake screen and handles them specially in
screen_scan() so that they are not deleted.

Note that I did not test this commit at all since I still haven't
figured out how to test RandR stuff without actually messing with
hardware.

Thanks to @madduck for bringing this up and making me fix this long
standing "huh? is that really supposed to work like that?".

Signed-off-by: Uli Schlachter <psychon@znc.in>

----------------

THIS IS UNTESTED!