### PR TITLE
Prototype: beautiful.init: Update init.lua #2

### DIFF
--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -186,7 +186,7 @@ end
 --   containing all the theme values.
 function beautiful.init(config)
     if config then
-        local state, err = nil, nil
+        local state = nil
         local homedir = os.getenv("HOME")
 
         -- If `config` is the path to a theme file, run this file,
@@ -195,11 +195,12 @@ function beautiful.init(config)
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
             local dir = Gio.File.new_for_path(config):get_parent()
-            beautiful.theme_path = dir and (dir:get_path().."/") or nil
-            state, err = pcall(function() theme = dofile(config) end)
+            theme[themes_path] = dir and (dir:get_path().."/") or nil
+            theme = protected_call(dofile, config)
+            state = theme != nil
         elseif type(config) == 'table' then
-            state = #config ~= 0
             theme = config
+            state = #config ~= 0
         end
 
         if state then
@@ -214,9 +215,7 @@ function beautiful.init(config)
             return true
         else
             theme = {}
-            gears_debug.print_error("beautiful: error loading theme: " .. tostring(config))
-            gears_debug.print_error("theme file error: " .. tostring(err))
-            return false, err
+            return gears_debug.print_error("beautiful: error loading theme file " .. config)
         end
     else
         return gears_debug.print_error("beautiful: error loading theme: no theme specified")

--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -186,7 +186,6 @@ end
 --   containing all the theme values.
 function beautiful.init(config)
     if config then
-        local state = nil
         local homedir = os.getenv("HOME")
 
         -- If `config` is the path to a theme file, run this file,
@@ -195,15 +194,14 @@ function beautiful.init(config)
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
             local dir = Gio.File.new_for_path(config):get_parent()
-            beautiful.theme_path = dir and (dir:get_path().."/") or nil
+            rawset(beautiful, "theme_path", dir and (dir:get_path().."/") or nil)
             theme = protected_call(dofile, config)
-            state = theme != nil
         elseif type(config) == 'table' then
+            rawset(beautiful, "theme_path", nil)
             theme = config
-            state = #config ~= 0
         end
 
-        if state then
+        if theme then
             -- expand '~'
             if homedir then
                 for k, v in pairs(theme) do
@@ -212,7 +210,6 @@ function beautiful.init(config)
             end
 
             if theme.font then set_font(theme.font) end
-            return true
         else
             theme = {}
             return gears_debug.print_error("beautiful: error loading theme file " .. config)

--- a/lib/beautiful/init.lua
+++ b/lib/beautiful/init.lua
@@ -195,7 +195,7 @@ function beautiful.init(config)
             -- Expand the '~' $HOME shortcut
             config = config:gsub("^~/", homedir .. "/")
             local dir = Gio.File.new_for_path(config):get_parent()
-            theme[themes_path] = dir and (dir:get_path().."/") or nil
+            beautiful.theme_path = dir and (dir:get_path().."/") or nil
             theme = protected_call(dofile, config)
             state = theme != nil
         elseif type(config) == 'table' then


### PR DESCRIPTION
Doesn't fail on beautiful.init( my_config ) when my_config = a number

As far as I can tell if theme then only catches the case where the protected_call fails

Doesn't fail on beautiful.init( my_config ) when my_config = {}

Would also be nice if it returned true if there was no problem so as to do...
```
if not beautiful.init( path_this .. "themes/shelby/theme.lua" ) then
	beautiful.init( path_this .. "themes/shelby/.last.theme.lua" ) -- a proven config 
end
```
The above would be nice assuming a theme error would not cause a full reversion to the default rc.lua

