### PR TITLE
Add categories path to icon lookup

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -208,6 +208,9 @@ local function get_icon_lookup_path()
             table.insert(app_in_theme_paths,
                          glib.build_filenamev({ icon_theme_directory,
                                                 size, 'apps' }))
+            table.insert(app_in_theme_paths,
+                         glib.build_filenamev({ icon_theme_directory,
+                                                size, 'categories' }))
         end
     end
     add_if_readable(icon_lookup_path, app_in_theme_paths)


### PR DESCRIPTION
In #2112 the way of loading category icons was changed to use
utils.lookup_icon. However this function does not look in the
categories paths where the categories icons are located, and
so the category icons are no longer being displayed.