### PR TITLE
Move delayed calls to g_idle_add

### DIFF
--- a/lib/gears/delayed_call.lua
+++ b/lib/gears/delayed_call.lua
@@ -15,12 +15,17 @@ local protected_call = require("gears.protected_call")
 local module = {}
 
 local delayed_calls = {}
-capi.awesome.connect_signal("refresh", function()
+
+--- Run all pending delayed calls now. This function should best not be used at
+-- all, because it means that less batching happens and the delayed calls run
+-- prematurely.
+-- @function gears.delayed_call.run_now
+function module.run_now()
     for _, callback in ipairs(delayed_calls) do
         protected_call(unpack(callback))
     end
     delayed_calls = {}
-end)
+end
 
 --- Call the given function at the end of the current main loop iteration
 -- @tparam function callback The function that should be called
@@ -30,6 +35,8 @@ function module.delayed_call(callback, ...)
     assert(type(callback) == "function", "callback must be a function, got: " .. type(callback))
     table.insert(delayed_calls, { callback, ... })
 end
+
+capi.awesome.connect_signal("refresh", module.run_now)
 
 return setmetatable(module, { __call = function(_, ...) return module.delayed_call(...) end })
 

--- a/lib/gears/delayed_call.lua
+++ b/lib/gears/delayed_call.lua
@@ -1,0 +1,36 @@
+---------------------------------------------------------------------------
+--- Do some operation 'later'
+--
+-- @author Uli Schlachter
+-- @copyright 2015 Uli Schlachter
+-- @classmod gears.delayed_call
+---------------------------------------------------------------------------
+
+local capi = { awesome = awesome }
+local ipairs = ipairs
+local table = table
+local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
+local protected_call = require("gears.protected_call")
+
+local module = {}
+
+local delayed_calls = {}
+capi.awesome.connect_signal("refresh", function()
+    for _, callback in ipairs(delayed_calls) do
+        protected_call(unpack(callback))
+    end
+    delayed_calls = {}
+end)
+
+--- Call the given function at the end of the current main loop iteration
+-- @tparam function callback The function that should be called
+-- @param ... Arguments to the callback function
+-- @function gears.delayed_call
+function module.delayed_call(callback, ...)
+    assert(type(callback) == "function", "callback must be a function, got: " .. type(callback))
+    table.insert(delayed_calls, { callback, ... })
+end
+
+return setmetatable(module, { __call = function(_, ...) return module.delayed_call(...) end })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/gears/delayed_call.lua
+++ b/lib/gears/delayed_call.lua
@@ -21,10 +21,11 @@ local delayed_calls = {}
 -- prematurely.
 -- @function gears.delayed_call.run_now
 function module.run_now()
-    for _, callback in ipairs(delayed_calls) do
+    local to_run
+    to_run, delayed_calls = delayed_calls, {}
+    for _, callback in ipairs(to_run) do
         protected_call(unpack(callback))
     end
-    delayed_calls = {}
 end
 
 --- Call the given function at the end of the current main loop iteration

--- a/lib/gears/init.lua
+++ b/lib/gears/init.lua
@@ -23,6 +23,7 @@ return
     string = require("gears.string");
     sort = require("gears.sort");
     filesystem = require("gears.filesystem");
+    delayed_call = require("gears.delayed_call");
 }
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -49,14 +49,10 @@
 -- @classmod gears.timer
 ---------------------------------------------------------------------------
 
-local capi = { awesome = awesome }
-local ipairs = ipairs
 local pairs = pairs
 local setmetatable = setmetatable
-local table = table
 local tonumber = tonumber
 local traceback = debug.traceback
-local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 local glib = require("lgi").GLib
 local object = require("gears.object")
 local protected_call = require("gears.protected_call")
@@ -81,6 +77,8 @@ local protected_call = require("gears.protected_call")
 -- @signal timeout
 
 local timer = { mt = {} }
+
+timer.delayed_call = require("gears.delayed_call") -- TODO v5 deprecate this
 
 --- Start the timer.
 function timer:start()
@@ -223,23 +221,6 @@ function timer.weak_start_new(timeout, callback)
             return cb()
         end
     end)
