### PR TITLE
signal_child: use "(void) res" to silence compiler warning

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -463,6 +463,7 @@ signal_child(int signum)
 {
     assert(signum == SIGCHLD);
     int res = write(sigchld_pipe[1], " ", 1);
+    (void) res;
     assert(res == 1);
 }
 


### PR DESCRIPTION
Fixes https://github.com/awesomeWM/awesome/issues/2418.