### PR TITLE
Move from asciidoc to asciidoctor to generate man pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
 
   # Install build dependencies.
   # See also `apt-cache showsrc awesome | grep -E '^(Version|Build-Depends)'`.
-  - sudo apt-get install -y libcairo2-dev gir1.2-gtk-3.0 xmlto asciidoc libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
+  - sudo apt-get install -y libcairo2-dev gir1.2-gtk-3.0 libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
+  - sudo gem install asciidoctor
 
   # Deps for tests.
   - sudo apt-get install -y dbus-x11 xterm xdotool xterm xvfb zsh x11-apps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,6 @@ if(GENERATE_MANPAGES)
 
             # set the final filenames
             set(txtfile ${SOURCE_DIR}/${relpath}/${basename2}.txt)
-            set(xmlfile ${BUILD_DIR}/${relpath2}/${basename}.xml)
             set(gzfile  ${BUILD_DIR}/${relpath2}/${basename}.gz)
             set(manfile ${BUILD_DIR}/${relpath2}/${basename})
 
@@ -240,16 +239,11 @@ if(GENERATE_MANPAGES)
                 set(asciilang ${lang})
             endif()
             add_custom_command(
-                COMMAND ${ASCIIDOC_EXECUTABLE} -a lang=${asciilang} -d manpage -b docbook -o ${xmlfile} - < ${txtfile}
+                COMMAND ${ASCIIDOCTOR_EXECUTABLE} -a lang=${asciilang} -d manpage -b manpage -o ${manfile} - < ${txtfile}
                 WORKING_DIRECTORY ${BUILD_DIR}/${relpath2}
-                OUTPUT  ${xmlfile}
+                OUTPUT  ${manfile}
                 DEPENDS ${txtfile}
                 VERBATIM)
-            add_custom_command(
-                COMMAND ${XMLTO_EXECUTABLE} man ${xmlfile}
-                OUTPUT  ${manfile}
-                WORKING_DIRECTORY ${BUILD_DIR}/${relpath2}
-                DEPENDS ${xmlfile})
 
             if(COMPRESS_MANPAGES)
                 add_custom_command(

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -37,8 +37,7 @@ endmacro()
 
 a_find_program(GIT_EXECUTABLE git FALSE)
 # programs needed for man pages
-a_find_program(ASCIIDOC_EXECUTABLE asciidoc FALSE)
-a_find_program(XMLTO_EXECUTABLE xmlto FALSE)
+a_find_program(ASCIIDOCTOR_EXECUTABLE asciidoctor FALSE)
 a_find_program(GZIP_EXECUTABLE gzip FALSE)
 # Lua documentation
 if(GENERATE_DOC)
@@ -77,12 +76,9 @@ endif()
 
 # {{{ Check if documentation can be build
 if(GENERATE_MANPAGES)
-    if(NOT ASCIIDOC_EXECUTABLE OR NOT XMLTO_EXECUTABLE OR (COMPRESS_MANPAGES AND NOT GZIP_EXECUTABLE))
-        if(NOT ASCIIDOC_EXECUTABLE)
-            SET(missing "asciidoc")
-        endif()
-        if(NOT XMLTO_EXECUTABLE)
-            SET(missing ${missing} " xmlto")
+    if(NOT ASCIIDOCTOR_EXECUTABLE OR (COMPRESS_MANPAGES AND NOT GZIP_EXECUTABLE))
+        if(NOT ASCIIDOCTOR_EXECUTABLE)
+            SET(missing "asciidoctor")
         endif()
         if(COMPRESS_MANPAGES AND NOT GZIP_EXECUTABLE)
             SET(missing ${missing} " gzip")

--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -66,8 +66,7 @@ Additionally, the following optional dependencies exist:
 
 - [DBus](https://www.freedesktop.org/wiki/Software/dbus/) for DBus integration
   and the `awesome-client` utility
-- [asciidoc](http://www.methods.co.nz/asciidoc/) and
-  [xmlto](https://fedorahosted.org/xmlto/) for generating man pages
+- [asciidoctor](https://asciidoctor.org/) for generating man pages
 - [gzip](http://www.gzip.org/) for compressing man pages
 - [ldoc >= 1.4.5](https://stevedonovan.github.io/ldoc/) for generating the
   documentation


### PR DESCRIPTION
Hi,

Asciidoc is EOL and only supports python2.
Upstream clearly encourages people to move to an equivalent such as asciidoctor, see: https://github.com/asciidoc/asciidoc/releases/tag/8.6.10
As the maintainer of asciidoc in Debian I'm working with the different projects to help the transition, hence the current PR.

Thanks
Joseph