### PR TITLE
beautiful.init: Fix return values and improve doco. fixes: #2588

### DIFF
--- a/spec/beautiful/init_spec.lua
+++ b/spec/beautiful/init_spec.lua
@@ -1,0 +1,80 @@
+---------------------------------------------------------------------------
+-- @author
+-- @copyright 2019
+---------------------------------------------------------------------------
+
+local beautiful = require("beautiful")
+local gdebug = require("gears.debug")
+
+describe("beautiful init", function()
+    local dir = (os.getenv("SOURCE_DIRECTORY") or '.') .. "/spec/beautiful/tests/"
+    local shim
+
+    -- Check beautiful.get_font and get_merged_font
+    it('Check beautiful.get_font', function()
+        assert.is_same(beautiful.get_font("Monospace Bold 12"),
+            beautiful.get_merged_font("Monospace 12", "Bold"))
+    end)
+
+    -- Check beautiful.get_font_height
+    it('Check beautiful.get_font_height', function()
+        -- TODO: Will requires lgi-dpi
+    end)
+
+    -- Check beautiful.init
+    it('Check beautiful.init', function()
+        -- Check the error messages (needs a shim)
+        shim = gdebug.print_error
+        gdebug.print_error = function(message) error(message) end
+
+        assert.has_error(function() beautiful.init({}) end,
+            "beautiful: error loading theme: got an empty table")
+        assert.has_error(function() beautiful.init(dir .. "Bad_1.lua") end,
+            "beautiful: error loading theme: got an empty table from: " .. dir .. "Bad_1.lua")
+        assert.has_error(function() beautiful.init(dir .. "Bad_2.lua") end,
+            "beautiful: error loading theme: got a function from: " .. dir .. "Bad_2.lua")
+        assert.has_error(function() beautiful.init(dir .. "Bad_3.lua") end,
+            "beautiful: error loading theme: got a number from: " .. dir .. "Bad_3.lua")
+        assert.has_error(function() beautiful.init(dir .. "Bad_4.lua") end,
+            "beautiful: error loading theme: got a nil from: " .. dir .. "Bad_4.lua")
+        assert.has_error(function() beautiful.init(dir .. "Bad_5.lua") end,
+            "beautiful: error loading theme: got a nil from: " .. dir .. "Bad_5.lua")
+        assert.has_error(function() beautiful.init(dir .. "NO_FILE") end,
+            "beautiful: error loading theme: got a nil from: " .. dir .. "NO_FILE")
+
+        assert.has_no_error(function() beautiful.init({ font = "Monospace Bold 12" }) end, "")
+        assert.has_no_error(function() beautiful.init(dir .. "Good.lua") end, "")
+
+        -- Check the return values (remove the shim)
+        gdebug.print_error = shim
+
+        assert.is_nil(beautiful.init({}))
+        assert.is_nil(beautiful.init(dir .. "Bad_1.lua"))
+        assert.is_nil(beautiful.init(dir .. "Bad_2.lua"))
+        assert.is_nil(beautiful.init(dir .. "Bad_3.lua"))
+        assert.is_nil(beautiful.init(dir .. "Bad_4.lua"))
+        assert.is_nil(beautiful.init(dir .. "Bad_5.lua"))
+        assert.is_nil(beautiful.init(dir .. "NO_FILE"))
+
+        assert.is_true(beautiful.init({ font = "Monospace Bold 12" }))
+        assert.is_true(beautiful.init(dir .. "Good.lua"))
+    end)
+
+    -- Check beautiful.get
+    it('Check beautiful.get', function()
+        assert.is_same(beautiful.get(), { font = "Monospace Bold 12" })
+    end)
+
+    -- Check getting a beautiful.value
+    it('Check getting a beautiful.value', function()
+        assert.is_same(beautiful.font, "Monospace Bold 12")
+    end)
+
+    -- Check setting a beautiful.value
+    it('Check setting a beautiful.value', function()
+        beautiful.font = "Monospace Bold 10"
+        assert.is_same(beautiful.font, "Monospace Bold 10")
+    end)
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/spec/beautiful/tests/Bad_1.lua
+++ b/spec/beautiful/tests/Bad_1.lua
@@ -1,0 +1,2 @@
+local me = {}
+return me

--- a/spec/beautiful/tests/Bad_2.lua
+++ b/spec/beautiful/tests/Bad_2.lua
@@ -1,0 +1,2 @@
+local me = function() end
+return me

--- a/spec/beautiful/tests/Bad_3.lua
+++ b/spec/beautiful/tests/Bad_3.lua
@@ -1,0 +1,2 @@
+local me = 9
+return me

--- a/spec/beautiful/tests/Bad_4.lua
+++ b/spec/beautiful/tests/Bad_4.lua
@@ -1,0 +1,2 @@
+local me = nil
+return me

--- a/spec/beautiful/tests/Bad_5.lua
+++ b/spec/beautiful/tests/Bad_5.lua
@@ -1,0 +1,2 @@
+local var = nil
+print( var.bad )

--- a/spec/beautiful/tests/Good.lua
+++ b/spec/beautiful/tests/Good.lua
@@ -1,0 +1,2 @@
+local me = { font = "Monospace Bold 12" }
+return me

--- a/spec/preload.lua
+++ b/spec/preload.lua
@@ -7,6 +7,6 @@ require("lgi")
 _G.awesome = {version = "v9999"}
 
 -- "fix" some intentional beautiful breakage done by .travis.yml
-require("beautiful").init{}
+require("beautiful").init{a_key="a_value"}
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
beautiful.init return values incomplete and some invalid parameters not picked up #2588

Some behaviour that doesn't really seem right...

Doesn't fail on beautiful.init( my_config ) when my_config = a function
Doesn't fail on beautiful.init( my_config ) when my_config = a number

As far as I can tell `if theme then` only catches the case where the protected_call fails

Doesn't fail on beautiful.init( my_config ) when my_config = {}

Would also be nice if it returned true if there was no problem so as to do...
```
if not beautiful.init( path_this .. "themes/shelby/theme.lua" ) then
	beautiful.init( path_this .. "themes/shelby/.last.theme.lua" ) -- a proven config 
end
```
The above would be nice assuming a theme error would not cause a full reversion to the default rc.lua