### PR TITLE
Revert "Makefile: get rid of cmake-build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -246,10 +246,6 @@ script:
         echo "Testing commit $commit"
         git checkout "$commit"
         git --no-pager show --stat
-
-        # Remove/clean any existing build dir.
-        sudo make distclean
-
         if ! make all check CMAKE_ARGS+="-D DO_COVERAGE=0"; then
           failed="$failed $commit"
         fi

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,12 @@ else
     ECHO=@:
 endif
 
+TARGETS=awesome
 BUILDDIR=build
 
-all: awesome ;
+all: $(TARGETS) ;
+
+$(TARGETS): cmake-build
 
 $(BUILDDIR)/Makefile:
 	$(ECHO) "Creating build directory and running cmake in it. You can also run CMake directly, if you want."
@@ -15,6 +18,10 @@ $(BUILDDIR)/Makefile:
 	mkdir -p $(BUILDDIR)
 	$(ECHO) "Running cmake…"
 	cd $(BUILDDIR) && cmake $(CMAKE_ARGS) "$(CURDIR)"
+
+cmake-build: $(BUILDDIR)/Makefile
+	$(ECHO) "Building…"
+	$(MAKE) -C $(BUILDDIR)
 
 tags:
 	git ls-files | xargs ctags


### PR DESCRIPTION
Reverts awesomeWM/awesome#2547

Meant to fix master, https://github.com/awesomeWM/awesome/issues/2576.