### PR TITLE
build: Auto-add example tests outputs.

### DIFF
--- a/tests/examples/runner.sh
+++ b/tests/examples/runner.sh
@@ -38,6 +38,12 @@ then
     exit 1
 fi
 
+# Automatically add the output for new examples
+if [ ! -e "${expected_output}" ]
+then
+    cp "${file_stdout}" "${expected_output}"
+fi
+
 # Check if we got the output we wanted
 if ! cmp --silent "${file_stdout}" "${expected_output}"
 then


### PR DESCRIPTION
Next step

This PR add the runner.sh code again. To mitigate @psychon concerns, I propose to check if the number of outputs file is the same before and after running the tests when `${STRICT_TESTS}` is set. This avoid the overhead when adding new tests locally.

Another change might be to add a commit hook that checks if the commit add files in `tests/examples` and automatically `git add foo.output.txt` if it exists.

This pull request does not implement the last 2 ideas and exists mainly to start the discussion.