### PR TITLE
Use reproducible timestamps in more doc examples

### DIFF
--- a/tests/examples/awful/popup/wiboxtypes.lua
+++ b/tests/examples/awful/popup/wiboxtypes.lua
@@ -1,6 +1,7 @@
 --DOC_GEN_IMAGE
 --DOC_HIDE_ALL
 --DOC_NO_USAGE
+require("_date")
 local awful     = require("awful")
 local gears     = require("gears")
 local wibox     = require("wibox")

--- a/tests/examples/awful/tooltip/textclock.lua
+++ b/tests/examples/awful/tooltip/textclock.lua
@@ -1,5 +1,6 @@
 --DOC_GEN_IMAGE
 --DOC_NO_USAGE
+require("_date") --DOC_HIDE
 screen[1]._resize {width = 300, height = 75} --DOC_HIDE
 local awful = {tooltip = require("awful.tooltip"), wibar = require("awful.wibar")} --DOC_HIDE
 local wibox = { widget = { textclock = require("wibox.widget.textclock") }, --DOC_HIDE

--- a/tests/examples/awful/tooltip/textclock2.lua
+++ b/tests/examples/awful/tooltip/textclock2.lua
@@ -1,5 +1,6 @@
 --DOC_GEN_IMAGE
 --DOC_NO_USAGE
+require("_date") --DOC_HIDE
 screen[1]._resize {width = 300, height = 75} --DOC_HIDE
 local awful = {tooltip = require("awful.tooltip"), wibar = require("awful.wibar")} --DOC_HIDE
 local wibox = { widget = { textclock = require("wibox.widget.textclock") }, --DOC_HIDE


### PR DESCRIPTION
This adds require("_date") to some example tests that use the current
date via os.date. This allows reproducibility by replacing os.date()
with a function that uses a static date from $SOURCE_DATE_EPOCH. See
commit 9d7eaf0 for more details.

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @reinerh Thanks for pointing out that this is indeed needed.