### PR TITLE
Make beautiful.theme_path actually work again

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -194,7 +194,7 @@ function beautiful.init(config)
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
             local dir = Gio.File.new_for_path(config):get_parent()
-            beautiful.theme_path = dir and (dir:get_path().."/") or nil
+            rawset(beautiful, "theme_path", dir and (dir:get_path().."/") or nil)
             theme = protected_call(dofile, config)
         elseif type(config) == 'table' then
             theme = config

--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -197,6 +197,7 @@ function beautiful.init(config)
             rawset(beautiful, "theme_path", dir and (dir:get_path().."/") or nil)
             theme = protected_call(dofile, config)
         elseif type(config) == 'table' then
+            rawset(beautiful, "theme_path", nil)
             theme = config
         end
 


### PR DESCRIPTION
Details in the commit messages. This fixes #2573 (by using `rawset` instead of an ordinary table assignment).