### PR TITLE
Move code from rc.lua to awful.menu

### DIFF
--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -544,7 +544,7 @@ end
 local clients_menu = nil
 function menu.client_list(args, item_args, filter)
     if clients_menu and clients_menu.wibox.visible then
-	clients_menu:hide()
+        clients_menu:hide()
         clients_menu = nil
     else
         clients_menu = menu.clients(args, item_args, filter)

--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -541,6 +541,16 @@ function menu.clients(args, item_args, filter)
     return m
 end
 
+local clients_menu = nil
+function menu.client_list(args, item_args, filter)
+    if clients_menu and clients_menu.wibox.visible then
+	clients_menu:hide()
+        clients_menu = nil
+    else
+        clients_menu = menu.clients(args, item_args, filter)
+    end
+end
+
 --------------------------------------------------------------------------------
 
 --- Default awful.menu.entry constructor


### PR DESCRIPTION
Allow for the removal of the following from rc.lua...

```
-- {{{ Helper functions
local function client_menu_toggle_fn()
    local instance = nil

    return function ()
        if instance and instance.wibox.visible then
            instance:hide()
            instance = nil
        else
            instance = awful.menu.clients({ theme = { width = 250 } })
        end
    end
end
-- }}}
```

Then a small change further on in rc.lua...
`
                     awful.button({ }, 3, client_menu_toggle_fn()),
`
becomes...
` 
                    awful.button({ }, 3, function() awful.menu.client_list({ theme = { width = 250 } }) end),
`

Maintains existing user functionality by not removing/modifying awful.menu.clients

If this fits with future plans I can add the changes to rc,lua to the PR

Doco change? : I'd suggest that the existing awful.menu.clients documentation replaced by a note detailing the change to rc.lua and the existing simply moved to the new awful.menu.client_list 
