### PR TITLE
Initialise Lua's pseudo-RNG from C from a good source

### DIFF
--- a/lib/gears/filesystem.lua
+++ b/lib/gears/filesystem.lua
@@ -153,8 +153,6 @@ function filesystem.get_dir(d)
     end
 end
 
-math.randomseed( os.clock() % 1 * 1e6 )
-
 --- Get the name of a random file from a given directory.
 -- @tparam string path The directory to search.
 -- @tparam[opt] table exts Specific extensions to limit the search to. eg:`{ "jpg", "png" }`


### PR DESCRIPTION
GLib has an internal pseudo-RNG that it initialises from /dev/urandom.
This commit adds code that uses this RNG to initialise various random
number generators that can be used by Lua.

This also removes some Lua code that initialises the random number
generator badly.

Signed-off-by: Uli Schlachter <psychon@znc.in>