### PR TITLE
Migrate a bit away from luaL_register().

### DIFF
--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -131,7 +131,7 @@ luaA_openlib(lua_State *L, const char *name,
     lua_pushvalue(L, -1);           /* dup metatable                      2 */
     lua_setfield(L, -2, "__index"); /* metatable.__index = metatable      1 */
 
-    luaA_registerlib(L, NULL, meta);                                   /* 1 */
+    luaA_setfuncs(L, meta);                                            /* 1 */
     luaA_registerlib(L, name, methods);                                /* 2 */
     lua_pushvalue(L, -1);           /* dup self as metatable              3 */
     lua_setmetatable(L, -2);        /* set self as metatable              2 */
@@ -267,7 +267,7 @@ luaA_class_setup(lua_State *L, lua_class_t *class,
 
     lua_setfield(L, -2, "__index"); /* metatable.__index = metatable      1 */
 
-    luaA_registerlib(L, NULL, meta);                                   /* 1 */
+    luaA_setfuncs(L, meta);                                            /* 1 */
     luaA_registerlib(L, name, methods);                                /* 2 */
     lua_pushvalue(L, -1);           /* dup self as metatable              3 */
     lua_setmetatable(L, -2);        /* set self as metatable              2 */

--- a/luaa.h
+++ b/luaa.h
@@ -128,18 +128,24 @@ luaA_rawlen(lua_State *L, int idx)
 static inline void
 luaA_registerlib(lua_State *L, const char *libname, const luaL_Reg *l)
 {
+    assert(libname);
 #if LUA_VERSION_NUM >= 502
-    if (libname)
-    {
-        lua_newtable(L);
-        luaL_setfuncs(L, l, 0);
-        lua_pushvalue(L, -1);
-        lua_setglobal(L, libname);
-    }
-    else
-        luaL_setfuncs(L, l, 0);
+    lua_newtable(L);
+    luaL_setfuncs(L, l, 0);
+    lua_pushvalue(L, -1);
+    lua_setglobal(L, libname);
 #else
     luaL_register(L, libname, l);
+#endif
+}
+
+static inline void
+luaA_setfuncs(lua_State *L, const luaL_Reg *l)
+{
+#if LUA_VERSION_NUM >= 502
+    luaL_setfuncs(L, l, 0);
+#else
+    luaL_register(L, NULL, l);
 #endif
 }
 


### PR DESCRIPTION
luaL_register() only exists in Lua 5.1 and was removed in never
versions. It has two completely different behaviours depending on
whether its second argument is NULL or not.

This commit splits that up by adding a wrapper for luaL_setfuncs()
(which does not exist in Lua 5.1) and using that everywhere instead of
our wrapper for luaL_register().

No behavioural changes are intended. This is simply meant as a cleanup.

Signed-off-by: Uli Schlachter <psychon@znc.in>