### PR TITLE
Fix summary of TEST_PREV_COMMITS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -242,7 +242,7 @@ script:
       git checkout -qf FETCH_HEAD
       if [ -n "$failed" ]; then
         echo "Checks failed for these commits:"
-        for c in $commits; do
+        for c in $failed; do
           git log -1 --pretty="%h %s (%an, %ad)" "$c"
         done
         false


### PR DESCRIPTION
Instead of printing the list of commits for which tests failed, this
printed all commits.

Testing done on this change: None. Testing the infrastructure for Travis
is a bit hard and quite meta. (Tests for the tests?)

Signed-off-by: Uli Schlachter <psychon@znc.in>