### PR TITLE
awful.widget.common: Use a template for the default template

### DIFF
--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -38,32 +38,6 @@ function common.create_buttons(buttons, object)
     end
 end
 
-local function default_template()
-    local ib  = wibox.widget.imagebox()
-    local tb  = wibox.widget.textbox()
-    local bgb = wibox.container.background()
-    local tbm = wibox.container.margin(tb, dpi(4), dpi(4))
-    local ibm = wibox.container.margin(ib, dpi(4))
-    local l   = wibox.layout.fixed.horizontal()
-
-    -- All of this is added in a fixed widget
-    l:fill_space(true)
-    l:add(ibm)
-    l:add(tbm)
-
-    -- And all of this gets a background
-    bgb:set_widget(l)
-
-    return {
-        ib      = ib,
-        tb      = tb,
-        bgb     = bgb,
-        tbm     = tbm,
-        ibm     = ibm,
-        primary = bgb,
-    }
-end
-
 local function custom_template(args)
     local l = base.make_widget_from_value(args.widget_template)
 
@@ -81,6 +55,38 @@ local function custom_template(args)
         primary         = l,
         update_callback = l.update_callback,
         create_callback = l.create_callback,
+    }
+end
+
+local function default_template()
+    return custom_template {
+        widget_template = {
+            id = 'background_role',
+            widget = wibox.container.background,
+            {
+                widget = wibox.layout.fixed.horizontal,
+                fill_space = true,
+                {
+                    id = 'icon_margin_role',
+                    widget = wibox.container.margin,
+                    {
+                        id = 'icon_role',
+                        widget = wibox.widget.imagebox,
+                        left = dpi(4),
+                    },
+                },
+                {
+                    id = 'text_margin_role',
+                    widget = wibox.container.margin,
+                    left = dpi(4),
+                    right = dpi(4),
+                    {
+                        id = 'text_role',
+                        widget = wibox.widget.textbox,
+                    },
+                }
+            }
+        }
     }
 end
 


### PR DESCRIPTION
Instead of having the default template hardcoded as code, this turns the
template into a descriptive version. This makes it easier to come up
with own templates: Just copy the default template and make a slight
change to it.

No functional changes are intended, but I cannot rule out that I did no
mistakes.

Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

@Elv13 Can you check if I converted this correctly? Are there any downsides to this conversion that I do not know about?