### PR TITLE
Add parameters to awful.widget.prompt constructor.

### DIFF
--- a/lib/awful/widget/prompt.lua
+++ b/lib/awful/widget/prompt.lua
@@ -39,12 +39,21 @@ local function run(promptbox)
     return prompt.run {
         prompt              = promptbox.prompt,
         textbox             = promptbox.widget,
+        fg_cursor           = promptbox.fg_cursor,
+        bg_cursor           = promptbox.bg_cursor,
+        ul_cursor           = promptbox.ul_cursor,
+        font                = promptbox.font,
+        autoexec            = promptbox.autoexec,
+        highlighter         = promptbox.highlighter,
+        exe_callback        = promptbox.exe_callback,
         completion_callback = promptbox.completion_callback,
-        history_path        = gfs.get_cache_dir() .. "/history",
-        exe_callback        = function (...)
-            promptbox:spawn_and_handle_error(...)
-        end,
-        done_callback = promptbox.done_callback
+        history_path        = promptbox.history_path,
+        history_max         = promptbox.history_max,
+        done_callback       = promptbox.done_callback,
+        changed_callback    = promptbox.changed_callback,
+        keypressed_callback = promptbox.keypressed_callback,
+        keyreleased_callback = promptbox.keyreleased_callback,
+        hook                = promptbox.hook
     }
 end
 
@@ -56,16 +65,38 @@ local function spawn_and_handle_error(self, ...)
 end
 
 --- Create a prompt widget which will launch a command.
+-- For additional documentation about `args` parameter, please refer to
+-- @{awful.prompt} and @{awful.prompt.run}.
 --
 -- @tparam table args Prompt arguments.
 -- @tparam[opt="Run: "] string args.prompt Prompt text.
 -- @tparam[opt=`beautiful.prompt_bg` or `beautiful.bg_normal`] color args.bg Prompt background color.
 -- @tparam[opt=`beautiful.prompt_fg` or `beautiful.fg_normal`] color args.fg Prompt foreground color.
+-- @tparam[opt] gears.color args.fg_cursor
+-- @tparam[opt] gears.color args.bg_cursor
+-- @tparam[opt] gears.color args.ul_cursor
+-- @tparam[opt] string args.font
+-- @tparam[opt] boolean args.autoexec
+-- @tparam[opt] function args.highlighter A function to add syntax highlighting
+--   to the command.
+-- @tparam[opt] function args.exe_callback The callback function to call with
+--  command as argument when finished.
 -- @tparam[opt=`awful.completion.shell`] function args.completion_callback
 --   The callback function to call to get completion. See @{awful.prompt.run} for details.
+-- @tparam[opt=`gears.filesystem.get_cache_dir() .. '/history'`] string
+--   args.history_path File path where the history should be saved.
+-- @tparam[opt=50] integer args.history_max Set the maximum entries in history file.
 -- @tparam[opt] function args.done_callback
 --  The callback function to always call without arguments, regardless of
 --  whether the prompt was cancelled. See @{awful.prompt.run} for details.
+-- @tparam[opt] function args.changed_callback The callback function to call
+--   with command as argument when a command was changed.
+-- @tparam[opt] function args.keypressed_callback The callback function to call
+--   with mod table, key and command as arguments when a key was pressed.
+-- @tparam[opt] function args.keyreleased_callback The callback function to call
+--   with mod table, key and command as arguments when a key was pressed.
+-- @tparam[opt] table args.hook Similar to @{awful.key}. It will call a function
+--   for the matching modifiers + key. See @{awful.prompt.run} for details.
 -- @return An instance of prompt widget, inherits from `wibox.container.background`.
 -- @function awful.widget.prompt
 function widgetprompt.new(args)
@@ -78,8 +109,21 @@ function widgetprompt.new(args)
     promptbox.prompt = args.prompt or "Run: "
     promptbox.fg = args.fg or beautiful.prompt_fg or beautiful.fg_normal
     promptbox.bg = args.bg or beautiful.prompt_bg or beautiful.bg_normal
+    promptbox.fg_cursor = args.fg_cursor or nil
+    promptbox.bg_cursor = args.bg_cursor or nil
+    promptbox.ul_cursor = args.ul_cursor or nil
+    promptbox.font = args.font or nil
+    promptbox.autoexec = args.autoexec or nil
+    promptbox.highlighter = args.highlighter or nil
+    promptbox.exe_callback = args.exe_callback or function (...) promptbox:spawn_and_handle_error(...) end
     promptbox.completion_callback = args.completion_callback or completion.shell
