### PR TITLE
Makefile: run CMake with CMAKE_ARGS defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ cmake-build: $(BUILDDIR)/Makefile
 	$(ECHO) "Building…"
 	$(MAKE) -C $(BUILDDIR)
 
-# Run CMake always with CMAKE_ARGS defined.
-ifdef CMAKE_ARGS
+# Run CMake with CMAKE_ARGS defined on command line ("make CMAKE_ARGS=…").
+ifeq ($(origin CMAKE_ARGS),command line)
 .PHONY: $(BUILDDIR)/Makefile
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ all: $(TARGETS) ;
 
 $(TARGETS): cmake-build
 
+# Run CMake always with CMAKE_ARGS defined.
+ifdef CMAKE_ARGS
+.PHONY: $(BUILDDIR)/Makefile
+endif
+
 $(BUILDDIR)/Makefile:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."
 	$(ECHO)


### PR DESCRIPTION
This ensures to re-run CMake when using something like:

> make check-unit CMAKE_ARGS="-DSTRICT_TESTS=true -DDO_COVERAGE=1"