### PR TITLE
keygrabber: Turn into an object.

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -71,7 +71,8 @@
 #ifdef WITH_DBUS
 extern const struct luaL_Reg awesome_dbus_lib[];
 #endif
-extern const struct luaL_Reg awesome_keygrabber_lib[];
+extern const struct luaL_Reg awesome_keygrabber_methods[];
+extern const struct luaL_Reg awesome_keygrabber_meta[];
 extern const struct luaL_Reg awesome_mousegrabber_lib[];
 extern const struct luaL_Reg awesome_root_lib[];
 extern const struct luaL_Reg awesome_mouse_methods[];
@@ -843,9 +844,8 @@ luaA_init(xdgHandle* xdg, string_array_t *searchpath)
     lua_pop(L, 1); /* luaA_registerlib() leaves the table on stack */
 #endif
 
-    /* Export keygrabber lib */
-    luaA_registerlib(L, "keygrabber", awesome_keygrabber_lib);
-    lua_pop(L, 1); /* luaA_registerlib() leaves the table on stack */
+    /* Export keygrabber */
+    luaA_openlib(L, "keygrabber", awesome_keygrabber_methods, awesome_keygrabber_meta);
 
     /* Export mousegrabber lib */
     luaA_registerlib(L, "mousegrabber", awesome_mousegrabber_lib);


### PR DESCRIPTION
Previously, the capi.keygrabber was global with some kind of incomplete
wrapper called awful.keygrabber that would attempt to turn it into a
self contained object.

The API was also primitive and hard to use. Given the use case for the
keygrabber is almost limited to transactions or sequences, then the API
should focus on making this trivial and idiot proof.

In an ideal world, it should be merged before the shims because the shims implement the changes from this PR. But given nothing uses it yet, its irrelevant.

This commit is a port from the `capi.mouse` commit I did 2 years ago, but for the keygrabber.