### PR TITLE
background container: Actually set the foreground color

### DIFF
--- a/lib/wibox/container/background.lua
+++ b/lib/wibox/container/background.lua
@@ -55,6 +55,10 @@ function background:before_draw_children(context, cr, width, height)
         end
         cr:restore()
     end
+
+    if self._private.foreground then
+        cr:set_source(self._private.foreground)
+    end
 end
 
 -- Draw the border


### PR DESCRIPTION
Commit ba75da7976e6 worked around a bug in LGI. However, it did so by
just dropping the code that set the foreground color. Instead, it should
have changed the code so that cr:set_source() is only called if the
background container has a foreground color configured instead of "just
always".

Fixes: https://github.com/awesomeWM/awesome/pull/2609#issuecomment-459580395
Signed-off-by: Uli Schlachter <psychon@znc.in>

------

@actionless When you wrote the following, what did you actually mean? As far as I see, my "work around a bug in LGI"-commit just always broke the foreground.

> it broken background's `set_fg()` under some tricky usecase, 

------

Oh, by the way: Testing done by myself: None at all.