### PR TITLE
Create globalkeys early

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -45,6 +45,9 @@ do
 end
 -- }}}
 
+-- Define globalkeys table for later use
+globalkeys = {}
+
 -- {{{ Variable definitions
 -- @DOC_LOAD_THEME@
 -- Themes define colours, icons, font and wallpapers.
@@ -255,7 +258,7 @@ root.buttons(gears.table.join(
 
 -- {{{ Key bindings
 -- @DOC_GLOBAL_KEYBINDINGS@
-globalkeys = gears.table.join(
+globalkeys = gears.table.join(globalkeys,
     awful.key({ modkey,           }, "s",      hotkeys_popup.show_help,
               {description="show help", group="awesome"}),
     awful.key({ modkey,           }, "Left",   awful.tag.viewprev,


### PR DESCRIPTION
Allows for keys to be added in widgets created in a theme in beautiful (as per copycatz)

Consistent with line 409 (now 412)

A small step towards making rc,lua more modular

Can't see how it can hurt anyone

Personally I prefer variables to be defined/created before use (but that's just me)

Opens the possibility of splitting the huge key definition section into chunks with areas of impact

Bring on the debate ;-)