### PR TITLE
Fix awful.placement.next_to

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -1383,6 +1383,14 @@ end
 --
 --@DOC_awful_placement_next_to_EXAMPLE@
 --
+-- The `args.mode` parameters allows to control from which `next_to` takes its
+-- source object from. The valid values are:
+--
+-- * geometry: Next to this geometry, `args.geometry` has to be set.
+-- * cursor: Next to the mouse.
+-- * cursor_inside
+-- * geometry_inside
+--
 -- @tparam drawable d A wibox or client
 -- @tparam table args
 -- @tparam string args.mode The mode

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -1377,6 +1377,8 @@ end
 -- In that case, if there is room on the top of the geometry, then it will have
 -- priority, followed by all the others, in order.
 --
+--@DOC_awful_placement_next_to_EXAMPLE@
+--
 -- @tparam drawable d A wibox or client
 -- @tparam table args
 -- @tparam string args.mode The mode

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -391,6 +391,16 @@ function tooltip:set_margins(val)
     self.marginbox:set_margins(val)
 end
 
+
+function tooltip:set_border_width(val)
+    self.widget.shape_border_width = val
+end
+
+
+function tooltip:set_border_color(val)
+    self.widget.shape_border_color = val
+end
+
 --- Set the margins around the left and right of the tooltip textbox
 --
 -- @property margins_leftright

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -10,13 +10,16 @@
 -- How to create a tooltip?
 -- ---
 --
---     myclock = wibox.widget.textclock("%T", 1)
---     myclock_t = awful.tooltip({
---         objects = { myclock },
---         timer_function = function()
---                 return os.date("Today is %A %B %d %Y\nThe time is %T")
---             end,
---         })
+-- @DOC_awful_tooltip_textclock_EXAMPLE@
+--
+-- Alternatively, you can use `mouse::enter` signal:
+--
+-- @DOC_awful_tooltip_textclock2_EXAMPLE@
+--
+-- How to create a tooltip without objects?
+-- ---
+--
+-- @DOC_awful_tooltip_mouse_EXAMPLE@
 --
 -- How to add the same tooltip to multiple objects?
 -- ---
@@ -229,6 +232,13 @@ end
 
 --- The horizontal alignment.
 --
+-- This is valid for the mouse mode only. For the outside mode, use
+-- `preferred_positions`.
+--
+-- @DOC_awful_tooltip_align_EXAMPLE@
+--
+-- @DOC_awful_tooltip_align2_EXAMPLE@
+--
 -- The following values are valid:
 --
 -- * top_left
@@ -242,6 +252,8 @@ end
 --
 -- @property align
 -- @see beautiful.tooltip_align
+-- @see mode
+-- @see preferred_positions
 
 --- The default tooltip alignment.
 -- @beautiful beautiful.tooltip_align
@@ -265,6 +277,9 @@ end
 
 --- The shape of the tooltip window.
 -- If the shape require some parameters, use `set_shape`.
+--
+-- @DOC_awful_tooltip_shape_EXAMPLE@
+--
 -- @property shape
 -- @see gears.shape
 -- @see set_shape
@@ -275,7 +290,6 @@ end
 -- @tparam gears.shape s The shape
 -- @see shape
 -- @see gears.shape
-
 function tooltip:set_shape(s)
     self.backgroundbox:set_shape(s)
 end
@@ -284,6 +298,14 @@ end
 -- This affects how the tooltip is placed. By default, the tooltip is `align`ed
 -- close to the mouse cursor. It is also possible to place the tooltip relative
 -- to the widget geometry.
+--
+-- **mouse:**
+--
+-- @DOC_awful_tooltip_mode_EXAMPLE@
+--
+-- **outside:**
+--
+-- @DOC_awful_tooltip_mode2_EXAMPLE@
 --
 -- Valid modes are:
 --
@@ -306,8 +328,17 @@ end
 
 --- The preferred positions when in `outside` mode.
 --
+-- @DOC_awful_tooltip_preferred_positions_EXAMPLE@
+--
 -- If the tooltip fits on multiple sides of the drawable, then this defines the
