### PR TITLE
awful.spawn: Make rules optional in once / single_instance

### DIFF
--- a/lib/awful/rules.lua
+++ b/lib/awful/rules.lua
@@ -388,7 +388,9 @@ local function apply_singleton_rules(c, props, callbacks)
 
     if info then
         c.single_instance_id = info.hash
-        gtable.crush(props, info.rules)
+        if info.rules then
+            gtable.crush(props, info.rules)
+        end
         table.insert(callbacks, info.callback)
         table.insert(info.instances, c)
 

--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -637,7 +637,7 @@ end
 -- Note that this also wont work with shell or terminal commands.
 --
 -- @tparam string|table cmd The command.
--- @tparam table rules The properties that need to be applied to the client.
+-- @tparam[opt] table rules The properties that need to be applied to the client.
 -- @tparam[opt] function matcher A matching function to find the instance
 --  among running clients.
 -- @tparam[opt] string unique_id A string to identify the client so it isn't executed
@@ -669,7 +669,7 @@ end
 -- faster than the client has time to start.
 --
 -- @tparam string|table cmd The command.
--- @tparam table rules The properties that need to be applied to the client.
+-- @tparam[opt] table rules The properties that need to be applied to the client.
 -- @tparam[opt] function matcher A matching function to find the instance
 --  among running clients.
 -- @tparam[opt] string unique_id A string to identify the client so it isn't executed

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -334,6 +334,20 @@ local steps = {
     function()
         if #client.get() ~= 1 then return end
         assert(matcher_called)
+        client.get()[1]:kill()
+        return true
+    end,
+    -- Test that rules are optional
+    function()
+        if #client.get() ~= 0 then return end
+
+        spawn.single_instance(tiny_client("client4"))
+        spawn.once(tiny_client("client5"))
+
+        return true
+    end,
+    function()
+        if #client.get() ~= 2 then return end
         return true
     end,
 }


### PR DESCRIPTION
There is not much good reason why this should be required and making it
optional is almost trivial, as this patch shows.

Signed-off-by: Uli Schlachter <psychon@znc.in>