### PR TITLE
program.Terminal is a boolean, not a string

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -395,7 +395,7 @@ function utils.parse_desktop_file(file)
         else
             cmdline = cmdline:gsub('%%i', '')
         end
-        if program.Terminal == "true" then
+        if program.Terminal == true then
             cmdline = utils.terminal .. ' -e ' .. cmdline
         end
         program.cmdline = cmdline


### PR DESCRIPTION
Wrong conditional results in Terminal apps not opening correctly. This commit fixes the problem.