### PR TITLE
[RFC/WIP] call awesome_restart_delayed via main loop

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -524,12 +524,19 @@ exit_on_signal(gpointer data)
     return TRUE;
 }
 
-void
-awesome_restart(void)
+static gboolean
+awesome_restart_delayed(gpointer unused)
 {
     awesome_atexit(true);
     execvp(awesome_argv[0], awesome_argv);
     fatal("execv() failed: %s", strerror(errno));
+    return true;
+}
+
+void
+awesome_restart(void)
+{
+    g_idle_add_full(G_PRIORITY_DEFAULT, awesome_restart_delayed, NULL, NULL);
 }
 
 /** Function to restart awesome on some signals.


### PR DESCRIPTION
Fixes `echo 'awesome.restart()' | awesome-client` to not display an
error about failed dbus-send, caused by awesome restarting before
replying through DBus.

Inspired by / via https://www.reddit.com/r/awesomewm/comments/a3xug0/how_to_restart_awesome_from_the_command_line/ebcisiw/ .