### PR TITLE
cmake: remove check-examples

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -312,9 +312,4 @@ endforeach()
 
 add_custom_target(generate-examples ALL DEPENDS ${EXAMPLE_DOC_GENERATED_FILES} ${EXAMPLE_DOC_EXTRA_TARGETS})
 
-add_custom_target(check-examples
-    ${CMAKE_COMMAND} ${CMAKE_SOURCE_DIR}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-list(APPEND CHECK_TARGETS check-examples)
-
 # vim: filetype=cmake:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80:foldmethod=marker


### PR DESCRIPTION
This was meant to explicitly test/check the examples, when caching for
generated output was added (02f894ce0), but is no longer useful/required
anymore, especially since it only works when run from tests/examples
anyway (what Travis is doing explicitly).