### PR TITLE
Fix c.requests_no_titlebar

### DIFF
--- a/docs/05-awesomerc.md.lua
+++ b/docs/05-awesomerc.md.lua
@@ -221,7 +221,7 @@ sections.DOC_TITLEBARS = [[
 sections.DOC_CSD_TITLEBARS = [[
  For client side decorations, clients might request no titlebars via
  Motif WM hints. To honor these hints, use:
- `titlebars_enabled = function(c) return c.requests_no_titlebar end`
+ `titlebars_enabled = function(c) return not c.requests_no_titlebar end`
 
  See `client.requests_no_titlebar` for more details.
 ]]

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1144,7 +1144,7 @@ function client.object.get_requests_no_titlebar(c)
     local hints = c.motif_wm_hints
     if not hints then return false end
 
-    local decor = hints.deocrations
+    local decor = hints.decorations
     if not decor then return false end
 
     local result = not decor.title


### PR DESCRIPTION
The `c.requests_no_titlebar` property was always false because of a typo. I fixed this and added some tests for it, and also fixed a wrong example in documentation.

The test for the first commit is supposed to fail, but I want to be sure it actually fails in the CI environment; after the test completes, I will push commits in a different order so that there will be no test failures.