### PR TITLE
Handle unsetting of .transient_for

### DIFF
--- a/property.c
+++ b/property.c
@@ -107,9 +107,13 @@ property_update_wm_transient_for(client_t *c, xcb_get_property_cookie_t cookie)
     xcb_window_t trans;
 
     if(!xcb_icccm_get_wm_transient_for_reply(globalconf.connection,
-					     cookie,
-					     &trans, NULL))
-            return;
+                                             cookie,
+                                             &trans, NULL))
+    {
+        c->transient_for_window = XCB_NONE;
+        client_find_transient_for(c);
+        return;
+    }
 
     c->transient_for_window = trans;
 


### PR DESCRIPTION
When a window has a WM_TRANSIENT_FOR property that is later unset,
awesome would still keep c.transient_for pointing to the previous
"parent client". This commit fixes that.

First, property_update_wm_transient_for() is fixed so that it unsets
c->transient_for_window if the WM_TRANSIENT_FOR property is deleted.
Additionally, this then calls client_find_transient_for() to update the
c->transient_for pointer.

Secondly (and a bit unrelated), this changes client_find_transient_for()
so that it always sets c->transient_for. Previously, if updating this
property would introduce a cycle in the transient_for relation, it would
just leave c->transient_for with its old value. After this change, it
gets explicitly set to NULL instead.

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @p-himik Here is a new version of the patch (without the debugging-prints). The important part is the change to `property.c`. While writing the commit message, I noticed that the change to `client.c` is actually unrelated to this issue, but I was too lazy to change the commit...