### PR TITLE
Fix doc signals

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -140,6 +140,10 @@ custom_display_name_handler = function(item, default_handler)
         return name ~= "" and name or item.name
     end
 
+    if item.type == "deprecated" then
+        return default_handler(item) .. "</a> <i class=\"deprecated_label\">[deprecated]</i><a>"
+    end
+
     return default_handler(item)
 end
 

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -132,4 +132,15 @@ file = {
     }
 }
 
+custom_display_name_handler = function(item, default_handler)
+
+    -- Remove the "namespace" from the signals and properties
+    if item.type == "property" or item.type == "signal" then
+        local name = item.name:match("%.([^.]+)$")
+        return name ~= "" and name or item.name
+    end
+
+    return default_handler(item)
+end
+
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/docs/ldoc.css
+++ b/docs/ldoc.css
@@ -277,6 +277,11 @@ ul.nowrap {
     padding-right: 15px;
 }
 
+.deprecated_label {
+    color: #9db9f3;
+    font-weight: normal;
+}
+
 /* stop sublists from having initial vertical space */
 ul ul { margin-top: 0px; }
 ol ul { margin-top: 0px; }

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1236,7 +1236,7 @@ end
 -- @tparam[opt=nil] table hints Some hints.
 
 --- The client marked signal (deprecated).
--- @signal .marked
+-- @signal marked
 
 --- The client unmarked signal (deprecated).
 -- @signal unmarked

--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -72,13 +72,13 @@ local protected_call = require("gears.protected_call")
 -- @table timer
 
 --- When the timer is started.
--- @signal .start
+-- @signal start
 
 --- When the timer is stopped.
--- @signal .stop
+-- @signal stop
 
 --- When the timer had a timeout event.
--- @signal .timeout
+-- @signal timeout
 
 local timer = { mt = {} }
 

--- a/objects/button.c
+++ b/objects/button.c
@@ -60,7 +60,7 @@
 
 /** When bound mouse button + modifiers are pressed.
  * @param ... One or more arguments are possible
- * @signal .press
+ * @signal press
  */
 
 /** When property changes.
@@ -73,7 +73,7 @@
 
 /** When bound mouse button + modifiers are pressed.
  * @param ... One or more arguments are possible
- * @signal .release
+ * @signal release
  */
 
 /** Create a new mouse button bindings.

--- a/objects/client.c
+++ b/objects/client.c
@@ -112,21 +112,21 @@
  */
 
 /** When a client gains focus.
- * @signal .focus
+ * @signal focus
  */
 
 /** Before manage, after unmanage, and when clients swap.
- * @signal .list
+ * @signal list
  */
 
 /** When 2 clients are swapped
  * @tparam client client The other client
  * @tparam boolean is_source If self is the source or the destination of the swap
- * @signal .swapped
+ * @signal swapped
  */
 
 /** When a new client appears and gets managed by Awesome.
- * @signal .manage
+ * @signal manage
  */
 
 /**
@@ -207,29 +207,29 @@
  */
 
 /** When a client gets tagged.
- * @signal .tagged
+ * @signal tagged
  * @tag t The tag object.
  */
 
 /** When a client gets unfocused.
- * @signal .unfocus
+ * @signal unfocus
  */
 
 /**
- * @signal .unmanage
+ * @signal unmanage
  */
 
 /** When a client gets untagged.
- * @signal .untagged
+ * @signal untagged
  * @tag t The tag object.
  */
 
 /**
- * @signal .raised
+ * @signal raised
  */
 
 /**
- * @signal .lowered
+ * @signal lowered
  */
 
 /**

--- a/objects/key.c
+++ b/objects/key.c
@@ -56,7 +56,7 @@
  */
 
 /**
- * @signal .press
+ * @signal press
  */
 
 /**
@@ -68,7 +68,7 @@
  */
 
 /**
- * @signal .release
+ * @signal release
  */
 
 /** Get the number of instances.

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -71,12 +71,12 @@
  */
 
 /**
- * @signal .primary_changed
+ * @signal primary_changed
  */
 
 /**
  * This signal is emitted when a new screen is added to the current setup.
- * @signal .added
+ * @signal added
  */
 
 /**
@@ -85,13 +85,13 @@
  */
 
 /** This signal is emitted when the list of available screens changes.
- * @signal .list
+ * @signal list
  */
 
 /** When 2 screens are swapped
  * @tparam screen screen The other screen
  * @tparam boolean is_source If self is the source or the destination of the swap
- * @signal .swapped
+ * @signal swapped
  */
 
  /**


### PR DESCRIPTION
While looking at the doc for an unrelated project, I found that there *was* a way to fix #965 in newer versions of ldoc. Given that "newer" versions of ldoc are already ancient, lets use it.

Fix  #965

![screenshot_20180528_141803](https://user-images.githubusercontent.com/340384/40625676-eb803c20-6281-11e8-8730-b381c0181de1.png)

![screenshot_20180528_141834](https://user-images.githubusercontent.com/340384/40625688-fdc86092-6281-11e8-90fe-492088dcc4fb.png)

Before this PR, the signal name would wither have been `awful.client.mysignal`, `client.mysignal` or using the "." hack `.mysignal`. Now it's `mysignal`. Same for the properties. The deprecated functions now have a nice `[deprecated]` label. Otherwise it wasn't clear they were deprecated if you used `ctrl+f` to search the page.