### PR TITLE
cmake: clarify comment for check-unit with not found busted [ci skip]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,7 +440,7 @@ if(BUSTED_EXECUTABLE)
         VERBATIM)
 else()
     add_custom_target(check-unit true
-        COMMENT "Skipping check-unit, since busted was not found"
+        COMMENT "Skipping check-unit, since busted was not found (during configuration)"
         VERBATIM)
 endif()
 a_find_program(LUACHECK_EXECUTABLE luacheck FALSE)


### PR DESCRIPTION
[ci skip]