### PR TITLE
CMake: Add "AUTO" state for WITH_DBUS and GENERATE_MANPAGES

### DIFF
--- a/AutoOption.cmake
+++ b/AutoOption.cmake
@@ -1,0 +1,42 @@
+# Add a new option with default value "auto":
+#   autoOption(FOOBAR "Support foobar")
+#
+# To check if FOOBAR support should be enabled, use:
+#   if(FOOBAR)
+#
+# If necessary dependencies for FOOBAR are missing, use:
+#   autoDisable(FOOBAR "Did not find baz")
+#
+# Example:
+#   autoOption(FOOBAR "Support foobar")
+#   if(FOOBAR)
+#     Check for FOOBAR here.
+#     if(NOT BAZ_FOUND)
+#       autoDisable(FOOBAR "Did not find baz")
+#     endif()
+#   endif()
+
+function(autoOption name description)
+    set(${name} AUTO CACHE STRING "${description}")
+    set_property(CACHE ${name} PROPERTY STRINGS AUTO ON OFF)
+
+    if((NOT ${name} STREQUAL ON) AND
+        (NOT ${name} STREQUAL OFF) AND
+        (NOT ${name} STREQUAL AUTO))
+        message(FATAL_ERROR "Value of ${name} must be one of ON/OFF/AUTO, but is ${${name}}")
+    endif()
+endfunction()
+
+function(autoDisable name reason)
+    message(STATUS "${reason}")
+    if(${name} STREQUAL AUTO)
+        message(STATUS "Disabled.")
+        SET(${name} OFF PARENT_SCOPE)
+    elseif(${name} STREQUAL ON)
+        message(SEND_ERROR "Aborting because ${name} was set to ON.")
+    else()
+        message(AUTHOR_WARNING "Unexpected value for ${name}: ${${name}}.")
+    endif()
+endfunction()
+
+# vim: filetype=cmake:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80:foldmethod=marker

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -6,8 +6,10 @@ set(VERSION devel)
 
 set(CODENAME "Too long")
 
-option(WITH_DBUS "build with D-BUS" ON)
-option(GENERATE_MANPAGES "generate manpages" ON)
+include(AutoOption.cmake)
+
+autoOption(WITH_DBUS "build with D-BUS")
+autoOption(GENERATE_MANPAGES "generate manpages")
 option(COMPRESS_MANPAGES "compress manpages" ON)
 option(GENERATE_DOC "generate API documentation" ON)
 option(DO_COVERAGE "build with coverage" OFF)
@@ -84,8 +86,7 @@ if(GENERATE_MANPAGES)
             SET(missing ${missing} " gzip")
         endif()
 
-        message(STATUS "Not generating manpages. Missing: " ${missing})
-        set(GENERATE_MANPAGES OFF)
+        autoDisable(GENERATE_MANPAGES "Not generating manpages. Missing: " ${missing})
     endif()
 endif()
 # }}}
@@ -214,8 +215,7 @@ if(WITH_DBUS)
         set(AWESOME_OPTIONAL_LDFLAGS ${AWESOME_OPTIONAL_LDFLAGS} ${DBUS_LDFLAGS})
         set(AWESOME_OPTIONAL_INCLUDE_DIRS ${AWESOME_OPTIONAL_INCLUDE_DIRS} ${DBUS_INCLUDE_DIRS})
     else()
-        set(WITH_DBUS OFF)
-        message(STATUS "DBUS not found. Disabled.")
+        autoDisable(WITH_DBUS "DBus not found.")
     endif()
 endif()
 # }}}


### PR DESCRIPTION
Previously, these options had two possible values: ON and OFF.

Now, they have three possible values: ON, OFF, and AUTO.

OFF still does what it always did: The feature is just disabled.

With ON and AUTO, we check for the feature. The difference is what
happens when the feature could not be enabled, e.g. because some
dependencies is missing: With AUTO, we just disable the feature (this is
what happened previously with ON). However, with ON, CMake aborts and
prints an error.

Implements: Suggestion by Daniel
    https://github.com/awesomeWM/awesome/pull/2665#pullrequestreview-204595138
Signed-off-by: Uli Schlachter <psychon@znc.in>