### PR TITLE
awful.rules: Also check for tag on other screens

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -451,6 +451,9 @@ function rules.high_priority_properties.tag(c, value, props)
         if type(value) == "string" then
             local name = value
             value = atag.find_by_name(c.screen, value)
+            if not value and not props.screen then
+                value = atag.find_by_name(nil, value)
+            end
             if not value then
                 require("gears.debug").print_error("awful.rules-rule specified "
                     .. "tag = '" .. name .. "', but no such tag exists")


### PR DESCRIPTION
When a tag is specified by name, awful.rules only searched for the tag
on the client's screen. This commit extends the search to all screens,
but only if no specific screen was specified for the new client by some
rule.

Signed-off-by: Uli Schlachter <psychon@znc.in>