--- priority
+-- priority.
+--
+-- The valid table values are:
+--
+-- * "top"
+-- * "right"
+-- * "left"
+-- * "bottom"
 --
 -- The default is:
 --
@@ -315,6 +346,9 @@ end
 --
 -- @property preferred_positions
 -- @tparam table preferred_positions The position, ordered by priorities
+-- @see align
+-- @see mode
+-- @see preferred_alignments
 
 function tooltip:get_preferred_positions()
     return self._private.preferred_positions or
@@ -327,6 +361,36 @@ function tooltip:set_preferred_positions(value)
     set_geometry(self)
 end
 
+--- The preferred alignment when using the `outside` mode.
+--
+-- The values of the table are ordered by priority, the first one that fits
+-- will be used.
+--
+-- **front:**
+--
+-- @DOC_awful_tooltip_preferred_alignment_EXAMPLE@
+--
+-- **middle:**
+--
+-- @DOC_awful_tooltip_preferred_alignment2_EXAMPLE@
+--
+-- **back:**
+--
+-- @DOC_awful_tooltip_preferred_alignment3_EXAMPLE@
+--
+-- The valid table values are:
+--
+-- * front
+-- * middle
+-- * back
+--
+-- The default is:
+--
+--    {"front", "back", "middle"}
+--
+-- @property preferred_alignments
+-- @param string
+-- @see preferred_positions
 
 function tooltip:get_preferred_alignments()
     return self._private.preferred_alignments or
@@ -383,6 +447,8 @@ end
 
 --- Set all margins around the tooltip textbox
 --
+-- @DOC_awful_tooltip_margins_EXAMPLE@
+--
 -- @property margins
 -- @tparam tooltip self A tooltip object
 -- @tparam number New margins value
@@ -391,17 +457,31 @@ function tooltip:set_margins(val)
     self.marginbox:set_margins(val)
 end
 
+--- The border width.
+--
+-- @DOC_awful_tooltip_border_width_EXAMPLE@
+--
+-- @property border_width
+-- @param number
 
 function tooltip:set_border_width(val)
     self.widget.shape_border_width = val
 end
 
+--- The border color.
+--
+-- @DOC_awful_tooltip_border_color_EXAMPLE@
+--
+-- @property border_color
+-- @param gears.color
 
 function tooltip:set_border_color(val)
     self.widget.shape_border_color = val
 end
 
 --- Set the margins around the left and right of the tooltip textbox
+--
+-- @DOC_awful_tooltip_margins_leftright_EXAMPLE@
 --
 -- @property margins_leftright
 -- @tparam tooltip self A tooltip object
@@ -418,6 +498,8 @@ function tooltip:set_margins_leftright(val)
 end
 
 --- Set the margins around the top and bottom of the tooltip textbox
+--
+-- @DOC_awful_tooltip_margins_topbottom_EXAMPLE@
 --
 -- @property margins_topbottom
 -- @tparam tooltip self A tooltip object

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -124,6 +124,7 @@ local function apply_outside_mode(self)
     local _, position = a_placement.next_to(w, {
         geometry            = self._private.widget_geometry,
         preferred_positions = self.preferred_positions,
+        preferred_anchors   = self.preferred_alignments,
         honor_workarea      = true,
     })
 
@@ -322,6 +323,18 @@ end
 
 function tooltip:set_preferred_positions(value)
     self._private.preferred_positions = value
+
+    set_geometry(self)
+end
+
+
+function tooltip:get_preferred_alignments()
+    return self._private.preferred_alignments or
+        {"front", "back", "middle"}
+end
+
+function tooltip:set_preferred_alignments(value)
+    self._private.preferred_alignments = value
 
     set_geometry(self)
 end

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -398,8 +398,13 @@ end
 -- @tparam number New margins value
 
 function tooltip:set_margin_leftright(val)
-    self.marginbox.left = val
-    self.marginbox.right = val
+    self.marginbox:set_left(val)
+    self.marginbox:set_right(val)
+end
+
+--TODO v5 deprecate this
+function tooltip:set_margins_leftright(val)
+    self:set_margin_leftright(val)
 end
 
 --- Set the margins around the top and bottom of the tooltip textbox
