### PR TITLE
cmake: fix generate-examples/check-examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -199,10 +199,7 @@ script:
         travis_fold_start "DO_COVERAGE"
 
         # Run tests/examples explicitly.
-        (mkdir -p tests/examples/build \
-         && cd tests/examples/build \
-         && cmake $CMAKE_ARGS .. \
-         && make)
+        make check-examples || exit 1
         do_codecov samples
 
         make check-unit || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,6 +212,7 @@ script:
 
         travis_fold_end
       else
+        # TODO: does not run check-examples.  Should it?
         travis_run_in_fold "make.check-unit" make check-unit
         travis_run_in_fold "make.check-integration" make check-integration
         travis_run_in_fold "make.check-themes" make check-themes

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -275,14 +275,14 @@ if(GENERATE_DOC)
     # Load the common documentation
     include(docs/load_ldoc.cmake)
 
-    # Use `include`, rather than `add_subdirectory`, to keep the variables
-    # The file is a valid CMakeLists.txt and can be executed directly if only
-    # the image artefacts are needed.
-    include(tests/examples/CMakeLists.txt)
-
     # Generate the widget lists
     include(docs/widget_lists.cmake)
 endif()
+
+# Use `include`, rather than `add_subdirectory`, to keep the variables
+# The file is a valid CMakeLists.txt and can be executed directly if only
+# the image artefacts are needed.
+include(tests/examples/CMakeLists.txt)
 
 # {{{ Configure files
 file(GLOB awesome_base_c_configure_files RELATIVE ${SOURCE_DIR}

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -310,11 +310,12 @@ foreach(file ${test_files})
     endif()
 endforeach()
 
-add_custom_target(generate-examples ALL DEPENDS ${EXAMPLE_DOC_GENERATED_FILES} ${EXAMPLE_DOC_EXTRA_TARGETS})
+add_custom_target(generate-examples ALL DEPENDS ${EXAMPLE_DOC_GENERATED_FILES})
 
 add_custom_target(check-examples
     ${CMAKE_COMMAND} ${CMAKE_SOURCE_DIR}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    DEPENDS ${EXAMPLE_DOC_EXTRA_TARGETS})
 list(APPEND CHECK_TARGETS check-examples)
 
 # vim: filetype=cmake:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80:foldmethod=marker

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -272,7 +272,7 @@ function(run_test test_path namespace escaped_content)
         file(RELATIVE_PATH rel_output "${TOP_SOURCE_DIR}" "${OUTPUT_IMAGE_PATH}")
         add_custom_command(
             COMMAND "${TOP_SOURCE_DIR}/tests/examples/runner.sh" "${expected_output_path}" ${LUA_COV_RUNNER} ${template} ${test_path} ${IMAGE_PATH} ${IGNORE_ERRORS}
-            COMMENT "Running ${rel_test_path} (via ${rel_template}, generating ${rel_output})"
+            # COMMENT "Running ${rel_test_path} (via ${rel_template}, generating ${rel_output})"
             DEPENDS ${template} ${test_path}
             OUTPUT  ${OUTPUT_IMAGE_PATH}
             VERBATIM)

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -20,7 +20,9 @@ cmake_minimum_required(VERSION 3.0.0)
 execute_process(COMMAND lua -e "p = package.path:gsub(';', '\\\\;'); io.stdout:write(p)"
     OUTPUT_VARIABLE "LUA_PATH_")
 
-# Make sure the system can be called from the test directory
+# Allow to use the example tests by themselves.
+# This was used on Travis for separate coverage reporting, but is not really
+# required anymore.
 if(NOT SOURCE_DIR AND ${CMAKE_CURRENT_SOURCE_DIR} MATCHES "/tests/examples")
     get_filename_component(TOP_SOURCE_DIR
                            "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
@@ -256,6 +258,16 @@ function(run_test test_path namespace escaped_content)
 
     file(RELATIVE_PATH rel_template "${TOP_SOURCE_DIR}" "${template}")
     file(RELATIVE_PATH rel_test_path "${TOP_SOURCE_DIR}" "${test_path}")
+
+    # Add target to run this as test (via check-examples, not ignoring errors).
+    set(TARGET_NAME "run-${rel_test_path}")
+    STRING(REPLACE "/" "-" TARGET_NAME ${TARGET_NAME})
+    set(EXAMPLE_DOC_TEST_TARGETS ${EXAMPLE_DOC_TEST_TARGETS} ${TARGET_NAME}
+        PARENT_SCOPE)
+    add_custom_target(${TARGET_NAME}
+        COMMAND "${TOP_SOURCE_DIR}/tests/examples/runner.sh" "${expected_output_path}" ${LUA_COV_RUNNER} ${template} ${test_path} ${IMAGE_PATH}
+        VERBATIM)
+
     if(NOT ${OUTPUT_IMAGE_PATH} STREQUAL "")
         file(RELATIVE_PATH rel_output "${TOP_SOURCE_DIR}" "${OUTPUT_IMAGE_PATH}")
         add_custom_command(
@@ -265,16 +277,6 @@ function(run_test test_path namespace escaped_content)
             OUTPUT  ${OUTPUT_IMAGE_PATH}
             VERBATIM)
         set(EXAMPLE_DOC_GENERATED_FILES ${OUTPUT_IMAGE_PATH} ${EXAMPLE_DOC_GENERATED_FILES}
-            PARENT_SCOPE)
-    else()
-        set(TARGET_NAME "run-${rel_test_path}")
-        STRING(REPLACE "/" "-" TARGET_NAME ${TARGET_NAME})
-        add_custom_target(${TARGET_NAME}
-            COMMAND "${TOP_SOURCE_DIR}/tests/examples/runner.sh" "${expected_output_path}" ${LUA_COV_RUNNER} ${template} ${test_path} ${IMAGE_PATH} ${IGNORE_ERRORS}
-            COMMENT "Running ${rel_test_path} (via ${rel_template})"
-            DEPENDS ${template} ${test_path}
-            VERBATIM)
-        set(EXAMPLE_DOC_EXTRA_TARGETS ${TARGET_NAME} ${EXAMPLE_DOC_EXTRA_TARGETS}
             PARENT_SCOPE)
     endif()
 
@@ -310,12 +312,7 @@ foreach(file ${test_files})
     endif()
 endforeach()
 
-add_custom_target(generate-examples ALL DEPENDS ${EXAMPLE_DOC_GENERATED_FILES})
-
-add_custom_target(check-examples
-    ${CMAKE_COMMAND} ${CMAKE_SOURCE_DIR}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    DEPENDS ${EXAMPLE_DOC_EXTRA_TARGETS})
-list(APPEND CHECK_TARGETS check-examples)
+add_custom_target(generate-examples DEPENDS ${EXAMPLE_DOC_GENERATED_FILES})
+add_custom_target(check-examples DEPENDS ${EXAMPLE_DOC_TEST_TARGETS})
 
 # vim: filetype=cmake:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80:foldmethod=marker


### PR DESCRIPTION
Those do not generate files, but only run the tests in there, and should
not be triggered with `make ldoc`.

Move them to `check-examples` instead.

TODO:

- [ ] squash-merge
- [ ] investigate coverage diff (after https://github.com/awesomeWM/awesome/pull/2574)
