### PR TITLE
Handle SIGCHLD ourselves instead of through GLib

### DIFF
--- a/spawn.h
+++ b/spawn.h
@@ -27,10 +27,9 @@
 #include <lua.h>
 
 void spawn_init(void);
-void spawn_handle_reap(const char *);
-char * const * spawn_transform_commandline(char **);
 void spawn_start_notify(client_t *, const char *);
 int luaA_spawn(lua_State *);
+void spawn_child_exited(pid_t, int);
 
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
GLib is very careful not to "fetch" any children that it was not asked
to fetch. Thus, if awesome inherits some children, it does not reap them
and starts collecting zombies.

Thus, this commit makes awesome handle SIGCHLD directly: On SIGCHLD, a
byte is written to a pipe. The main loop reads from this pipe and
collects children via waitpid(-1). Unknown children cause a warning to
be printed. We might want to remove this warning if it turns out to be
annoying.

This commit adds 79 lines and removes 89 lines. Thus, this is a net
reduction in lines of codes. This is because previously, we gave the
list of still-running children that we know about to the next awesome
instance we a --reap command line argument. This was added so that
awesome does not get zombie children. However, this commit fixes this
problem and makes all the code for this 'feature' unnecessary.

Fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=886393
Signed-off-by: Uli Schlachter <psychon@znc.in>