@@ -409,8 +414,13 @@ end
 -- @tparam number New margins value
 
 function tooltip:set_margin_topbottom(val)
-    self.marginbox.top = val
-    self.marginbox.bottom = val
+    self.marginbox:set_top(val)
+    self.marginbox:set_bottom(val)
+end
+
+--TODO v5 deprecate this
+function tooltip:set_margins_topbottom(val)
+    self:set_margin_topbottom(val)
 end
 
 --- Add tooltip to an object.

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -532,7 +532,7 @@ function tooltip.new(args)
         function self.show(other, geo)
             -- Auto detect clients and wiboxes
             if other.drawable or other.pid then
-                geo = other:geometry()
+                geo = other
             end
 
             -- Cache the geometry in case it is needed later

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -253,6 +253,10 @@ local function new(args)
     ret._drawable = wibox.drawable(w.drawable, { wibox = ret },
         "wibox drawable (" .. object.modulename(3) .. ")")
 
+    function ret._drawable.get_wibox()
+        return ret
+    end
+
     ret._drawable:_inform_visible(w.visible)
     w:connect_signal("property::visible", function()
         ret._drawable:_inform_visible(w.visible)

--- a/tests/examples/awful/placement/next_to.lua
+++ b/tests/examples/awful/placement/next_to.lua
@@ -1,0 +1,61 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local awful = { placement = require("awful.placement") }--DOC_HIDE
+screen[1]._resize {x= 0, width = 640, height=200} --DOC_HIDE
+
+local parent_client = client.gen_fake {x = 0, y = 0, width=350, height=70} --DOC_HIDE
+parent_client:_hide() --DOC_HIDE
+awful.placement.centered(client.focus) --DOC_HIDE
+parent_client:set_label("Parent client") --DOC_HIDE
+
+for _, pos in ipairs{"left", "right", "top", "bottom"} do
+    for _, anchor in ipairs{"front", "middle", "back"} do
+        local c1 = client.gen_fake {x = 0, y = 0, width=80, height=20} --DOC_HIDE
+        c1:_hide() --DOC_HIDE
+        local _,p,a = --DOC_HIDE
+        awful.placement.next_to(
+            client.focus,
+            {
+                preferred_positions = pos,
+                preferred_anchors   = anchor,
+                geometry            = parent_client,
+            }
+        )
+        c1:set_label(pos.."+"..anchor) --DOC_HIDE
+        assert(pos    == p) --DOC_HIDE
+        assert(anchor == a) --DOC_HIDE
+
+        --DOC_HIDE Make sure the border are correctly applied
+        if pos == "left" then  --DOC_HIDE
+            assert(c1.x + c1.width + 2*c1.border_width == parent_client.x) --DOC_HIDE
+        end --DOC_HIDE
+        if pos == "right" then --DOC_HIDE
+            assert(c1.x == parent_client.x+parent_client.width+2*parent_client.border_width) --DOC_HIDE
+        end --DOC_HIDE
+        if pos == "top" then --DOC_HIDE
+            assert(c1.y + c1.height + 2*c1.border_width == parent_client.y) --DOC_HIDE
+        end --DOC_HIDE
+        if pos == "bottom" then --DOC_HIDE
+            assert(c1.y == parent_client.y+parent_client.height+2*parent_client.border_width)--DOC_HIDE
+        end --DOC_HIDE
+
+        --DOC_HIDE Make sure the "children" don't overshoot the parent geometry
+        if pos ~= "right" then --DOC_HIDE
+            assert(c1.x+c1.width+2*c1.border_width--DOC_HIDE
+                <= parent_client.x+parent_client.width+2*parent_client.border_width) --DOC_HIDE
+        end --DOC_HIDE
+        if pos ~= "bottom" then --DOC_HIDE
+            assert(c1.y+c1.height+2*c1.border_width --DOC_HIDE
+                <= parent_client.y+parent_client.height+2*parent_client.border_width) --DOC_HIDE
+        end --DOC_HIDE
+        if pos ~= "left" then --DOC_HIDE
+            assert(c1.x >= parent_client.x) --DOC_HIDE
+        end --DOC_HIDE
+        if pos ~= "top"  then --DOC_HIDE
+            assert(c1.y >= parent_client.y) --DOC_HIDE
+        end --DOC_HIDE
+    end
+end
+
+return {hide_lines=true} --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/awful/tooltip/align.lua
+++ b/tests/examples/awful/tooltip/align.lua
@@ -1,0 +1,30 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 300, height = 75}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+-- mouse.coords{x=50, y= 10}
+
+    local wb = wibox {
+        width = 100, height = 44, x = 100, y = 10, visible = true, bg = "#00000000"
+    }
+
+awesome.emit_signal("refresh")
+
+for _, side in ipairs{ "top_left", "bottom_left", "top_right", "bottom_right"} do
+    local tt = awful.tooltip {
+        text = side,
+        objects = {wb},
+        mode = "mouse",
+        align = side,
+    }
+    tt.bg = beautiful.bg_normal
+end
+
+mouse.coords{x=125, y= 35}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/align2.lua
+++ b/tests/examples/awful/tooltip/align2.lua
@@ -1,0 +1,30 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 300, height = 75}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+-- mouse.coords{x=50, y= 10}
+
+    local wb = wibox {
+        width = 100, height = 44, x = 100, y = 10, visible = true, bg = "#00000000"
+    }
+
+awesome.emit_signal("refresh")
+
+for _, side in ipairs{ "left", "right", "bottom", "top" } do
+    local tt = awful.tooltip {
+        text = side,
+        objects = {wb},
+        mode = "mouse",
+        align = side,
+    }
+    tt.bg = beautiful.bg_normal
+end
+
+mouse.coords{x=125, y= 35}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/border_color.lua
+++ b/tests/examples/awful/tooltip/border_color.lua
@@ -1,0 +1,32 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 640, height = 55}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+
+-- mouse.coords{x=50, y= 10}
+
+awesome.emit_signal("refresh")
+
+local x_offset = 0
+
+for _, color in ipairs{ "#ff0000", "#00ff00", "#0000ff", "#00ffff" } do
+    local tt = awful.tooltip {
+        text = color,
+        mode = "mouse",
+        border_width = 2,
+        border_color = color,
+    }
+    tt.bg = beautiful.bg_normal
+    awesome.emit_signal("refresh")
+    tt:show()
+    awesome.emit_signal("refresh")
+    tt.wibox.x = x_offset
+    x_offset = x_offset + 640/5
+end
+
+mouse.coords{x=125, y= 0}
+-- mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/border_width.lua
+++ b/tests/examples/awful/tooltip/border_width.lua
@@ -1,0 +1,32 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 640, height = 55}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+
+-- mouse.coords{x=50, y= 10}
+
+awesome.emit_signal("refresh")
+
+local x_offset = 0
+
+for _, width in ipairs{ 1,2,4,6 } do
+    local tt = awful.tooltip {
+        text = "width: "..width,
+        mode = "mouse",
+        border_width = width,
+        border_color = beautiful.border_color,
+    }
+    tt.bg = beautiful.bg_normal
+    awesome.emit_signal("refresh")
+    tt:show()
+    awesome.emit_signal("refresh")
+    tt.wibox.x = x_offset
+    x_offset = x_offset + 640/5
+end
+
+mouse.coords{x=125, y= 0}
+-- mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/margins.lua
+++ b/tests/examples/awful/tooltip/margins.lua
@@ -1,0 +1,32 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 640, height = 55}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+
+-- mouse.coords{x=50, y= 10}
+
+awesome.emit_signal("refresh")
+
+local x_offset = 0
+
+for _, width in ipairs{ 1,2,4,6 } do
+    local tt = awful.tooltip {
+        text = "margins: "..width,
+        mode = "mouse",
+        margins = width,
+        border_color = beautiful.border_color,
+    }
+    tt.bg = beautiful.bg_normal
+    awesome.emit_signal("refresh")
+    tt:show()
+    awesome.emit_signal("refresh")
+    tt.wibox.x = x_offset
+    x_offset = x_offset + 640/5
+end
+
+mouse.coords{x=125, y= 0}
+-- mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/margins_leftright.lua
+++ b/tests/examples/awful/tooltip/margins_leftright.lua
@@ -1,0 +1,32 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 640, height = 55}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+
+-- mouse.coords{x=50, y= 10}
+
+awesome.emit_signal("refresh")
+
+local x_offset = 0
+
+for _, width in ipairs{ 1,2,4,6 } do
+    local tt = awful.tooltip {
+        text = "margins: "..width,
+        mode = "mouse",
+        margins_leftright = width,
+        border_color = beautiful.border_color,
+    }
+    tt.bg = beautiful.bg_normal
+    awesome.emit_signal("refresh")
+    tt:show()
+    awesome.emit_signal("refresh")
+    tt.wibox.x = x_offset
+    x_offset = x_offset + 640/5
+end
+
+mouse.coords{x=125, y= 0}
+-- mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/margins_topbottom.lua
+++ b/tests/examples/awful/tooltip/margins_topbottom.lua
@@ -1,0 +1,32 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 640, height = 55}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+
+-- mouse.coords{x=50, y= 10}
+
+awesome.emit_signal("refresh")
+
+local x_offset = 0
+
+for _, width in ipairs{ 1,2,4,6 } do
+    local tt = awful.tooltip {
+        text = "margins: "..width,
+        mode = "mouse",
+        margins_topbottom = width,
+        border_color = beautiful.border_color,
+    }
+    tt.bg = beautiful.bg_normal
+    awesome.emit_signal("refresh")
+    tt:show()
+    awesome.emit_signal("refresh")
+    tt.wibox.x = x_offset
+    x_offset = x_offset + 640/5
+end
+
+mouse.coords{x=125, y= 0}
+-- mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/mode.lua
+++ b/tests/examples/awful/tooltip/mode.lua
@@ -1,0 +1,23 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 200, height = 100}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+mouse.coords{x=50, y= 10}
+
+    local wb = wibox {width = 100, height = 44, x = 50, y = 25, visible = true}
+
+awesome.emit_signal("refresh")
+local tt = awful.tooltip {
+    text = "A tooltip!",
+    objects = {wb},
+}
+tt.bg = beautiful.bg_normal
+
+mouse.coords{x=75, y= 35}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/mode2.lua
+++ b/tests/examples/awful/tooltip/mode2.lua
@@ -1,0 +1,24 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 200, height = 100}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+mouse.coords{x=50, y= 10}
+
+    local wb = wibox {width = 100, height = 44, x = 50, y = 25, visible = true}
+
+awesome.emit_signal("refresh")
+local tt = awful.tooltip {
+    text = "A tooltip!",
+    objects = {wb},
+    mode = "outside",
+}
+tt.bg = beautiful.bg_normal
+
+mouse.coords{x=75, y= 35}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/mouse.lua
+++ b/tests/examples/awful/tooltip/mouse.lua
@@ -1,0 +1,20 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+screen[1]._resize {width = 200, height = 50} --DOC_HIDE
+screen.no_outline = true --DOC_HIDE
+local awful = {tooltip = require("awful.tooltip")} --DOC_HIDE
+local beautiful = require("beautiful") --DOC_HIDE
+
+mouse.coords{x=50, y= 10} --DOC_HIDE
+mouse.push_history() --DOC_HIDE
+
+    local tt = awful.tooltip {
+        text = "A tooltip!",
+        visible = true,
+    }
+
+--DOC_NEWLINE
+
+    tt.bg = beautiful.bg_normal
+
+--DOC_NEWLINE

