### PR TITLE
doc: fix type for cmd with easy_async_with_shell

### DIFF
--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -474,7 +474,7 @@ end
 
 --- Call `spawn.easy_async` with a shell.
 -- This calls `cmd` with `$SHELL -c` (via `awful.util.shell`).
--- @tparam string|table cmd The command.
+-- @tparam string cmd The command.
 -- @tab callback Function with the following arguments
 --   @tparam string callback.stdout Output on stdout.
 --   @tparam string callback.stderr Output on stderr.


### PR DESCRIPTION
It only accepts a string.

With a table it will return an error (string):

> "spawn: parse error: Non-string argument at table index 3"

[ci skip]