### PR TITLE
Add signal to call `rules.apply` when a window redefine its class property.

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -737,7 +737,19 @@ function rules.completed_with_payload_callback(c, props, callbacks)
     rules.execute(c, props, callbacks)
 end
 
-client.connect_signal("manage", rules.apply)
+client.connect_signal("manage", function (c)
+    -- Some applications (like Spotify) does not respect ICCCM rules correctly
+    -- and redefine the window class property.
+    -- This leads to having window which does *NOT* follow the user rules
+    -- defined in the table `awful.rules.rules`.
+    c:connect_signal("property::class", rules.apply)
+
+    rules.apply(c)
+end)
+
+client.connect_signal("unmanage", function (c)
+    c:disconnect_signal("property::class", rules.apply)
+end)
 
 return rules
 


### PR DESCRIPTION
This PR is to open discussions in the issue of Electron apps and rules in awesome wm.

# Basics

Last week, in "[This week in Usability & Productivity](https://pointieststick.wordpress.com/2018/11/11/this-week-in-usability-productivity-part-44/)" post, they mentioned KWin fixed the bug causing Electron apps to not follow window rules.

Here is the bugfix message:
> KWin window rules now work for Electron apps and other apps that change their window class during operation.

And here is the link to the merge thread in the KDE phabricator server: https://phabricator.kde.org/D16670#change-JBK9w4EqumD4

This bug is also present in awesome. Applications build with the Electron framework does not follow window rules defined by the user in the table `awful.rules.rules`.
In this PR, I propose a fix based on the solution implemented by KDE.

# Fix proposal and discussions

Based on the code from KDE, I wrote a fix in this PR. The following will be some discussions about what I wrote.

The basic idea of the fix is to attach a signal to the change of the window's `wm_class` property. With awesome it basically translates to something like this:

```lua
client.connect_signal("property::class", rules.apply)
```

To prevent multiple call of `awful.rules.apply` when a client sets its `wm_class` at its creation, this signal should only be set when the client is attached to awesome. That's why I put it in the `manage` signal defined in `awful.rules`.

Also, I disconnect this signal when the client get unmanaged. I'm not realy sure this is useful given that a client get unmanaged when it's deleted/closed. (I don't see any other case, maybe I'm wrong)

A quick explanation about why I call `c:connect_signal("property::class", rules.apply)` before `rules.apply(c)` in the client's managed signal callback. It's a trick I found to make Spotify not blinking.
Basically, I have a rule for Spotify to open on a specific tag. But the window has the time to appear on the screen just before awesome handles the `wm_class` change and calls again the `rules.apply` method. It also causes the destination tag to not appears as urgent.
This trick seams to fix this behavior.

# Unit tests

I tryed to do some unit tests but I'm actually stuck. Here is what I wrote so far in `tests/test-awful-rules.lua`:

```lua
test_rule {
    properties = {
        tag = "2"
    },
    test = function(class)
        local c = get_client_by_class(class)
        -- Make sure C-API properties are applied

        local new_class = "class_changed"
        local new_tag = "3"

        -- First, check the client follow initial rules
        assert(c:tags()[1].name == "2")

        -- Insert new rules for a specified wm_class
        table.insert(awful.rules.rules, {
            rule = { class =  new_class },
            properties = { screen = 1, tag = new_tag }
        })

        -- Change the client class
        c.class = new_class

        -- Test rules application
        assert(c:tags()[1].name == new_class)

        return true
    end
}
```

The problem is: the assertion to check if the rules are applied following the client `wm_class` change is automatically always false because awesome can't handle the event and so can't call the signal in this situation.

---

I hope my work can help doing something to fix this issue.
