### PR TITLE
naughty: Resize notification when setting text

### DIFF
--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -689,13 +689,32 @@ table.insert(steps, function()
     assert(not naughty.suspended)
 
     -- Replace the text
+    assert(n.title   == "foo")
     assert(n.message == "bar")
     assert(n.text    == "bar")
-    assert(n.title   == "foo")
+    local width, height = n.width, n.height
+    assert(width)
+    assert(height)
     naughty.replace_text(n, "foobar", "baz")
     assert(n.title   == "foobar")
     assert(n.message == "baz")
     assert(n.text    == "baz")
+    assert(n.width > width)
+    assert(n.height == height)
+    width, height = n.width, n.height
+    naughty.replace_text(n, "foo", "bar\nbaz")
+    assert(n.title   == "foo")
+    assert(n.message == "bar\nbaz")
+    assert(n.text    == "bar\nbaz")
+    assert(n.width < width)
+    assert(n.height > height)
+    width, height = n.width, n.height
+    naughty.replace_text(n, "foo", "bar")
+    assert(n.title   == "foo")
+    assert(n.message == "bar")
+    assert(n.text    == "bar")
+    assert(n.width == width)
+    assert(n.height < height)
 
     -- Test the ID system
     n.id = 1337


### PR DESCRIPTION
The notification used to update its size when the text or title was set through `naughty.replace_text`.

Moved a function, most relevant change: https://github.com/awesomeWM/awesome/pull/2696/files#diff-7950c90cea9d7c92298f5efc977117c6R241