### PR TITLE
Add API for setting clipboard contents

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -27,6 +27,7 @@ read_globals = {
     "keygrabber",
     "mousegrabber",
     "root",
+    "selection_acquire",
     "selection_getter",
     "selection",
     "selection_watcher",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(AWE_SRCS
     ${BUILD_DIR}/objects/drawin.c
     ${BUILD_DIR}/objects/key.c
     ${BUILD_DIR}/objects/screen.c
+    ${BUILD_DIR}/objects/selection_acquire.c
     ${BUILD_DIR}/objects/selection_watcher.c
     ${BUILD_DIR}/objects/tag.c
     ${BUILD_DIR}/objects/selection_getter.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(AWE_SRCS
     ${BUILD_DIR}/objects/key.c
     ${BUILD_DIR}/objects/screen.c
     ${BUILD_DIR}/objects/selection_acquire.c
+    ${BUILD_DIR}/objects/selection_transfer.c
     ${BUILD_DIR}/objects/selection_watcher.c
     ${BUILD_DIR}/objects/tag.c
     ${BUILD_DIR}/objects/selection_getter.c

--- a/event.c
+++ b/event.c
@@ -25,6 +25,7 @@
 #include "objects/tag.h"
 #include "objects/selection_getter.h"
 #include "objects/drawin.h"
+#include "objects/selection_acquire.h"
 #include "objects/selection_watcher.h"
 #include "xwindow.h"
 #include "ewmh.h"
@@ -1013,7 +1014,8 @@ event_handle_selectionclear(xcb_selection_clear_event_t *ev)
     {
         warn("Lost WM_Sn selection, exiting...");
         g_main_loop_quit(globalconf.loop);
-    }
+    } else
+        selection_handle_selectionclear(ev);
 }
 
 /** \brief awesome xerror function.

--- a/event.c
+++ b/event.c
@@ -1111,6 +1111,7 @@ void event_handle(xcb_generic_event_t *event)
         EVENT(XCB_UNMAP_NOTIFY, event_handle_unmapnotify);
         EVENT(XCB_SELECTION_CLEAR, event_handle_selectionclear);
         EVENT(XCB_SELECTION_NOTIFY, event_handle_selectionnotify);
+        EVENT(XCB_SELECTION_REQUEST, selection_handle_selectionrequest);
 #undef EVENT
     }
 

--- a/luaa.c
+++ b/luaa.c
@@ -50,6 +50,7 @@
 #include "objects/drawin.h"
 #include "objects/selection_getter.h"
 #include "objects/screen.h"
+#include "objects/selection_acquire.h"
 #include "objects/selection_watcher.h"
 #include "objects/tag.h"
 #include "property.h"
@@ -1039,6 +1040,9 @@ luaA_init(xdgHandle* xdg, string_array_t *searchpath)
 
     /* Export keys */
     key_class_setup(L);
+
+    /* Export selection acquire */
+    selection_acquire_class_setup(L);
 
     /* Export selection watcher */
     selection_watcher_class_setup(L);

--- a/luaa.c
+++ b/luaa.c
@@ -51,6 +51,7 @@
 #include "objects/selection_getter.h"
 #include "objects/screen.h"
 #include "objects/selection_acquire.h"
+#include "objects/selection_transfer.h"
 #include "objects/selection_watcher.h"
 #include "objects/tag.h"
 #include "property.h"
@@ -1043,6 +1044,9 @@ luaA_init(xdgHandle* xdg, string_array_t *searchpath)
 
     /* Export selection acquire */
     selection_acquire_class_setup(L);
+
+    /* Export selection transfer */
+    selection_transfer_class_setup(L);
 
     /* Export selection watcher */
     selection_watcher_class_setup(L);

--- a/objects/selection_acquire.c
+++ b/objects/selection_acquire.c
@@ -1,0 +1,29 @@
+/*
+ * selection_acquire.c - objects for selection ownership
+ *
+ * Copyright © 2019 Uli Schlachter <psychon@znc.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "objects/selection_acquire.h"
+
+void
+selection_acquire_class_setup(lua_State *L)
+{
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/selection_acquire.c
+++ b/objects/selection_acquire.c
@@ -28,16 +28,84 @@
 typedef struct selection_acquire_t
 {
     LUA_OBJECT_HEADER
+    /** The selection that is being owned. */
+    xcb_atom_t selection;
     /** Window used for owning the selection. */
     xcb_window_t window;
     /** Timestamp used for acquiring the selection. */
     xcb_timestamp_t timestamp;
-    /** Reference in the special table to this object. */
-    int ref;
 } selection_acquire_t;
 
 static lua_class_t selection_acquire_class;
 LUA_OBJECT_FUNCS(selection_acquire_class, selection_acquire_t, selection_acquire)