--- a/tests/examples/awful/tooltip/preferred_alignment.lua
+++ b/tests/examples/awful/tooltip/preferred_alignment.lua
@@ -1,0 +1,29 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 300, height = 150}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+-- mouse.coords{x=50, y= 10}
+
+    local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
+
+awesome.emit_signal("refresh")
+
+for _, side in ipairs{ "left", "right", "bottom", "top" } do
+    local tt = awful.tooltip {
+        text = side,
+        objects = {wb},
+        mode = "outside",
+        preferred_positions = {side},
+        preferred_alignments = {"front"},
+    }
+    tt.bg = beautiful.bg_normal
+end
+
+mouse.coords{x=125, y= 75}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/preferred_alignment2.lua
+++ b/tests/examples/awful/tooltip/preferred_alignment2.lua
@@ -1,0 +1,29 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 300, height = 150}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+-- mouse.coords{x=50, y= 10}
+
+    local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
+
+awesome.emit_signal("refresh")
+
+for _, side in ipairs{ "left", "right", "bottom", "top" } do
+    local tt = awful.tooltip {
+        text = side,
+        objects = {wb},
+        mode = "outside",
+        preferred_positions = {side},
+        preferred_alignments = {"middle"},
+    }
+    tt.bg = beautiful.bg_normal
+end
+
+mouse.coords{x=125, y= 75}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/preferred_alignment3.lua
+++ b/tests/examples/awful/tooltip/preferred_alignment3.lua
@@ -1,0 +1,29 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 300, height = 150}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+-- mouse.coords{x=50, y= 10}
+
+    local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
+
+awesome.emit_signal("refresh")
+
+for _, side in ipairs{ "left", "right", "bottom", "top" } do
+    local tt = awful.tooltip {
+        text = side,
+        objects = {wb},
+        mode = "outside",
+        preferred_positions = {side},
+        preferred_alignments = {"back"},
+    }
+    tt.bg = beautiful.bg_normal
+end
+
+mouse.coords{x=125, y= 75}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/preferred_positions.lua
+++ b/tests/examples/awful/tooltip/preferred_positions.lua
@@ -1,0 +1,28 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 300, height = 150}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local wibox = require("wibox")
+
+-- mouse.coords{x=50, y= 10}
+
+    local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
+
+awesome.emit_signal("refresh")
+
+for _, side in ipairs{ "left", "right", "bottom", "top" } do
+    local tt = awful.tooltip {
+        text = side,
+        objects = {wb},
+        mode = "outside",
+        preferred_positions = {side},
+    }
+    tt.bg = beautiful.bg_normal
+end
+
+mouse.coords{x=125, y= 75}
+mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/shape.lua
+++ b/tests/examples/awful/tooltip/shape.lua
@@ -1,0 +1,34 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+screen[1]._resize {width = 640, height = 55}
+screen.no_outline = true
+local awful = {tooltip = require("awful.tooltip")}
+local beautiful = require("beautiful")
+local gears = {shape = require("gears.shape")}
+
+-- mouse.coords{x=50, y= 10}
+
+awesome.emit_signal("refresh")
+
+local x_offset = 0
+
+for _, shape in ipairs{ "rounded_rect", "rounded_bar", "octogon", "infobubble"} do
+    local tt = awful.tooltip {
+        text = shape,
+        mode = "mouse",
+        border_width = 2,
+        shape = gears.shape[shape],
+        border_color = beautiful.border_color,
+    }
+    tt.bg = beautiful.bg_normal
+    awesome.emit_signal("refresh")
+    tt:show()
+    awesome.emit_signal("refresh")
+    tt.wibox.x = x_offset
+    x_offset = x_offset + 640/5
+end
+
+mouse.coords{x=125, y= 0}
+-- mouse.push_history()
+awesome.emit_signal("refresh")

