### PR TITLE
tile: Apply size hints correctly

### DIFF
--- a/lib/awful/layout/suit/tile.lua
+++ b/lib/awful/layout/suit/tile.lua
@@ -158,7 +158,14 @@ local function mouse_resize_handler(c, _, _, _, orientation)
                           end, cursor)
 end
 
-local function tile_group(gs, cls, wa, orientation, fact, group)
+local function apply_size_hints(c, width, height, useless_gap)
+    local bw = c.border_width
+    width, height = width - 2 * bw - useless_gap, height - 2 * bw - useless_gap
+    width, height = c:apply_size_hints(math.max(1, width), math.max(1, height))
+    return width + 2 * bw + useless_gap, height + 2 * bw + useless_gap
+end
+
+local function tile_group(gs, cls, wa, orientation, fact, group, useless_gap)
     -- get our orientation right
     local height = "height"
     local width = "width"
@@ -207,7 +214,7 @@ local function tile_group(gs, cls, wa, orientation, fact, group)
         geom[x] = group.coord
         geom[y] = coord
         gs[cls[c]] = geom
-        hints.width, hints.height = cls[c]:apply_size_hints(geom.width, geom.height)
+        hints.width, hints.height = apply_size_hints(cls[c], geom.width, geom.height, useless_gap)
         coord = coord + hints[height]
         unused = unused - hints[height]
         total_fact = total_fact - fact[i]
@@ -231,6 +238,7 @@ local function do_tile(param, orientation)
 
     local gs = param.geometries
     local cls = param.clients
+    local useless_gap = param.useless_gap
     local nmaster = math.min(t.master_count, #cls)
     local nother = math.max(#cls - nmaster,0)
 
@@ -267,7 +275,7 @@ local function do_tile(param, orientation)
                 data[0] = {}
             end
             coord = coord + tile_group(gs, cls, wa, orientation, data[0],
-                                       {first=1, last=nmaster, coord = coord, size = size})
+                                       {first=1, last=nmaster, coord = coord, size = size}, useless_gap)
         end
 
         if not place_master and nother > 0 then
@@ -288,7 +296,7 @@ local function do_tile(param, orientation)
                     data[i] = {}
                 end
                 coord = coord + tile_group(gs, cls, wa, orientation, data[i],
-                                           { first = first, last = last, coord = coord, size = size })
+                                           { first = first, last = last, coord = coord, size = size }, useless_gap)
             end
         end
         place_master = not place_master


### PR DESCRIPTION
Layouts work with the client's geometry in "space on screen that is
assigned to this client". This means that the geometry should include
decoration (titlebar and borders) and useless gaps.

Everything else (especially the C code) works with client's geometry in
"space that the client can draw on". This means that the titlebar,
borders and the useless gaps are not included into this size.

Thus, when applying size hints, the tile layout has to convert between
these two representations. Otherwise, size hints are applied incorrectly
and to a wrong geometry.

Fixes: https://github.com/awesomeWM/awesome/issues/1418
Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @dzhu Just for your information (and sorry that it took so long, I have about 50 mails from GitHub marked as "eventually someone should do something about this". Pinging usually helps to boost priorities here. :-) Also, I did not go with your proposed patch since that one does not handle the useless gap and this could not be handled in C.)

-----

Testing done: Well, the test suite did not complain... (after I stopped misspelling `useless_gap`)