### PR TITLE
Fix terminal exit after selecting manual from menu

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -105,7 +105,7 @@ end
 -- Create a launcher widget and a main menu
 myawesomemenu = {
    { "hotkeys", function() hotkeys_popup.show_help(nil, awful.screen.focused()) end },
-   { "manual", terminal .. " -e man awesome" },
+   { "manual", terminal .. " -e \"man awesome\"" },
    { "edit config", editor_cmd .. " " .. awesome.conffile },
    { "restart", awesome.restart },
    { "quit", function() awesome.quit() end },


### PR DESCRIPTION
Installed on Arch Linux. Was having issue with terminal (termite) immediately exiting after choosing "manual" from the menu.