### PR TITLE
Deprecate gears.filesystem.get_dir

### DIFF
--- a/docs/07-my-first-awesome.md
+++ b/docs/07-my-first-awesome.md
@@ -71,7 +71,7 @@ Awesome has four themes you can choose from: *default*, *sky*, *xresources*, and
 To change the theme, open your rc.lua and edit this line near the beginning of
 the file:
 
-    beautiful.init(gears.filesystem.get_dir("config") .. "/themes/default/theme.lua")
+    beautiful.init(gears.filesystem.get_themes_dir() .. "default/theme.lua")
 
 For this tutorial we will stick with the default theme.
 

--- a/docs/sample_theme.lua
+++ b/docs/sample_theme.lua
@@ -19,7 +19,7 @@ require("sample_files")(
 --
 -- with
 --
---    beautiful.init(gears.filesystem.get_dir("config") .. "mytheme.lua")
+--    beautiful.init(gears.filesystem.get_configuration_dir() .. "mytheme.lua")
 --
 -- in your `rc.lua`.
 --

--- a/lib/gears/filesystem.lua
+++ b/lib/gears/filesystem.lua
@@ -145,8 +145,10 @@ function filesystem.get_dir(d)
     if d == "config" then
         -- No idea why this is what is returned, I recommend everyone to use
         -- get_configuration_dir() instead
+        require("gears.debug").deprecate("gears.filesystem.get_xdg_config_home() .. 'awesome/'", {deprecated_in=5})
         return filesystem.get_xdg_config_home() .. "awesome/"
     elseif d == "cache" then
+        require("gears.debug").deprecate("gears.filesystem.get_cache_dir", {deprecated_in=5})
         return filesystem.get_cache_dir()
     end
 end

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -130,7 +130,7 @@ local function load_count_table()
         return instance.count_table
     end
     instance.count_table = {}
-    local count_file_name = gfs.get_dir("cache") .. "/menu_count_file"
+    local count_file_name = gfs.get_cache_dir() .. "/menu_count_file"
     local count_file = io.open (count_file_name, "r")
     if count_file then
         for line in count_file:lines() do
@@ -146,7 +146,7 @@ end
 
 local function write_count_table(count_table)
     count_table = count_table or instance.count_table
-    local count_file_name = gfs.get_dir("cache") .. "/menu_count_file"
+    local count_file_name = gfs.get_cache_dir() .. "/menu_count_file"
     local count_file = assert(io.open(count_file_name, "w"))
     for name, count in pairs(count_table) do
         local str = string.format("%s;%d\n", name, count)

--- a/tests/examples/wibox/awidget/prompt/hooks.lua
+++ b/tests/examples/wibox/awidget/prompt/hooks.lua
@@ -54,7 +54,7 @@ local gfs       = require("gears.filesystem") --DOC_HIDE
         prompt        = "<b>Run: </b>",
         hooks         = hooks,
         textbox       = atextbox,
-        history_path  = gfs.get_dir("cache") .. "/history",
+        history_path  = gfs.get_cache_dir() .. "/history",
         done_callback = clear,
     }
 

--- a/tests/examples/wibox/awidget/prompt/keypress.lua
+++ b/tests/examples/wibox/awidget/prompt/keypress.lua
@@ -24,7 +24,7 @@ local naughty   = {} --DOC_HIDE
             end
         end,
         textbox              = atextbox,
-        history_path         = gfs.get_dir("cache") .. "/history",
+        history_path         = gfs.get_cache_dir() .. "/history",
     }
 
 parent:add( wibox.widget {    --DOC_HIDE

--- a/tests/examples/wibox/awidget/prompt/vilike.lua
+++ b/tests/examples/wibox/awidget/prompt/vilike.lua
@@ -44,7 +44,7 @@ local terminal  = "xterm"  --DOC_HIDE
             end},
         },
         textbox      = atextbox,
-        history_path = gfs.get_dir('cache') .. '/history',
+        history_path = gfs.get_cache_dir() .. '/history',
         exe_callback = function(cmd) awful.spawn(cmd) end
     }
 


### PR DESCRIPTION
It is a useless thin wrapper around other functions. It's better to use
these other functions directly.

Signed-off-by: Uli Schlachter <psychon@znc.in>