### PR TITLE
Move setup of selection() to selection.c

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -385,9 +385,6 @@ luaA_fixups(lua_State *L)
     /* replace type */
     lua_pushcfunction(L, luaAe_type);
     lua_setglobal(L, "type");
-    /* set selection */
-    lua_pushcfunction(L, luaA_selection_get);
-    lua_setglobal(L, "selection");
 }
 
 static const char *
@@ -1042,6 +1039,9 @@ luaA_init(xdgHandle* xdg, string_array_t *searchpath)
 
     /* Export selection watcher */
     selection_watcher_class_setup(L);
+
+    /* Setup the selection interface */
+    selection_setup(L);
 
     /* add Lua search paths */
     lua_getglobal(L, "package");

--- a/selection.c
+++ b/selection.c
@@ -49,7 +49,7 @@ static xcb_window_t selection_window = XCB_NONE;
  * \luastack
  * \lreturn A string with the current X selection buffer.
  */
-int
+static int
 luaA_selection_get(lua_State *L)
 {
     if(selection_window == XCB_NONE)
@@ -130,6 +130,13 @@ luaA_selection_get(lua_State *L)
 
     p_delete(&event);
     return 0;
+}
+
+void
+selection_setup(lua_State *L)
+{
+    lua_pushcfunction(L, luaA_selection_get);
+    lua_setglobal(L, "selection");
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/selection.h
+++ b/selection.h
@@ -24,7 +24,7 @@
 
 #include <lua.h>
 
-int luaA_selection_get(lua_State *);
+void selection_setup(lua_State *);
 
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The function selection() is now registered in the Lua global table from
selection.c instead of in luaa.c. This "feels cleaner" to me and is
preparatory for later changes.

Signed-off-by: Uli Schlachter <psychon@znc.in>