### PR TITLE
awful.tag: Add awful tag layouts

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -21,6 +21,7 @@ local client = require("awful.client")
 local ascreen = require("awful.screen")
 local timer = require("gears.timer")
 local gmath = require("gears.math")
+local gtable = require("gears.table")
 local protected_call = require("gears.protected_call")
 
 local function get_screen(s)
@@ -73,6 +74,16 @@ layout.layouts = {
 --
 -- @field layout.layouts
 
+--- Return the tag layout index (from `awful.layout.layouts`).
+--
+-- If the layout isn't part of `awful.layout.layouts`, this function returns
+-- nil.
+--
+-- @tparam tag t The tag.
+-- @treturn nil|number The layout index.
+function layout.get_tag_layout_index(t)
+    return gtable.hasitem(layout.layouts, t.layout)
+end
 
 -- This is a special lock used by the arrange function.
 -- This avoids recurring call by emitted signals.

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -14,6 +14,7 @@ local gmath = require("gears.math")
 local object = require("gears.object")
 local timer = require("gears.timer")
 local gtable = require("gears.table")
+local alayout = nil
 local pairs = pairs
 local ipairs = ipairs
 local table = table
@@ -72,6 +73,68 @@ local function raw_tags(scr)
     end
 
     return tmp_tags
+end
+
+local function custom_layouts(self)
+    local cls = tag.getproperty(self, "_custom_layouts")
+
+    if not cls then
+        cls = {}
+        tag.setproperty(self, "_custom_layouts", cls)
+    end
+
+    return cls
+end
+
+-- Update the "user visible" list of layouts. If `from` and `to` are not the
+-- same, then `from` will be replaced. This is necessary for either the layouts
+-- defined as a function (called "template" below) and object oriented, stateful
+-- layouts where the original entry is only a constructor.
+local function update_layouts(self, from, to)
+    if not to then return end
+
+    alayout = alayout or require("awful.layout")
+    local override = tag.getproperty(self, "_layouts")
+
+    local pos = from and gtable.hasitem(override or {}, from) or nil
+
+    -- There is an override and the layout template is part of it, replace by
+    -- the instance.
+    if override and pos and from ~= to then
+        assert(type(pos) == 'number')
+        override[pos] = to
+        self:emit_signal("property::layouts")
+        return
+    end
+
+    -- Only add to the custom_layouts and preserve the ability to globally
+    -- set the layouts.
+    if override and not pos then
+        table.insert(override, to)
+        self:emit_signal("property::layouts")
+        return
+    end
+
+    pos = from and gtable.hasitem(alayout.layouts, from) or nil
+
+    local cls = custom_layouts(self)
+
+    -- The new layout is part of the global layouts. Fork the list.
+    if pos and from ~= to then
+        local cloned = gtable.clone(alayout.layouts, false)
+        cloned[pos] = to
+        gtable.merge(cloned, cls)
+        self.layouts = cloned
+        return
+    end
+
+    if pos then return end
+
+    if gtable.hasitem(cls, to) then return end
+
+    -- This layout is unknown, add it to the custom list
+    table.insert(cls, to)
+    self:emit_signal("property::layouts")
 end
 
 --- The number of elements kept in the history.
@@ -718,7 +781,26 @@ end
 -- @tparam layout|function layout A layout table or a constructor function
 -- @return The layout
 
+--- The (proposed) list of available layouts for this tag.
+--
+-- This property allows to define a subset (or superset) of layouts available
+-- in the "rotation table". In the default configuration file, `Mod4+Space`
+-- and `Mod4+Shift+Space` are used to switch between tags. The
+-- `awful.widget.layoutlist` also uses this as its default layout filter.
+--
+-- By default, it will be the same as `awful.layout.layouts` unless there the
+-- a layout not present is used. If that's the case they will be added at the
+-- front of the list.
+--
+-- @property layouts
+-- @param table
+-- @see awful.layout.layouts
+-- @see layout
+
 function tag.object.set_layout(t, layout)
+
+    local template = nil
+
     -- Check if the signature match a stateful layout
     if type(layout) == "function" or (
         type(layout) == "table"
@@ -741,12 +823,39 @@ function tag.object.set_layout(t, layout)
             t.dynamic_layout_cache[layout] = instance
         end
 
+        template = layout
         layout = instance
     end
 
     tag.setproperty(t, "layout", layout)
 
+    update_layouts(t, template or layout, layout)
+
     return layout
+end
+
+function tag.object.get_layouts(self)
+    local override = tag.getproperty(self, "_layouts")
+
+    if override then
+        return override
+    end
+
+    -- Required to get the default/fallback list of layouts
+    alayout = alayout or require("awful.layout")
+
+    local cls = custom_layouts(self)
+
+    -- Without the clone, the custom_layouts would grow
+    return #cls > 0 and gtable.merge(gtable.clone(cls, false), alayout.layouts) or
+        alayout.layouts
+end
+
+function tag.object.set_layouts(self, layouts)
+    tag.setproperty(self, "_custom_layouts", {})
+    tag.setproperty(self, "_layouts", gtable.clone(layouts, false))
+    update_layouts(self, self.layout, self.layout)
+    self:emit_signal("property::layouts")
 end
 
 function tag.object.get_layout(t)


### PR DESCRIPTION
Another one split out of the bigger popup PR.

There was an issue in my previous layoutlist implementation where if `awful.layout.layouts` was "trimmed down" or the user had an external module like lain, it would cause errors.

This PR adds `t.layouts` as a tag level way to set the accepted layouts. By default, it will try to squash `awful.layout.layouts` with the non-listed ones. If the user set this property manually, it's their problem and they have to handle this themselves.

Plus, it's nice since it allow different layout order depending on the tag. I see myself using that now.