### PR TITLE
fix(menubar): escape XML entities in the item name

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -142,7 +142,7 @@ local function label(o)
         fg_color = theme.menubar_fg_focus or theme.menu_fg_focus or theme.fg_focus
         bg_color = theme.menubar_bg_focus or theme.menu_bg_focus or theme.bg_focus
     end
-    return colortext(o.name, fg_color),
+    return colortext(gstring.xml_escape(o.name), fg_color),
            bg_color,
            nil,
            o.icon


### PR DESCRIPTION
This fixes `<Invalid text>` shown instead of the item name when the item name contains XML special characters like '&' (see `awful.widget.common.list_update`). Note that `compute_text_width` called from `get_current_page` already escapes the text before calculation.