+
+static void
+luaA_pushatom(lua_State *L, xcb_atom_t atom)
+{
+    lua_pushnumber(L, atom);
+}
+
+static int
+selection_acquire_find_by_window(lua_State *L, xcb_window_t window)
+{
+    /* Iterate over all active selection acquire objects */
+    lua_pushliteral(L, REGISTRY_ACQUIRE_TABLE_INDEX);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    lua_pushnil(L);
+    while (lua_next(L, -2) != 0) {
+        if (lua_type(L, -1) == LUA_TUSERDATA) {
+            selection_acquire_t *selection = lua_touserdata(L, -1);
+            if (selection->window == window)
+            {
+                /* Remove table and key */
+                lua_remove(L, -2);
+                lua_remove(L, -2);
+                return 1;
+            }
+        }
+        /* Remove the value, leaving only the key */
+        lua_pop(L, 1);
+    }
+    /* Remove the table */
+    lua_pop(L, 1);
+
+    return 0;
+}
+
+static void
+selection_release(lua_State *L, int ud)
+{
+    selection_acquire_t *selection = luaA_checkudata(L, ud, &selection_acquire_class);
+
+    luaA_object_emit_signal(L, ud, "release", 0);
+
+    /* Destroy the window, this also releases the selection in X11 */
+    xcb_destroy_window(globalconf.connection, selection->window);
+    selection->window = XCB_NONE;
+
+    /* Unreference the object, it's now dead */
+    lua_pushliteral(L, REGISTRY_ACQUIRE_TABLE_INDEX);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    luaA_pushatom(L, selection->selection);
+    lua_pushnil(L);
+    lua_rawset(L, -3);
+
+    selection->selection = XCB_NONE;
+
+    lua_pop(L, 1);
+}
+
+void
+selection_handle_selectionclear(xcb_selection_clear_event_t *ev)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    if (selection_acquire_find_by_window(L, ev->owner) == 0)
+        return;
+
+    selection_release(L, -1);
+    lua_pop(L, 1);
+}
 
 static int
 luaA_selection_acquire_new(lua_State *L)
@@ -51,13 +119,6 @@ luaA_selection_acquire_new(lua_State *L)
 
     name = luaL_checklstring(L, 2, &name_length);
 
-    /* Create a selection object */
-    selection = (void *) selection_acquire_class.allocator(L);
-    selection->window = xcb_generate_id(globalconf.connection);
-    xcb_create_window(globalconf.connection, globalconf.screen->root_depth,
-            selection->window, globalconf.screen->root, -1, -1, 1, 1, 0,
-            XCB_COPY_FROM_PARENT, globalconf.screen->root_visual, 0, NULL);
-
     /* Get the atom identifying the selection */
     reply = xcb_intern_atom_reply(globalconf.connection,
             xcb_intern_atom_unchecked(globalconf.connection, false, name_length, name),
@@ -65,8 +126,16 @@ luaA_selection_acquire_new(lua_State *L)
     name_atom = reply ? reply->atom : XCB_NONE;
     p_delete(&reply);
 
-    /* Try to acquire the selection */
+    /* Create a selection object */
+    selection = (void *) selection_acquire_class.allocator(L);
+    selection->selection = name_atom;
     selection->timestamp = globalconf.timestamp;
+    selection->window = xcb_generate_id(globalconf.connection);
+    xcb_create_window(globalconf.connection, globalconf.screen->root_depth,
+            selection->window, globalconf.screen->root, -1, -1, 1, 1, 0,
+            XCB_COPY_FROM_PARENT, globalconf.screen->root_visual, 0, NULL);
+
+    /* Try to acquire the selection */
     xcb_set_selection_owner(globalconf.connection, selection->window, name_atom, selection->timestamp);
     selection_reply = xcb_get_selection_owner_reply(globalconf.connection,
             xcb_get_selection_owner(globalconf.connection, name_atom),
@@ -80,12 +149,24 @@ luaA_selection_acquire_new(lua_State *L)
         return 0;
     }
 
-    /* Everything worked, register the object in table */
+    /* Everything worked, register the object in the table */
     lua_pushliteral(L, REGISTRY_ACQUIRE_TABLE_INDEX);
     lua_rawget(L, LUA_REGISTRYINDEX);
-    lua_pushvalue(L, -2);
-    selection->ref = luaL_ref(L, -2);
-    lua_pop(L, 1);
+
+    luaA_pushatom(L, name_atom);
+    lua_rawget(L, -2);
+    if (!lua_isnil(L, -1)) {
+        /* There is already another selection_acquire object for this selection,
+         * release it now. X11 does not send us SelectionClear events for our
+         * own changes to the selection.
+         */
+        selection_release(L, -1);
+    }
+
+    luaA_pushatom(L, name_atom);
+    lua_pushvalue(L, -4);
+    lua_rawset(L, -4);
+    lua_pop(L, 2);
 
     return 1;
 }
