### PR TITLE
doc: Merge some documentation pages

### DIFF
--- a/lib/awful/hotkeys_popup/keys/termite.lua
+++ b/lib/awful/hotkeys_popup/keys/termite.lua
@@ -3,7 +3,7 @@
 --
 -- @author ikselven
 -- @copyright 2017 ikselven
--- @module awful.hotkeys_popup.keys.termite
+-- @submodule awful.hotkeys_popup
 ---------------------------------------------------------------------------
 
 local hotkeys_popup = require("awful.hotkeys_popup.widget")

--- a/lib/beautiful/theme_assets.lua
+++ b/lib/beautiful/theme_assets.lua
@@ -3,7 +3,7 @@
 --
 -- @author Yauhen Kirylau &lt;yawghen@gmail.com&gt;
 -- @copyright 2015 Yauhen Kirylau
--- @module beautiful.theme_assets
+-- @submodule beautiful
 ----------------------------------------------------------------------------
 
 local cairo = require("lgi").cairo

--- a/lib/beautiful/xresources.lua
+++ b/lib/beautiful/xresources.lua
@@ -3,7 +3,7 @@
 --
 -- @author Yauhen Kirylau &lt;yawghen@gmail.com&gt;
 -- @copyright 2015 Yauhen Kirylau
--- @module beautiful.xresources
+-- @submodule beautiful
 ----------------------------------------------------------------------------
 
 -- Grab environment

--- a/lib/gears/object/properties.lua
+++ b/lib/gears/object/properties.lua
@@ -4,7 +4,7 @@
 --
 -- @author Emmanuel Lepage-Vallee &lt;elv1313@gmail.com&gt;
 -- @copyright 2016 Emmanuel Lepage-Vallee
--- @module gears.object.properties
+-- @submodule gears.object
 ---------------------------------------------------------------------------
 
 local object = {}
@@ -26,6 +26,7 @@ local object = {}
 --
 -- @param class A standard luaobject derived object
 -- @tparam[opt={}] table args A set of accessors configuration parameters
+-- @function gears.object.properties.capi_index_fallback
 function object.capi_index_fallback(class, args)
     args = args or {}
 


### PR DESCRIPTION
Open question: Should we ship 2 documentation (ldoc) instance. One for Awesome and one for the widgets? ldoc "supports" cross referencing multiple instances. Right now 50% of the documentation index are widgets. The documentation would look cleaner if both of these thing would be in their own little universe, no?