### PR TITLE
Fix a CMake warning when GENERATE_DOC is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,10 @@ if(LUACHECK_EXECUTABLE)
     list(APPEND CHECK_QA_TARGETS luacheck)
 endif()
 add_custom_target(check-qa DEPENDS ${CHECK_QA_TARGETS})
-add_dependencies(check check-qa check-examples)
+add_dependencies(check check-qa)
+if(GENERATE_DOC)
+    add_dependencies(check check-examples)
+endif()
 # }}}
 
 INCLUDE(${CMAKE_SOURCE_DIR}/Packaging.cmake)


### PR DESCRIPTION
This fixes the following CMake warning that I saw in some NixOS build:

CMake Warning (dev) at CMakeLists.txt:457 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.
  The dependency target "check-examples" of target "check" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

Signed-off-by: Uli Schlachter <psychon@znc.in>