@@ -93,18 +174,8 @@ luaA_selection_acquire_new(lua_State *L)
 static int
 luaA_selection_acquire_release(lua_State *L)
 {
-    selection_acquire_t *selection = luaA_checkudata(L, 1, &selection_acquire_class);
-
-    xcb_destroy_window(globalconf.connection, selection->window);
-    selection->window = XCB_NONE;
-
-    /* Unreference the object, it's now dead */
-    lua_pushliteral(L, REGISTRY_ACQUIRE_TABLE_INDEX);
-    lua_rawget(L, LUA_REGISTRYINDEX);
-    luaL_unref(L, -1, selection->ref);
-    lua_pop(L, 1);
-
-    selection->ref = LUA_NOREF;
+    luaA_checkudata(L, 1, &selection_acquire_class);
+    selection_release(L, 1);
 
     return 0;
 }
@@ -112,7 +183,7 @@ luaA_selection_acquire_release(lua_State *L)
 static bool
 selection_acquire_checker(selection_acquire_t *selection)
 {
-    return selection->window != XCB_NONE;
+    return selection->selection != XCB_NONE;
 }
 
 void

--- a/objects/selection_acquire.c
+++ b/objects/selection_acquire.c
@@ -139,7 +139,10 @@ luaA_selection_acquire_new(lua_State *L)
     xcb_atom_t name_atom;
     selection_acquire_t *selection;
 
-    name = luaL_checklstring(L, 2, &name_length);
+    luaA_checktable(L, 2);
+    lua_pushliteral(L, "selection");
+    lua_gettable(L, 2);
+    name = luaL_checklstring(L, -1, &name_length);
 
     /* Get the atom identifying the selection */
     reply = xcb_intern_atom_reply(globalconf.connection,

--- a/objects/selection_acquire.c
+++ b/objects/selection_acquire.c
@@ -20,6 +20,7 @@
  */
 
 #include "objects/selection_acquire.h"
+#include "objects/selection_transfer.h"
 #include "common/luaobject.h"
 #include "globalconf.h"
 
@@ -105,41 +106,6 @@ selection_handle_selectionclear(xcb_selection_clear_event_t *ev)
 
     selection_release(L, -1);
     lua_pop(L, 1);
-}
-
-static void
-selection_transfer_notify(xcb_window_t requestor, xcb_atom_t selection, xcb_atom_t target, xcb_atom_t property, xcb_timestamp_t time)
-{
-    xcb_selection_notify_event_t ev;
-
-    p_clear(&ev, 1);
-    ev.response_type = XCB_SELECTION_NOTIFY;
-    ev.requestor = requestor;
-    ev.selection = selection;
-    ev.target = target;
-    ev.property = property;
-    ev.time = time;
-
-    xcb_send_event(globalconf.connection, false, requestor, XCB_EVENT_MASK_NO_EVENT, (char *) &ev);
-}
-
-static void
-selection_transfer_reject(xcb_window_t requestor, xcb_atom_t selection,
-        xcb_atom_t target, xcb_timestamp_t time)
-{
-    selection_transfer_notify(requestor, selection, target, XCB_NONE, time);
-}
-
-#include "common/atoms.h" /* TODO remove */
-static void
-selection_transfer_begin(lua_State *L, int ud, xcb_window_t requestor,
-        xcb_atom_t selection, xcb_atom_t target, xcb_atom_t property,
-        xcb_timestamp_t time)
-{
-    /* TODO implement this */
-    xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
-            requestor, property, UTF8_STRING, 8, 5, "Test\n");
-    selection_transfer_notify(requestor, selection, target, property, time);
 }
 
 void

--- a/objects/selection_acquire.c
+++ b/objects/selection_acquire.c
@@ -20,10 +20,109 @@
  */
 
 #include "objects/selection_acquire.h"
