### PR TITLE
Makefile: get rid of cmake-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -234,6 +234,10 @@ script:
         echo "Testing commit $commit"
         git checkout "$commit"
         git --no-pager show --stat
+
+        # Remove/clean any existing build dir.
+        sudo make distclean
+
         if ! make all check CMAKE_ARGS+="-D DO_COVERAGE=0"; then
           failed="$failed $commit"
         fi

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,9 @@ else
     ECHO=@:
 endif
 
-TARGETS=awesome
 BUILDDIR=build
 
-all: $(TARGETS) ;
-
-$(TARGETS): cmake-build
+all: cmake-build ;
 
 $(BUILDDIR)/Makefile:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 
 BUILDDIR=build
 
-all: cmake-build ;
+all: awesome ;
 
 $(BUILDDIR)/Makefile:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."
@@ -15,10 +15,6 @@ $(BUILDDIR)/Makefile:
 	mkdir -p $(BUILDDIR)
 	$(ECHO) "Running cmake…"
 	cd $(BUILDDIR) && cmake $(CMAKE_ARGS) "$(CURDIR)"
-
-cmake-build: $(BUILDDIR)/Makefile
-	$(ECHO) "Building…"
-	$(MAKE) -C $(BUILDDIR)
 
 tags:
 	git ls-files | xargs ctags


### PR DESCRIPTION
Previously `make` would first run `cmake-build` (`make` in `build/`),
and then run `make -C build awesome` afterwards again (which gets built
by the first step already).