### PR TITLE
Change the badge URL from travis-ci.org to travis-ci.com

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -168,7 +168,7 @@ You can submit pull requests on the [github repository](https://github.com/aweso
 Please read the [contributing guide](https://github.com/awesomeWM/awesome/blob/master/docs/02-contributing.md) for any coding, documentation or patch guidelines.
 
 ## Status
-[![Build Status](https://travis-ci.org/awesomeWM/awesome.svg?branch=master)](https://travis-ci.org/awesomeWM/awesome)
+[![Build Status](https://travis-ci.com/awesomeWM/awesome.svg?branch=master)](https://travis-ci.com/awesomeWM/awesome)
 
 ## Documentation
 


### PR DESCRIPTION
I moved the CI from .org to .com to get updates and new features again.