+    promptbox.history_path = args.history_path or gfs.get_cache_dir() .. '/history'
+    promptbox.history_max = args.history_max or nil
     promptbox.done_callback = args.done_callback or nil
+    promptbox.changed_callback = args.changed_callback or nil
+    promptbox.keypressed_callback = args.keypressed_callback or nil
+    promptbox.keyreleased_callback = args.keyreleased_callback or nil
+    promptbox.hook = args.hook or nil
     return promptbox
 end
 

--- a/lib/awful/widget/prompt.lua
+++ b/lib/awful/widget/prompt.lua
@@ -5,6 +5,7 @@
 --
 -- @author Julien Danjou &lt;julien@danjou.info&gt;
 -- @copyright 2009 Julien Danjou
+-- @copyright 2018 Aire-One
 -- @classmod awful.widget.prompt
 ---------------------------------------------------------------------------
 
@@ -43,6 +44,7 @@ local function run(promptbox)
         exe_callback        = function (...)
             promptbox:spawn_and_handle_error(...)
         end,
+        done_callback = promptbox.done_callback
     }
 end
 
@@ -61,6 +63,9 @@ end
 -- @tparam[opt=`beautiful.prompt_fg` or `beautiful.fg_normal`] color args.fg Prompt foreground color.
 -- @tparam[opt=`awful.completion.shell`] function args.completion_callback
 --   The callback function to call to get completion. See @{awful.prompt.run} for details.
+-- @tparam[opt] function args.done_callback
+--  The callback function to always call without arguments, regardless of
+--  whether the prompt was cancelled. See @{awful.prompt.run} for details.
 -- @return An instance of prompt widget, inherits from `wibox.container.background`.
 -- @function awful.widget.prompt
 function widgetprompt.new(args)
@@ -74,6 +79,7 @@ function widgetprompt.new(args)
     promptbox.fg = args.fg or beautiful.prompt_fg or beautiful.fg_normal
     promptbox.bg = args.bg or beautiful.prompt_bg or beautiful.bg_normal
     promptbox.completion_callback = args.completion_callback or completion.shell
+    promptbox.done_callback = args.done_callback or nil
     return promptbox
 end
 

--- a/lib/awful/widget/prompt.lua
+++ b/lib/awful/widget/prompt.lua
@@ -37,23 +37,23 @@ local widgetprompt = { mt = {} }
 -- @param promptbox The promptbox to run.
 local function run(promptbox)
     return prompt.run {
-        prompt              = promptbox.prompt,
-        textbox             = promptbox.widget,
-        fg_cursor           = promptbox.fg_cursor,
-        bg_cursor           = promptbox.bg_cursor,
-        ul_cursor           = promptbox.ul_cursor,
-        font                = promptbox.font,
-        autoexec            = promptbox.autoexec,
-        highlighter         = promptbox.highlighter,
-        exe_callback        = promptbox.exe_callback,
-        completion_callback = promptbox.completion_callback,
-        history_path        = promptbox.history_path,
-        history_max         = promptbox.history_max,
-        done_callback       = promptbox.done_callback,
-        changed_callback    = promptbox.changed_callback,
-        keypressed_callback = promptbox.keypressed_callback,
+        prompt               = promptbox.prompt,
+        textbox              = promptbox.widget,
+        fg_cursor            = promptbox.fg_cursor,
+        bg_cursor            = promptbox.bg_cursor,
+        ul_cursor            = promptbox.ul_cursor,
+        font                 = promptbox.font,
+        autoexec             = promptbox.autoexec,
+        highlighter          = promptbox.highlighter,
+        exe_callback         = promptbox.exe_callback,
+        completion_callback  = promptbox.completion_callback,
+        history_path         = promptbox.history_path,
+        history_max          = promptbox.history_max,
+        done_callback        = promptbox.done_callback,
+        changed_callback     = promptbox.changed_callback,
+        keypressed_callback  = promptbox.keypressed_callback,
         keyreleased_callback = promptbox.keyreleased_callback,
-        hook                = promptbox.hook
+        hook                 = promptbox.hook
     }
 end
 
