### PR TITLE
spec/beautiful: Don't print noise

### DIFF
--- a/spec/beautiful/init_spec.lua
+++ b/spec/beautiful/init_spec.lua
@@ -46,7 +46,7 @@ describe("beautiful init", function()
         assert.has_no_error(function() beautiful.init(dir .. "Good.lua") end, "")
 
         -- Check the return values (remove the shim)
-        gdebug.print_error = shim
+        gdebug.print_error = function() end
 
         assert.is_nil(beautiful.init({}))
         assert.is_nil(beautiful.init(dir .. "Bad_1.lua"))
@@ -55,6 +55,8 @@ describe("beautiful init", function()
         assert.is_nil(beautiful.init(dir .. "Bad_4.lua"))
         assert.is_nil(beautiful.init(dir .. "Bad_5.lua"))
         assert.is_nil(beautiful.init(dir .. "NO_FILE"))
+
+        gdebug.print_error = shim
 
         assert.is_true(beautiful.init({ font = "Monospace Bold 12" }))
         assert.is_true(beautiful.init(dir .. "Good.lua"))


### PR DESCRIPTION
This gets rid of the following output when running the unit tests:
```
2019-01-26 18:31:44 E: awesome: beautiful: error loading theme: got an empty table
2019-01-26 18:31:44 E: awesome: beautiful: error loading theme: got an empty table from: ./spec/beautiful/tests/Bad_1.lua
2019-01-26 18:31:44 E: awesome: beautiful: error loading theme: got a function from: ./spec/beautiful/tests/Bad_2.lua
2019-01-26 18:31:44 E: awesome: beautiful: error loading theme: got a number from: ./spec/beautiful/tests/Bad_3.lua
2019-01-26 18:31:44 E: awesome: beautiful: error loading theme: got a nil from: ./spec/beautiful/tests/Bad_4.lua
2019-01-26 18:31:44 E: awesome: Error during a protected call: ./spec/beautiful/tests/Bad_5.lua:2: attempt to index local 'var' (a nil value)
stack traceback:
	./spec/beautiful/tests/Bad_5.lua:2: in main chunk
	[C]: in function 'dofile'
	[C]: in function 'xpcall'
	lib/gears/protected_call.lua:36: in function <lib/gears/protected_call.lua:35>
	(...tail calls...)
	lib/beautiful/init.lua:224: in function 'init'
	spec/beautiful/init_spec.lua:56: in function <spec/beautiful/init_spec.lua:25>
	[C]: in function 'xpcall'
	/usr/share/lua/5.2/busted/core.lua:178: in function 'safe'
	/usr/share/lua/5.2/busted/init.lua:40: in function 'executor'
	...
	/usr/share/lua/5.2/busted/core.lua:312: in function 'execute'
	/usr/share/lua/5.2/busted/block.lua:155: in function 'execute'
	/usr/share/lua/5.2/busted/init.lua:7: in function 'executor'
	/usr/share/lua/5.2/busted/core.lua:312: in function </usr/share/lua/5.2/busted/core.lua:312>
	[C]: in function 'xpcall'
	/usr/share/lua/5.2/busted/core.lua:178: in function 'safe'
	/usr/share/lua/5.2/busted/core.lua:312: in function 'execute'
	/usr/share/lua/5.2/busted/execute.lua:58: in function 'execute'
	/usr/share/lua/5.2/busted/runner.lua:174: in function </usr/share/lua/5.2/busted/runner.lua:11>
	/usr/bin/busted:3: in main chunk
	[C]: in ?
2019-01-26 18:31:44 E: awesome: beautiful: error loading theme: got a nil from: ./spec/beautiful/tests/Bad_5.lua
2019-01-26 18:31:44 E: awesome: Error during a protected call: cannot open ./spec/beautiful/tests/NO_FILE: No such file or directory
stack traceback:
	[C]: in function 'dofile'
	[C]: in function 'xpcall'
	lib/gears/protected_call.lua:36: in function <lib/gears/protected_call.lua:35>
	(...tail calls...)
	lib/beautiful/init.lua:224: in function 'init'
	spec/beautiful/init_spec.lua:57: in function <spec/beautiful/init_spec.lua:25>
	[C]: in function 'xpcall'
	/usr/share/lua/5.2/busted/core.lua:178: in function 'safe'
	/usr/share/lua/5.2/busted/init.lua:40: in function 'executor'
	/usr/share/lua/5.2/busted/core.lua:312: in function </usr/share/lua/5.2/busted/core.lua:312>
	...
	/usr/share/lua/5.2/busted/core.lua:312: in function 'execute'
	/usr/share/lua/5.2/busted/block.lua:155: in function 'execute'
	/usr/share/lua/5.2/busted/init.lua:7: in function 'executor'
	/usr/share/lua/5.2/busted/core.lua:312: in function </usr/share/lua/5.2/busted/core.lua:312>
	[C]: in function 'xpcall'
	/usr/share/lua/5.2/busted/core.lua:178: in function 'safe'
	/usr/share/lua/5.2/busted/core.lua:312: in function 'execute'
	/usr/share/lua/5.2/busted/execute.lua:58: in function 'execute'
	/usr/share/lua/5.2/busted/runner.lua:174: in function </usr/share/lua/5.2/busted/runner.lua:11>
	/usr/bin/busted:3: in main chunk
	[C]: in ?
2019-01-26 18:31:44 E: awesome: beautiful: error loading theme: got a nil from: ./spec/beautiful/tests/NO_FILE
```
Signed-off-by: Uli Schlachter <psychon@znc.in>