### PR TITLE
flex: Remove exit condition

### DIFF
--- a/lib/wibox/layout/flex.lua
+++ b/lib/wibox/layout/flex.lua
@@ -98,14 +98,9 @@ function flex:layout(_, width, height)
             w, h = floor(space_per_item), height
         end
 
-        table.insert(result, base.place_widget_at(v, x, y, w, h))
-
         pos = pos + space_per_item + spacing
 
-        if (is_y and pos-spacing >= height) or
-            (is_x and pos-spacing >= width) then
-            break
-        end
+        table.insert(result, base.place_widget_at(v, x, y, w, h))
 
         if k > 1 and spacing ~= 0 and spacing_widget then
             table.insert(result, base.place_widget_at(


### PR DESCRIPTION
Fixes #2251

The last `spacing_widget` was not inserted, even though there is enough space. The removed condition was formulated incorrectly:

+ the condition should've be e.g. `pos-spacing > width`
+ this exit condition is evaluated based on the next iteration's `pos` (which isn't incorrect, but it does look fishy)
+ the concrete drawing coordinate `x` is calculated with `gmath.round(pos)`, whereas the conditional check is done with plain `pos`, this may have caused the behavior described in #2251

Moreover, this conditional exit misses the case where `space_per_item` is smaller than `spacing`. So if this check indeed has another purpose, it seems like it is incomplete.

Moved up calculation of new `pos` to be analog to `fixed` and `ratio` layouts' codes.