### PR TITLE
Gracefully fail when history file is inaccessible

### DIFF
--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -211,7 +211,10 @@ local function history_save(id)
     if data.history[id] then
         gfs.make_parent_directories(id)
         local f = io.open(id, "w")
-        if not f then return end
+        if not f then
+            gdebug.print_warning("Failed to write the history to "..id)
+            return
+        end
         for i = 1, math.min(#data.history[id].table, data.history[id].max) do
             f:write(data.history[id].table[i] .. "\n")
         end

--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -110,7 +110,6 @@
 -- @see string
 
 -- Grab environment we need
-local assert = assert
 local io = io
 local table = table
 local math = math
@@ -210,8 +209,9 @@ end
 -- @param id The data.history identifier
 local function history_save(id)
     if data.history[id] then
-        assert(gfs.make_parent_directories(id))
-        local f = assert(io.open(id, "w"))
+        gfs.make_parent_directories(id)
+        local f = io.open(id, "w")
+        if not f then return end
         for i = 1, math.min(#data.history[id].table, data.history[id].max) do
             f:write(data.history[id].table[i] .. "\n")
         end


### PR DESCRIPTION
If the history file (or its parents) can't be created, running a command will fail entirely. Since saving command history is not an integral part of running a command, it would be nicer if it carried on, just without saving history. This is what shells usually do.

This patch changes removes assertions in the history saving function and instead adds an early return, so if the history isn't saved the command invocation simply carries on.

This is my first time writing Lua. I am extremely open to modifying the patch to make it more idiomatic.