### PR TITLE
ci: mergify: remove Codacy from required checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - label!=no-mergify
       - '#approved-reviews-by>=2'
-      - status-success=continuous-integration/travis-ci/pr
+      - status-success=Travis CI - Pull Request
       - status-success=codecov/patch
       - status-success=coverage/coveralls
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ pull_request_rules:
       - label!=no-mergify
       - '#approved-reviews-by>=2'
       - status-success=continuous-integration/travis-ci/pr
-      - status-success=Codacy/PR Quality Review
       - status-success=codecov/patch
       - status-success=coverage/coveralls
     actions:


### PR DESCRIPTION
It might be hanging, and is not really valuable enough currently to
require a rebuild etc.