### PR TITLE
Add selection watcher objects

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,6 +28,7 @@ read_globals = {
     "mousegrabber",
     "root",
     "selection",
+    "selection_watcher",
     "tag",
     "window",
     "table.unpack",

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 
   # Install build dependencies.
   # See also `apt-cache showsrc awesome | grep -E '^(Version|Build-Depends)'`.
-  - sudo apt-get install -y libcairo2-dev gir1.2-gtk-3.0 libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev
+  - sudo apt-get install -y libcairo2-dev gir1.2-gtk-3.0 libpango1.0-dev libxcb-xtest0-dev libxcb-icccm4-dev libxcb-randr0-dev libxcb-keysyms1-dev libxcb-xinerama0-dev libdbus-1-dev libxdg-basedir-dev libstartup-notification0-dev imagemagick libxcb1-dev libxcb-shape0-dev libxcb-util0-dev libx11-xcb-dev libxcb-cursor-dev libxcb-xkb-dev libxcb-xfixes0-dev libxkbcommon-dev libxkbcommon-x11-dev
   - sudo gem install asciidoctor
 
   # Deps for tests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(AWE_SRCS
     ${BUILD_DIR}/objects/drawin.c
     ${BUILD_DIR}/objects/key.c
     ${BUILD_DIR}/objects/screen.c
+    ${BUILD_DIR}/objects/selection_watcher.c
     ${BUILD_DIR}/objects/tag.c
     ${BUILD_DIR}/objects/window.c)
 

--- a/awesome.c
+++ b/awesome.c
@@ -53,6 +53,7 @@
 #include <xcb/xinerama.h>
 #include <xcb/xtest.h>
 #include <xcb/shape.h>
+#include <xcb/xfixes.h>
 
 #include <glib-unix.h>
 
@@ -733,6 +734,7 @@ main(int argc, char **argv)
     xcb_prefetch_extension_data(globalconf.connection, &xcb_randr_id);
     xcb_prefetch_extension_data(globalconf.connection, &xcb_xinerama_id);
     xcb_prefetch_extension_data(globalconf.connection, &xcb_shape_id);
+    xcb_prefetch_extension_data(globalconf.connection, &xcb_xfixes_id);
 
     if (xcb_cursor_context_new(globalconf.connection, globalconf.screen, &globalconf.cursor_ctx) < 0)
         fatal("Failed to initialize xcb-cursor");
@@ -793,6 +795,13 @@ main(int argc, char **argv)
                 (reply->major_version == 1 && reply->minor_version >= 1));
         p_delete(&reply);
     }