--- a/tests/examples/awful/tooltip/textclock.lua
+++ b/tests/examples/awful/tooltip/textclock.lua
@@ -1,0 +1,31 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+screen[1]._resize {width = 300, height = 75} --DOC_HIDE
+local awful = {tooltip = require("awful.tooltip"), wibar = require("awful.wibar")} --DOC_HIDE
+local wibox = { widget = { textclock = require("wibox.widget.textclock") }, --DOC_HIDE
+    layout = { align = require("wibox.layout.align") } } --DOC_HIDE
+
+    local mytextclock = wibox.widget.textclock()
+
+--DOC_NEWLINE
+
+local wb = awful.wibar { position = "top" } --DOC_HIDE
+
+wb:setup { layout = wibox.layout.align.horizontal, --DOC_HIDE
+    nil, nil, mytextclock} --DOC_HIDE
+
+awesome.emit_signal("refresh") --DOC_HIDE the hierarchy is async
+
+    local myclock_t = awful.tooltip {
+        objects        = { mytextclock },
+        timer_function = function()
+            return os.date("Today is %A %B %d %Y\nThe time is %T")
+        end,
+    }
+
+awesome.emit_signal("refresh") --DOC_HIDE
+
+mouse.coords{x=250, y= 10} --DOC_HIDE
+mouse.push_history() --DOC_HIDE
+
+assert(myclock_t.wibox and myclock_t.wibox.visible) --DOC_HIDE

