### PR TITLE
Correct descriptions of border colors

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -75,15 +75,15 @@ local active_font
 --- The client border width.
 -- @beautiful beautiful.border_width
 
---- The default clients border width.
+--- The default clients border color.
 -- Note that only solid colors are supported.
 -- @beautiful beautiful.border_normal
 
---- The focused client border width.
+--- The focused client border color.
 -- Note that only solid colors are supported.
 -- @beautiful beautiful.border_focus
 
---- The marked clients border width.
+--- The marked clients border color.
 -- Note that only solid colors are supported.
 -- @beautiful beautiful.border_marked
 


### PR DESCRIPTION
The docs seem to incorrectly say that border_normal, border_focus and border_marked relate to width. These settings actually control color.