### PR TITLE
Set _NET_WM_DESKTOP for sticky windows specially

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -35,6 +35,8 @@
 #define _NET_WM_STATE_ADD 1
 #define _NET_WM_STATE_TOGGLE 2
 
+#define ALL_DESKTOPS 0xffffffff
+
 /** Update client EWMH hints.
  * \param L The Lua VM state.
  */
@@ -430,7 +432,7 @@ ewmh_process_desktop(client_t *c, uint32_t desktop)
 {
     lua_State *L = globalconf_get_lua_State();
     int idx = desktop;
-    if(desktop == 0xffffffff)
+    if(desktop == ALL_DESKTOPS)
     {
         luaA_object_push(L, c);
         lua_pushboolean(L, true);
@@ -517,6 +519,13 @@ ewmh_client_update_desktop(client_t *c)
 {
     int i;
 
+    if(c->sticky)
+    {
+        xcb_change_property(globalconf.connection, XCB_PROP_MODE_REPLACE,
+                            c->window, _NET_WM_DESKTOP, XCB_ATOM_CARDINAL, 32, 1,
+                            (uint32_t[]) { ALL_DESKTOPS });
+        return;
+    }
     for(i = 0; i < globalconf.tags.len; i++)
         if(is_client_tagged(c, globalconf.tags.tab[i]))
         {

--- a/objects/client.c
+++ b/objects/client.c
@@ -2025,6 +2025,7 @@ client_set_sticky(lua_State *L, int cidx, bool s)
     {
         c->sticky = s;
         banning_need_update();
+        ewmh_client_update_desktop(c);
         if(strut_has_value(&c->strut))
             screen_update_workarea(c->screen);
         luaA_object_emit_signal(L, cidx, "property::sticky", 0);


### PR DESCRIPTION
Today I learnt that _NET_WM_STATE_STICKY means something else than I
previously thought.

ICCCM and EWMH support virtual desktops that are larger than the actual
screen. The idea is that one can scroll through this virtual desktop,
which means that e.g. all windows move to the left, so one can see the
windows that are further to the right.

_NET_WM_STATE_STICKY indicates that a window is sticky. This means that
it does not scroll with the virtual desktop, but instead sticks to its
current position.

In AwesomeWM, we use a different definition. A sticky window is always
visible, even when it is not tagged with any of the currently selected
tags. This behaviour is indicated in EWMH with a special value of
_NET_WM_DESKTOP. This commit updates the code to actually set this
special value.

This fixes attaching tabs in Google Chrome when the "target window" is
sticky (in the AwesomeWM sense).

Fixes: https://github.com/awesomeWM/awesome/issues/2652
Signed-off-by: Uli Schlachter <psychon@znc.in>