### PR TITLE
Add a container window around clients

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -1270,9 +1270,19 @@ client_geometry_refresh(void)
         xcb_configure_window(globalconf.connection, c->frame_window,
                 XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
                 (uint32_t[]) { geometry.x, geometry.y, geometry.width, geometry.height });
-        xcb_configure_window(globalconf.connection, c->window,
-                XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
-                (uint32_t[]) { real_geometry.x, real_geometry.y, real_geometry.width, real_geometry.height });
+        if (c->container_window != XCB_NONE)
+        {
+            xcb_configure_window(globalconf.connection, c->container_window,
+                    XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
+                    (uint32_t[]) { real_geometry.x, real_geometry.y, real_geometry.width, real_geometry.height });
+            xcb_configure_window(globalconf.connection, c->window,
+                    XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
+                    (uint32_t[]) { real_geometry.width, real_geometry.height });
+        } else {
+            xcb_configure_window(globalconf.connection, c->window,
+                    XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
+                    (uint32_t[]) { real_geometry.x, real_geometry.y, real_geometry.width, real_geometry.height });
+        }
 
         c->x11_frame_geometry = geometry;
         c->x11_client_geometry = real_geometry;
@@ -1371,6 +1381,26 @@ client_update_properties(lua_State *L, int cidx, client_t *c)
     window_set_opacity(L, cidx, xwindow_get_opacity_from_cookie(opacity));
 }
 
+static xcb_visualid_t
+pick_visual_for_depth (uint8_t depth)
+{
+    xcb_depth_iterator_t depth_iter = xcb_screen_allowed_depths_iterator(globalconf.screen);
+
+    if (depth == globalconf.default_depth)
+        return globalconf.visual->visual_id;
+    if (depth == globalconf.screen->root_depth)
+        return globalconf.screen->root_visual;
+
+    /* Just pick the first visual of that depth */
+    for(; depth_iter.rem; xcb_depth_next (&depth_iter))
+        if (depth_iter.data->depth == depth)
+            for(xcb_visualtype_iterator_t visual_iter = xcb_depth_visuals_iterator(depth_iter.data);
+                visual_iter.rem; xcb_visualtype_next (&visual_iter))
+                return visual_iter.data->visual_id;
+
+    return XCB_COPY_FROM_PARENT;
+}
+
 /** Manage a new client.
  * \param w The window.
  * \param wgeom Window geometry.
@@ -1424,6 +1454,41 @@ client_manage(xcb_window_t w, xcb_get_geometry_reply_t *wgeom, xcb_get_window_at
                           globalconf.default_cmap
                       });
 
+    /* is a container window needed? */
+    c->container_window = XCB_NONE;
+    if (wgeom->depth != globalconf.default_depth) {
+        /* The window has a different depth than the window that we would put it
+         * in. If it also has a ParentRelative background, ReparentWindow would
+         * fail. We cannot check for that, so assume the worst.
+         */
+        xcb_colormap_t colormap;
+        xcb_visualid_t visual = pick_visual_for_depth(wgeom->depth);
+
+        if (wgeom->depth == globalconf.screen->root_depth)
+            colormap = globalconf.screen->default_colormap;
+        else
+        {
+            colormap = xcb_generate_id(globalconf.connection);
+            xcb_create_colormap(globalconf.connection, XCB_COLORMAP_ALLOC_NONE,
+                    colormap, globalconf.screen->root, visual);
+        }
+
+        c->container_window = xcb_generate_id(globalconf.connection);
+        xcb_create_window(globalconf.connection, wgeom->depth, c->container_window, c->frame_window,
+                0, 0, wgeom->width, wgeom->height, 0, XCB_COPY_FROM_PARENT,
+                visual, XCB_CW_BACK_PIXMAP | XCB_CW_BORDER_PIXEL | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP,
+                (const uint32_t[]) {
+                    XCB_BACK_PIXMAP_NONE,
+                    globalconf.screen->black_pixel,
+                    XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT,
+                    colormap
+                });
+        xcb_map_window(globalconf.connection, c->container_window);
+
+        if (colormap != globalconf.screen->default_colormap)
+            xcb_free_colormap(globalconf.connection, colormap);
+    }
+
     /* The client may already be mapped, thus we must be sure that we don't send
      * ourselves an UnmapNotify due to the xcb_reparent_window().
      *
@@ -1436,7 +1501,10 @@ client_manage(xcb_window_t w, xcb_get_geometry_reply_t *wgeom, xcb_get_window_at
                                  globalconf.screen->root,
                                  XCB_CW_EVENT_MASK,
                                  no_event);
-    xcb_reparent_window(globalconf.connection, w, c->frame_window, 0, 0);
+    if (c->container_window != XCB_NONE)
+        xcb_reparent_window(globalconf.connection, w, c->container_window, 0, 0);
+    else
+        xcb_reparent_window(globalconf.connection, w, c->frame_window, 0, 0);
     xcb_map_window(globalconf.connection, w);
     xcb_change_window_attributes(globalconf.connection,
                                  globalconf.screen->root,
@@ -2215,6 +2283,7 @@ client_unmanage(client_t *c, bool window_valid)
 
     if (c->nofocus_window != XCB_NONE)
         window_array_append(&globalconf.destroy_later_windows, c->nofocus_window);
+    /* container_window is automatically destroyed when its parent is destroyed */
     window_array_append(&globalconf.destroy_later_windows, c->frame_window);
 
     if(window_valid)

--- a/objects/client.h
+++ b/objects/client.h
@@ -51,6 +51,8 @@ typedef enum {
 struct client_t
 {
     WINDOW_OBJECT_HEADER
+    /** Window we use as a container for windows with non-default depth */
+    xcb_window_t container_window;
     /** Window we use for input focus and no-input clients */
     xcb_window_t nofocus_window;
     /** Client logical screen */


### PR DESCRIPTION
Apparently, Gtk started giving its windows a ParentRelative background.
This means that Gtk's windows can only be reparented into windows with
the same depth. Since we want working transparency in titlebars, we
however use a window with depth 32 to reparent clients into. Thus,
ReparentWindow would fail and Gtk's window would just be always visible.

We fix this by creating a useless container window of the same depth as
the client window. Instead of reparenting client windows directly into
the window used for titlebars, they are reparented into this container
window and the container window is put into the window used for
titlebars.

Let's see how long it takes someone to find some program that gets
confused when the WM reparents its window into a window contained in
another window, instead of just one window...

Signed-off-by: Uli Schlachter <psychon@znc.in>

@alfunx Could you test this? Sorry, but it has some differences to the earlier patch you tested (aka "it should hopefully be better").