### PR TITLE
wibox: Stop monkey-patching the `get_children_by_id` function.

### DIFF
--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -192,6 +192,19 @@ function wibox:set_screen(s)
     self._drawable:_force_screen(s)
 end
 
+function wibox:get_children_by_id(name)
+    --TODO v5: Move the ID management to the hierarchy.
+    if rawget(self, "_by_id") then
+        return rawget(self, "_by_id")[name]
+    elseif self._drawable.widget
+      and self._drawable.widget._private
+      and self._drawable.widget._private.by_id then
+          return self._drawable.widget._private.by_id[name]
+    end
+
+    return {}
+end
+
 for _, k in pairs{ "buttons", "struts", "geometry", "get_xproperty", "set_xproperty" } do
     wibox[k] = function(self, ...)
         return self.drawin[k](self.drawin, ...)

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -543,7 +543,9 @@ function base.widget:setup(args)
         rawset(self, "_by_id", ids)
     end
 
-    rawset(self, "get_children_by_id", get_children_by_id)
+    if not rawget(self, "get_children_by_id") then
+        rawset(self, "get_children_by_id", get_children_by_id)
+    end
 end
 
 --- Create a widget from a declarative description.


### PR DESCRIPTION
It was on my stash for a while. Not a complete solution at all, but something.

Mitigate #2181