### PR TITLE
Making Tor Browser a floating window by default.

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -504,10 +504,10 @@ awful.rules.rules = {
           "Kruler",
           "MessageWin",  -- kalarm.
           "Sxiv",
+          "Tor Browser", -- Needs a fixed window size to avoid fingerprinting by screen size.
           "Wpa_gui",
           "veromix",
-          "xtightvncviewer",
-          "Tor Browser"},
+          "xtightvncviewer"},
 
         -- Note that the name property shown in xprop might be set slightly after creation of the client
         -- and the name shown there might not match defined rules here.

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -506,7 +506,8 @@ awful.rules.rules = {
           "Sxiv",
           "Wpa_gui",
           "veromix",
-          "xtightvncviewer"},
+          "xtightvncviewer",
+          "Tor Browser"},
 
         -- Note that the name property shown in xprop might be set slightly after creation of the client
         -- and the name shown there might not match defined rules here.


### PR DESCRIPTION
Tor Browser uses a default window size to make its users indistinguishable. Overriding this default window size is a privacy risk for Awesome's users. (Details at [issue #2504 at awesomeWM](https://github.com/awesomeWM/awesome/issues/2504)