### PR TITLE
awful.spawn.read_lines: Shrink input stream buffer when done

### DIFF
--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -404,6 +404,7 @@ function spawn.read_lines(input_stream, line_callback, done_callback, close)
         if close then
             stream:close()
         end
+        stream:set_buffer_size(0)
         if done_callback then
             protected_call(done_callback)
         end


### PR DESCRIPTION
I do not know how a GDataInputStream / GBufferedInputStream decides
about the size of its internal buffer when reading input by line, but in
issue #2288, an example where the output of date (about 30 bytes) was
read ten times per second caused ten megabytes of memory usage for this
internal buffer. Try to save some memory by explicitly shrinking the
buffer size when we are done reading from the stream.

Reference: https://github.com/awesomeWM/awesome/issues/2288
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----------

No idea if this is a good idea, nor whether this would actually help in "non-crazy" situations (and spawning a shell script, that then starts `date` and something else, ten times per second does count as crazy)