--- a/tests/examples/awful/tooltip/textclock2.lua
+++ b/tests/examples/awful/tooltip/textclock2.lua
@@ -1,0 +1,32 @@
+--DOC_GEN_IMAGE
+--DOC_NO_USAGE
+screen[1]._resize {width = 300, height = 75} --DOC_HIDE
+local awful = {tooltip = require("awful.tooltip"), wibar = require("awful.wibar")} --DOC_HIDE
+local wibox = { widget = { textclock = require("wibox.widget.textclock") }, --DOC_HIDE
+    layout = { align = require("wibox.layout.align") } } --DOC_HIDE
+
+    local mytextclock = wibox.widget.textclock()
+
+--DOC_NEWLINE
+
+local wb = awful.wibar { position = "top" } --DOC_HIDE
+
+wb:setup { layout = wibox.layout.align.horizontal, --DOC_HIDE
+    nil, nil, mytextclock} --DOC_HIDE
+
+awesome.emit_signal("refresh") --DOC_HIDE the hierarchy is async
+
+    local myclock_t = awful.tooltip { }
+--DOC_NEWLINE
+    myclock_t:add_to_object(mytextclock)
+--DOC_NEWLINE
+    mytextclock:connect_signal("mouse::enter", function()
+        myclock_t.text = os.date("Today is %A %B %d %Y\nThe time is %T")
+    end)
+
+awesome.emit_signal("refresh") --DOC_HIDE
+
+mouse.coords{x=250, y= 10} --DOC_HIDE
+mouse.push_history() --DOC_HIDE
+
+assert(myclock_t.wibox and myclock_t.wibox.visible) --DOC_HIDE

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -63,6 +63,9 @@ end
 -- Always show deprecated messages
 awesome.version = "v9999"
 
