### PR TITLE
Add a client shape test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - sudo apt-get install -y libcairo2-dev gir1.2-gtk-3.0 xmlto asciidoc libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
 
   # Deps for tests.
-  - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb zsh
+  - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb zsh x11-apps
 
   # Need xorg-macros
   - sudo apt-get install -y xutils-dev

--- a/tests/test-client-shape.lua
+++ b/tests/test-client-shape.lua
@@ -1,0 +1,34 @@
+-- Test that client shapes work
+
+local runner = require("_runner")
+local spawn = require("awful.spawn")
+local surface = require("gears.surface")
+
+runner.run_steps{
+    function(count)
+        if count == 1 then
+            local a = spawn("xeyes")
+            assert(type(a) == "number", a)
+        end
+        if #client.get() == 1 then
+            return true
+        end
+    end,
+
+    function()
+        -- Here would be the right place to actually test anything.
+        -- However, this test just exists to stabilise code coverage (without
+        -- it, it would always fluctuate). Thus, this is not really a test...
+        local c = client.get()[1]
+        assert(c.name == "xeyes", c.name)
+        assert(surface.load_silently(c.client_shape_bounding, false))
+        assert(surface.load_silently(c.shape_bounding, false))
+
+        assert(not surface.load_silently(c.client_shape_clip, false))
+        assert(not surface.load_silently(c.shape_clip, false))
+
+        return true
+    end
+}
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This is not really a test. It just starts xeyes and sees if anything
explodes.

However, the reason for this test is to stabilise code coverage.
Apparently, Gtk(?) sometimes creates shaped windows. This had the effect
that codecov always reports random changes to code coverage, depending
on if this specific test run saw any shaped client windows or not.

Thus, by explicitly adding a test that runs a shaped client, hopefully
these random fluctuations disappear.

Hopefully-fixes: https://github.com/awesomeWM/awesome/issues/1975
Signed-off-by: Uli Schlachter <psychon@znc.in>