### PR TITLE
don't replace 'destroy' in existing notification, set destroy_cb

### DIFF
--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -207,6 +207,7 @@ capi.dbus.connect_signal("org.freedesktop.Notifications",
 
                 if notification then
                     for k, v in pairs(args) do
+                        if k == "destroy" then k = "destroy_cb" end
                         notification[k] = v
                     end
                 else


### PR DESCRIPTION
The value passed as `args.destroy` becomes `destroy_cb`,
so use that name when updating an existing notification.

Fixes #2721.
Might also resolve #2692.