### PR TITLE
Return nil for screen string index lookup instead of throwing error

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1040,7 +1040,9 @@ luaA_screen_module_index(lua_State *L)
             foreach(output, (*screen)->outputs)
                 if(A_STREQ(output->name, name))
                     return luaA_object_push(L, *screen);
-        luaL_error(L, "Unknown screen output name: %s", name);
+        luaA_warn(L, "Unknown screen output name: %s", name);
+        lua_pushnil(L);
+        return 1;
     }
 
     return luaA_object_push(L, luaA_checkscreen(L, 2));

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -229,8 +229,13 @@ luaA_checkscreen(lua_State *L, int sidx)
     {
         int screen = lua_tointeger(L, sidx);
         if(screen < 1 || screen > globalconf.screens.len)
-            luaL_error(L, "invalid screen number: %d (of %d existing)",
-                    screen, globalconf.screens.len);
+        {
+            //luaL_error(L, "invalid screen number: %d (of %d existing)",
+            //        screen, globalconf.screens.len);
+            luaA_warn(L, "invalid screen number: %d (of %d existing)", screen, globalconf.screens.len);
+            lua_pushnil(L);
+            return NULL;
+        }
         return globalconf.screens.tab[screen - 1];
     } else
         return luaA_checkudata(L, sidx, &screen_class);


### PR DESCRIPTION
There's often times when I'll have code to use a specific screen, and it always stops when the string lookup throws an error. This just makes it return nil instead so you can continue with the script (and handle nil return).

For example, in my rules I have a callback (which errors if the screen doesn't exist instead of putting it to the focused screen):
```lua
callback = function(c)
  c:move_to_tag(awful.tag.find_by_name(screen['DP-2'] or awful.screen.focused(), "EMAIL"))
end,
```

Also, I wasn't sure what value to return from this function, so I assumed 1.