+
+    /* check for xfixes extension */
+    query = xcb_get_extension_data(globalconf.connection, &xcb_xfixes_id);
+    globalconf.have_xfixes = query && query->present;
+    if (globalconf.have_xfixes)
+        xcb_discard_reply(globalconf.connection,
+                xcb_xfixes_query_version(globalconf.connection, 1, 0).sequence);
 
     event_init();
 

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -141,6 +141,7 @@ set(AWESOME_DEPENDENCIES
     xcb-keysyms>=0.3.4
     xcb-icccm
     xcb-icccm>=0.3.8
+    xcb-xfixes
     # NOTE: it's not clear what version is required, but 1.10 works at least.
     # See https://github.com/awesomeWM/awesome/pull/149#issuecomment-94208356.
     xcb-xkb

--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -68,6 +68,7 @@ environment):
 - [libxcb-util >= 0.3.8](https://xcb.freedesktop.org/)
 - [libxcb-keysyms >= 0.3.4](https://xcb.freedesktop.org/)
 - [libxcb-icccm >= 0.3.8](https://xcb.freedesktop.org/)
+- [libxcb-xfixes](https://xcb.freedesktop.org/)
 - [xcb-util-xrm >= 1.0](https://github.com/Airblader/xcb-util-xrm)
 - [libxkbcommon](http://xkbcommon.org/) with X11 support enabled
 - [libstartup-notification >=

--- a/event.c
+++ b/event.c
@@ -24,6 +24,7 @@
 #include "property.h"
 #include "objects/tag.h"
 #include "objects/drawin.h"
+#include "objects/selection_watcher.h"
 #include "xwindow.h"
 #include "ewmh.h"
 #include "objects/client.h"
@@ -43,6 +44,7 @@
 #include <xcb/xcb_icccm.h>
 #include <xcb/xcb_event.h>
 #include <xcb/xkb.h>
+#include <xcb/xfixes.h>
 
 #define DO_EVENT_HOOK_CALLBACK(type, xcbtype, xcbeventprefix, arraytype, match) \
     static void \
@@ -1116,6 +1118,7 @@ void event_handle(xcb_generic_event_t *event)
     EXTENSION_EVENT(randr, XCB_RANDR_NOTIFY, event_handle_randr_output_change_notify);
     EXTENSION_EVENT(shape, XCB_SHAPE_NOTIFY, event_handle_shape_notify);
     EXTENSION_EVENT(xkb, 0, event_handle_xkb_notify);
+    EXTENSION_EVENT(xfixes, XCB_XFIXES_SELECTION_NOTIFY, event_handle_xfixes_selection_notify);
 #undef EXTENSION_EVENT
 }
 
@@ -1134,6 +1137,10 @@ void event_init(void)
     reply = xcb_get_extension_data(globalconf.connection, &xcb_xkb_id);
     if (reply && reply->present)
         globalconf.event_base_xkb = reply->first_event;
+
+    reply = xcb_get_extension_data(globalconf.connection, &xcb_xfixes_id);
+    if (reply && reply->present)
+        globalconf.event_base_xfixes = reply->first_event;
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/globalconf.h
+++ b/globalconf.h
@@ -110,6 +110,8 @@ typedef struct
     bool have_input_shape;
     /** Check for XKB extension */
     bool have_xkb;
+    /** Check for XFixes extension */
+    bool have_xfixes;
     uint8_t event_base_shape;
     uint8_t event_base_xkb;
     uint8_t event_base_randr;

--- a/globalconf.h
+++ b/globalconf.h
@@ -115,6 +115,7 @@ typedef struct
     uint8_t event_base_shape;
     uint8_t event_base_xkb;
     uint8_t event_base_randr;
+    uint8_t event_base_xfixes;
     /** Clients list */
     client_array_t clients;
     /** Embedded windows */

--- a/luaa.c
+++ b/luaa.c
@@ -49,6 +49,7 @@
 #include "objects/drawable.h"
 #include "objects/drawin.h"
 #include "objects/screen.h"
+#include "objects/selection_watcher.h"
 #include "objects/tag.h"
 #include "property.h"
 #include "selection.h"
@@ -1034,6 +1035,9 @@ luaA_init(xdgHandle* xdg, string_array_t *searchpath)
 
     /* Export keys */
     key_class_setup(L);
+
+    /* Export selection watcher */
+    selection_watcher_class_setup(L);
 
     /* add Lua search paths */
     lua_getglobal(L, "package");

--- a/objects/selection_watcher.c
+++ b/objects/selection_watcher.c
@@ -1,0 +1,34 @@
+/*
+ * selection_watcher.h - selection change watcher
+ *
+ * Copyright © 2019 Uli Schlachter <psychon@znc.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "objects/selection_watcher.h"
+
+void
+event_handle_xfixes_selection_notify(xcb_generic_event_t *ev)
+{
+}
+
+void
+selection_watcher_class_setup(lua_State *L)
+{
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/selection_watcher.h
+++ b/objects/selection_watcher.h
@@ -1,0 +1,33 @@
+/*
+ * selection_watcher.h - selection change watcher header
+ *
+ * Copyright © 2019 Uli Schlachter <psychon@znc.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef AWESOME_OBJECTS_SELECTION_WATCHER_H
+#define AWESOME_OBJECTS_SELECTION_WATCHER_H
+
+#include <lua.h>
+#include <xcb/xcb.h>
+
+void selection_watcher_class_setup(lua_State*);
+void event_handle_xfixes_selection_notify(xcb_generic_event_t*);
+
+#endif
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-selection-watcher.lua
+++ b/tests/test-selection-watcher.lua
@@ -1,0 +1,118 @@
+-- Test the selection watcher API
+
+local runner = require("_runner")
+local spawn = require("awful.spawn")
+
+local header = [[
+local lgi = require("lgi")
+local Gdk = lgi.Gdk
+local Gtk = lgi.Gtk
+local GLib = lgi.GLib
+local clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+clipboard:set_text("This is an experiment", -1)
+]]
+
+local acquire_and_clear_clipboard = header .. [[
+GLib.idle_add(GLib.PRIORITY_DEFAULT, Gtk.main_quit)
+Gtk.main()
+]]
+
+local acquire_clipboard = header .. [[
+GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 60, Gtk.main_quit)
+GLib.idle_add(GLib.PRIORITY_DEFAULT, function()
+    print("initialisation done")
+    io.stdout:flush()
+end)
+Gtk.main()
+]]
+
+local had_error = false
+local owned_clipboard_changes, unowned_clipboard_changes = 0, 0
+
+local clipboard_watcher = selection_watcher("CLIPBOARD")
+local clipboard_watcher_inactive = selection_watcher("CLIPBOARD")
+local primary_watcher = selection_watcher("PRIMARY")
+
+clipboard_watcher:connect_signal("selection_changed", function(_, owned)
+    if owned then
+        owned_clipboard_changes = owned_clipboard_changes + 1
+    else
+        unowned_clipboard_changes = unowned_clipboard_changes + 1
+    end
+end)
+clipboard_watcher_inactive:connect_signal("selection_changed", function()
+    had_error = true
+    error("Unexpected signal on inactive CLIPBOARD watcher")
+end)
+primary_watcher:connect_signal("selection_changed", function()
+    had_error = true
+    error("Unexpected signal on PRIMARY watcher")
+end)
+
+local function check_state(owned, unowned)
+    assert(not had_error, "there was an error")
+    assert(owned_clipboard_changes == owned, string.format("expected %d owned changes, but got %d", owned, owned_clipboard_changes))
+    assert(unowned_clipboard_changes == unowned, string.format("expected %d unowned changes, but got %d", unowned, unowned_clipboard_changes))
+end
+
+local continue = false
+runner.run_steps{
+    -- Clear the clipboard to get to a known state
+    function()
+        check_state(0, 0)
+        spawn.with_line_callback({ "lua", "-e", acquire_and_clear_clipboard },
+            { exit = function() continue = true end })
+        return true
+    end,
+
+    function()
+        -- Wait for the clipboard to be cleared
+        check_state(0, 0)
+        if not continue then
+            return
+        end
+
+        -- Activate the watchers
+        clipboard_watcher.active = true
+        primary_watcher.active = true
+        awesome.sync()
+
+        -- Set the clipboard
+        continue = false
+        spawn.with_line_callback({ "lua", "-e", acquire_clipboard },
+            { stdout = function(line)
+                assert(line == "initialisation done",
+                    "Unexpected line: " .. line)
+                continue = true
+            end })
+
+        return true
+    end,
+
+    function()
+        -- Wait for the clipboard to be set
+        if not continue then
+            return
+        end
+        check_state(1, 0)
+
+        -- Now clear the clipboard again
+        continue = false
+        spawn.with_line_callback({ "lua", "-e", acquire_and_clear_clipboard },
+            { exit = function() continue = true end })
+
+        return true
+    end,
+
+    function()
+        -- Wait for the clipboard to be set
+        if not continue then
+            return
+        end
+
+        check_state(2, 1)
+        return true
+    end
+}
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-selection-watcher.lua
+++ b/tests/test-selection-watcher.lua
@@ -51,8 +51,10 @@ end)
 
 local function check_state(owned, unowned)
     assert(not had_error, "there was an error")
-    assert(owned_clipboard_changes == owned, string.format("expected %d owned changes, but got %d", owned, owned_clipboard_changes))
-    assert(unowned_clipboard_changes == unowned, string.format("expected %d unowned changes, but got %d", unowned, unowned_clipboard_changes))
+    assert(owned_clipboard_changes == owned,
+        string.format("expected %d owned changes, but got %d", owned, owned_clipboard_changes))
+    assert(unowned_clipboard_changes == unowned,
+        string.format("expected %d unowned changes, but got %d", unowned, unowned_clipboard_changes))
 end
 
 local continue = false


### PR DESCRIPTION
This implements a tiny part of #492 by adding a new class to awesomeWM: Selection watcher.
A selection watcher watches some selection and emits a signal when the selection owner changes.

I put this into its own object, because watching for selection changes is completely independent from actually transferring selection contents (Copy&paste).

Simple example showing how to use this new API:
```lua
local watcher = selection_watcher("PRIMARY")
watcher.active = true
watcher:connect_signal("selection_changed", function(_, owned)
    if owned then
        print("PRIMARY selection changed")
    else
        print("PRIMARY selection is now unowned and thus guaranteed to be empty")
    end
end)
```
The plan is to also add separate classes for copy & paste to keep things simple in the C code.

Also, I did not add any API documentation on this new objects (yet). Mostly because I kind of expect @Elv13 to later remove them anyway and add some Lua code that simplifies the uglyness that the C API provides. Should I add LDoc documentation anyway?

Comments?