### PR TITLE
Initialize the appropiate properties for max and max fullscreen layouts

### DIFF
--- a/lib/awful/layout/suit/max.lua
+++ b/lib/awful/layout/suit/max.lua
@@ -38,6 +38,11 @@ local function fmax(p, fs)
             height = area.height
         }
         p.geometries[c] = g
+        if fs then
+            c.fullscreen = true
+        else
+            c.maximized = true
+        end
     end
 end
 


### PR DESCRIPTION
Without this c.{maximized,fullscreen} aren't reliable until setting it
manually via hotkeys. For example this causes new clients to have borders
when fullscreen_hide_border is true and the layout is max.fullscreen.