+-- SVG are composited. Without it we need a root surface
+awesome.composite_manager_running = true
+
 return awesome
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/shims/drawin.lua
+++ b/tests/examples/shims/drawin.lua
@@ -11,6 +11,10 @@ local function new_drawin(_, args)
     ret.y=0
     ret.width=1
     ret.height=1
+    ret.border_width=0
+    ret.ontop = false
+    ret.below = false
+    ret.above = false
 
     ret.geometry = function(_, new)
         new = new or {}

--- a/tests/examples/shims/drawin.lua
+++ b/tests/examples/shims/drawin.lua
@@ -2,6 +2,7 @@ local gears_obj = require("gears.object")
 
 local drawin, meta = awesome._shim_fake_class()
 local drawins = setmetatable({}, {__mode="v"})
+local cairo = require("lgi").cairo
 
 local function new_drawin(_, args)
     local ret = gears_obj()
@@ -29,6 +30,11 @@ local function new_drawin(_, args)
             height = ret.height
         }
     end
+
+    ret.data.drawable.valid    = true
+    ret.data.drawable.surface  = cairo.ImageSurface(cairo.Format.ARGB32, 0, 0)
+    ret.data.drawable.geometry = ret.geometry
+    ret.data.drawable.refresh  = function() end
 
     for _, k in pairs{ "buttons", "struts", "get_xproperty", "set_xproperty" } do
         ret[k] = function() end


### PR DESCRIPTION
Imported from the popup PR. The heisenbug is gone and should not come back. This PR also add a new commit that adds images to the tooltip doc. It should now be easier to spot regression.

Finally, it add some more code to the shims to make `mouse::enter` and `mouse::move` work.