### PR TITLE
cmake: remove check-unit-coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,7 @@ script:
          && make)
         do_codecov samples
 
-        make check-unit-coverage || exit 1
+        make check-unit || exit 1
         do_codecov unittests
         make check-integration || exit 1
         make check-themes || exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,20 +424,17 @@ add_custom_target(check-requires
 list(APPEND CHECK_QA_TARGETS check-requires)
 a_find_program(BUSTED_EXECUTABLE busted FALSE)
 if(BUSTED_EXECUTABLE)
-    # Keep the arguments in sync with the version below!
+    if(DO_COVERAGE)
+        set(BUSTED_ARGS "--coverage")
+    else()
+        set(BUSTED_ARGS)
+    endif()
     add_custom_target(check-unit
-        ${BUSTED_EXECUTABLE}
+        COMMAND ${BUSTED_EXECUTABLE} ${BUSTED_ARGS}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Running unit tests"
         VERBATIM)
     list(APPEND CHECK_TARGETS check-unit)
-
-    # Same as above, but with --coverage argument
-    add_custom_target(check-unit-coverage
-        ${BUSTED_EXECUTABLE} "--coverage"
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMENT "Running unit tests under LuaCov"
-        VERBATIM)
 else()
     add_custom_target(check-unit true
         COMMENT "Skipping check-unit, since busted was not found"


### PR DESCRIPTION
Just configure `check-unit` to use `--coverage` with `busted` with
`DO_COVERAGE=1`.

I got confused why `check-unit` would not generate coverage.
This keeps it in line with other targets that generate coverage when
used with the same name.