### PR TITLE
Fix incwfact() error with maximized windows

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -974,6 +974,8 @@ function client.incwfact(add, c)
 
     local t = c.screen.selected_tag
     local w = client.idx(c)
+    if not w then return end
+
     local data = t.windowfact or {}
     local colfact = data[w.col] or {}
     local curr = colfact[w.idx] or 1

--- a/tests/test-awful-client.lua
+++ b/tests/test-awful-client.lua
@@ -105,6 +105,25 @@ local steps = {
 
         return true
     end,
+
+    -- Ensure that window factor is ignored on maximized clients
+    function()
+        local c = client.get()[1]
+        assert(c ~= nil)
+
+        local signal_count = 0
+        c:connect_signal("property::windowfact", function()
+            signal_count = signal_count + 1
+        end)
+
+        c.maximized = true
+
+        awful.client.incwfact(0.1, c)
+        awful.client.setwfact(0.5, c)
+        assert(signal_count == 0)
+
+        return true
+    end,
 }
 
 local original_count, c1, c2 = 0


### PR DESCRIPTION
When the window is maximized, calling `awful.client.incwfact()` results in an error because `w` is nil.