### PR TITLE
Update the shims

### DIFF
--- a/lib/awful/key.lua
+++ b/lib/awful/key.lua
@@ -99,6 +99,8 @@ function key.new(mod, _key, press, release, data)
     data = data and gtable.clone(data) or {}
     data.mod = mod
     data.key = _key
+    data.press = press
+    data.release = release
     table.insert(key.hotkeys, data)
     data.execute = function(_) key.execute(mod, _key) end
 

--- a/spec/awful/prompt_spec.lua
+++ b/spec/awful/prompt_spec.lua
@@ -46,6 +46,10 @@ insulate('main', function ()
     _G.awesome = {
         connect_signal = function() end
     }
+    _G.keygrabber = {
+        run                       = function() end,
+        stop                      = function() end,
+    }
     -- luacheck: globals string
     function string.wlen(self)
           return #self

--- a/tests/examples/shims/_common_template.lua
+++ b/tests/examples/shims/_common_template.lua
@@ -7,7 +7,7 @@ return function(_, _)
 
     -- Set the global shims
     -- luacheck: globals awesome root tag screen client mouse drawin button
-    -- luacheck: globals mousegrabber keygrabber dbus
+    -- luacheck: globals mousegrabber keygrabber dbus key
     awesome      = require( "awesome"      )
     root         = require( "root"         )
     tag          = require( "tag"          )
@@ -19,6 +19,7 @@ return function(_, _)
     keygrabber   = require( "keygrabber"   )
     mousegrabber = require( "mousegrabber" )
     dbus         = require( "dbus"         )
+    key          = require( "key"          )
 
     -- Force luacheck to be silent about setting those as unused globals
     assert(awesome and root and tag and screen and client and mouse)

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -46,6 +46,14 @@ awesome.startup = true
 function awesome.register_xproperty()
 end
 
+function awesome.xkb_get_group_names()
+    return "pc+us+inet(evdev)"
+end
+
+function awesome.xkb_get_layout_group()
+    return 0
+end
+
 awesome.load_image = lgi.cairo.ImageSurface.create_from_png
 
 function awesome.pixbuf_to_surface(_, path)

--- a/tests/examples/shims/beautiful.lua
+++ b/tests/examples/shims/beautiful.lua
@@ -29,9 +29,12 @@ end
 local module = {
     fg_normal    = "#000000"  ,
     bg_normal    = "#6181FF7D",
+    bg_focus     = "#AA00FF7D",
     bg_highlight = "#AA00FF7D",
     border_color = "#6181FF"  ,
     border_width = 1.5        ,
+
+    prompt_bg_cursor = "#00FF7D",
 
     -- Fake resources handling
     xresources = require("beautiful.xresources"),

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -31,6 +31,7 @@ function client.gen_fake(args)
     ret.size_hints = {}
     ret.border_width = 1
     ret.icon_sizes = {{16,16}}
+    ret.name = "Example Client"
 
     -- Apply all properties
     for k,v in pairs(args or {}) do
@@ -119,6 +120,20 @@ function client.gen_fake(args)
 
     -- Set the attributes
     ret.screen = args.screen or screen[1]
+
+    -- Good enough for the geometry and border
+    ret.drawin = ret
+    ret.drawable = ret
+
+    -- Make sure the layer properties are not `nil`
+    ret.ontop = false
+    ret.below = false
+    ret.above = false
+    ret.sticky = false
+    ret.maximized = false
+    ret.fullscreen = false
+    ret.maximized_vertical = false
+    ret.maximized_horizontal = false
 
     -- Add to the client list
     table.insert(clients, ret)

--- a/tests/examples/shims/key.lua
+++ b/tests/examples/shims/key.lua
@@ -1,0 +1,6 @@
+local gobject = require("gears.object")
+local gtable  = require("gears.table")
+
+return setmetatable({}, {__call = function(_, args)
+    return gtable.crush(gobject(), args)
+end})

--- a/tests/examples/shims/keygrabber.lua
+++ b/tests/examples/shims/keygrabber.lua
@@ -1,10 +1,19 @@
+-- Needed for root.fake_inputs
+local keygrabber = {_current_grabber = nil}
 
-local keygrabber = {
-    run = function() end,
-    stop = function() end,
-    is_running = function() return false end,
+local function stop()
+    keygrabber._current_grabber = nil
+end
+
+local function run(grabber)
+    keygrabber._current_grabber = grabber
+end
+
+keygrabber = {
+    run       = run,
+    stop      = stop,
+    isrunning = function() return keygrabber._current_grabber ~= nil end,
 }
-
 
 return keygrabber
 

--- a/tests/examples/shims/mouse.lua
+++ b/tests/examples/shims/mouse.lua
@@ -3,7 +3,6 @@ local screen = require("screen")
 local coords = {x=100,y=100}
 
 local mouse = {
-    screen  = screen[1],
     old_histories = {},
     history       = {},
 }
@@ -17,11 +16,35 @@ function mouse.coords(args)
     return coords
 end
 
+function mouse.set_newindex_miss_handler(h)
+    rawset(mouse, "_ni_handler", h)
+end
+
+function mouse.set_index_miss_handler(h)
+    rawset(mouse, "_i_handler", h)
+end
+
 function mouse.push_history()
     table.insert(mouse.old_histories, mouse.history)
     mouse.history = {}
 end
 
-return mouse
+return setmetatable(mouse, {
+    __index = function(self, key)
+        if key == "screen" then
+            return screen[1]
+        end
+        local h = rawget(mouse,"_i_handler")
+        if h then
+            return h(self, key)
+        end
+    end,
+    __newindex = function(...)
+        local h = rawget(mouse,"_ni_handler")
+        if h then
+            h(...)
+        end
+    end,
+})
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/shims/root.lua
+++ b/tests/examples/shims/root.lua
@@ -1,7 +1,121 @@
 local root = {_tags={}}
 
+local gtable = require("gears.table")
+
+local hotkeys = nil
+
 function root:tags()
     return root._tags
+end
+
+function root:size() --TODO use the screens
+    return 0, 0
+end
+
+function root:size_mm()
+    return 0, 0
+end
+
+function root.cursor() end
+
+-- GLOBAL KEYBINDINGS --
+
+local keys = {}
+
+function root.keys(k)
+    keys = k or keys
+    return keys
+end
+
+-- FAKE INPUTS --
+
+-- Turn keysym into modkey names
+local conversion = {
+    Super_L   = "Mod4",
+    Control_L = "Control",
+    Shift_L   = "Shift",
+    Alt_L     = "Mod1",
+    Super_R   = "Mod4",
+    Control_R = "Control",
+    Shift_R   = "Shift",
+    Alt_R     = "Mod1",
+}
+
+-- The currently pressed modkeys.
+local mods = {}
+local function get_mods()
+    local ret = {}
+
+    for mod in pairs(mods) do
+        table.insert(ret, mod)
+    end
+
+    return ret
+end
+
+local function add_modkey(key)
+    if not conversion[key] then return end
+    mods[conversion[key]] = true
+end
+
+local function remove_modkey(key)
+    if not conversion[key] then return end
+    mods[conversion[key]] = nil
+end
+
+local function match_modifiers(mods1, mods2)
+    if #mods1 ~= #mods2 then return false end
+
+    for _, mod1 in ipairs(mods1) do
+        if not gtable.hasitem(mods2, mod1) then
+            return false
+        end
+    end
+
+    return true
+end
+
+local function execute_keybinding(key, event)
+    -- It *could* be extracted from gears.object private API, but it's equally
+    -- ugly as using the list used by the hotkey widget.
+    if not hotkeys then
+        hotkeys = require("awful.key").hotkeys
+    end
+
+    for _, v in ipairs(hotkeys) do
+        if key == v.key and match_modifiers(v.mod, get_mods()) and v[event] then
+            v[event]()
+            return
+        end
+    end
+end
+
+local fake_input_handlers = {
+    key_press      = function(key)
+        add_modkey(key)
+        if keygrabber._current_grabber then
+            keygrabber._current_grabber(get_mods(), key, "press")
+        else
+            execute_keybinding(key, "press")
+        end
+    end,
+    key_release    = function(key)
+        remove_modkey(key)
+        if keygrabber._current_grabber then
+            keygrabber._current_grabber(get_mods(), key, "release")
+        else
+            execute_keybinding(key, "release")
+        end
+    end,
+    button_press   = function() --[[TODO]] end,
+    button_release = function() --[[TODO]] end,
+    motion_notify  = function() --[[TODO]] end,
+}
+
+function root.fake_inputs(event_type, detail, x, y)
+    assert(fake_input_handlers[event_type], "Unknown event_type")
+
+    fake_input_handlers[event_type](detail, x, y)
 end
 
 return root


### PR DESCRIPTION
Extracted from the other pull requests (both the popup, dynamic layout and keygrabber ones)

It try to unify all the coding style of the different squashed commits and have a (fake) commit log.

All the issues that I agreed from @psychon comments in all related PRs are addressed or voluntarily ignored.

The goal of the shims is to be able to load awful and wibox and have semi accurate documentation examples. The core principle of what is and what is not in the shims are:

 * Only add what's being used by the tests, everything else is dead-code
 * Keep the implementation as simple as possible
 * Do not handle errors that would create unwanted side effects, if they are triggered, then the documentation examples are badly written.
 * Ignore corner cases that are not part of the documentation examples, it adds complexity and is dead-code.