### PR TITLE
tests/_runner: Don't lower timeouts for later steps

### DIFF
--- a/tests/_runner.lua
+++ b/tests/_runner.lua
@@ -89,7 +89,7 @@ runner.run_steps = function(steps, options)
                 -- Next step.
                 step = step+1
                 step_count = 0
-                wait = 5
+                wait = 20
                 t.timeout = 0
                 t:again()
                 return


### PR DESCRIPTION
The first step of a test is called 20 times before a failure is
diagnosed. Later steps only get five calls to finish. I guess the idea
is that the first step sets everything up and opens all necessary
clients, while later steps then do something with these clients.

However, looking at our existing tests, they are not structured like
that. Later steps open more clients etc.

Since this limit has no negative impact on the run-time of tests, but
only means that failures are detected later, let's just remove this
limit of five calls.

Signed-off-by: Uli Schlachter <psychon@znc.in>