### PR TITLE
Remove unsatisifiable condition when destination screen is empty

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -226,7 +226,7 @@ function client.swap.global_bydirection(dir, sel)
             c:swap(sel)
 
         -- swapping to an empty screen
-        elseif get_screen(sel.screen) ~= get_screen(c.screen) and sel == c then
+        elseif sel == c then
             sel:move_to_screen(screen.focused())
 
         -- swapping to a nonempty screen


### PR DESCRIPTION
This commit fixes the following issue: https://github.com/awesomeWM/awesome/issues/2365