### PR TITLE
doc: Fix a copy+paste mistake

### DIFF
--- a/lib/awful/widget/layoutlist.lua
+++ b/lib/awful/widget/layoutlist.lua
@@ -382,7 +382,7 @@ end
 -- @tparam string|pattern args.style.shape_border_width_selected
 -- @tparam string|pattern args.style.shape_border_color_selected
 -- @treturn widget The action widget.
--- @function naughty.widget.layoutlist
+-- @function awful.widget.layoutlist
 
 local is_connected, instances = false, setmetatable({}, {__mode = "v"})
 


### PR DESCRIPTION
The current `awful.widget.layoutlist` is a fork of the so far uncommitted `naughty.widget.actionlist`. It was created because some of the support code for the new `naughty` implementation needed "easier to merge" usage examples. The `layoutlist` was chosen because it was both a low hanging fruit and genuinely useful.

Thanks to @actionless for spotting it