### PR TITLE
Add common source

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -64,6 +64,8 @@ new_type("deprecated", "Deprecated functions", false, "param")
 new_type("legacylayout", "Layout related functions", false, "param")
 -- Have a category for the client layouts
 new_type("clientlayout", "Client layouts", false, "param")
+-- Source functions for the taglist/tasklist/layoutlist
+new_type("sourcefunction", "List source functions", false)
 -- Document some callback prototypes
 new_type("callback", "Callback functions prototype", false, "Parameters")
 -- awful.rules sources

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -61,7 +61,7 @@ local function get_screen(s)
 end
 
 local taglist = { mt = {} }
-taglist.filter = {}
+taglist.filter, taglist.source = {}, {}
 
 --- The tag list main foreground (text) color.
 -- @beautiful beautiful.taglist_fg_focus
@@ -386,7 +386,11 @@ end
 
 local function taglist_update(s, w, buttons, filter, data, style, update_function, args)
     local tags = {}
-    for _, t in ipairs(s.tags) do
+
+    local source = args and args.source or taglist.source.for_screen or nil
+    local list   = source and source(s, args) or s.tags
+
+    for _, t in ipairs(list) do
         if not tag.getproperty(t, "hide") and filter(t) then
             table.insert(tags, t)
         end
@@ -411,6 +415,8 @@ end
 --   update. See `awful.widget.common`.
 -- @tparam[opt] widget args.layout Optional layout widget for tag widgets. Default
 --   is wibox.layout.fixed.horizontal().
+-- @tparam[opt=awful.taglist.source.for_screen] function args.source The
+--  function used to generate the list of tag.
 -- @tparam[opt] table args.widget_template A custom widget to be used for each tag
 -- @tparam[opt={}] table args.style The style overrides default theme.
 -- @tparam[opt=nil] string|pattern args.style.fg_focus
@@ -568,6 +574,16 @@ end
 -- @filterfunction awful.taglist.filter.all
 function taglist.filter.all()
     return true
+end
+
+--- All tags for the defined screen ordered by indices.
+--
+-- This is the default source.
+--
+-- @sourcefunction awful.taglist.source.for_screen
+-- @see screen
+function taglist.source.for_screen(s)
+    return s.tags
 end
 
 function taglist.mt:__call(...)

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -245,7 +245,7 @@ local instances
 -- @see gears.color
 
 -- Public structures
-tasklist.filter = {}
+tasklist.filter, tasklist.source = {}, {}
 
 local function tasklist_label(c, args, tb)
     if not args then args = {} end
@@ -401,7 +401,11 @@ end
 
 local function tasklist_update(s, w, buttons, filter, data, style, update_function, args)
     local clients = {}
-    for _, c in ipairs(capi.client.get()) do
+
+    local source = args and args.source or tasklist.source.all_clients or nil
+    local list   = source and source(s, args) or capi.client.get()
+
+    for _, c in ipairs(list) do
         if not (c.skip_taskbar or c.hidden
             or c.type == "splash" or c.type == "dock" or c.type == "desktop")
             and filter(c, s) then
@@ -430,6 +434,8 @@ end
 --   update. See `awful.widget.common.list_update`.
 -- @tparam[opt] table args.layout Container widget for tag widgets. Default
 --   is `wibox.layout.flex.horizontal`.
+-- @tparam[opt=awful.tasklist.source.all_clients] function args.source The
+--  function used to generate the list of client.
 -- @tparam[opt] table args.widget_template A custom widget to be used for each client
 -- @tparam[opt={}] table args.style The style overrides default theme.
 -- @tparam[opt=nil] string|pattern args.style.fg_normal
@@ -675,6 +681,15 @@ end
 function tasklist.filter.focused(c, screen)
     -- Only print client on the same screen as this widget
     return get_screen(c.screen) == get_screen(screen) and capi.client.focus == c
+end
+
+--- Get all the clients in an undefined order.
+--
+-- This is the default source.
+--
+-- @sourcefunction awful.tasklist.source.all_clients
+function tasklist.source.all_clients()
+    return capi.client.get()
 end
 
 function tasklist.mt:__call(...)


### PR DESCRIPTION
This change solves 2 problems:

 * While the taglist and tasklist objects or managed internally, layoutlist allows random ones to be created and it was difficult to handle when the layouts were removed from `awful.layout.layouts` (for example, a `lain` layout not added to the default list)
 * Ordering wasn't trivial and prevented some code re-use. This is useful if you want to order your alt+tab popup with the newest at the top