### PR TITLE
Fix awful.placement.no_overlap + awful.placement.no_offscreen

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -851,7 +851,7 @@ function placement.no_offscreen(c, args)
 
     c = c or capi.client.focus
     args = add_context(args, "no_offscreen")
-    local geometry = area_common(c)
+    local geometry = geometry_common(c, args)
     local screen = get_screen(args.screen or c.screen or a_screen.getbycoord(geometry.x, geometry.y))
     local screen_geometry = screen.workarea
 

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -941,6 +941,7 @@ function placement.no_overlap(c, args)
     new.width = geometry.width
     new.height = geometry.height
 
+    remove_border(c, args, new)
     geometry_common(c, args, new)
     return fix_new_geometry(new, args, true)
 end

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -12,8 +12,8 @@ Gtk.init()
 
 local function open_window(class, title, options)
     local window = Gtk.Window {
-        default_width  = 100,
-        default_height = 100,
+        default_width  = options.default_width  or 100,
+        default_height = options.default_height or 100,
         title          = title
     }
     if options.gravity then
@@ -140,6 +140,15 @@ return function(class, title, sn_rules, callback, resize_increment, args)
     end
     if args.maximize_after then
         options = options .. "maximize_after,"
+    end
+    if args.size then
+        options = table.concat {
+            options,
+            "default_width=",
+            args.size.width, ",",
+            "default_height=",
+            args.size.height, ","
+        }
     end
     if args.resize then
         options = table.concat {

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -145,9 +145,9 @@ return function(class, title, sn_rules, callback, resize_increment, args)
         options = table.concat {
             options,
             "resize_after_width=",
-            args.resize.height, ",",
+            args.resize.width, ",",
             "resize_after_height=",
-            args.resize.width, ","
+            args.resize.height, ","
         }
     end
     if args.gravity then

--- a/tests/examples/awful/placement/no_offscreen.output.txt
+++ b/tests/examples/awful/placement/no_offscreen.output.txt
@@ -1,2 +1,2 @@
 Before:	x=-30, y=-30, width=100, height=100
-After:	x=50, y=50, width=20, height=20
+After:	x=50, y=50, width=100, height=100

--- a/tests/test-awful-placement.lua
+++ b/tests/test-awful-placement.lua
@@ -1,0 +1,170 @@
+local awful = require("awful")
+local gears = require("gears")
+local beautiful = require("beautiful")
+local test_client = require("_client")
+local runner = require("_runner")
+
+-- This test makes some assumptions about the no_overlap behavior which may not
+-- be correct if the screen is in the portrait orientation.
+if mouse.screen.workarea.height >= mouse.screen.workarea.width then
+    print("This test does not work with the portrait screen orientation.")
+    runner.run_steps { function() return true end }
+    return
+end
+
+local tests = {}
+
+local tb_height = gears.math.round(beautiful.get_font_height() * 1.5)
+local border_width = beautiful.border_width
+
+local class = "test-awful-placement"
+local rule = {
+    rule = {
+        class = class
+    },
+    properties = {
+        floating = true,
+        placement = awful.placement.no_overlap + awful.placement.no_offscreen
+    }
+}
+table.insert(awful.rules.rules, rule)
+
+local function check_geometry(c, x, y, width, height)
+    local g = c:geometry()
+    if g.x ~= x or g.y ~= y or g.width ~= width or g.height ~= height then
+        assert(false, string.format("(%d, %d, %d, %d) ~= (%d, %d, %d, %d)",
+            g.x, g.y, g.width, g.height, x, y, width, height))
+    end
+end
+
+local function default_test(c, geometry)
+    check_geometry(c, geometry.expected_x, geometry.expected_y,
+        geometry.expected_width  or geometry.width,
+        geometry.expected_height or (geometry.height + tb_height))
+    return true
+end
+
+local client_count = 0
+local client_data = {}
+local function add_client(args)
+    client_count = client_count + 1
+    local client_index = client_count
+    table.insert(tests, function(count)
+        local name = string.format("client%010d", client_index)
+        if count <= 1 then
+            local geometry = args.geometry(mouse.screen.workarea)
+            test_client(class, name, nil, nil, nil, {
+                size = {
+                    width = geometry.width,
+                    height = geometry.height
+                }
+            })
+            client_data[client_index] = { geometry = geometry }
+            return nil
+        elseif #client.get() >= client_index then
+            local data = client_data[client_index]
+            local c = data.c
+            if not c then
+                c = client.get()[1]
+                assert(c.name == name)
+                data.c = c
+            end
+            local test = args.test or default_test
+            return test(c, data.geometry)
+        end
+    end)
+end
+
+-- The first 100x100 window should be placed at the top left corner.
+add_client {
+    geometry = function(wa)
+        return {
+            width       = 100,
+            height      = 100,
+            expected_x  = wa.x,
+            expected_y  = wa.y
+        }
+    end
+}
+
+-- The second 100x100 window should be placed to the right of the first window.
+-- Note that this assumption fails if the screen is in the portrait orientation
+-- (e.g., the test succeeds with a 600x703 screen and fails with 600x704).
+add_client {
+    geometry = function(wa)
+        return {
+            width       = 100,
+            height      = 100,
+            expected_x  = wa.x + 100 + 2*border_width,
+            expected_y  = wa.y
+        }
+    end
+}
+
+-- The wide window should be placed below the two 100x100 windows.
+add_client {
+    geometry = function(wa)
+        return {
+            width       = wa.width - 50,
+            height      = 100,
+            expected_x  = wa.x,
+            expected_y  = wa.y + tb_height + 2*border_width + 100
+        }
+    end
+}
+
+-- The first large window which does not completely fit in any free area should
+-- be placed at the bottom left corner (no_overlap should place it below the
+-- wide window, and then no_offscreen should shift it up so that it would be
+-- completely inside the workarea).
+add_client {
+    geometry = function(wa)
+        return {
+            width       = wa.width - 10,
+            height      = wa.height - 50,
+            expected_x  = wa.x,
+            expected_y  = wa.y + 50 - 2*border_width - tb_height
+        }
+    end
+}
+
+-- The second large window should be placed at the top right corner.
+add_client {
+    geometry = function(wa)
+        return {
+            width       = wa.width - 10,
+            height      = wa.height - 50,
+            expected_x  = wa.x + 10 - 2*border_width,
+            expected_y  = wa.y
+        }
+    end
+}
+
+-- The third large window should be placed at the bottom right corner.
+add_client {
+    geometry = function(wa)
+        return {
+            width       = wa.width - 10,
+            height      = wa.height - 50,
+            expected_x  = wa.x + 10 - 2*border_width,
+            expected_y  = wa.y + 50 - 2*border_width - tb_height
+        }
+    end
+}
+
+-- The fourth large window should be placed at the top left corner (the whole
+-- workarea is occupied now).
+add_client {
+    geometry = function(wa)
+        return {
+            width       = wa.width - 50,
+            height      = wa.height - 50,
+            expected_x  = wa.x,
+            expected_y  = wa.y
+        }
+    end
+}
+
+runner.run_steps(tests)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Fix multiple problems in `awful.placement.no_overlap` and `awful.placement.no_offscreen` related to their conversion to the new placement infrastructure:

- `no_offscreen` did not work properly when composed with other placement functions — it used the real client geometry instead of the geometry returned by the previous placement function; this usually resulted in all windows being placed at the top left corner of the workarea.
- When getting the client geometry, `no_offscreen` did not adjust it for margins specified in arguments, but the reverse adjustment was performed before returning the result; because of this, after adding margins the client size was incorrectly decreased by the values of those margins.
- `no_overlap` did not perform the reverse adjustment for the border width before returning the result, therefore after applying `no_overlap` the client width and height were increased by `2*border_width`. This error was not noticeable in the default configuration (`no_overlap + no_offscreen`), because the bug in `no_overlap` was masked by the above bug in `no_offscreen` (the result of `no_overlap` was discarded).

Actual fixes are 1 added line in `no_overlap` and 1 changed line in `no_offscreen`; the rest of the pull request contains a test for `no_overlap + no_offscreen` which should hopefully catch similar problems in the future.