### PR TITLE
chore(common: version): replace unicode symbols to yes/no

### DIFF
--- a/common/version.c
+++ b/common/version.c
@@ -50,19 +50,19 @@ eprint_version(void)
     (void) luaL_dostring(L, "return require('lgi.version')");
 
 #ifdef WITH_DBUS
-    const char *has_dbus = "✔";
+    const char *has_dbus = "yes";
 #else
-    const char *has_dbus = "✘";
+    const char *has_dbus = "no";
 #endif
 #ifdef WITH_XCB_ERRORS
-    const char *has_xcb_errors = "✔";
+    const char *has_xcb_errors = "yes";
 #else
-    const char *has_xcb_errors = "✘";
+    const char *has_xcb_errors = "no";
 #endif
 #ifdef HAS_EXECINFO
-    const char *has_execinfo = "✔";
+    const char *has_execinfo = "yes";
 #else
-    const char *has_execinfo = "✘";
+    const char *has_execinfo = "no";
 #endif
 
     printf("awesome %s (%s)\n"


### PR DESCRIPTION
There are some usecases when terminal font not providing those characters at all or they're provided by fallback font with different dimensions.
Both of the issues above could affect readability/clarity of the version output.

![tty](https://user-images.githubusercontent.com/1655669/53110172-b2768d80-353a-11e9-893b-28d9bd49aba5.png)
