### PR TITLE
Example tests: Make it explicit what kind of output is expected

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -229,6 +229,9 @@ function(run_test test_path namespace escaped_content)
     # If there is an output, assume it is relevant and add it to the
     # documentation under the image.
     if(NOT ${TEST_OUTPUT} STREQUAL "")
+        if(NOT tmp_content MATCHES "--DOC_GEN_OUTPUT")
+            message(FATAL_ERROR "Unexpected output from ${test_path}: ${TEST_OUTPUT}")
+        endif()
         set(TEST_DOC_CONTENT
             "${TEST_DOC_CONTENT}\n${DOC_LINE_PREFIX}\n${DOC_LINE_PREFIX}**Usage example output**:\n${DOC_LINE_PREFIX}"
         )

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -186,9 +186,7 @@ function(run_test test_path namespace escaped_content)
     get_filename_component(${test_path} TEST_FILE_NAME NAME)
     set(IMAGE_PATH "${IMAGE_DIR}/AUTOGEN${namespace}_${TEST_FILE_NAME}")
 
-    # Execute the script, leave the image extension decision to the test.
-    # SVG is preferred, but PNG is better suited for some tests, like bitmap
-    # patterns.
+    # Execute the script.
     file(RELATIVE_PATH rel_test_path "${TOP_SOURCE_DIR}" "${test_path}")
     message(STATUS "Running ${rel_test_path}…")
 
@@ -222,12 +220,6 @@ function(run_test test_path namespace escaped_content)
         set(OUTPUT_IMAGE_PATH "${IMAGE_PATH}.svg")
         escape_string(
             "![Usage example](../images/AUTOGEN${namespace}_${TEST_FILE_NAME}.svg)\n"
-            "${TEST_DOC_CONTENT}" TEST_DOC_CONTENT ""
-        )
-    elseif(EXISTS "${IMAGE_PATH}.png")
-        set(OUTPUT_IMAGE_PATH "${IMAGE_PATH}.png")
-        escape_string(
-            "![Usage example](../images/AUTOGEN${namespace}_${TEST_FILE_NAME}.png)\n"
             "${TEST_DOC_CONTENT}" TEST_DOC_CONTENT ""
         )
     else()

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -215,8 +215,8 @@ function(run_test test_path namespace escaped_content)
     # Build the documentation.
     set(TEST_DOC_CONTENT "${TEST_PRE_HEADER}")
 
