### PR TITLE
a_glib_poll: Preserve errno from g_poll()

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -404,6 +404,7 @@ a_glib_poll(GPollFD *ufds, guint nfsd, gint timeout)
     guint res;
     struct timeval now, length_time;
     float length;
+    int saved_errno;
     lua_State *L = globalconf_get_lua_State();
 
     /* Do all deferred work now */
@@ -434,8 +435,10 @@ a_glib_poll(GPollFD *ufds, guint nfsd, gint timeout)
 
     /* Actually do the polling, record time of wakeup and check for new xcb events */
     res = g_poll(ufds, nfsd, timeout);
+    saved_errno = errno;
     gettimeofday(&last_wakeup, NULL);
     a_xcb_check();
+    errno = saved_errno;
 
     return res;
 }


### PR DESCRIPTION
When poll() is interrupted because of a signal, it sets errno to EINTR.
GLib ignores this kind of failure.

However, a_glib_poll() calls a_xcb_check() at its end. This will call
xcb_poll_for_event() which internally might call recv(), which can fail
with EAGAIN if no new events are available. Thus, a_glib_poll() will
return an error and set errno to EAGAIN. This leads to the following
error message being printed by GLib:

  GLib-WARNING: poll(2) failed due to: Resource temporarily unavailable.

Fix this by preserving the errno from g_poll() in a_glib_poll().

Signed-off-by: Uli Schlachter <psychon@znc.in>