### PR TITLE
New theme API groundwork

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -163,7 +163,7 @@ local tasklist_buttons = gears.table.join(
                                           end))
 
 -- @DOC_WALLPAPER@
-local function set_wallpaper(s)
+screen.connect_signal("request::wallpaper", function(s)
     -- Wallpaper
     if beautiful.wallpaper then
         local wallpaper = beautiful.wallpaper
@@ -173,16 +173,10 @@ local function set_wallpaper(s)
         end
         gears.wallpaper.maximized(wallpaper, s, true)
     end
-end
-
--- Re-set wallpaper when a screen's geometry changes (e.g. different resolution)
-screen.connect_signal("property::geometry", set_wallpaper)
+end)
 
 -- @DOC_FOR_EACH_SCREEN@
-awful.screen.connect_for_each_screen(function(s)
-    -- Wallpaper
-    set_wallpaper(s)
-
+screen.connect_signal("request::desktop_decoration", function(s)
     -- Each screen has its own tag table.
     awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.layouts[1])
 

--- a/docs/89-NEWS.md
+++ b/docs/89-NEWS.md
@@ -14,6 +14,9 @@ This document was last updated at commit v4.3-148-g795c792d1.
 
 ## New features
 
+* `awful.screen` now has a `request::wallpaper` and a
+  `request::desktop_decoration` signal. They make some workflow implementation
+  cleaner.
 * Lua code can interact with the selection contents via the new
   `selection.acquire`, `selection.getter`, and `selection.watcher` objects
 * Pending delayed calls (`gears.timer.delayed_call`) can be dispatched via

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -602,6 +602,54 @@ function screen.object.set_dpi(s, dpi)
     s.data.dpi = dpi
 end
 
+--- Emitted when a new screen is added.
+--
+-- The handler(s) of this signal are responsible of adding elements such as
+-- bars, docks or other elements to a screen. The signal is emitted when a
+-- screen is added, including during startup.
+--
+-- The only default implementation is the one provided by `rc.lua`.
+--
+-- @signal request::desktop_decoration
+-- @tparam screen s The screen object.
+
+--- Emitted when a new screen needs a wallpaper.
+--
+-- The handler(s) of this signal are responsible to set the wallpaper. The
+-- signal is emitted when a screen is added (including at startup), when its
+-- DPI changes or when its geometry changes.
+--
+-- The only default implementation is the one provided by `rc.lua`.
+--
+-- @signal request::wallpaper
+-- @tparam screen s The screen object.
+
+-- Set the wallpaper(s) and create the bar(s) for new screens
+capi.screen.connect_signal("added", function(s)
+    s:emit_signal("request::desktop_decoration")
+    s:emit_signal("request::wallpaper")
+end)
+
+-- Resize the wallpaper(s)
+for _, prop in ipairs {"geometry", "dpi" } do
+    capi.screen.connect_signal("property::"..prop, function(s)
+        s:emit_signal("request::wallpaper")
+    end)
+end
+
+-- Create the bar for existing screens when an handler is added
+capi.screen.connect_signal("request::desktop_decoration::connected", function(new_handler)
+    for s in capi.screen do
+        new_handler(s)
+    end
+end)
+
+-- Set the wallpaper when an handler is added.
+capi.screen.connect_signal("request::wallpaper::connected", function(new_handler)
+    for s in capi.screen do
+        new_handler(s)
+    end
+end)
 
 --- When the tag history changed.
 -- @signal tag::history::update

--- a/spec/awful/screen_spec.lua
+++ b/spec/awful/screen_spec.lua
@@ -6,6 +6,7 @@
 local fake_screens = {}
 
 _G.screen = setmetatable({
+    connect_signal = function() end,
     set_index_miss_handler = function() end,
     set_newindex_miss_handler = function() end,
 }, {


### PR DESCRIPTION
This pull request extends CAPI `luaclass` to allow global connections to be introspected. This is used to allow `awful.screen.connect_for_each_screen` like signals to be created. It could eventually be extended to also filter connections, but currently it does not implement such features.

I use this to "port" the screen and wallpaper sections of `rc.lua` to use the `request::` API as used in other components such as the titlebar. With this change, we get closer to an unified "pipeline" for components initialization. The goal of the `request::` API is to allow themes and modules to cleanly integrate themselves into Awesome without too much effort from the users.

@actionless Here's a clearer view of what I propose. I know you are not sold, but I think this PR is conservative enough to avoid conflicts. The next, and more controversial given what you said in the past, would be to allow theme to deny (with a proper warning popup) `rc.lua` from adding new bars and saying they already handle that. Idem for the titlebars, notification (WIP) and wallpapers. With those capabilities in place, the themes should now finally be free to define different GUI layout than the current unmodified `rc.lua` allows.