+#include "common/luaobject.h"
+#include "globalconf.h"
+
+#define REGISTRY_ACQUIRE_TABLE_INDEX "awesome_selection_acquires"
+
+typedef struct selection_acquire_t
+{
+    LUA_OBJECT_HEADER
+    /** Window used for owning the selection. */
+    xcb_window_t window;
+    /** Timestamp used for acquiring the selection. */
+    xcb_timestamp_t timestamp;
+    /** Reference in the special table to this object. */
+    int ref;
+} selection_acquire_t;
+
+static lua_class_t selection_acquire_class;
+LUA_OBJECT_FUNCS(selection_acquire_class, selection_acquire_t, selection_acquire)
+
+static void
+selection_acquire_wipe(selection_acquire_t *selection)
+{
+    if (selection->window != XCB_NONE)
+        xcb_destroy_window(globalconf.connection, selection->window);
+}
+
+static int
+luaA_selection_acquire_new(lua_State *L)
+{
+    size_t name_length;
+    const char *name;
+    xcb_intern_atom_reply_t *reply;
+    xcb_get_selection_owner_reply_t *selection_reply;
+    xcb_atom_t name_atom;
+    selection_acquire_t *selection;
+
+    name = luaL_checklstring(L, 2, &name_length);
+
+    /* Create a selection object */
+    selection = (void *) selection_acquire_class.allocator(L);
+    selection->window = xcb_generate_id(globalconf.connection);
+    xcb_create_window(globalconf.connection, globalconf.screen->root_depth,
+            selection->window, globalconf.screen->root, -1, -1, 1, 1, 0,
+            XCB_COPY_FROM_PARENT, globalconf.screen->root_visual, 0, NULL);
+
+    /* Get the atom identifying the selection */
+    reply = xcb_intern_atom_reply(globalconf.connection,
+            xcb_intern_atom_unchecked(globalconf.connection, false, name_length, name),
+            NULL);
+    name_atom = reply ? reply->atom : XCB_NONE;
+    p_delete(&reply);
+
+    /* Try to acquire the selection */
+    selection->timestamp = globalconf.timestamp;
+    xcb_set_selection_owner(globalconf.connection, selection->window, name_atom, selection->timestamp);
+    selection_reply = xcb_get_selection_owner_reply(globalconf.connection,
+            xcb_get_selection_owner(globalconf.connection, name_atom),
+            NULL);
+    if (selection_reply == NULL || selection_reply->owner != selection->window) {
+        /* Acquiring the selection failed, return nothing */
+        p_delete(&selection_reply);
+
+        xcb_destroy_window(globalconf.connection, selection->window);
+        selection->window = XCB_NONE;
+        return 0;
+    }
+
+    /* Everything worked, register the object in table */
+    lua_pushliteral(L, REGISTRY_ACQUIRE_TABLE_INDEX);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    lua_pushvalue(L, -2);
+    selection->ref = luaL_ref(L, -2);
+    lua_pop(L, 1);
+
+    return 1;
+}
 
 void
 selection_acquire_class_setup(lua_State *L)
 {
+    static const struct luaL_Reg selection_acquire_methods[] =
+    {
+        { "__call", luaA_selection_acquire_new },
+        { NULL, NULL }
+    };
+
+    static const struct luaL_Reg selection_acquire_meta[] =
+    {
+        LUA_OBJECT_META(selection_acquire)
+        LUA_CLASS_META
+        { NULL, NULL }
+    };
+
+    /* Store a table in the registry that tracks active selection_acquire_t. */
+    lua_pushliteral(L, REGISTRY_ACQUIRE_TABLE_INDEX);
+    lua_newtable(L);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+
+    luaA_class_setup(L, &selection_acquire_class, "selection_acquire", NULL,
+            (lua_class_allocator_t) selection_acquire_new,
+            (lua_class_collector_t) selection_acquire_wipe, NULL,
+            luaA_class_index_miss_property, luaA_class_newindex_miss_property,
+            selection_acquire_methods, selection_acquire_meta);
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/selection_acquire.h
+++ b/objects/selection_acquire.h
@@ -27,6 +27,7 @@
 
 void selection_acquire_class_setup(lua_State*);
 void selection_handle_selectionclear(xcb_selection_clear_event_t*);
+void selection_handle_selectionrequest(xcb_selection_request_event_t*);
 
 #endif
 

--- a/objects/selection_acquire.h
+++ b/objects/selection_acquire.h
@@ -1,0 +1,31 @@
+/*
+ * selection_acquire.c - objects for selection ownership header
+ *
+ * Copyright © 2019 Uli Schlachter <psychon@znc.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef AWESOME_OBJECTS_SELECTION_ACQUIRE_H
+#define AWESOME_OBJECTS_SELECTION_ACQUIRE_H
+
+#include <lua.h>
+
+void selection_acquire_class_setup(lua_State*);
+
+#endif
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/selection_acquire.h
+++ b/objects/selection_acquire.h
@@ -23,8 +23,10 @@
 #define AWESOME_OBJECTS_SELECTION_ACQUIRE_H
 
 #include <lua.h>
+#include <xcb/xcb.h>
 
 void selection_acquire_class_setup(lua_State*);
+void selection_handle_selectionclear(xcb_selection_clear_event_t*);
 
 #endif
 

--- a/objects/selection_transfer.c
+++ b/objects/selection_transfer.c
@@ -1,0 +1,106 @@
+/*
+ * selection_transfer.c - objects for selection transfer header
+ *
+ * Copyright © 2019 Uli Schlachter <psychon@znc.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "objects/selection_transfer.h"
+#include "common/luaobject.h"
+#include "globalconf.h"
+
+#define REGISTRY_TRANSFER_TABLE_INDEX "awesome_selection_transfers"
+
+typedef struct selection_transfer_t
+{
+    LUA_OBJECT_HEADER
+} selection_transfer_t;
+
+static lua_class_t selection_transfer_class;
+LUA_OBJECT_FUNCS(selection_transfer_class, selection_transfer_t, selection_transfer)
+
+static void
+selection_transfer_notify(xcb_window_t requestor, xcb_atom_t selection,
+        xcb_atom_t target, xcb_atom_t property, xcb_timestamp_t time)
+{
+    xcb_selection_notify_event_t ev;
+
+    p_clear(&ev, 1);
+    ev.response_type = XCB_SELECTION_NOTIFY;
+    ev.requestor = requestor;
+    ev.selection = selection;
+    ev.target = target;
+    ev.property = property;
+    ev.time = time;
+
+    xcb_send_event(globalconf.connection, false, requestor,
+            XCB_EVENT_MASK_NO_EVENT, (char *) &ev);
+}
+
+void
+selection_transfer_reject(xcb_window_t requestor, xcb_atom_t selection,
+        xcb_atom_t target, xcb_timestamp_t time)
+{
+    selection_transfer_notify(requestor, selection, target, XCB_NONE, time);
+}
+
+#include "common/atoms.h" /* TODO remove */
+void
+selection_transfer_begin(lua_State *L, int ud, xcb_window_t requestor,
+        xcb_atom_t selection, xcb_atom_t target, xcb_atom_t property,
+        xcb_timestamp_t time)
+{
+    /* TODO implement this */
+    xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
+            requestor, property, UTF8_STRING, 8, 5, "Test\n");
+    selection_transfer_notify(requestor, selection, target, property, time);
+}
+
+static bool
+selection_transfer_checker(selection_transfer_t *selection)
+{
+    return true;
+}
+
+void
+selection_transfer_class_setup(lua_State *L)
+{
+    static const struct luaL_Reg selection_transfer_methods[] =
+    {
+        { NULL, NULL }
+    };
+
+    static const struct luaL_Reg selection_transfer_meta[] =
+    {
+        LUA_OBJECT_META(selection_transfer)
+        LUA_CLASS_META
+        { NULL, NULL }
+    };
+
+    /* Store a table in the registry that tracks active selection_transfer_t. */
+    lua_pushliteral(L, REGISTRY_TRANSFER_TABLE_INDEX);
+    lua_newtable(L);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+
+    luaA_class_setup(L, &selection_transfer_class, "selection_transfer", NULL,
+            (lua_class_allocator_t) selection_transfer_new, NULL,
+            (lua_class_checker_t) selection_transfer_checker,
+            luaA_class_index_miss_property, luaA_class_newindex_miss_property,
+            selection_transfer_methods, selection_transfer_meta);
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/selection_transfer.c
+++ b/objects/selection_transfer.c
@@ -128,12 +128,12 @@ transfer_continue_incremental(lua_State *L, int ud)
             }
         }
         /* End of transfer */
