### PR TITLE
awful.menu: Fix typo "moue" -> "mouse"

### DIFF
--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -450,7 +450,7 @@ function menu:add(args, index)
 
     item._mouse = function ()
         local num = gtable.hasitem(self.items, item)
-        self:item_enter(num, { hover = true, moue = true })
+        self:item_enter(num, { hover = true, mouse = true })
     end
     item.widget:connect_signal("mouse::enter", item._mouse)
 


### PR DESCRIPTION
The typo was introduced in commit a1941efc9.

Its effect should be minimal: :item_enter() itself does not care about
the 'mouse' option, but it forwards to :exec(). Here, an action is
invoked either if it was not caused by the mouse, or if it was caused by
the mouse and either auto_expand is enabled (which is the default), or
the item-to-be-executed is actually the active item.

In other words, it is quite non-trivial to come up with a case where
this typo made a difference. But of course that's no reason to leave the
typo in.

Fixes: https://github.com/awesomeWM/awesome/issues/2347
Signed-off-by: Uli Schlachter <psychon@znc.in>