### PR TITLE
Remove systray_cleanup() from drawin_systray_kickout() (#2301)

### DIFF
--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -156,7 +156,6 @@ drawin_systray_kickout(drawin_t *w)
         /* Who! Check that we're not deleting a drawin with a systray, because it
          * may be its parent. If so, we reparent to root before, otherwise it will
          * hurt very much. */
-        systray_cleanup();
         xcb_reparent_window(globalconf.connection,
                             globalconf.systray.window,
                             globalconf.screen->root,


### PR DESCRIPTION
The systray_cleanup() function gives up the _NET_SYSTEM_TRAY_Sn
selection ownership and should be called only when Awesome exits.
Calling systray_cleanup() from drawin_systray_kickout() is not correct,
because drawin_systray_kickout() is called when the system tray window
needs to be hidden, including the case when the last tray icon was
removed and the tray became empty.

Fixes: https://github.com/awesomeWM/awesome/issues/2301
Signed-off-by: Sergey Vlasov <sigprof@gmail.com>