-        xcb_change_window_attributes(globalconf.connection,
-                transfer->requestor, XCB_CW_EVENT_MASK,
-                (uint32_t[]) { 0 });
         xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
                 transfer->requestor, transfer->property, UTF8_STRING, 8,
                 0, NULL);
+        xcb_change_window_attributes(globalconf.connection,
+                transfer->requestor, XCB_CW_EVENT_MASK,
+                (uint32_t[]) { 0 });
         transfer_done(L, transfer);
     } else {
         /* Send next piece of data */

--- a/objects/selection_transfer.c
+++ b/objects/selection_transfer.c
@@ -198,7 +198,6 @@ static int
 luaA_selection_transfer_send(lua_State *L)
 {
     size_t data_length;
-    const char *data;
     bool incr = false;
     size_t incr_size = 0;
 
@@ -278,7 +277,7 @@ luaA_selection_transfer_send(lua_State *L)
                 len, &atoms[0]);
     } else {
         /* 'data' is a string with the data to transfer */
-        data = luaL_checklstring(L, -1, &data_length);
+        const char *data = luaL_checklstring(L, -1, &data_length);
 
         if (!incr)
             incr_size = data_length;

--- a/objects/selection_transfer.c
+++ b/objects/selection_transfer.c
@@ -21,13 +21,29 @@
 
 #include "objects/selection_transfer.h"
 #include "common/luaobject.h"
+#include "common/atoms.h"
 #include "globalconf.h"
 
 #define REGISTRY_TRANSFER_TABLE_INDEX "awesome_selection_transfers"
 
+enum transfer_state {
+    TRANSFER_WAIT_FOR_DATA,
+    TRANSFER_DONE
+};
+
 typedef struct selection_transfer_t
 {
     LUA_OBJECT_HEADER
+    /** Reference in the special table to this object */
+    int ref;
+    /* Information from the xcb_selection_request_event_t */
+    xcb_window_t requestor;
+    xcb_atom_t selection;
+    xcb_atom_t target;
+    xcb_atom_t property;
+    xcb_timestamp_t time;
+    /* Current state of the transfer */
+    enum transfer_state state;
 } selection_transfer_t;
 
 static lua_class_t selection_transfer_class;
@@ -58,22 +74,69 @@ selection_transfer_reject(xcb_window_t requestor, xcb_atom_t selection,
     selection_transfer_notify(requestor, selection, target, XCB_NONE, time);
 }
 
-#include "common/atoms.h" /* TODO remove */
+static void
+transfer_done(lua_State *L, selection_transfer_t *transfer)
+{
+    transfer->state = TRANSFER_DONE;
+
+    lua_pushliteral(L, REGISTRY_TRANSFER_TABLE_INDEX);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    luaL_unref(L, -1, transfer->ref);
+    transfer->ref = LUA_NOREF;
+    lua_pop(L, 1);
+}
+
 void
 selection_transfer_begin(lua_State *L, int ud, xcb_window_t requestor,
         xcb_atom_t selection, xcb_atom_t target, xcb_atom_t property,
         xcb_timestamp_t time)
 {
-    /* TODO implement this */
-    xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
-            requestor, property, UTF8_STRING, 8, 5, "Test\n");
-    selection_transfer_notify(requestor, selection, target, property, time);
+    ud = luaA_absindex(L, ud);
+
+    /* Allocate a transfer object */
+    selection_transfer_t *transfer = (void *) selection_transfer_class.allocator(L);
+    transfer->requestor = requestor;
+    transfer->selection = selection;
+    transfer->target = target;
+    transfer->property = property;
+    transfer->time = time;
+    transfer->state = TRANSFER_WAIT_FOR_DATA;
+
+    /* Save the object in the registry */
+    lua_pushliteral(L, REGISTRY_TRANSFER_TABLE_INDEX);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    lua_pushvalue(L, -2);
+    transfer->ref = luaL_ref(L, -2);
+    lua_pop(L, 1);
+
+    /* Get the atom name */
+    xcb_get_atom_name_reply_t *reply = xcb_get_atom_name_reply(globalconf.connection,
+            xcb_get_atom_name_unchecked(globalconf.connection, target), NULL);
+    if (reply) {
+        lua_pushlstring(L, xcb_get_atom_name_name(reply),
+                xcb_get_atom_name_name_length(reply));
+        p_delete(&reply);
+    } else
+        lua_pushnil(L);
+
+    /* Emit the request signal with target and transfer object */
+    lua_pushvalue(L, -2);
+    luaA_object_emit_signal(L, ud, "request", 2);
+
+    /* Reject the transfer if Lua did not do anything */
+    if (transfer->state == TRANSFER_WAIT_FOR_DATA) {
+        selection_transfer_reject(requestor, selection, target, time);
+        transfer_done(L, transfer);
+    }
+
+    /* Remove the transfer object from the stack */
+    lua_pop(L, 1);
 }
 
 static bool