@@ -70,8 +70,10 @@ end
 --
 -- @tparam table args Prompt arguments.
 -- @tparam[opt="Run: "] string args.prompt Prompt text.
--- @tparam[opt=`beautiful.prompt_bg` or `beautiful.bg_normal`] color args.bg Prompt background color.
--- @tparam[opt=`beautiful.prompt_fg` or `beautiful.fg_normal`] color args.fg Prompt foreground color.
+-- @tparam[opt=`beautiful.prompt_bg` or `beautiful.bg_normal`] color args.bg
+--   Prompt background color.
+-- @tparam[opt=`beautiful.prompt_fg` or `beautiful.fg_normal`] color args.fg
+--   Prompt foreground color.
 -- @tparam[opt] gears.color args.fg_cursor
 -- @tparam[opt] gears.color args.bg_cursor
 -- @tparam[opt] gears.color args.ul_cursor
@@ -80,15 +82,17 @@ end
 -- @tparam[opt] function args.highlighter A function to add syntax highlighting
 --   to the command.
 -- @tparam[opt] function args.exe_callback The callback function to call with
---  command as argument when finished.
+--   command as argument when finished.
 -- @tparam[opt=`awful.completion.shell`] function args.completion_callback
---   The callback function to call to get completion. See @{awful.prompt.run} for details.
+--   The callback function to call to get completion. See @{awful.prompt.run}
+--   for details.
 -- @tparam[opt=`gears.filesystem.get_cache_dir() .. '/history'`] string
 --   args.history_path File path where the history should be saved.
--- @tparam[opt=50] integer args.history_max Set the maximum entries in history file.
+-- @tparam[opt=50] integer args.history_max Set the maximum entries in
+--   history file.
 -- @tparam[opt] function args.done_callback
---  The callback function to always call without arguments, regardless of
---  whether the prompt was cancelled. See @{awful.prompt.run} for details.
+--   The callback function to always call without arguments, regardless of
+--   whether the prompt was cancelled. See @{awful.prompt.run} for details.
 -- @tparam[opt] function args.changed_callback The callback function to call
 --   with command as argument when a command was changed.
 -- @tparam[opt] function args.keypressed_callback The callback function to call
@@ -97,7 +101,8 @@ end
 --   with mod table, key and command as arguments when a key was pressed.
 -- @tparam[opt] table args.hook Similar to @{awful.key}. It will call a function
 --   for the matching modifiers + key. See @{awful.prompt.run} for details.
--- @return An instance of prompt widget, inherits from `wibox.container.background`.
+-- @return An instance of prompt widget, inherits from
+--   `wibox.container.background`.
 -- @function awful.widget.prompt
 function widgetprompt.new(args)
     args = args or {}
@@ -115,9 +120,12 @@ function widgetprompt.new(args)
     promptbox.font = args.font or nil
     promptbox.autoexec = args.autoexec or nil
     promptbox.highlighter = args.highlighter or nil
-    promptbox.exe_callback = args.exe_callback or function (...) promptbox:spawn_and_handle_error(...) end
+    promptbox.exe_callback = args.exe_callback or function (...)
+        promptbox:spawn_and_handle_error(...)
+    end
     promptbox.completion_callback = args.completion_callback or completion.shell
-    promptbox.history_path = args.history_path or gfs.get_cache_dir() .. '/history'
+    promptbox.history_path = args.history_path or
+        gfs.get_cache_dir() .. 'history'
     promptbox.history_max = args.history_max or nil
     promptbox.done_callback = args.done_callback or nil
     promptbox.changed_callback = args.changed_callback or nil


### PR DESCRIPTION
Hello!

Lately, I had a few time to work on my awesomewm configs and I tried to improve my prompt widget. I don't have enough time to create my own widget so I just took the existing one on the `awful.widget` library.

To do what I wanted to do, I needed to use the `done_callback` parameter of `awful.prompt` but this parameter is not implemented in `awful.widget.prompt`. So I added it. Because it's an optional parameter of `awful.prompt`, I used `nil` as a default value and marked only `param[opt]` on the ldoc header comment.

I hope this addition can help other people.

PS 1: I'm not sure how to test widgets so I didn't do any "test script" for the addition of this parameter. Only manual testing. If it's require, please point me some documentation or examples I can use to implement tests for this specific case.

PS 2: I only implemented the `done_callback`, but if you care, I can also add the other parameters from `awful.prompt`to make a complete PR on this topic.