### PR TITLE
keygrabber: Rename release_event to stop_event

### DIFF
--- a/lib/awful/keygrabber.lua
+++ b/lib/awful/keygrabber.lua
@@ -546,10 +546,8 @@ end
 
 --TODO v5 remove this
 function keygrabber:set_release_event(event)
-    gdebug.deprecate("release_event has been renamed to stop_event",
-        -- It has never been in a release, so it can be deprecated right away
-        {deprecated_in=4}
-    )
+    -- It has never been in a release, so it can be deprecated right away
+    gdebug.deprecate("release_event has been renamed to stop_event")
 
     self.stop_event = event
 end

--- a/tests/examples/text/awful/keygrabber/alttab.lua
+++ b/tests/examples/text/awful/keygrabber/alttab.lua
@@ -16,8 +16,8 @@ local awful = {keygrabber = require("awful.keygrabber"), --DOC_HIDE
             {{"Mod1", "Shift"}, "Tab", awful.client.focus.history.select_next    },
         },
         -- Note that it is using the key name and not the modifier name.
-        stop_key        = "Alt_L",
-        release_event      = "release",
+        stop_key           = "Alt_L",
+        stop_event         = "release",
         start_callback     = awful.client.focus.history.disable_tracking,
         stop_callback      = awful.client.focus.history.enable_tracking,
         export_keybindings = true,


### PR DESCRIPTION
In the earlier revision of the keygrabber PR, there was a `release_key`
and it was suggested to rename it `stop_key`. However its sibling
`release_event` wasn't, so it is now confusing.

The commit adds a mild deprecation codepath to avoid breaking configs
based on git-master. However it isn't a "long term" deprecation notice
and the code can probably be removed in 5.0 without further delay.