### PR TITLE
fix(awful: hotkeys_popup): don't fail if _import_awful_keys hasn't been called

### DIFF
--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -323,7 +323,8 @@ function widget.new(args)
         local max_height_px = height - group_label_height
         local column_layouts = {}
         for _, group in ipairs(available_groups) do
-            local keys = gtable.join(self._cached_awful_keys[group], self._additional_hotkeys[group])
+            local cached = self._cached_awful_keys or {}
+            local keys = gtable.join(cached[group], self._additional_hotkeys[group])
             local joined_descriptions = ""
             for i, key in ipairs(keys) do
                 joined_descriptions = joined_descriptions .. key.description .. (i~=#keys and "\n" or "")


### PR DESCRIPTION
I'm using `hotkeys_popup` to show hotkey descriptions independent of the current client (I call `_create_wibox` directly).
So I end up not calling `show_help` and thus not calling `_import_awful_keys`.

Perhaps there's a better way to extend the `hotkeys_popup` interface for my use case but this change seemed innocuous enough and it's the only thing standing in the way.
