### PR TITLE
Fix STRICT_TESTS

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -45,6 +45,12 @@ else()
   set(LUA_COV_RUNNER lua)
 endif()
 
+if (STRICT_TESTS)
+    set(IGNORE_ERRORS)
+else()
+    set(IGNORE_ERRORS "||" "true")
+endif()
+
 # Add the main awesome lua libraries.
 set(LUA_PATH_ "\
 ${TOP_SOURCE_DIR}/lib/?.lua\\;\
@@ -205,7 +211,7 @@ function(run_test test_path namespace escaped_content)
     message(STATUS "Running ${rel_test_path}…")
 
     execute_process(
-        COMMAND "${TOP_SOURCE_DIR}/tests/examples/runner.sh" "${expected_output_path}" ${LUA_COV_RUNNER} ${template} ${test_path} ${IMAGE_PATH}
+        COMMAND "${TOP_SOURCE_DIR}/tests/examples/runner.sh" "${expected_output_path}" ${LUA_COV_RUNNER} ${template} ${test_path} ${IMAGE_PATH} ${IGNORE_ERRORS}
         RESULT_VARIABLE TEST_RESULT
         OUTPUT_VARIABLE TEST_OUTPUT
         ERROR_VARIABLE  TEST_ERROR
@@ -274,7 +280,7 @@ function(run_test test_path namespace escaped_content)
         file(RELATIVE_PATH rel_template "${TOP_SOURCE_DIR}" "${template}")
         file(RELATIVE_PATH rel_output "${TOP_SOURCE_DIR}" "${OUTPUT_IMAGE_PATH}")
         add_custom_command(
-            COMMAND ${LUA_COV_RUNNER} ${template} ${test_path} ${IMAGE_PATH}
+            COMMAND ${LUA_COV_RUNNER} ${template} ${test_path} ${IMAGE_PATH} ${IGNORE_ERRORS}
             COMMENT "Generating ${rel_output} (via ${rel_test_path} (${rel_template}))"
             DEPENDS ${template} ${test_path}
             OUTPUT  ${OUTPUT_IMAGE_PATH}


### PR DESCRIPTION
STRICT_TESTS was introduced in commit c22b93963. Some people have setups
where e.g. fontconfig produces warnings. These warnings made the tests
under tests/examples/ fail. The above commit changes things so that
these warnings are ignored by default, unless STRICT_TESTS is enabled.

Commit b5ca8bf9377 broke this by making example test failures fatal
again.

Fix this by appending "|| true" to the command to run in case strict
tests are disabled. Thus, all failures from tests/examples/runner.sh get
ignored.

Signed-off-by: Uli Schlachter <psychon@znc.in>