### PR TITLE
Add forgotten nil-check to `notification.reset_timeout`

### DIFF
--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -266,7 +266,7 @@ function notification:reset_timeout(new_timeout)
 
     self.timeout = new_timeout or self.timeout
 
-    if not self.timer.started then
+    if self.timer and not self.timer.started then
         self.timer:start()
     end
 end


### PR DESCRIPTION
When you call `reset_timeout` on a notification with 0 timeout and thus no timer, a nil field error occures.
(can be tested with `awesome-client 'require"naughty".notification{message="TEST",timeout=0}:reset_timeout()'`)
Everywhere else in similar places (even at the beginning of the `reset_timeout`) the `self.timer` field is checked so i guess it was just forgotten there.