### PR TITLE
awful.spawn: Check arguments in once and single_instance

### DIFF
--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -645,6 +645,8 @@ end
 -- @tparam[opt] function callback A callback function when the client is created.
 -- @see awful.rules
 function spawn.once(cmd, rules, matcher, unique_id, callback)
+    assert(type(cmd) == "string" or type(cmd) == "table")
+    assert(type(rules) == "table")
     local hash = unique_id or hash_command(cmd, rules)
     local status = register_common(hash, rules, matcher, callback)
     run_after_startup(function()
@@ -677,6 +679,8 @@ end
 -- @tparam[opt] function callback A callback function when the client is created.
 -- @see awful.rules
 function spawn.single_instance(cmd, rules, matcher, unique_id, callback)
+    assert(type(cmd) == "string" or type(cmd) == "table")
+    assert(type(rules) == "table")
     local hash = unique_id or hash_command(cmd, rules)
     register_common(hash, rules, matcher, callback)
     run_after_startup(function()


### PR DESCRIPTION
Doing awful.spawn.once("gvim") and awful.spawn.single_instance("gvim")
resulted in the following non-intuitive error:
```
2019-03-02 11:55:46 W: awesome: luaA_dofunction:78: error while running function!
stack traceback:
	[C]: in function 'pairs'
	lib/gears/table.lua:51: in function 'gears.table.crush'
	lib/awful/rules.lua:462: in field 'callback'
	lib/awful/rules.lua:491: in function 'awful.rules.apply'
error: lib/gears/table.lua:51: bad argument #1 to 'pairs' (table expected, got nil)
```
What is going on here is that thanks to startup-notification, the new
instance of GVim is found. Then, rules are applied. However, no rules
were provided.

Since this error happens only some time later, the traceback does not
say anything useful and I was at first confused at was going on.

Improve this by making sure these two functions actually get the
required arguments.

Signed-off-by: Uli Schlachter <psychon@znc.in>