### PR TITLE
A better run_or_raise/spawn.once/singleton API

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1140,6 +1140,7 @@ end
 --   If it is a function, it will be called with the client as argument.
 -- @see awful.spawn.once
 -- @see awful.spawn.single_instance
+-- @see awful.spawn.raise_or_spawn
 --
 -- @deprecated awful.client.run_or_raise
 -- @usage -- run or raise urxvt (perhaps, with tabs) on modkey + semicolon

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -8,7 +8,7 @@
 
 -- Grab environment we need
 local gdebug = require("gears.debug")
-local spawn = require("awful.spawn")
+local spawn = nil --TODO v5 deprecate
 local set_shape = require("awful.client.shape").update.all
 local object = require("gears.object")
 local grect = require("gears.geometry").rectangle
@@ -1138,8 +1138,10 @@ end
 -- @tparam bool|function merge If true then merge tags (select the client's
 --   first tag additionally) when the client is not visible.
 --   If it is a function, it will be called with the client as argument.
+-- @see awful.spawn.once
+-- @see awful.spawn.single_instance
 --
--- @function awful.client.run_or_raise
+-- @deprecated awful.client.run_or_raise
 -- @usage -- run or raise urxvt (perhaps, with tabs) on modkey + semicolon
 -- awful.key({ modkey, }, 'semicolon', function ()
 --     local matcher = function (c)
@@ -1148,6 +1150,10 @@ end
 --     awful.client.run_or_raise('urxvt', matcher)
 -- end);
 function client.run_or_raise(cmd, matcher, merge)
