### PR TITLE
Mergify: do not use strict mode

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,6 @@ rules:
   default:
     protection:
       required_status_checks:
-        strict: True
         contexts:
           - continuous-integration/travis-ci
           - Codacy/PR Quality Review


### PR DESCRIPTION
It has the drawback of having intermediate merge commits for when
Mergify merges master before because of this, and then does not
squash-merge or rebases it when merging.