### PR TITLE
Fix no_offscreen test

### DIFF
--- a/tests/examples/awful/placement/no_offscreen.output.txt
+++ b/tests/examples/awful/placement/no_offscreen.output.txt
@@ -1,2 +1,2 @@
 Before:	x=-30, y=-30, width=100, height=100
-After:	x=10, y=10, width=100, height=100
+After:	x=50, y=50, width=20, height=20


### PR DESCRIPTION
Commit fec8d6aa8fe257f2d1 fixes awful.placement.no_offscreen to behave
like other placement functions. This means that the margins=40 argument
that this test used and that was previously was just ignored, now
started working. Thus, there are now 40 pixels less on each side of the
client in this test.

Signed-off-by: Uli Schlachter <psychon@znc.in>