### PR TITLE
Fixed input_passthrough property not being set

### DIFF
--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -81,8 +81,7 @@ function wibox:to_widget()
         shape              = self._shape,
         forced_width       = self:geometry().width  + 2*bw,
         forced_height      = self:geometry().height + 2*bw,
-        widget             = wibox.container.background,
-        input_passthrough  = false
+        widget             = wibox.container.background
     }
 end
 

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -81,7 +81,8 @@ function wibox:to_widget()
         shape              = self._shape,
         forced_width       = self:geometry().width  + 2*bw,
         forced_height      = self:geometry().height + 2*bw,
-        widget             = wibox.container.background
+        widget             = wibox.container.background,
+        input_passthrough  = false
     }
 end
 
@@ -340,7 +341,7 @@ local function new(args)
         ret.shape = args.shape
     end
 
-    if args.screen then
+    if args.input_passthrough then
         ret.input_passthrough = args.input_passthrough
     end
 


### PR DESCRIPTION
In the table of properties supplied to the `wibox` function, you couldn't set the `input_passthrough` property. You could only set it after the wibox was created. 
So this wouldn't work: 
`my_wibox = wibox({
    x = 0,
    y = 0,
    -- etc, etc,
    input_passthrough = true 
    })
`
But this would work:
`my_shlick_wibox = ({
    x = 0,
    y = 0,
    -- etc, etc,
    })
my_shlick_wibox.input_passthrough = true` 
This commit fixes that and now you can set it in both ways.
Sorry if I did something wrong this is my first time submitting a pull request ever.