+    gdebug.deprecate("Use awful.spawn.single_instance instead of"..
+        "awful.client.run_or_raise", {deprecated_in=5})
+
+    spawn = spawn or require("awful.spawn")
     local clients = capi.client.get()
     local findex  = gtable.hasitem(clients, capi.client.focus) or 1
     local start   = gmath.cycle(#clients, findex + 1)

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -16,6 +16,7 @@ local aplace = require("awful.placement")
 local asuit = require("awful.layout.suit")
 local beautiful = require("beautiful")
 local alayout = require("awful.layout")
+local atag = require("awful.tag")
 
 local ewmh = {
     generic_activate_filters    = {},
@@ -83,6 +84,10 @@ end
 -- @tparam string context The context where this signal was used.
 -- @tparam[opt] table hints A table with additional hints:
 -- @tparam[opt=false] boolean hints.raise should the client be raised?
+-- @tparam[opt=false] boolean hints.switch_to_tag should the client's first tag
+--  be selected if none of the client's tags are selected?
+-- @tparam[opt=false] boolean hints.switch_to_tags Select all tags associated
+--  with the client.
 function ewmh.activate(c, context, hints) -- luacheck: no unused args
     hints = hints or  {}
 
@@ -121,11 +126,17 @@ function ewmh.activate(c, context, hints) -- luacheck: no unused args
         return
     end
 
-    if hints and hints.raise then
+    if hints.raise then
         c:raise()
         if not awesome.startup and not c:isvisible() then
             c.urgent = true
         end
+    end
+
+    -- The rules use `switchtotag`. For consistency and code re-use, support it,
+    -- but keep undocumented.
+    if hints.switchtotag or hints.switch_to_tag or hints.switch_to_tags then
+        atag.viewmore(c:tags(), c.screen, (not hints.switch_to_tags) and 0 or nil)
     end
 end
 

--- a/lib/awful/ewmh.lua
+++ b/lib/awful/ewmh.lua
@@ -134,7 +134,7 @@ function ewmh.activate(c, context, hints) -- luacheck: no unused args
     end
 
     -- The rules use `switchtotag`. For consistency and code re-use, support it,
-    -- but keep undocumented.
+    -- but keep undocumented. --TODO v5 remove switchtotag
     if hints.switchtotag or hints.switch_to_tag or hints.switch_to_tags then
         atag.viewmore(c:tags(), c.screen, (not hints.switch_to_tags) and 0 or nil)
     end

--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -15,7 +15,7 @@
 -- * honor_workarea
 -- * tag
 -- * new_tag
--- * switchtotag
+-- * switch_to_tags (also called switchtotag)
 -- * focus
 -- * titlebars_enabled
 -- * callback
@@ -83,7 +83,7 @@ If you want to put Emacs on a specific tag at startup, and immediately switch
 to that tag you can add:
 
     { rule = { class = "Emacs" },
-      properties = { tag = mytagobject, switchtotag = true } }
+      properties = { tag = mytagobject, switch_to_tags = true } }
 
 If you want to apply a custom callback to execute when a rule matched,
 for example to pause playing music from mpd when you start dosbox, you
@@ -477,7 +477,7 @@ rules.high_priority_properties = {}
 -- @tfield table awful.rules.delayed_properties
 -- By default, the table has the following functions:
 --
--- * switchtotag
+-- * switch_to_tags
 rules.delayed_properties = {}
 
 local force_ignore = {
@@ -511,9 +511,15 @@ function rules.high_priority_properties.tag(c, value, props)
     end
 end
 
-function rules.delayed_properties.switchtotag(c, value)
+function rules.delayed_properties.switch_to_tags(c, value)
     if not value then return end
     atag.viewmore(c:tags(), c.screen)
+end
+
+function rules.delayed_properties.switchtotag(c, value)
+    gdebug.deprecate("Use switch_to_tags instead of switchtotag", {deprecated_in=5})
+
+    rules.delayed_properties.switch_to_tags(c, value)
 end
 
 function rules.extra_properties.geometry(c, _, props)

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -1281,19 +1281,39 @@ function tag.viewonly(t)
 end
 
 --- View only a set of tags.
+--
+-- If `maximum` is set, there will be a limit on the number of new tag being
+-- selected. The tags already selected do not count. To do nothing if one or
+-- more of the tags are already selected, set `maximum` to zero.
+--
 -- @function awful.tag.viewmore
 -- @param tags A table with tags to view only.
 -- @param[opt] screen The screen of the tags.
-function tag.viewmore(tags, screen)
+-- @tparam[opt=#tags] number maximum The maximum number of tags to select.
+function tag.viewmore(tags, screen, maximum)
+    maximum = maximum or #tags
+    local selected = 0
     screen = get_screen(screen or ascreen.focused())
     local screen_tags = screen.tags
     for _, _tag in ipairs(screen_tags) do
         if not gtable.hasitem(tags, _tag) then
             _tag.selected = false
+        elseif _tag.selected then
+            selected = selected + 1
         end
     end
     for _, _tag in ipairs(tags) do
-        _tag.selected = true
+        if selected == 0 and maximum == 0 then
+            _tag.selected = true
+            break
+        end
+
+        if selected >= maximum then break end
+
+        if not _tag.selected then
+            selected = selected + 1
+            _tag.selected = true
+        end
     end
     screen:emit_signal("tag::history::update")
 end

--- a/lib/gears/table.lua
+++ b/lib/gears/table.lua
@@ -18,7 +18,7 @@ local gtable = {}
 -- @return A new table containing all keys from the arguments.
 function gtable.join(...)
     local ret = {}
-    for _, t in pairs({...}) do
+    for _, t in ipairs({...}) do
         if t then
             for k, v in pairs(t) do
                 if type(k) == "number" then

--- a/tests/test-awful-rules.lua
+++ b/tests/test-awful-rules.lua
@@ -292,11 +292,11 @@ assert(not awful.rules.add_rule_source("invalid_source", function()
 end, {"awful.rules"}, {"awful.spawn"}))
 gears.debug.print_warning = temp
 
--- Test tag and switchtotag
+-- Test tag and switch_to_tags
 test_rule {
     properties = {
-        tag         = "9",
-        switchtotag = true
+        tag            = "9",
+        switch_to_tags = true
     },
     test = function(class)
         local c = get_client_by_class(class)
@@ -311,8 +311,8 @@ test_rule {
 }
 test_rule {
     properties = {
-        tag         = "8",
-        switchtotag = false
+        tag            = "8",
+        switch_to_tags = false
     },
     test = function(class)
         local c = get_client_by_class(class)

--- a/tests/test-urgent.lua
+++ b/tests/test-urgent.lua
@@ -72,7 +72,7 @@ local steps = {
             awful.screen.focused().tags[1]:view_only()
 
             runner.add_to_default_rules({ rule = { class = "XTerm" },
-                                        properties = { tag = "2", focus = true, switchtotag = true }})
+                                        properties = { tag = "2", focus = true, switch_to_tags = true }})
 
             awful.spawn("xterm")
 


### PR DESCRIPTION
Following a [stackoverflow](https://stackoverflow.com/questions/52523256/auto-start-programs-on-specific-screen-tags) question, I took a look at how to build a more reliable way to handle this use case. Previously, we had a wiki page with a bunch of equally unreliable solutions the user could choose to avoid each other issues. We also have `awful.client.run_or_raise` which is often useless because it doesn't integrate well with the `awful.rules`.

This commit implement the proposed solution from StackOverflow. I admit it has so far limited testing but seem to work as intended for `inkscape` and `urxvt`. I post this more as a request for comment than "lets merge this as-is". It has a bunch of limitations like weak hashing and unreliable use of startup notifications.

What could change, but I am not sure makes thing any better:

 * Get the startup clients before "manage" instead of using a `delayed_call`
 * Also use the PID and a 30 second timer to prevent re-use issues to mitigate the lack of startup_id.
 * Use the Lua `debug` API to get more information into the hash using the stack and environment 
 * Use a better hashing algorithm

They would add hacks and make the code more complex for negligible gain in reliability. The code could be cleaned up a bit more, but right now I am mostly interested in opinions.