### PR TITLE
awful.rules: Fix shape function not being set as client property

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -688,7 +688,7 @@ function rules.execute(c, props, callbacks)
 
     -- Apply the remaining properties (after known race conditions are handled).
     for property, value in pairs(props) do
-        if property ~= "focus" and type(value) == "function" then
+        if property ~= "focus" and property ~= "shape" and type(value) == "function" then
             value = value(c, props)
         end
 


### PR DESCRIPTION
As of 48c6c11d1721f40ec5136cfbd4a8125e4208277f
> When a property is now set to a function, the function's return value will be
used for the value of the property. The function gets the new client as its only
argument.
> 
> There is no property which accepts a function as its value and thus this change
can't break anything (yeah, famous last words...).

Unfortunately the shape property (which was probably later introduced) also gets called instead of being set on the client.

This just adds an exception for shape, but I wonder if a way to except properties from this would be useful, maybe a new property that accepts a table of property names? Or would this go completely unused?