### PR TITLE
doc: Add filter section for the taglist and tasklist

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -68,6 +68,8 @@ new_type("clientlayout", "Client layouts", false, "param")
 new_type("callback", "Callback functions prototype", false, "Parameters")
 -- awful.rules sources
 new_type("rulesources", "Rule sources", false, "param")
+-- Filter functions for the taglist/tasklist/layoutlist
+new_type("filterfunction", "List filters", false)
 
 -- More fitting section names
 kind_names={topic='Documentation', module='Libraries', script='Sample files'}

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -550,6 +550,7 @@ end
 --- Filtering function to include all nonempty tags on the screen.
 -- @param t The tag.
 -- @return true if t is not empty, else false
+-- @filterfunction awful.taglist.filter.noempty
 function taglist.filter.noempty(t)
     return #t:clients() > 0 or t.selected
 end
@@ -557,12 +558,14 @@ end
 --- Filtering function to include selected tags on the screen.
 -- @param t The tag.
 -- @return true if t is not empty, else false
+-- @filterfunction awful.taglist.filter.selected
 function taglist.filter.selected(t)
     return t.selected
 end
 
 --- Filtering function to include all tags on the screen.
 -- @return true
+-- @filterfunction awful.taglist.filter.all
 function taglist.filter.all()
     return true
 end

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -599,6 +599,7 @@ end
 
 --- Filtering function to include all clients.
 -- @return true
+-- @filterfunction awful.tasklist.filter.allscreen
 function tasklist.filter.allscreen()
     return true
 end
@@ -607,6 +608,7 @@ end
 -- @param c The client.
 -- @param screen The screen we are drawing on.
 -- @return true if c is on screen, false otherwise
+-- @filterfunction awful.tasklist.filter.alltags
 function tasklist.filter.alltags(c, screen)
     -- Only print client on the same screen as this widget
     return get_screen(c.screen) == get_screen(screen)
@@ -616,6 +618,7 @@ end
 -- @param c The client.
 -- @param screen The screen we are drawing on.
 -- @return true if c is in a selected tag on screen, false otherwise
+-- @filterfunction awful.tasklist.filter.currenttags
 function tasklist.filter.currenttags(c, screen)
     screen = get_screen(screen)
     -- Only print client on the same screen as this widget
@@ -640,6 +643,7 @@ end
 -- @param c The client.
 -- @param screen The screen we are drawing on.
 -- @return true if c is in a selected tag on screen and is minimized, false otherwise
+-- @filterfunction awful.tasklist.filter.minimizedcurrenttags
 function tasklist.filter.minimizedcurrenttags(c, screen)
     screen = get_screen(screen)
     -- Only print client on the same screen as this widget
@@ -667,6 +671,7 @@ end
 -- @param c The client.
 -- @param screen The screen we are drawing on.
 -- @return true if c is focused on screen, false otherwise
+-- @filterfunction awful.tasklist.filter.focused
 function tasklist.filter.focused(c, screen)
     -- Only print client on the same screen as this widget
     return get_screen(c.screen) == get_screen(screen) and capi.client.focus == c


### PR DESCRIPTION
This is cherry picked from the [rebased version of the] popup branch.

This is done for most other independent components already. It groups the elements in the doc and makes everything more readable. It will also be used by the layoutlist (from the popup PR, soon to be its own PR) and the client layout module `tablist` widget.