### PR TITLE
Travis: coverage: report check-themes with separate flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,8 +187,9 @@ script:
         make check-unit-coverage || exit 1
         do_codecov unittests
         make check-integration || exit 1
-        make check-themes || exit 1
         do_codecov functionaltests
+        make check-themes || exit 1
+        do_codecov themes
         do_codecov_gcov c_code
 
         travis_fold_end


### PR DESCRIPTION
This makes sense in general (every check target should get its own
flag), and might help with tracking down unexpected coverage changes
(although those appear to be related to the C code only (gcov)).