### PR TITLE
Remove a weird comment

### DIFF
--- a/color.c
+++ b/color.c
@@ -66,8 +66,6 @@ color_parse(const char *colstr, ssize_t len,
 }
 
 /** Send a request to initialize a X color.
- * If you are only interested in the rgba values and don't need the color's
- * pixel value, you should use color_init_unchecked() instead.
  * \param color color_t struct to store color into.
  * \param colstr Color specification.
  * \param len The length of colstr (which still MUST be NULL terminated).


### PR DESCRIPTION
No idea what this is meant to tell us, but color_init_unchecked()
pointing at itself with "use this instead" makes no sense.

Signed-off-by: Uli Schlachter <psychon@znc.in>

@actionless Is this what you meant with the comment being weird?