### PR TITLE
tests/run.sh: Print log on awesome-client failures

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -222,7 +222,7 @@ for f in $tests; do
     fi
 
     # Execute the test file in awesome.
-    DISPLAY=$D "$AWESOME_CLIENT" 2>&1 "dofile('$f')"
+    DISPLAY=$D "$AWESOME_CLIENT" 2>&1 "dofile('$f')" || echo "Error: awesome-client failed" >> "$awesome_log"
 
     # Tail the log and quit, when awesome quits.
     # Use a single `grep`, otherwise `--line-buffered` would be required.


### PR DESCRIPTION
tests/run.sh uses awesome-client to actually make awesome run the test.
If awesome-client fails, then the only error message that is printed look like:
```
== Running /home/travis/build/awesomeWM/awesome/tests/test-leaks.lua ==
Error org.freedesktop.DBus.Error.NoReply: Message did not receive a reply (timeout by message bus)
E: dbus-send failed.
make[4]: *** [CMakeFiles/check-integration] Error 1
```
To also get the output from awesome, this commit makes failures from
awesome-client non-fatal so that the following shell code can notice the
failure and hopefully print some useful information.

Signed-off-by: Uli Schlachter <psychon@znc.in>