### PR TITLE
travis: Pull the release from github.com using https://

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
       (echo '#!/bin/sh' ; echo 'set -x' ; echo 'gcc -shared -Wl,--no-undefined -o "$@" -ldl -lm') > /tmp/myar
       chmod a+x /tmp/myar
       (cd /tmp
-       wget http://www.lua.org/ftp/lua-5.3.4.tar.gz -O lua.tar.gz
+       wget https://github.com/lua/lua/releases/download/v5-3-4/lua-5.3.4.tar.gz -O lua.tar.gz
        tar -xvzf lua.tar.gz
        cd lua-5.3.*/src \
         && make SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2 -DLUA_USE_APICHECK -Dlua_assert=assert" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="/tmp/myar" liblua.so \


### PR DESCRIPTION
(only merge is the lua.org outage end up lasting for long enough to become a problem, it's been 12h already)

www.lua.org is currently down and it may last for a while. They say on
IRC we can trust the github.com mirror as it is mostly official (but
maintained by the community and often off by a few days from the official
release)

The official mirrors are:

http://www.lua.org/ftp
http://webserver2.tecgraf.puc-rio.br/lua/mirror/ftp/

None have working https.