-end
-
-local delayed_calls = {}
-capi.awesome.connect_signal("refresh", function()
-    for _, callback in ipairs(delayed_calls) do
-        protected_call(unpack(callback))
-    end
-    delayed_calls = {}
-end)
-
---- Call the given function at the end of the current main loop iteration
--- @tparam function callback The function that should be called
--- @param ... Arguments to the callback function
--- @function gears.timer.delayed_call
-function timer.delayed_call(callback, ...)
-    assert(type(callback) == "function", "callback must be a function, got: " .. type(callback))
-    table.insert(delayed_calls, { callback, ... })
 end
 
 function timer.mt.__call(_, ...)

--- a/luaa.c
+++ b/luaa.c
@@ -141,13 +141,6 @@ extern const struct luaL_Reg awesome_mouse_meta[];
  * @signal xkb::group_changed.
  */
 
-/** Refresh.
- *
- * This signal is emitted as a kind of idle signal in the event loop.
- * One example usage is in `gears.timer` to executed delayed calls.
- * @signal refresh
- */
-
 /** Awesome is about to enter the event loop.
  *
  * This means all initialization has been done.
@@ -1185,6 +1178,7 @@ luaA_emit_startup()
 void
 luaA_emit_refresh()
 {
+    /* TODO v5: Deprecate / remove this */
     lua_State *L = globalconf_get_lua_State();
     signal_object_emit(L, &global_signals, "refresh", 0);
 }

--- a/tests/examples/awful/popup/position2.lua
+++ b/tests/examples/awful/popup/position2.lua
@@ -32,7 +32,7 @@ local p = awful.popup { --DOC_HIDE
     placement    = awful.placement.centered, --DOC_HIDE
 } --DOC_HIDE
 p:_apply_size_now() --DOC_HIDE
-awesome.emit_signal("refresh") --DOC_HIDE
+require("gears.delayed_call").run_now() --DOC_HIDE
 p._drawable._do_redraw() --DOC_HIDE
 
 --DOC_HIDE Necessary as the widgets are drawn later

--- a/tests/examples/awful/popup/wiboxtypes.lua
+++ b/tests/examples/awful/popup/wiboxtypes.lua
@@ -111,7 +111,7 @@ local p10 = awful.popup {
     shape = gears.shape.infobubble,
 }
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 p10:bind_to_widget(mytextclock)
 
 -- The titlebar

--- a/tests/examples/awful/template.lua
+++ b/tests/examples/awful/template.lua
@@ -13,7 +13,7 @@ local args = loadfile(file_path)() or {}
 
 -- Emulate the event loop for 5 iterations
 for _ = 1, 5 do
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
 end
 
 -- Draw the result
@@ -172,7 +172,7 @@ end
 
 -- Emulate the event loop for another 5 iterations
 for _ = 1, 5 do
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
 end
 
 for _, d in ipairs(drawin.get()) do

--- a/tests/examples/awful/tooltip/align.lua
+++ b/tests/examples/awful/tooltip/align.lua
@@ -13,7 +13,7 @@ local wibox = require("wibox")
         width = 100, height = 44, x = 100, y = 10, visible = true, bg = "#00000000"
     }
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 for _, side in ipairs{ "top_left", "bottom_left", "top_right", "bottom_right"} do
     local tt = awful.tooltip {
@@ -27,4 +27,4 @@ end
 
 mouse.coords{x=125, y= 35}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/align2.lua
+++ b/tests/examples/awful/tooltip/align2.lua
@@ -13,7 +13,7 @@ local wibox = require("wibox")
         width = 100, height = 44, x = 100, y = 10, visible = true, bg = "#00000000"
     }
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 for _, side in ipairs{ "left", "right", "bottom", "top" } do
     local tt = awful.tooltip {
@@ -27,4 +27,4 @@ end
 
 mouse.coords{x=125, y= 35}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/border_color.lua
+++ b/tests/examples/awful/tooltip/border_color.lua
@@ -8,7 +8,7 @@ local beautiful = require("beautiful")
 
 -- mouse.coords{x=50, y= 10}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 local x_offset = 0
 
@@ -20,13 +20,13 @@ for _, color in ipairs{ "#ff0000", "#00ff00", "#0000ff", "#00ffff" } do
         border_color = color,
     }
     tt.bg = beautiful.bg_normal
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt:show()
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt.wibox.x = x_offset
     x_offset = x_offset + 640/5
 end
 
 mouse.coords{x=125, y= 0}
 -- mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/border_width.lua
+++ b/tests/examples/awful/tooltip/border_width.lua
@@ -8,7 +8,7 @@ local beautiful = require("beautiful")
 
 -- mouse.coords{x=50, y= 10}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 local x_offset = 0
 
