### PR TITLE
gears.protected_call: Automatically detect xpcall features

### DIFF
--- a/lib/gears/protected_call.lua
+++ b/lib/gears/protected_call.lua
@@ -23,7 +23,7 @@ local function handle_result(success, ...)
 end
 
 local do_pcall
-if _VERSION <= "Lua 5.1" then
+if not select(2, xpcall(function(a) return a end, error, true)) then
     -- Lua 5.1 doesn't support arguments in xpcall :-(
     do_pcall = function(func, ...)
         local args = { ... }


### PR DESCRIPTION
In Lua 5.1, xpcall() has exactly two arguments: The function to call and
the error handler. Everywhere else, xpcall() passes extra arguments on
to the function to call. This includes LuaJIT, however since LuaJIT sets
_VERSION to "Lua 5.1", so far gears.protected_call used the workaround
for Lua 5.1 here.

This commit switches gears.protected_call to actually test for this
feature instead of just guessing based on _VERSION. Thus, this now also
uses the better code with LuaJIT.

Signed-off-by: Uli Schlachter <psychon@znc.in>