-selection_transfer_checker(selection_transfer_t *selection)
+selection_transfer_checker(selection_transfer_t *transfer)
 {
-    return true;
+    return transfer->state != TRANSFER_DONE;
 }
 
 void

--- a/objects/selection_transfer.h
+++ b/objects/selection_transfer.h
@@ -29,6 +29,7 @@ void selection_transfer_class_setup(lua_State*);
 void selection_transfer_reject(xcb_window_t, xcb_atom_t, xcb_atom_t, xcb_timestamp_t);
 void selection_transfer_begin(lua_State*, int, xcb_window_t, xcb_atom_t,
         xcb_atom_t, xcb_atom_t, xcb_timestamp_t);
+void selection_transfer_handle_propertynotify(xcb_property_notify_event_t*);
 
 #endif
 

--- a/objects/selection_transfer.h
+++ b/objects/selection_transfer.h
@@ -1,0 +1,35 @@
+/*
+ * selection_transfer.c - objects for selection transfer header
+ *
+ * Copyright © 2019 Uli Schlachter <psychon@znc.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef AWESOME_OBJECTS_SELECTION_TRANSFER_H
+#define AWESOME_OBJECTS_SELECTION_TRANSFER_H
+
+#include <lua.h>
+#include <xcb/xcb.h>
+
+void selection_transfer_class_setup(lua_State*);
+void selection_transfer_reject(xcb_window_t, xcb_atom_t, xcb_atom_t, xcb_timestamp_t);
+void selection_transfer_begin(lua_State*, int, xcb_window_t, xcb_atom_t,
+        xcb_atom_t, xcb_atom_t, xcb_timestamp_t);
+
+#endif
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/property.c
+++ b/property.c
@@ -26,6 +26,7 @@
 #include "objects/client.h"
 #include "objects/drawin.h"
 #include "objects/selection_getter.h"
+#include "objects/selection_transfer.h"
 #include "xwindow.h"
 
 #include <xcb/xcb_atom.h>
@@ -487,6 +488,7 @@ property_handle_propertynotify(xcb_property_notify_event_t *ev)
     globalconf.timestamp = ev->time;
 
     property_handle_propertynotify_xproperty(ev);
+    selection_transfer_handle_propertynotify(ev);
 
     /* Find the correct event handler */
 #define HANDLE(atom_, cb) \

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -66,20 +66,20 @@ end
 runner.run_steps{
     function()
         -- Get the selection
-        local s = assert(selection_acquire("CLIPBOARD"),
+        local s = assert(selection_acquire{ selection = "CLIPBOARD" },
             "Failed to acquire the clipboard selection")
 
         -- Steal selection ownership from ourselves and test that it works
         local s_released
         s:connect_signal("release", function() s_released = true end)
 
-        selection = assert(selection_acquire("CLIPBOARD"),
+        selection = assert(selection_acquire{ selection = "CLIPBOARD" },
             "Failed to acquire the clipboard selection")
 
         assert(s_released)
 
         -- Now test selection transfers
-        selection = assert(selection_acquire("CLIPBOARD"),
+        selection = assert(selection_acquire{ selection = "CLIPBOARD" },
             "Failed to acquire the clipboard selection")
         selection:connect_signal("request", function(_, target, transfer)
             if target == "TARGETS" then
@@ -108,7 +108,7 @@ runner.run_steps{
         continue = false
 
         -- Now test piece-wise selection transfers
-        selection = assert(selection_acquire("CLIPBOARD"),
+        selection = assert(selection_acquire{ selection = "CLIPBOARD" },
             "Failed to acquire the clipboard selection")
         selection:connect_signal("request", function(_, target, transfer)
             if target == "TARGETS" then
@@ -148,7 +148,7 @@ runner.run_steps{
         continue = false
 
         -- Now test a huge transfer
-        selection = assert(selection_acquire("CLIPBOARD"),
+        selection = assert(selection_acquire{ selection = "CLIPBOARD" },
             "Failed to acquire the clipboard selection")
         selection:connect_signal("request", function(_, target, transfer)
             if target == "TARGETS" then
@@ -212,7 +212,7 @@ runner.run_steps{
         continue = false
 
         -- Test for "release" signal when we lose selection
-        selection = assert(selection_acquire("CLIPBOARD"),
+        selection = assert(selection_acquire{ selection = "CLIPBOARD" },
             "Failed to acquire the clipboard selection")
         selection:connect_signal("release", function() selection_released = true end)
         awesome.sync()

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -1,0 +1,235 @@
+-- Test the selection ownership and transfer API
+
+local runner = require("_runner")
+local spawn = require("awful.spawn")
+
+-- Assemble data for the large transfer that will be done later
+local large_transfer_piece = "a"
+for _ = 1, 25 do
+    large_transfer_piece = large_transfer_piece .. large_transfer_piece
+end
+large_transfer_piece = large_transfer_piece .. large_transfer_piece .. large_transfer_piece
+
+local large_transfer_piece_count = 3
+local large_transfer_size = #large_transfer_piece * large_transfer_piece_count
+
+local header = [[
+local lgi = require("lgi")
+local Gdk = lgi.Gdk
+local Gtk = lgi.Gtk
+local GLib = lgi.GLib
+local function assert_equal(a, b)
+    assert(a == b,
+        string.format("%s == %s", a or "nil/false", b or "nil/false"))
+end
+local clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+]]
+
+local acquire_and_clear_clipboard = header .. [[
+clipboard:set_text("This is an experiment", -1)
+GLib.idle_add(GLib.PRIORITY_DEFAULT, Gtk.main_quit)
+Gtk.main()
+]]
+
+local done_footer = [[
+io.stdout:write("done")
+io.stdout:flush()
+]]
+
+local check_targets_and_text = header .. [[
+local targets = clipboard:wait_for_targets()
+assert_equal(targets[1]:name(), "TARGETS")
+assert_equal(targets[2]:name(), "UTF8_STRING")
+assert_equal(#targets, 2)
+assert_equal(clipboard:wait_for_text(), "Hello World!")
+]] .. done_footer
+
+local check_large_transfer = header
+    .. string.format("\nassert_equal(#clipboard:wait_for_text(), %d)\n", large_transfer_size)
+    .. done_footer
+
+local check_empty_selection = header .. [[
+assert_equal(clipboard:wait_for_targets(), nil)
+assert_equal(clipboard:wait_for_text(), nil)
+]] .. done_footer
+
+local selection
+local selection_released
+local continue
+
+local function wait_a_bit(count)
+    if continue or count == 5 then
+        return true
+    end
+end
+
+runner.run_steps{
+    function()
+        -- Get the selection
+        local s = assert(selection_acquire("CLIPBOARD"),
+            "Failed to acquire the clipboard selection")
+
+        -- Steal selection ownership from ourselves and test that it works
+        local s_released
+        s:connect_signal("release", function() s_released = true end)
+
+        selection = assert(selection_acquire("CLIPBOARD"),
+            "Failed to acquire the clipboard selection")
+
+        assert(s_released)
+
+        -- Now test selection transfers
+        selection = assert(selection_acquire("CLIPBOARD"),
+            "Failed to acquire the clipboard selection")
+        selection:connect_signal("request", function(_, target, transfer)
+            if target == "TARGETS" then
+                transfer:send{
+                    format = "atom",
+                    data = { "TARGETS", "UTF8_STRING" },
+                }
+            elseif target == "UTF8_STRING" then
+                transfer:send{ data = "Hello World!" }
+            end
+        end)
+        awesome.sync()
+        spawn.with_line_callback({ "lua", "-e", check_targets_and_text },
+            { stdout = function(line)
+                assert(line == "done", "Unexpected line: " .. line)
+                continue = true
+            end })
+        return true
+    end,
+
+    function()
+        -- Wait for the test to succeed
+        if not continue then
+            return
+        end
+        continue = false
+
+        -- Now test piece-wise selection transfers
+        selection = assert(selection_acquire("CLIPBOARD"),
+            "Failed to acquire the clipboard selection")
+        selection:connect_signal("request", function(_, target, transfer)
+            if target == "TARGETS" then
+                transfer:send{
+                    format = "atom",
+                    data = { "TARGETS", "UTF8_STRING" },
+                }
+            elseif target == "UTF8_STRING" then
+                local offset = 1
+                local data = "Hello World!"
+                local function send_piece()
+                    local piece = data:sub(offset, offset)
+                    transfer:send{
+                        data = piece,
+                        continue = piece ~= ""
+                    }
+                    offset = offset + 1
+                end
+                transfer:connect_signal("continue", send_piece)
+                send_piece()
+            end
+        end)
+        awesome.sync()
+        spawn.with_line_callback({ "lua", "-e", check_targets_and_text },
+            { stdout = function(line)
+                assert(line == "done", "Unexpected line: " .. line)
+                continue = true
+            end })
+        return true
+    end,
+
+    function()
+        -- Wait for the test to succeed
+        if not continue then
+            return
+        end
+        continue = false
+
+        -- Now test a huge transfer
+        selection = assert(selection_acquire("CLIPBOARD"),
+            "Failed to acquire the clipboard selection")
+        selection:connect_signal("request", function(_, target, transfer)
+            if target == "TARGETS" then
+                transfer:send{
+                    format = "atom",
+                    data = { "TARGETS", "UTF8_STRING" },
+                }
+            elseif target == "UTF8_STRING" then
+                local count = 0
+                local function send_piece()
+                    count = count + 1
+                    local done = count == large_transfer_piece_count
+                    transfer:send{
+                        data = large_transfer_piece,
+                        continue = not done,
+                    }
+                end
+                transfer:connect_signal("continue", send_piece)
+                send_piece()
+            end
+        end)
+        awesome.sync()
+        spawn.with_line_callback({ "lua", "-e", check_large_transfer },
+            { stdout = function(line)
+                assert(line == "done", "Unexpected line: " .. line)
+                continue = true
+            end })
+        return true
+    end,
+
+    wait_a_bit,
+    wait_a_bit,
+    wait_a_bit,
+    wait_a_bit,
+    wait_a_bit,
+
+    function()
+        -- Wait for the test to succeed
+        if not continue then
+            return
+        end
+        continue = false
+
+        -- Now test that :release() works
+        selection:release()
+        awesome.sync()
+        spawn.with_line_callback({ "lua", "-e", check_empty_selection },
+            { stdout = function(line)
+                assert(line == "done", "Unexpected line: " .. line)
+                continue = true
+            end })
+
+        return true
+    end,
+
+    function()
+        -- Wait for the test to succeed
+        if not continue then
+            return
+        end
+        continue = false
+
+        -- Test for "release" signal when we lose selection
+        selection = assert(selection_acquire("CLIPBOARD"),
+            "Failed to acquire the clipboard selection")
+        selection:connect_signal("release", function() selection_released = true end)
+        awesome.sync()
+        spawn.with_line_callback({ "lua", "-e", acquire_and_clear_clipboard },
+            { exit = function() continue = true end })
+        return true
+    end,
+
+    function()
+        -- Wait for the previous test to succeed
+        if not continue then
+            return
+        end
+        continue = false
+        assert(selection_released)
+        return true
+    end,
+}
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -179,6 +179,8 @@ runner.run_steps{
         return true
     end,
 
+    -- The large data transfer above transfers 3 * 2^25 bytes of data. That's
+    -- 96 MiB and takes a while.
     wait_a_bit,
     wait_a_bit,
     wait_a_bit,


### PR DESCRIPTION
This fixes #2642. (although I was too lazy to implement `MULTIPLE` and will just wait for someone to request this; even though the spec requires support for it, I still doubt it is used much. We will see...)

Example code that I used for testing:
```lua
    local o1 = selection_acquire("PRIMARY")
    o1:connect_signal("release", function() print("o1 released") end)
    o1:connect_signal("request", function(_, target, t)
        if target == "TARGETS" then
            t:send{ data = { "TARGETS", "UTF8_STRING" }, format = "atom" }
        else
            local data = {}
            for i=1, 2^23 do
                table.insert(data, "Hi")
            end
            print(#data)
            local data = table.concat(data)
            print(#data)
            print(string.format("data has length %d == 0x%x, %d bytes of space left", #data, #data, 16777212-#data))
            t:send{ data = data, continue = true }

            local count = 0
            t:connect_signal("continue", function()
                print("got continue signal");
                count = count + 1
                if count == 0 then
                    t:send{ data = ". Thanks for listening.", continue = true }
                elseif count == 1 then
                    t:send{ data = "", continue = true }
                elseif count == 2 then
                    t:send{ data = "\n" }
                end
            end)
        end
    end)
```

Fun fact: I looked at the GTK API after writing this and the API that I came up with is surprisingly close to GTK's API. Isn't GTK's API known for being hard to use...?