-    # If the image has been created, then add it.
-    if(EXISTS "${IMAGE_PATH}.svg")
+    # Does the test generate an output image?
+    if(tmp_content MATCHES "--DOC_GEN_IMAGE")
         set(OUTPUT_IMAGE_PATH "${IMAGE_PATH}.svg")
         escape_string(
             "![Usage example](../images/AUTOGEN${namespace}_${TEST_FILE_NAME}.svg)\n"

--- a/tests/examples/awful/mouse/coords.lua
+++ b/tests/examples/awful/mouse/coords.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE --DOC_HIDE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {x = 175, width = 128, height = 96} --DOC_HIDE
 mouse.coords {x=175+60,y=60} --DOC_HIDE
 

--- a/tests/examples/awful/mouse/coords.lua
+++ b/tests/examples/awful/mouse/coords.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {x = 175, width = 128, height = 96} --DOC_HIDE
 mouse.coords {x=175+60,y=60} --DOC_HIDE
 

--- a/tests/examples/awful/placement/align.lua
+++ b/tests/examples/awful/placement/align.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local placement = require("awful.placement")
 screen[1]._resize {x= 50}
 for _, pos in ipairs{

--- a/tests/examples/awful/placement/bottom.lua
+++ b/tests/examples/awful/placement/bottom.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the bottom of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/bottom_left.lua
+++ b/tests/examples/awful/placement/bottom_left.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the bottom left of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/bottom_right.lua
+++ b/tests/examples/awful/placement/bottom_right.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the bottom right of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/center_horizontal.lua
+++ b/tests/examples/awful/placement/center_horizontal.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the horizontal center left of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/center_vertical.lua
+++ b/tests/examples/awful/placement/center_vertical.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the vertical center of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/centered.lua
+++ b/tests/examples/awful/placement/centered.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the center of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/closest_mouse.lua
+++ b/tests/examples/awful/placement/closest_mouse.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 
 local c = client.gen_fake {x = 20, y = 20, width= 280, height=200, screen =screen[1]} --DOC_HIDE

--- a/tests/examples/awful/placement/closest_mouse.lua
+++ b/tests/examples/awful/placement/closest_mouse.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE --DOC_HIDE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 
 local c = client.gen_fake {x = 20, y = 20, width= 280, height=200, screen =screen[1]} --DOC_HIDE

--- a/tests/examples/awful/placement/compose.lua
+++ b/tests/examples/awful/placement/compose.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {x = 175, width = 128, height = 96} --DOC_NO_USAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 local c = client.gen_fake {x = 220, y = 35, width=40, height=30} --DOC_HIDE

--- a/tests/examples/awful/placement/compose2.lua
+++ b/tests/examples/awful/placement/compose2.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {x = 175, width = 128, height = 96} --DOC_NO_USAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 local c = client.gen_fake {x = 220, y = 35, width=40, height=30} --DOC_HIDE

--- a/tests/examples/awful/placement/left.lua
+++ b/tests/examples/awful/placement/left.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the left of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/maximize.lua
+++ b/tests/examples/awful/placement/maximize.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {width = 128, height = 96} --DOC_HIDE
 screen._add_screen {x = 140, y = 0, width = 128, height = 96} --DOC_HIDE
 screen._add_screen {x = 280, y = 0, width = 128, height = 96} --DOC_HIDE

--- a/tests/examples/awful/placement/maximize_horizontally.lua
+++ b/tests/examples/awful/placement/maximize_horizontally.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Horizontally maximize the drawable in the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/maximize_vertically.lua
+++ b/tests/examples/awful/placement/maximize_vertically.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Vetically maximize the drawable in the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/next_to_mouse.lua
+++ b/tests/examples/awful/placement/next_to_mouse.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {width = 128, height = 96} --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 client.gen_fake {x = 10, y = 10, width=40, height=30} --DOC_HIDE

--- a/tests/examples/awful/placement/no_offscreen.lua
+++ b/tests/examples/awful/placement/no_offscreen.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE --DOC_HIDE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 
 local c = client.gen_fake {x = -30, y = -30, width= 100, height=100} --DOC_HIDE

--- a/tests/examples/awful/placement/no_offscreen.lua
+++ b/tests/examples/awful/placement/no_offscreen.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 
 local c = client.gen_fake {x = -30, y = -30, width= 100, height=100} --DOC_HIDE

--- a/tests/examples/awful/placement/no_overlap.lua
+++ b/tests/examples/awful/placement/no_overlap.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {width = 128, height = 96} --DOC_HIDE
 screen._add_screen {x = 140, y = 0  , width = 128, height = 96} --DOC_HIDE
 screen._add_screen {x = 0  , y = 110, width = 128, height = 96} --DOC_HIDE

--- a/tests/examples/awful/placement/resize_to_mouse.lua
+++ b/tests/examples/awful/placement/resize_to_mouse.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local awful = {placement = require("awful.placement")}
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 

--- a/tests/examples/awful/placement/right.lua
+++ b/tests/examples/awful/placement/right.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the right of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/stretch.lua
+++ b/tests/examples/awful/placement/stretch.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 screen[1]._resize {width = 128, height = 96}
 screen._add_screen {x = 140, y = 0  , width = 128, height = 96}
 screen._add_screen {x = 0  , y = 110, width = 128, height = 96}

--- a/tests/examples/awful/placement/stretch_down.lua
+++ b/tests/examples/awful/placement/stretch_down.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Stretch the drawable to the bottom of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments --DOC_HEADER

--- a/tests/examples/awful/placement/stretch_left.lua
+++ b/tests/examples/awful/placement/stretch_left.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Stretch the drawable to the left of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments --DOC_HEADER

--- a/tests/examples/awful/placement/stretch_right.lua
+++ b/tests/examples/awful/placement/stretch_right.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Stretch the drawable to the right of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments --DOC_HEADER

--- a/tests/examples/awful/placement/stretch_up.lua
+++ b/tests/examples/awful/placement/stretch_up.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Stretch the drawable to the top of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments --DOC_HEADER

--- a/tests/examples/awful/placement/top.lua
+++ b/tests/examples/awful/placement/top.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the top of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/top_left.lua
+++ b/tests/examples/awful/placement/top_left.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the top left of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/top_right.lua
+++ b/tests/examples/awful/placement/top_right.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 -- Align a client to the top right of the parent area. --DOC_HEADER
 -- @tparam drawable d A drawable (like `client`, `mouse` or `wibox`) --DOC_HEADER
 -- @tparam[opt={}] table args Other arguments") --DOC_HEADER

--- a/tests/examples/awful/placement/under_mouse.lua
+++ b/tests/examples/awful/placement/under_mouse.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 screen[1]._resize {width = 128, height = 96} --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE
 client.gen_fake {x = 10, y = 10, width=40, height=30} --DOC_HIDE

--- a/tests/examples/awful/titlebar/default.lua
+++ b/tests/examples/awful/titlebar/default.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 --DOC_NO_USAGE
 local place = require("awful.placement") --DOC_HIDE
 local awful = { titlebar = require("awful.titlebar"), --DOC_HIDE

--- a/tests/examples/gears/shape/arc.lua
+++ b/tests/examples/gears/shape/arc.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.arc(cr,70,70, 10)

--- a/tests/examples/gears/shape/arrow.lua
+++ b/tests/examples/gears/shape/arrow.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.arrow(cr, 70, 70)

--- a/tests/examples/gears/shape/circle.lua
+++ b/tests/examples/gears/shape/circle.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.circle(cr, 70, 70)

--- a/tests/examples/gears/shape/cross.lua
+++ b/tests/examples/gears/shape/cross.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.cross(cr, 70, 70)

--- a/tests/examples/gears/shape/hexagon.lua
+++ b/tests/examples/gears/shape/hexagon.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.hexagon(cr, 70, 70)

--- a/tests/examples/gears/shape/infobubble.lua
+++ b/tests/examples/gears/shape/infobubble.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.infobubble(cr, 70, 70)

--- a/tests/examples/gears/shape/isosceles_triangle.lua
+++ b/tests/examples/gears/shape/isosceles_triangle.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.isosceles_triangle(cr, 70, 70)

--- a/tests/examples/gears/shape/losange.lua
+++ b/tests/examples/gears/shape/losange.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.losange(cr, 70, 70)

--- a/tests/examples/gears/shape/octogon.lua
+++ b/tests/examples/gears/shape/octogon.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.octogon(cr, 70, 70)

--- a/tests/examples/gears/shape/parallelogram.lua
+++ b/tests/examples/gears/shape/parallelogram.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.parallelogram(cr, 70, 70)

--- a/tests/examples/gears/shape/partially_rounded_rect.lua
+++ b/tests/examples/gears/shape/partially_rounded_rect.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.partially_rounded_rect(cr, 70, 70)

--- a/tests/examples/gears/shape/pie.lua
+++ b/tests/examples/gears/shape/pie.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.pie(cr, 70, 70)

--- a/tests/examples/gears/shape/powerline.lua
+++ b/tests/examples/gears/shape/powerline.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.powerline(cr, 70, 70)

--- a/tests/examples/gears/shape/radial_progress.lua
+++ b/tests/examples/gears/shape/radial_progress.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.radial_progress(cr, 70, 20, .3)

--- a/tests/examples/gears/shape/rectangle.lua
+++ b/tests/examples/gears/shape/rectangle.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.rectangle(cr, 70, 70)

--- a/tests/examples/gears/shape/rectangular_tag.lua
+++ b/tests/examples/gears/shape/rectangular_tag.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.rectangular_tag(cr, 70, 70)

--- a/tests/examples/gears/shape/rounded_bar.lua
+++ b/tests/examples/gears/shape/rounded_bar.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.rounded_bar(cr, 70, 70)

--- a/tests/examples/gears/shape/rounded_rect.lua
+++ b/tests/examples/gears/shape/rounded_rect.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local shape,cr,show = ... --DOC_HIDE
 
 shape.rounded_rect(cr, 70, 70, 10)

--- a/tests/examples/text/gears/object/properties.lua
+++ b/tests/examples/text/gears/object/properties.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_OUTPUT --DOC_HIDE
 local gears = require("gears") --DOC_HIDE
 
 -- Create a class for this object. It will be used as a backup source for

--- a/tests/examples/text/gears/object/signal.lua
+++ b/tests/examples/text/gears/object/signal.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_OUTPUT --DOC_HIDE
 local gears = require("gears") --DOC_HIDE
 
 local o = gears.object{}

--- a/tests/examples/text/gears/sort/topological.lua
+++ b/tests/examples/text/gears/sort/topological.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_OUTPUT --DOC_HIDE
 local gears = {sort={topological = require("gears.sort.topological")}} --DOC_HIDE
 
 local tsort = gears.sort.topological()

--- a/tests/examples/wibox/awidget/defaults/prompt.lua
+++ b/tests/examples/wibox/awidget/defaults/prompt.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local awful     = { widget = {  --DOC_HIDE
                     prompt = require("awful.widget.prompt")}}--DOC_HIDE

--- a/tests/examples/wibox/awidget/prompt/highlight.lua
+++ b/tests/examples/wibox/awidget/prompt/highlight.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local awful     = { prompt = require("awful.prompt") }--DOC_HIDE

--- a/tests/examples/wibox/awidget/prompt/hooks.lua
+++ b/tests/examples/wibox/awidget/prompt/hooks.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local awful     = { prompt = require("awful.prompt"),--DOC_HIDE

--- a/tests/examples/wibox/awidget/prompt/keypress.lua
+++ b/tests/examples/wibox/awidget/prompt/keypress.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local awful     = { prompt = require("awful.prompt"),--DOC_HIDE

--- a/tests/examples/wibox/awidget/prompt/simple.lua
+++ b/tests/examples/wibox/awidget/prompt/simple.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local awful     = { prompt = require("awful.prompt") }--DOC_HIDE

--- a/tests/examples/wibox/awidget/prompt/vilike.lua
+++ b/tests/examples/wibox/awidget/prompt/vilike.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local awful     = { prompt = require("awful.prompt"),--DOC_HIDE

--- a/tests/examples/wibox/awidget/taglist/indexed.lua
+++ b/tests/examples/wibox/awidget/taglist/indexed.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_NO_USAGE --DOC_HIDE
 local awful = { --DOC_HIDE
     tag = require("awful.tag"), --DOC_HIDE

--- a/tests/examples/wibox/awidget/tasklist/rounded.lua
+++ b/tests/examples/wibox/awidget/tasklist/rounded.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_NO_USAGE --DOC_HIDE
 local awful = { --DOC_HIDE
     tag = require("awful.tag"), --DOC_HIDE

--- a/tests/examples/wibox/awidget/tasklist/windows10.lua
+++ b/tests/examples/wibox/awidget/tasklist/windows10.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_NO_USAGE --DOC_HIDE
 local awful = { --DOC_HIDE
     tag = require("awful.tag"), --DOC_HIDE

--- a/tests/examples/wibox/container/arcchart/bg.lua
+++ b/tests/examples/wibox/container/arcchart/bg.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/container/arcchart/border_width.lua
+++ b/tests/examples/wibox/container/arcchart/border_width.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/container/arcchart/paddings.lua
+++ b/tests/examples/wibox/container/arcchart/paddings.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/container/arcchart/rounded_edge.lua
+++ b/tests/examples/wibox/container/arcchart/rounded_edge.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/container/arcchart/start_angle.lua
+++ b/tests/examples/wibox/container/arcchart/start_angle.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/container/arcchart/thickness.lua
+++ b/tests/examples/wibox/container/arcchart/thickness.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/container/arcchart/value.lua
+++ b/tests/examples/wibox/container/arcchart/value.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/container/background/bg.lua
+++ b/tests/examples/wibox/container/background/bg.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/container/background/clip.lua
+++ b/tests/examples/wibox/container/background/clip.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")} --DOC_HIDE

--- a/tests/examples/wibox/container/background/fg.lua
+++ b/tests/examples/wibox/container/background/fg.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/container/background/shape.lua
+++ b/tests/examples/wibox/container/background/shape.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")} --DOC_HIDE

--- a/tests/examples/wibox/container/defaults/arcchart.lua
+++ b/tests/examples/wibox/container/defaults/arcchart.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox     = require("wibox")
 local beautiful = require("beautiful")
 

--- a/tests/examples/wibox/container/defaults/background.lua
+++ b/tests/examples/wibox/container/defaults/background.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox     = require("wibox")
 local gears     = {shape = require("gears.shape")}
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/container/defaults/constraint.lua
+++ b/tests/examples/wibox/container/defaults/constraint.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox = require("wibox")
 
 return {

--- a/tests/examples/wibox/container/defaults/margin.lua
+++ b/tests/examples/wibox/container/defaults/margin.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox     = require("wibox")
 local beautiful = require("beautiful")
 

--- a/tests/examples/wibox/container/defaults/mirror.lua
+++ b/tests/examples/wibox/container/defaults/mirror.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox     = require("wibox")
 
 return {

--- a/tests/examples/wibox/container/defaults/only_on_screen.lua
+++ b/tests/examples/wibox/container/defaults/only_on_screen.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox = require("wibox")
 local awful = { widget = { only_on_screen = require("awful.widget.only_on_screen") } }
 

--- a/tests/examples/wibox/container/defaults/place.lua
+++ b/tests/examples/wibox/container/defaults/place.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox     = require("wibox")
 
 return {

--- a/tests/examples/wibox/container/defaults/radialprogressbar.lua
+++ b/tests/examples/wibox/container/defaults/radialprogressbar.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox     = require("wibox")
 
 return {

--- a/tests/examples/wibox/container/defaults/rotate.lua
+++ b/tests/examples/wibox/container/defaults/rotate.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox     = require("wibox")
 
 return {

--- a/tests/examples/wibox/container/defaults/scroll.lua
+++ b/tests/examples/wibox/container/defaults/scroll.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local wibox = require("wibox")
 
 return {

--- a/tests/examples/wibox/container/radialprogressbar/border_color.lua
+++ b/tests/examples/wibox/container/radialprogressbar/border_color.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 

--- a/tests/examples/wibox/container/radialprogressbar/border_width.lua
+++ b/tests/examples/wibox/container/radialprogressbar/border_width.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 

--- a/tests/examples/wibox/container/radialprogressbar/color.lua
+++ b/tests/examples/wibox/container/radialprogressbar/color.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 

--- a/tests/examples/wibox/container/radialprogressbar/padding.lua
+++ b/tests/examples/wibox/container/radialprogressbar/padding.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/container/radialprogressbar/value.lua
+++ b/tests/examples/wibox/container/radialprogressbar/value.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 

--- a/tests/examples/wibox/container/rotate/angle.lua
+++ b/tests/examples/wibox/container/rotate/angle.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")} --DOC_HIDE

--- a/tests/examples/wibox/layout/defaults/align.lua
+++ b/tests/examples/wibox/layout/defaults/align.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/defaults/fixed.lua
+++ b/tests/examples/wibox/layout/defaults/fixed.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/defaults/flex.lua
+++ b/tests/examples/wibox/layout/defaults/flex.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/defaults/grid.lua
+++ b/tests/examples/wibox/layout/defaults/grid.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/defaults/manual.lua
+++ b/tests/examples/wibox/layout/defaults/manual.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/defaults/ratio.lua
+++ b/tests/examples/wibox/layout/defaults/ratio.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/defaults/stack.lua
+++ b/tests/examples/wibox/layout/defaults/stack.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/fixed/spacing.lua
+++ b/tests/examples/wibox/layout/fixed/spacing.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/fixed/spacing_widget.lua
+++ b/tests/examples/wibox/layout/fixed/spacing_widget.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")}--DOC_HIDE

--- a/tests/examples/wibox/layout/flex/spacing.lua
+++ b/tests/examples/wibox/layout/flex/spacing.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/flex/spacing_widget.lua
+++ b/tests/examples/wibox/layout/flex/spacing_widget.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")}--DOC_HIDE

--- a/tests/examples/wibox/layout/grid/add.lua
+++ b/tests/examples/wibox/layout/grid/add.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE
 local generic_widget, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE

--- a/tests/examples/wibox/layout/grid/add.lua
+++ b/tests/examples/wibox/layout/grid/add.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE

--- a/tests/examples/wibox/layout/grid/expand.lua
+++ b/tests/examples/wibox/layout/grid/expand.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget = ... --DOC_HIDE_ALL
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/layout/grid/extend_column.lua
+++ b/tests/examples/wibox/layout/grid/extend_column.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/extend_column.lua
+++ b/tests/examples/wibox/layout/grid/extend_column.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/imperative.lua
+++ b/tests/examples/wibox/layout/grid/imperative.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/insert_column.lua
+++ b/tests/examples/wibox/layout/grid/insert_column.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/insert_column.lua
+++ b/tests/examples/wibox/layout/grid/insert_column.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/min_size.lua
+++ b/tests/examples/wibox/layout/grid/min_size.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget = ... --DOC_HIDE_ALL
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE

--- a/tests/examples/wibox/layout/grid/orientation.lua
+++ b/tests/examples/wibox/layout/grid/orientation.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE
 local generic_widget = ... --DOC_HIDE_ALL
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE

--- a/tests/examples/wibox/layout/grid/orientation.lua
+++ b/tests/examples/wibox/layout/grid/orientation.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget = ... --DOC_HIDE_ALL
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE

--- a/tests/examples/wibox/layout/grid/remove.lua
+++ b/tests/examples/wibox/layout/grid/remove.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/remove.lua
+++ b/tests/examples/wibox/layout/grid/remove.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/remove_column.lua
+++ b/tests/examples/wibox/layout/grid/remove_column.lua
@@ -1,4 +1,4 @@
---DOC_GEN_IMAGE
+--DOC_GEN_OUTPUT --DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/remove_column.lua
+++ b/tests/examples/wibox/layout/grid/remove_column.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local _, generic_before_after = ... --DOC_HIDE_ALL
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/grid/spacing.lua
+++ b/tests/examples/wibox/layout/grid/spacing.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget = ... --DOC_HIDE_ALL
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE

--- a/tests/examples/wibox/layout/grid/superpose.lua
+++ b/tests/examples/wibox/layout/grid/superpose.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget = ... --DOC_HIDE_ALL
 local wibox = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/layout/manual/add_at.lua
+++ b/tests/examples/wibox/layout/manual/add_at.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE

--- a/tests/examples/wibox/layout/manual/move_widget.lua
+++ b/tests/examples/wibox/layout/manual/move_widget.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local awful = {placement = require("awful.placement")} --DOC_HIDE

--- a/tests/examples/wibox/layout/ratio/ajust_ratio.lua
+++ b/tests/examples/wibox/layout/ratio/ajust_ratio.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1) --DOC_HIDE

--- a/tests/examples/wibox/layout/ratio/inc_ratio.lua
+++ b/tests/examples/wibox/layout/ratio/inc_ratio.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/ratio/spacing.lua
+++ b/tests/examples/wibox/layout/ratio/spacing.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/ratio/spacing_widget.lua
+++ b/tests/examples/wibox/layout/ratio/spacing_widget.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")}--DOC_HIDE

--- a/tests/examples/wibox/layout/ratio/strategy.lua
+++ b/tests/examples/wibox/layout/ratio/strategy.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 local generic_widget = ... --DOC_HIDE_ALL
 local wibox     = require("wibox")
 

--- a/tests/examples/wibox/layout/stack/offset.lua
+++ b/tests/examples/wibox/layout/stack/offset.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/layout/stack/spacing.lua
+++ b/tests/examples/wibox/layout/stack/spacing.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local generic_widget = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/logo/logo.lua
+++ b/tests/examples/wibox/logo/logo.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox" ) --DOC_HIDE
 local assets    = require( "beautiful.theme_assets" ) --DOC_HIDE

--- a/tests/examples/wibox/logo/logo_and_name.lua
+++ b/tests/examples/wibox/logo/logo_and_name.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox" ) --DOC_HIDE
 local assets    = require( "beautiful.theme_assets" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/fn_embed_cell.lua
+++ b/tests/examples/wibox/widget/calendar/fn_embed_cell.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = require("gears") --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/font.lua
+++ b/tests/examples/wibox/widget/calendar/font.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/long_weekdays.lua
+++ b/tests/examples/wibox/widget/calendar/long_weekdays.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/month.lua
+++ b/tests/examples/wibox/widget/calendar/month.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE_ALL
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/start_sunday.lua
+++ b/tests/examples/wibox/widget/calendar/start_sunday.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/week_numbers.lua
+++ b/tests/examples/wibox/widget/calendar/week_numbers.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/calendar/year.lua
+++ b/tests/examples/wibox/widget/calendar/year.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/checkbox/bg.lua
+++ b/tests/examples/wibox/widget/checkbox/bg.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/checkbox/check_shape.lua
+++ b/tests/examples/wibox/widget/checkbox/check_shape.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/checkbox/custom.lua
+++ b/tests/examples/wibox/widget/checkbox/custom.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/checkbox/shape.lua
+++ b/tests/examples/wibox/widget/checkbox/shape.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/calendar.lua
+++ b/tests/examples/wibox/widget/defaults/calendar.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/checkbox.lua
+++ b/tests/examples/wibox/widget/defaults/checkbox.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/graph.lua
+++ b/tests/examples/wibox/widget/defaults/graph.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/widget/defaults/imagebox.lua
+++ b/tests/examples/wibox/widget/defaults/imagebox.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/piechart.lua
+++ b/tests/examples/wibox/widget/defaults/piechart.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/progressbar.lua
+++ b/tests/examples/wibox/widget/defaults/progressbar.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 local gears  = {shape = require("gears.shape") } --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/separator.lua
+++ b/tests/examples/wibox/widget/defaults/separator.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 

--- a/tests/examples/wibox/widget/defaults/slider.lua
+++ b/tests/examples/wibox/widget/defaults/slider.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require( "wibox"     ) --DOC_HIDE
 local beautiful = require( "beautiful" ) --DOC_HIDE

--- a/tests/examples/wibox/widget/defaults/textbox.lua
+++ b/tests/examples/wibox/widget/defaults/textbox.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/widget/graph/step.lua
+++ b/tests/examples/wibox/widget/graph/step.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")} --DOC_HIDE

--- a/tests/examples/wibox/widget/piechart/border_color.lua
+++ b/tests/examples/wibox/widget/piechart/border_color.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/widget/piechart/border_width.lua
+++ b/tests/examples/wibox/widget/piechart/border_width.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/widget/piechart/label.lua
+++ b/tests/examples/wibox/widget/piechart/label.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require( "wibox"     )
 local beautiful = require( "beautiful" )

--- a/tests/examples/wibox/widget/progressbar/bar_shape.lua
+++ b/tests/examples/wibox/widget/progressbar/bar_shape.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 local gears  = {shape = require("gears.shape") } --DOC_HIDE

--- a/tests/examples/wibox/widget/progressbar/clip.lua
+++ b/tests/examples/wibox/widget/progressbar/clip.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 local gears  = {shape = require("gears.shape") } --DOC_HIDE

--- a/tests/examples/wibox/widget/progressbar/encapsulation.lua
+++ b/tests/examples/wibox/widget/progressbar/encapsulation.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_NO_USAGE --DOC_NO_DASH --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 local color  = require("gears.color") --DOC_HIDE

--- a/tests/examples/wibox/widget/progressbar/shape.lua
+++ b/tests/examples/wibox/widget/progressbar/shape.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 local gears  = {shape = require("gears.shape") } --DOC_HIDE

--- a/tests/examples/wibox/widget/progressbar/text.lua
+++ b/tests/examples/wibox/widget/progressbar/text.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE

--- a/tests/examples/wibox/widget/progressbar/vertical.lua
+++ b/tests/examples/wibox/widget/progressbar/vertical.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_NO_USAGE --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
 

--- a/tests/examples/wibox/widget/separator/border_color.lua
+++ b/tests/examples/wibox/widget/separator/border_color.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")}--DOC_HIDE

--- a/tests/examples/wibox/widget/separator/orientation.lua
+++ b/tests/examples/wibox/widget/separator/orientation.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE_ALL
 local wibox  = require("wibox")
 

--- a/tests/examples/wibox/widget/separator/shape.lua
+++ b/tests/examples/wibox/widget/separator/shape.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE --DOC_HIDE
 local parent    = ... --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")}--DOC_HIDE

--- a/tests/examples/wibox/widget/slider/bar_border.lua
+++ b/tests/examples/wibox/widget/slider/bar_border.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/widget/slider/bar_color.lua
+++ b/tests/examples/wibox/widget/slider/bar_color.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/widget/slider/bar_height.lua
+++ b/tests/examples/wibox/widget/slider/bar_height.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/widget/slider/bar_margins.lua
+++ b/tests/examples/wibox/widget/slider/bar_margins.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/widget/slider/bar_shape.lua
+++ b/tests/examples/wibox/widget/slider/bar_shape.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local gears     = {shape = require("gears.shape")}

--- a/tests/examples/wibox/widget/slider/handle_border.lua
+++ b/tests/examples/wibox/widget/slider/handle_border.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/widget/slider/handle_color.lua
+++ b/tests/examples/wibox/widget/slider/handle_color.lua
@@ -1,3 +1,4 @@
+--DOC_GEN_IMAGE
 --DOC_HIDE_ALL
 local parent    = ...
 local wibox     = require("wibox")

--- a/tests/examples/wibox/widget/slider/handle_margins.lua
+++ b/tests/examples/wibox/widget/slider/handle_margins.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/widget/slider/handle_shape.lua
+++ b/tests/examples/wibox/widget/slider/handle_shape.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local gears     = {shape = require("gears.shape")}

--- a/tests/examples/wibox/widget/slider/handle_width.lua
+++ b/tests/examples/wibox/widget/slider/handle_width.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")

--- a/tests/examples/wibox/widget/slider/value.lua
+++ b/tests/examples/wibox/widget/slider/value.lua
@@ -1,4 +1,5 @@
 --DOC_HIDE_ALL
+--DOC_GEN_IMAGE
 local parent    = ...
 local wibox     = require("wibox")
 local beautiful = require("beautiful")


### PR DESCRIPTION
This modifies the tests in `tests/examples` so that we already know before running them what kind of output is expected. I expect this to be necessary for hopefully some times moving running these tests from the configure phase to the test phase (but I might be wrong?).