### PR TITLE
Default config: Unify mouse dragging behavior

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -458,7 +458,10 @@ end
 
 -- @DOC_CLIENT_BUTTONS@
 clientbuttons = gears.table.join(
-    awful.button({ }, 1, function (c) client.focus = c; c:raise() end),
+    awful.button({ }, 1, function (c)
+        client.focus = c;
+        c:raise()
+    end),
     awful.button({ modkey }, 1, function (c)
         client.focus = c
         c:raise()

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -459,8 +459,17 @@ end
 -- @DOC_CLIENT_BUTTONS@
 clientbuttons = gears.table.join(
     awful.button({ }, 1, function (c) client.focus = c; c:raise() end),
-    awful.button({ modkey }, 1, awful.mouse.client.move),
-    awful.button({ modkey }, 3, awful.mouse.client.resize))
+    awful.button({ modkey }, 1, function (c)
+        client.focus = c
+        c:raise()
+        awful.mouse.client.move(c)
+    end),
+    awful.button({ modkey }, 3, function (c)
+        client.focus = c
+        c:raise()
+        awful.mouse.client.resize(c)
+    end)
+)
 
 -- Set keys
 root.keys(globalkeys)


### PR DESCRIPTION
When moving or resizing a client by dragging its titlebar with mouse,
the client is automatically focused and raised. However, this behavior
is not replicated by tne other dragging method, i.e. grabbing it with
mouse while pressing the modkey. Sometimes, this causes a client to
disappear below another one while moving.

This commit unifies handling of dragging clients with mouse, by ensuring
that the client is focused and raised, whichever dragging method is
used. The fix applies both to moving and resizing clients.

Signed-off-by: Piotr Śliwka <contact@psliwka.info>