@@ -20,13 +20,13 @@ for _, width in ipairs{ 1,2,4,6 } do
         border_color = beautiful.border_color,
     }
     tt.bg = beautiful.bg_normal
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt:show()
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt.wibox.x = x_offset
     x_offset = x_offset + 640/5
 end
 
 mouse.coords{x=125, y= 0}
 -- mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/margins.lua
+++ b/tests/examples/awful/tooltip/margins.lua
@@ -8,7 +8,7 @@ local beautiful = require("beautiful")
 
 -- mouse.coords{x=50, y= 10}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 local x_offset = 0
 
@@ -20,13 +20,13 @@ for _, width in ipairs{ 1,2,4,6 } do
         border_color = beautiful.border_color,
     }
     tt.bg = beautiful.bg_normal
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt:show()
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt.wibox.x = x_offset
     x_offset = x_offset + 640/5
 end
 
 mouse.coords{x=125, y= 0}
 -- mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/margins_leftright.lua
+++ b/tests/examples/awful/tooltip/margins_leftright.lua
@@ -8,7 +8,7 @@ local beautiful = require("beautiful")
 
 -- mouse.coords{x=50, y= 10}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 local x_offset = 0
 
@@ -20,13 +20,13 @@ for _, width in ipairs{ 1,2,4,6 } do
         border_color = beautiful.border_color,
     }
     tt.bg = beautiful.bg_normal
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt:show()
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt.wibox.x = x_offset
     x_offset = x_offset + 640/5
 end
 
 mouse.coords{x=125, y= 0}
 -- mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/margins_topbottom.lua
+++ b/tests/examples/awful/tooltip/margins_topbottom.lua
@@ -8,7 +8,7 @@ local beautiful = require("beautiful")
 
 -- mouse.coords{x=50, y= 10}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 local x_offset = 0
 
@@ -20,13 +20,13 @@ for _, width in ipairs{ 1,2,4,6 } do
         border_color = beautiful.border_color,
     }
     tt.bg = beautiful.bg_normal
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt:show()
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt.wibox.x = x_offset
     x_offset = x_offset + 640/5
 end
 
 mouse.coords{x=125, y= 0}
 -- mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/mode.lua
