### PR TITLE
docs: update URL for vicious

### DIFF
--- a/docs/03-declarative-layout.md
+++ b/docs/03-declarative-layout.md
@@ -260,7 +260,7 @@ Code:
 
 
 In this example, the system is extended so that the popular
-[Vicious](https://github.com/Mic92/vicious) extension module can be
+[Vicious](https://github.com/vicious-widgets/vicious) extension module can be
 used directly in the layout declaration. This example will update the textbox
 every 3 seconds to show the CPU usage.
 


### PR DESCRIPTION
It has been turned into an organization [1].

1: https://github.com/vicious-widgets/vicious/issues/60

[ci skip]