### PR TITLE
awful.placement: Fix no_offscreen when composed with other functions

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -851,7 +851,7 @@ function placement.no_offscreen(c, args)
 
     c = c or capi.client.focus
     args = add_context(args, "no_offscreen")
-    local geometry = area_common(c)
+    local geometry = area_common(c, nil, false, args)
     local screen = get_screen(args.screen or c.screen or a_screen.getbycoord(geometry.x, geometry.y))
     local screen_geometry = screen.workarea
 


### PR DESCRIPTION
The `awful.placement.no_offscreen` function did not work properly when composed with other placement functions; in particular, the default configuration (`awful.placement.no_overlap+awful.placement.no_offscreen`) was broken.  The compose function sets `args.pretend=true` and puts the result of the previous placement function into `args.override_geometry`
before calling the next placement function, but `no_offscreen` did not use `args.override_geometry`, therefore the result of the previous placement function was discarded.

Fixes: https://github.com/awesomeWM/awesome/issues/1092 (the previous attempt (https://github.com/awesomeWM/awesome/pull/2033) did not fix the problem completely),