+++ b/tests/examples/awful/tooltip/mode.lua
@@ -11,7 +11,7 @@ mouse.coords{x=50, y= 10}
 
     local wb = wibox {width = 100, height = 44, x = 50, y = 25, visible = true}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 local tt = awful.tooltip {
     text = "A tooltip!",
     objects = {wb},
@@ -20,4 +20,4 @@ tt.bg = beautiful.bg_normal
 
 mouse.coords{x=75, y= 35}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/mode2.lua
+++ b/tests/examples/awful/tooltip/mode2.lua
@@ -11,7 +11,7 @@ mouse.coords{x=50, y= 10}
 
     local wb = wibox {width = 100, height = 44, x = 50, y = 25, visible = true}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 local tt = awful.tooltip {
     text = "A tooltip!",
     objects = {wb},
@@ -21,4 +21,4 @@ tt.bg = beautiful.bg_normal
 
 mouse.coords{x=75, y= 35}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/preferred_alignment.lua
+++ b/tests/examples/awful/tooltip/preferred_alignment.lua
@@ -11,7 +11,7 @@ local wibox = require("wibox")
 
     local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 for _, side in ipairs{ "left", "right", "bottom", "top" } do
     local tt = awful.tooltip {
@@ -26,4 +26,4 @@ end
 
 mouse.coords{x=125, y= 75}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/preferred_alignment2.lua
+++ b/tests/examples/awful/tooltip/preferred_alignment2.lua
@@ -11,7 +11,7 @@ local wibox = require("wibox")
 
     local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 for _, side in ipairs{ "left", "right", "bottom", "top" } do
     local tt = awful.tooltip {
@@ -26,4 +26,4 @@ end
 
 mouse.coords{x=125, y= 75}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/preferred_alignment3.lua
+++ b/tests/examples/awful/tooltip/preferred_alignment3.lua
@@ -11,7 +11,7 @@ local wibox = require("wibox")
 
     local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 for _, side in ipairs{ "left", "right", "bottom", "top" } do
     local tt = awful.tooltip {
@@ -26,4 +26,4 @@ end
 
 mouse.coords{x=125, y= 75}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/preferred_positions.lua
+++ b/tests/examples/awful/tooltip/preferred_positions.lua
@@ -11,7 +11,7 @@ local wibox = require("wibox")
 
     local wb = wibox {width = 100, height = 44, x = 100, y = 50, visible = true}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 for _, side in ipairs{ "left", "right", "bottom", "top" } do
     local tt = awful.tooltip {
@@ -25,4 +25,4 @@ end
 
 mouse.coords{x=125, y= 75}
 mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/shape.lua
+++ b/tests/examples/awful/tooltip/shape.lua
@@ -9,7 +9,7 @@ local gears = {shape = require("gears.shape")}
 
 -- mouse.coords{x=50, y= 10}
 
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()
 
 local x_offset = 0
 
@@ -22,13 +22,13 @@ for _, shape in ipairs{ "rounded_rect", "rounded_bar", "octogon", "infobubble"} 
         border_color = beautiful.border_color,
     }
     tt.bg = beautiful.bg_normal
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt:show()
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
     tt.wibox.x = x_offset
     x_offset = x_offset + 640/5
 end
 
 mouse.coords{x=125, y= 0}
 -- mouse.push_history()
-awesome.emit_signal("refresh")
+require("gears.delayed_call").run_now()

--- a/tests/examples/awful/tooltip/textclock.lua
+++ b/tests/examples/awful/tooltip/textclock.lua
@@ -15,7 +15,7 @@ local wb = awful.wibar { position = "top" } --DOC_HIDE
 wb:setup { layout = wibox.layout.align.horizontal, --DOC_HIDE
     nil, nil, mytextclock} --DOC_HIDE
 
-awesome.emit_signal("refresh") --DOC_HIDE the hierarchy is async
+require("gears.delayed_call").run_now() --DOC_HIDE the hierarchy is async
 
     local myclock_t = awful.tooltip {
         objects        = { mytextclock },
@@ -24,7 +24,7 @@ awesome.emit_signal("refresh") --DOC_HIDE the hierarchy is async
         end,
     }
 
-awesome.emit_signal("refresh") --DOC_HIDE
+require("gears.delayed_call").run_now() --DOC_HIDE
 
 mouse.coords{x=250, y= 10} --DOC_HIDE
 mouse.push_history() --DOC_HIDE

--- a/tests/examples/awful/tooltip/textclock2.lua
+++ b/tests/examples/awful/tooltip/textclock2.lua
@@ -15,7 +15,7 @@ local wb = awful.wibar { position = "top" } --DOC_HIDE
 wb:setup { layout = wibox.layout.align.horizontal, --DOC_HIDE
     nil, nil, mytextclock} --DOC_HIDE
 
-awesome.emit_signal("refresh") --DOC_HIDE the hierarchy is async
+require("gears.delayed_call").run_now() --DOC_HIDE the hierarchy is async
 
     local myclock_t = awful.tooltip { }
 --DOC_NEWLINE
@@ -25,7 +25,7 @@ awesome.emit_signal("refresh") --DOC_HIDE the hierarchy is async
         myclock_t.text = os.date("Today is %A %B %d %Y\nThe time is %T")
     end)
 
-awesome.emit_signal("refresh") --DOC_HIDE
+require("gears.delayed_call").run_now() --DOC_HIDE
 
 mouse.coords{x=250, y= 10} --DOC_HIDE
 mouse.push_history() --DOC_HIDE

--- a/tests/examples/text/awful/keygrabber/alttab.lua
+++ b/tests/examples/text/awful/keygrabber/alttab.lua
@@ -24,7 +24,7 @@ local awful = {keygrabber = require("awful.keygrabber"), --DOC_HIDE
     }
 
 --DOC_HIDE Trigger the keybinging
-awesome.emit_signal("refresh") --DOC_HIDE `export_keybindings` is async
+require("gears.delayed_call").run_now() --DOC_HIDE `export_keybindings` is async
 root.fake_input("key_press", "Alt_L")--DOC_HIDE
 root.fake_input("key_press", "Tab")--DOC_HIDE
 root.fake_input("key_release", "Tab")--DOC_HIDE

--- a/tests/examples/text/awful/keygrabber/root_keybindings.lua
+++ b/tests/examples/text/awful/keygrabber/root_keybindings.lua
@@ -27,7 +27,7 @@ awful.keygrabber {
 --DOC_NEWLINE
 -- The following will **NOT** trigger the keygrabbing because it isn't exported
 -- to the root (global) keys. Adding `export_keybindings` would solve that
-awesome.emit_signal("refresh") --DOC_HIDE `root_keybindings` is async
+require("gears.delayed_call").run_now() --DOC_HIDE `root_keybindings` is async
 root._execute_keybinding({"Mod4", "Shift"}, "i")
 assert(#keybinding_works == 0)
 

--- a/tests/examples/wibox/container/defaults/template.lua
+++ b/tests/examples/wibox/container/defaults/template.lua
@@ -64,7 +64,7 @@ local container = wibox.widget {
 
 -- Emulate the event loop for 10 iterations
 for _ = 1, 10 do
-    awesome:emit_signal("refresh")
+    require("gears.delayed_call").run_now()
 end
 
 -- Get the example fallback size (the tests can return a size if the want)

--- a/tests/examples/wibox/layout/template.lua
+++ b/tests/examples/wibox/layout/template.lua
@@ -99,7 +99,7 @@ local widget, w, h = loadfile(file_path)(generic_widget, generic_before_after)
 
 -- Emulate the event loop for 10 iterations
 for _ = 1, 10 do
-    awesome:emit_signal("refresh")
+    require("gears.delayed_call").run_now()
 end
 
 -- Save to the output file

--- a/tests/examples/wibox/template.lua
+++ b/tests/examples/wibox/template.lua
@@ -13,7 +13,7 @@ image_type = image_type or "svg"
 
 -- Emulate the event loop for 10 iterations
 for _ = 1, 10 do
-    awesome:emit_signal("refresh")
+    require("gears.delayed_call").run_now()
 end
 
 -- Get the example fallback size (the tests can return a size if the want)

--- a/tests/test-benchmark.lua
+++ b/tests/test-benchmark.lua
@@ -41,7 +41,7 @@ do
 end
 
 local function do_pending_repaint()
-    awesome.emit_signal("refresh")
+    require("gears.delayed_call").run_now()
 end
 
 local function create_and_draw_wibox()

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -7,8 +7,8 @@ local create_wibox = require("_wibox_helper").create_wibox
 local wibox = require("wibox")
 
 local prepare_for_collect = nil
-local function emit_refresh()
-    awesome.emit_signal("refresh")
+local function run_delayed_calls()
+    require("gears.delayed_call").run_now()
 end
 
 -- Make the layoutbox in the default config GC'able
@@ -18,7 +18,7 @@ for s in screen do
     s.mywibox = nil
     s.mylayoutbox = nil
 end
-emit_refresh()
+run_delayed_calls()
 
 -- Test if some objects can be garbage collected
 local function collectable(a, b, c, d, e, f, g, h, last)
@@ -66,19 +66,19 @@ collectable(wibox.widget.textclock())
 collectable(awful.widget.layoutbox(1))
 
 -- Some widgets do things via timer.delayed_call
-prepare_for_collect = emit_refresh
+prepare_for_collect = run_delayed_calls
 collectable(tooltip_delayed())
 
-prepare_for_collect = emit_refresh
+prepare_for_collect = run_delayed_calls
 collectable(tooltip_now())
 
-prepare_for_collect = emit_refresh
+prepare_for_collect = run_delayed_calls
 collectable(awful.widget.taglist{screen=1, filter=awful.widget.taglist.filter.all})
 
-prepare_for_collect = emit_refresh
+prepare_for_collect = run_delayed_calls
 collectable(awful.widget.tasklist{screen=1, filter=awful.widget.tasklist.filter.currenttags})
 
-prepare_for_collect = emit_refresh
+prepare_for_collect = run_delayed_calls
 collectable(create_wibox())
 
 runner.run_steps({ function() return true end })


### PR DESCRIPTION
This removes all usages of the `refresh` signal. Instead, the code now uses `g_idle_add`. Thanks to this, it becomes possible to do what @blueyed wanted to do in #1970: Recursive delayed calls still cause 100% CPU usage, but now the main loop continue to run and other things still work.

This is technically an API break, since everyone who uses `awesome.emit_signal("refresh")` to run delayed calls will have to change his config. However, it was never documented that `delayed_call` uses the `refresh` signal, so we are not breaking any promises here, I think... Well, I'm unsure.

Oh and this also moves delayed calls to `gears.delayed_call` since I prefer small modules doing only one thing (although I do often fail in this).

More details can be found in the individual commit messages.

-----

By the way: Previously, `for i=1,5 do awesome.emit_signal("refresh") end` was pointless, because the first iteration already ran all delayed calls. After this PR, this now actually does something (but this code still seems odd because of the random constant `5`).