### PR TITLE
awesome.kill: allow negative PIDs (and 0) to support process groups

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -254,7 +254,8 @@ luaA_restart(lua_State *L)
 
 /** Send a signal to a process identified by its process id. See
  * `awesome.unix_signal` for a list of signals.
- * @tparam integer pid Process identifier
+ * @tparam integer pid Process identifier.  0 and negative values have special
+ *   meaning.  See `man 3 kill`.
  * @tparam integer sig Signal number
  * @treturn boolean true if the signal was successfully sent, else false
  * @function kill
@@ -262,7 +263,7 @@ luaA_restart(lua_State *L)
 static int
 luaA_kill(lua_State *L)
 {
-    int pid = luaA_checknumber_range(L, 1, 1, INT_MAX);
+    int pid = lua_tonumber(L, 1);
     int sig = luaA_checknumber_range(L, 2, 0, INT_MAX);
 
     int result = kill(pid, sig);


### PR DESCRIPTION
From `kill(3p)`:

> If pid is greater than 0, sig shall be sent to the process whose
> process ID is equal to pid.

> If pid is 0, sig shall be sent to all processes (excluding an
> unspecified set of system processes) whose process group ID is equal to
> the process group ID of the sender, and for which the process has
> permission to send a signal.

> If pid is −1, sig shall be sent to all processes (excluding an
> unspecified set of system processes) for which the process has
> permission to send that signal.

> If  pid  is  negative,  but not −1, sig shall be sent to all processes
> (excluding an unspecified set of system processes) whose process group
> ID is equal to the absolute value of pid, and for which the process has
> permission to send a signal.

IIRC @Elv13 mentioned this somewhere, but I could not find it now.