### PR TITLE
Improve no_overlap placement

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -874,7 +874,10 @@ function placement.no_overlap(c, args)
     local curlay = layout.get()
     local areas = { screen.workarea }
     for _, cl in pairs(cls) do
-        if cl ~= c and cl.type ~= "desktop" and (cl.floating or curlay == layout.suit.floating) then
+        if cl ~= c
+           and cl.type ~= "desktop"
+           and (cl.floating or curlay == layout.suit.floating)
+           and not (cl.maximized or cl.fullscreen) then
             areas = grect.area_remove(areas, area_common(cl))
         end
     end

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -908,13 +908,18 @@ function placement.no_overlap(c, args)
     -- This makes sure to have the whole screen's area in case it has been
     -- removed.
     if not found then
-        if #areas == 0 then
-            areas = { screen.workarea }
-        end
-        for _, r in ipairs(areas) do
-            if r.width * r.height > new.width * new.height then
-                new = r
+        if #areas > 0 then
+            for _, r in ipairs(areas) do
+                if r.width * r.height > new.width * new.height then
+                    new = r
+                end
             end
+        elseif grect.area_intersect_area(geometry, screen.workarea) then
+            new.x = geometry.x
+            new.y = geometry.y
+        else
+            new.x = screen.workarea.x
+            new.y = screen.workarea.y
         end
     end
 

--- a/lib/gears/geometry.lua
+++ b/lib/gears/geometry.lua
@@ -151,7 +151,7 @@ end
 -- @param a The area.
 -- @param b The other area.
 -- @return True if they intersect, false otherwise.
-local function area_intersect_area(a, b)
+function gears.geometry.rectangle.area_intersect_area(a, b)
     return (b.x < a.x + a.width
             and b.x + b.width > a.x
             and b.y < a.y + a.height
@@ -194,7 +194,7 @@ end
 function gears.geometry.rectangle.area_remove(areas, elem)
     for i = #areas, 1, -1 do
         -- Check if the 'elem' intersect
-        if area_intersect_area(areas[i], elem) then
+        if gears.geometry.rectangle.area_intersect_area(areas[i], elem) then
             -- It does? remove it
             local r = table.remove(areas, i)
             local inter = gears.geometry.rectangle.get_intersection(r, elem)


### PR DESCRIPTION
1) Improve placement heuristic by ignoring fullscreen/maximized clients. On tile layouts such clients are ignored, but not on the `awful.layout.suit.floating`.
2) Fix  #2139. If there is no free space and client located on the same screen - keep position unchanged. In case of offscreen client - fall back to old logic (move top left).