### PR TITLE
ci: codecov: use env vars instead of flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,9 @@ install:
       if [ "$DO_COVERAGE" = "codecov" ]; then
         test -f build/luacov.stats.out || { echo 'build/luacov.stats.out does not exist.'; return 1; }
         luacov || return 1
-        travis_retry bash /tmp/codecov-bash -f build/luacov.report.out -X gcov -X coveragepy -F "$1,${LUANAME//./}" || return 1
+        # Set env variable for codecov.
+        TESTS="$1"
+        travis_retry bash /tmp/codecov-bash -f build/luacov.report.out -X gcov -X coveragepy -e LUANAME,TESTS || return 1
         rm build/luacov.report.out build/luacov.stats.out
       fi
       return 0
@@ -145,7 +147,9 @@ install:
           done
 
           # Upload to Codecov.
-          travis_retry bash /tmp/codecov-bash -X gcov -X coveragepy -F "$1,${LUANAME//./}"
+          # Set env variable for codecov.
+          TESTS="$1"
+          travis_retry bash /tmp/codecov-bash -X gcov -X coveragepy -e LUANAME,TESTS
         )
       fi
       return 0


### PR DESCRIPTION
Using flags appears to trigger timeouts with codecov's backend.
This uses env variables instead.