### PR TITLE
utils.lua: make it compatible with more terminals

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -399,13 +399,8 @@ function utils.parse_desktop_file(file)
             cmdline = cmdline:gsub('%%i', '')
         end
         if program.Terminal == true then
-            if string.find(utils.terminal, "xfce4%-terminal") or string.find(utils.terminal, "gnome%-terminal") or string.find(utils.terminal, "mate%-terminal") then
-                cmdline = utils.terminal .. ' -x ' .. cmdline
-            elseif string.find(utils.terminal, "termite") then
-                cmdline = utils.terminal .. ' -e \"' .. cmdline .. '\"'
-            else
-                cmdline = utils.terminal .. ' -e ' .. cmdline
-            end
+            cmdline = cmdline:gsub('"', '\"')
+            cmdline = utils.terminal .. ' -e "' .. cmdline .. '"'
         end
         program.cmdline = cmdline
     end

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -399,8 +399,8 @@ function utils.parse_desktop_file(file)
             cmdline = cmdline:gsub('%%i', '')
         end
         if program.Terminal == true then
-            cmdline = cmdline:gsub('"', '\"')
-            cmdline = utils.terminal .. ' -e "' .. cmdline .. '"'
+            cmdline = '"' .. cmdline:gsub('"', '\\"') .. '"'
+            cmdline = utils.terminal .. ' -e ' .. cmdline
         end
         program.cmdline = cmdline
     end

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -399,7 +399,13 @@ function utils.parse_desktop_file(file)
             cmdline = cmdline:gsub('%%i', '')
         end
         if program.Terminal == true then
-            cmdline = utils.terminal .. ' -e ' .. cmdline
+            if string.find(utils.terminal, "xfce4%-terminal") or string.find(utils.terminal, "gnome%-terminal") or string.find(utils.terminal, "mate%-terminal") then
+                cmdline = utils.terminal .. ' -x ' .. cmdline
+            elseif string.find(utils.terminal, "termite") then
+                cmdline = utils.terminal .. ' -e \"' .. cmdline .. '\"'
+            else
+                cmdline = utils.terminal .. ' -e ' .. cmdline
+            end
         end
         program.cmdline = cmdline
     end


### PR DESCRIPTION
Terminal applications don't work with many terminals when they have many options (for example in manjaro we use manjaro architect with `Exec = sudo /usr/bin/setup`).

For xfce4-terminal, mate-terminal, gnome-terminal it is better to use the `-x` option which interprets the rest parameters as command parameters. Termite has only `-e` option but it needs it to be in quotes in order to understand many parameters (I don't know if it gets messed up if the Exec command includes quotes on its own like for example `Exec=sh -c "something"` or how to make sure it doesn't). Terminals like xterm and lxterminal work with just the `-e` option.

I use **string.find()** instead of just **==** in case someone sets terminal with the full path like `menubar.utils.terminal = /usr/bin/xfce4-terminal`.

Adding special cases for each terminal seems like a bad solution but I cannot think of anything better.