### PR TITLE
Some gravity changes

### DIFF
--- a/event.c
+++ b/event.c
@@ -345,17 +345,13 @@ event_handle_configurerequest(xcb_configure_request_event_t *ev)
 
         if(ev->value_mask & XCB_CONFIG_WINDOW_X)
         {
-            int16_t diff = 0;
             geometry.x = ev->x;
-            xwindow_translate_for_gravity(c->size_hints.win_gravity, deco_left, 0, deco_right, 0, &diff, NULL);
-            geometry.x += diff;
+            xwindow_translate_for_gravity(c->size_hints.win_gravity, deco_left, 0, deco_right, 0, &geometry.x, NULL);
         }
         if(ev->value_mask & XCB_CONFIG_WINDOW_Y)
         {
-            int16_t diff = 0;
             geometry.y = ev->y;
-            xwindow_translate_for_gravity(c->size_hints.win_gravity, 0, deco_top, 0, deco_bottom, NULL, &diff);
-            geometry.y += diff;
+            xwindow_translate_for_gravity(c->size_hints.win_gravity, 0, deco_top, 0, deco_bottom, NULL, &geometry.y);
         }
         if(ev->value_mask & XCB_CONFIG_WINDOW_WIDTH)
         {

--- a/objects/client.c
+++ b/objects/client.c
@@ -1387,12 +1387,9 @@ border_width_callback(client_t *c, uint16_t old_width, uint16_t new_width)
     {
         area_t geometry = c->geometry;
         int16_t diff = new_width - old_width;
-        int16_t diff_x = 0, diff_y = 0;
         xwindow_translate_for_gravity(c->size_hints.win_gravity,
                                       diff, diff, diff, diff,
-                                      &diff_x, &diff_y);
-        geometry.x += diff_x;
-        geometry.y += diff_y;
+                                      &geometry.x, &geometry.y);
         /* inform client about changes */
         client_resize_do(c, geometry);
     }
@@ -2870,13 +2867,10 @@ titlebar_resize(lua_State *L, int cidx, client_t *c, client_titlebar_t bar, int 
 
     if(c->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY)
     {
-        int16_t diff_x = 0, diff_y = 0;
         xwindow_translate_for_gravity(c->size_hints.win_gravity,
                                       diff_left, diff_top,
                                       diff_right, diff_bottom,
-                                      &diff_x, &diff_y);
-        geometry.x += diff_x;
-        geometry.y += diff_y;
+                                      &geometry.x, &geometry.y);
     }
 
     c->titlebar[bar].size = size;

--- a/xwindow.c
+++ b/xwindow.c
@@ -400,8 +400,8 @@ xwindow_set_shape(xcb_window_t win, int width, int height, enum xcb_shape_sk_t k
  * \param change_height_before The window height difference that will be applied.
  * \param change_width_after The window width difference that will be applied.
  * \param change_height_after The window height difference that will be applied.
- * \param dx On return, this will be set to the amount the pixel has to be moved.
- * \param dy On return, this will be set to the amount the pixel has to be moved.
+ * \param dx On return, this will be changed by the amount the pixel has to be moved.
+ * \param dy On return, this will be changed by the amount the pixel has to be moved.
  */
 void xwindow_translate_for_gravity(xcb_gravity_t gravity, int16_t change_width_before, int16_t change_height_before,
         int16_t change_width_after, int16_t change_height_after, int16_t *dx, int16_t *dy)
@@ -449,9 +449,9 @@ void xwindow_translate_for_gravity(xcb_gravity_t gravity, int16_t change_width_b
     }
 
     if (dx)
-        *dx = x;
+        *dx += x;
     if (dy)
-        *dy = y;
+        *dy += y;
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
First commit should not result in any functional changes, but I think it slightly simplifies some code. Second commit makes `test-gravity.c` less strict for gravities which involve division by two: Both rounding up and rounding down is now accepted.

CC @sigprof Does the second commit in here seem good to you? I have some local changes laying around that would make `test-gravity.c` fail, but that are fixed by this.