### PR TITLE
awful.tag.object.set_screen: Cope with screen being nil

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -500,7 +500,9 @@ function tag.object.set_screen(t, s)
 
     -- Change the screen
     tag.setproperty(t, "screen", s)
-    tag.setproperty(t, "index", #s:get_tags(true))
+    if s then
+        tag.setproperty(t, "index", #s:get_tags(true))
+    end
 
     -- Make sure the client's screen matches its tags
     for _,c in ipairs(t:clients()) do
@@ -508,14 +510,16 @@ function tag.object.set_screen(t, s)
         c:tags({t})
     end
 
-    -- Update all indexes
-    for i,t2 in ipairs(old_screen.tags) do
-        tag.setproperty(t2, "index", i)
-    end
+    if old_screen then
+        -- Update all indexes
+        for i,t2 in ipairs(old_screen.tags) do
+            tag.setproperty(t2, "index", i)
+        end
 
-    -- Restore the old screen history if the tag was selected
-    if sel then
-        tag.history.restore(old_screen, 1)
+        -- Restore the old screen history if the tag was selected
+        if sel then
+            tag.history.restore(old_screen, 1)
+        end
     end
 end
 


### PR DESCRIPTION
For "stuff around screen's 'removed' signal", it might make sense to
temporarily set a tags screen to nil. The idea is that it will only
later be assigned to a new screen, not immediately.

However, currently a tag with screen nil causes quite some problems in
the set_screen() function. This commit works around this with a generous
amount of "wrap this in if".

Signed-off-by: Uli Schlachter <psychon@znc.in>