### PR TITLE
cmake: pass DO_COVERAGE=1 in env for tests/run.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,15 +400,18 @@ endif()
 add_executable(test-gravity tests/test-gravity.c)
 target_link_libraries(test-gravity
     ${AWESOME_COMMON_REQUIRED_LDFLAGS} ${AWESOME_REQUIRED_LDFLAGS})
+if(DO_COVERAGE)
+    set(TESTS_RUN_ENV DO_COVERAGE=1)
+endif()
 add_custom_target(check-integration
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${TESTS_RUN_ENV} ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
     DEPENDS ${PROJECT_AWE_NAME}
     USES_TERMINAL)
 add_dependencies(check-integration test-gravity)
 add_custom_target(check-themes
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ./tests/themes/run.sh
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${TESTS_RUN_ENV} ./tests/themes/run.sh
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Testing themes"
     USES_TERMINAL

--- a/tests/themes/run.sh
+++ b/tests/themes/run.sh
@@ -3,6 +3,8 @@
 # Test all themes.
 # This should be run via `make check-themes` (or manually from the build
 # directory).
+#
+# It uses tests/run.sh internally, which handles coverage.
 
 set -e
 


### PR DESCRIPTION
`$DO_COVERAGE` is used in tests/run.sh, and should be set with the
`DO_COVERAGE` CMake option.

This is not a problem on Travis, where `$DO_COVERAGE` is set in the env.
It should get renamed there maybe to avoid confusion.