### PR TITLE
Use reproducible timestamps in more doc examples

### DIFF
--- a/tests/examples/awful/popup/wiboxtypes.lua
+++ b/tests/examples/awful/popup/wiboxtypes.lua
@@ -5,6 +5,7 @@ local awful     = require("awful")
 local gears     = require("gears")
 local wibox     = require("wibox")
 local beautiful = require("beautiful") --DOC_HIDE
+require("_date")
 
 screen[1]._resize {width = 640, height = 480}
 

--- a/tests/examples/awful/tooltip/textclock.lua
+++ b/tests/examples/awful/tooltip/textclock.lua
@@ -4,6 +4,7 @@ screen[1]._resize {width = 300, height = 75} --DOC_HIDE
 local awful = {tooltip = require("awful.tooltip"), wibar = require("awful.wibar")} --DOC_HIDE
 local wibox = { widget = { textclock = require("wibox.widget.textclock") }, --DOC_HIDE
     layout = { align = require("wibox.layout.align") } } --DOC_HIDE
+require("_date") --DOC_HIDE
 
     local mytextclock = wibox.widget.textclock()
 

--- a/tests/examples/awful/tooltip/textclock2.lua
+++ b/tests/examples/awful/tooltip/textclock2.lua
@@ -4,6 +4,7 @@ screen[1]._resize {width = 300, height = 75} --DOC_HIDE
 local awful = {tooltip = require("awful.tooltip"), wibar = require("awful.wibar")} --DOC_HIDE
 local wibox = { widget = { textclock = require("wibox.widget.textclock") }, --DOC_HIDE
     layout = { align = require("wibox.layout.align") } } --DOC_HIDE
+require("_date") --DOC_HIDE
 
     local mytextclock = wibox.widget.textclock()
 

--- a/tests/examples/awful/widget/layoutlist/wibar.lua
+++ b/tests/examples/awful/widget/layoutlist/wibar.lua
@@ -1,6 +1,7 @@
 --DOC_NO_USAGE --DOC_GEN_IMAGE
 local awful     = require("awful") --DOC_HIDE
 local wibox     = require("wibox") --DOC_HIDE
+require("_date") --DOC_HIDE
 
 screen[1]._resize {width = 480, height = 100} --DOC_HIDE
 


### PR DESCRIPTION
This adds require("_date") to some example tests that use the current
date. This allows reproducibility by replacing os.date() with a function
that uses a static date. See commit 9d7eaf020d75a for details.

Signed-off-by: Uli Schlachter <psychon@znc.in>