### PR TITLE
`wibox.layout.manual:insert()` implementation

### DIFF
--- a/lib/wibox/layout/manual.lua
+++ b/lib/wibox/layout/manual.lua
@@ -33,6 +33,16 @@ local manual_layout = {}
 -- @treturn boolean If the operation is successful
 -- @name insert
 -- @class function
+function manual_layout:insert(index, widget)
+    table.insert(self._private.widgets, index, widget)
+
+    -- Add the point
+    if widget.point then
+        table.insert(self._private.pos, index, widget.point)
+    end
+
+    self:emit_signal("widget::layout_changed")
+end
 
 --- Remove one or more widgets from the layout
 -- The last parameter can be a boolean, forcing a recursive seach of the


### PR DESCRIPTION
Following my issue #2556, here is my implementation try :)

Some notes:

* From my understanding, `manual_layout._private.widgets` and `manual_layout._private.pos` are arrays so elements can be "magically" shifted/organized ;
* I used `table.insert` because it shifts up the elements, so it will keep the widgets ordered (https://www.lua.org/manual/5.3/manual.html#pdf-table.insert) ;
* I wrote the code under the documentation-comment because I think it's easier to read the code / review it. All functions from this file are not written with this rule... Tell me if I need to change that ; 
* I don't know how to do that : New elements will not be accessible as children by their id property ;