### PR TITLE
Fix 3rd party toolbar unminimization and the default rc.lua focusable issue

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -155,16 +155,11 @@ local tasklist_buttons = gears.table.join(
                                               if c == client.focus then
                                                   c.minimized = true
                                               else
-                                                  -- Without this, the following
-                                                  -- :isvisible() makes no sense
-                                                  c.minimized = false
-                                                  if not c:isvisible() and c.first_tag then
-                                                      c.first_tag:view_only()
-                                                  end
-                                                  -- This will also un-minimize
-                                                  -- the client, if needed
-                                                  client.focus = c
-                                                  c:raise()
+                                                  c:emit_signal(
+                                                      "request::activate",
+                                                      "tasklist",
+                                                      {raise = true}
+                                                  )
                                               end
                                           end),
                      awful.button({ }, 3, client_menu_toggle_fn()),
@@ -335,8 +330,9 @@ globalkeys = gears.table.join(
                   local c = awful.client.restore()
                   -- Focus restored client
                   if c then
-                      client.focus = c
-                      c:raise()
+                    c:emit_signal(
+                        "request::activate", "key.unminimize", {raise = true}
+                    )
                   end
               end,
               {description = "restore minimized", group = "client"}),
@@ -459,17 +455,14 @@ end
 -- @DOC_CLIENT_BUTTONS@
 clientbuttons = gears.table.join(
     awful.button({ }, 1, function (c)
-        client.focus = c;
-        c:raise()
+        c:emit_signal("request::activate", "mouse_click", {raise = true})
     end),
     awful.button({ modkey }, 1, function (c)
-        client.focus = c
-        c:raise()
+        c:emit_signal("request::activate", "mouse_click", {raise = true})
         awful.mouse.client.move(c)
     end),
     awful.button({ modkey }, 3, function (c)
-        client.focus = c
-        c:raise()
+        c:emit_signal("request::activate", "mouse_click", {raise = true})
         awful.mouse.client.resize(c)
     end)
 )
@@ -559,13 +552,11 @@ client.connect_signal("request::titlebars", function(c)
     -- buttons for the titlebar
     local buttons = gears.table.join(
         awful.button({ }, 1, function()
-            client.focus = c
-            c:raise()
+            c:emit_signal("request::activate", "titlebar", {raise = true})
             awful.mouse.client.move(c)
         end),
         awful.button({ }, 3, function()
-            client.focus = c
-            c:raise()
+            c:emit_signal("request::activate", "titlebar", {raise = true})
             awful.mouse.client.resize(c)
         end)
     )
@@ -598,10 +589,7 @@ end)
 
 -- Enable sloppy focus, so that focus follows mouse.
 client.connect_signal("mouse::enter", function(c)
-    if awful.layout.get(c.screen) ~= awful.layout.suit.magnifier
-        and awful.client.focus.filter(c) then
-        client.focus = c
-    end
+    c:emit_signal("request::activate", "mouse_enter", {raise = true})
 end)
 
 -- @DOC_BORDER@

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -81,7 +81,13 @@ end
 function ewmh.activate(c, context, hints) -- luacheck: no unused args
     hints = hints or  {}
 
-    if c.focusable == false and not hints.force then return end
+    if c.focusable == false and not hints.force then
+        if hints.raise then
+            c:raise()
+        end
+
+        return
+    end
 
     local found, ret = false
 

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -98,6 +98,12 @@ function ewmh.activate(c, context, hints) -- luacheck: no unused args
         if found then break end
     end
 
+    -- Minimized clients can be requested to have focus by, for example, 3rd
+    -- party toolbars and they might not try to unminimize it first.
+    if ret ~= false and hints.raise then
+        c.minimized = false
+    end
+
     if ret ~= false and c:isvisible() then
         client.focus = c
     elseif ret == false and not hints.force then

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -15,6 +15,7 @@ local aclient = require("awful.client")
 local aplace = require("awful.placement")
 local asuit = require("awful.layout.suit")
 local beautiful = require("beautiful")
+local alayout = require("awful.layout")
 
 local ewmh = {
     generic_activate_filters    = {},
@@ -400,6 +401,15 @@ function ewmh.client_geometry_requests(c, context, hints)
     end
 end
 
+-- The magnifier layout doesn't work with focus follow mouse.
+ewmh.add_activate_filter(function(c)
+    if alayout.get(c.screen) ~= alayout.suit.magnifier
+      and aclient.focus.filter(c) then
+        return nil
+    else
+        return false
+    end
+end, "mouse_enter")
 
 client.connect_signal("request::activate", ewmh.activate)
 client.connect_signal("request::tag", ewmh.tag)


### PR DESCRIPTION
Try to clear the v4.3 milestone.

The unminimize commit only add the code proposed in the pull request. It isn't tested and I get it will take a C program (or can LGI do it?) to actually trigger the issue on the CI.

The second commit fix the `c.focusable = false` issue mentionned in the bug report. This way, nothing is done when well, nothing should be done.

As said in the commit message, the alternative might be to use `request::activate` which already handle this, but it might make `rc.lua` more confusing for new users?