### PR TITLE
menubar.utils: Remove some (basically) dead code

### DIFF
--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -41,16 +41,6 @@ local default_icon = nil
 --- Name of the WM for the OnlyShowIn entry in the .desktop file.
 utils.wm_name = "awesome"
 
---- Possible escape characters (not including the preceding backslash) in
---.desktop files and their equates.
-local escape_sequences = {
-    [ [[\\]] ]  = [[\]],
-    [ [[\n]] ]  = '\n',
-    [ [[\r]] ]  = '\r',
-    [ [[\s]] ]  = ' ',
-    [ [[\t]] ]  = '\t',
-}
-
 -- Maps keys in desktop entries to suitable getter function.
 -- The order of entries is as in the spec.
 -- https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
@@ -226,49 +216,6 @@ function utils.rtrim(s)
         return string.sub(s, 1, #s - 1)
     end
     return s
-end
-
---- Unescape strings read from desktop files.
--- Possible sequences are \n, \r, \s, \t, \\, which have the usual meanings.
--- @tparam string s String to unescape
--- @treturn string The unescaped string
-function utils.unescape(s)
-    if not s then return end
-
-    -- Ignore the second return value of string.gsub() (number replaced)
-    s = string.gsub(s, "\\.", function(sequence)
-        return escape_sequences[sequence] or sequence
-    end)
-    return s
-end
-
---- Separate semi-colon separated lists.
--- Semi-colons in lists are escaped as '\;'.
--- @tparam string s String to parse
--- @treturn table A table containing the separated strings. Each element is
--- unescaped by utils.unescape().
-function utils.parse_list(s)
-    if not s then return end
-
-    -- Append terminating semi-colon if not already there.
-    if string.sub(s, -1) ~= ';' then
-        s = s .. ';'
-    end
-
-    local segments = {}
-    local part = ""
-    -- Iterate over sub-strings between semicolons
-    for word, backslashes in string.gmatch(s, "([^;]-(\\*));") do
-        if #backslashes % 2 ~= 0 then
-            -- The semicolon was escaped, remember this part for later
-            part = part .. word:sub(1, -2) .. ";"
-        else
-            table.insert(segments, utils.unescape(part .. word))
-            part = ""
-        end
-    end
-
-    return segments
 end
 
 --- Lookup an icon in different folders of the filesystem.

--- a/spec/menubar/utils_spec.lua
+++ b/spec/menubar/utils_spec.lua
@@ -7,51 +7,6 @@ local utils = require("menubar.utils")
 local theme = require("beautiful")
 local glib = require("lgi").GLib
 
-describe("menubar.utils unescape", function()
-    local single_strings = {
-        [ [[\n:\r:\s:\t:\\]] ] = "\n:\r: :\t:\\",
-        -- Make sure escapes are not read recursively
-        [ [[\\s]] ] = [[\s]],
-        -- Make sure ';' is not escaped for non-list strings and other
-        -- characters are not escaped
-        [ [[ab\c\;1\23]] ] = [[ab\c\;1\23]],
-    }
-
-    for escaped, unescaped in pairs(single_strings) do
-        it(escaped, function()
-            assert.is.equal(unescaped, utils.unescape(escaped))
-        end)
-    end
-
-    local list_strings = {
-        -- Normal list
-        [ [[abc;123;xyz]] ] = { "abc", "123", "xyz" },
-        -- Optional terminating semicolon
-        [ [[abc;123;xyz;]] ] = { "abc", "123", "xyz" },
-        -- Blank item
-        [ [[abc;;123]] ] = { "abc", "", "123" },
-        -- Trailing whitespace
-        [ [[abc;123;   ]] ] = { "abc", "123", "   " },
-        -- Escape semicolon
-        [ [[abc\;;12\;3;\;xyz]] ] = { "abc;", "12;3", ";xyz" },
-        -- Normal escapes are parsed like normal
-        [ [[ab\c;1\s23;x\\yz]] ] = { "ab\\c", "1 23", "x\\yz" },
-        -- Escaped backslashes before semicolon
-        [ [[abc\\\;;12\\;3;xyz]] ] = { "abc\\;", "12\\", "3", "xyz" },
-    }
-
-    for escaped, unescaped in pairs(list_strings) do
-        it(escaped, function()
-            local returned = utils.parse_list(escaped)
-            assert.is.equal(#unescaped, #returned)
-
-            for i = 1, #unescaped do
-                assert.is.equal(unescaped[i], returned[i])
-            end
-        end)
-    end
-end)
-
 describe("menubar.utils lookup_icon_uncached", function()
     local shimmed = {}
     local icon_theme


### PR DESCRIPTION
This removes unused public functions from menubar.utils. This is not an
API break, because these functions were only added in commit
8d34201ec3dd76ce9d8, which is after v4.2. These new functions became
unused in commit e88f1e873594bf, not long after they were added.

Signed-off-by: Uli Schlachter <psychon@znc.in>