### PR TITLE
Split the reviewed groundwork commits from the notification widgets pull request

### DIFF
--- a/docs/89-NEWS.md
+++ b/docs/89-NEWS.md
@@ -21,6 +21,15 @@ This document was last updated at commit v4.3-148-g795c792d1.
 * `naughty` was rewritten TODO TODO say more about this TODO TODO
 * The `rules` argument in `awful.spawn.once` and `.single_instance` is now
   optional
+* The `wibox.container.background` now has a `border_strategy` property to
+  define how the content is resized when a border is present.
+* The `wibox.container.margin` now allows tables in the `margins` property.
+* The declarative widget systax now allows to directly use functions instead of
+  `{widget = myfunction}`.
+* The `awful.widget.tasklist` now resize the client icons properly.
+* The `awful.widget.tasklist` and `awful.widget.taglist` will now set the
+  `client` and `tag` properly respectively on each widget of the template
+  automatically. This reduces the amount of boilerplate code.
 
 ## Noteworthy fixes
 

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -53,6 +53,8 @@ tparam_alias('screen_or_idx', 'screen|int')
 new_type("function", "Functions")
 -- Documentation for objects properties
 new_type("property", "Object properties", false, "Type")
+-- Documentation for objects deprecated properties
+new_type("deprecatedproperty", "Deprecated object properties", false, "Type")
 -- New type for signals
 new_type("signal", "Signals", false, "Arguments")
 -- New type for signals connections
@@ -142,7 +144,8 @@ file = {
 }
 
 local no_prefix = {
-    property = true, signal = true, clientruleproperty = true
+    property = true, signal = true, clientruleproperty = true,
+    deprecatedproperty = true,
 }
 
 custom_display_name_handler = function(item, default_handler)
@@ -153,7 +156,7 @@ custom_display_name_handler = function(item, default_handler)
         return name ~= "" and name or item.name
     end
 
-    if item.type == "deprecated" then
+    if item.type == "deprecated" or item.type == "deprecatedproperty" then
         return default_handler(item) .. "</a> <i class=\"deprecated_label\">[deprecated]</i><a>"
     end
 

--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -465,7 +465,7 @@ end
 -- @param number
 
 function tooltip:set_border_width(val)
-    self.widget.shape_border_width = val
+    self.widget.border_width = val
 end
 
 --- The border color.
@@ -476,7 +476,7 @@ end
 -- @param gears.color
 
 function tooltip:set_border_color(val)
-    self.widget.shape_border_color = val
+    self.widget.border_color = val
 end
 
 --- Set the margins around the left and right of the tooltip textbox
@@ -679,23 +679,23 @@ function tooltip.new(args)
     self.widget = wibox.widget {
         {
             {
-                id = 'text_role',
-                font = font,
+                id     = 'text_role',
+                font   = font,
                 widget = wibox.widget.textbox,
             },
-            id = 'margin_role',
-            left = m_lr,
-            right = m_lr,
-            top = m_tb,
+            id     = 'margin_role',
+            left   = m_lr,
+            right  = m_lr,
+            top    = m_tb,
             bottom = m_tb,
             widget = wibox.container.margin,
         },
-        id = 'background_role',
-        bg = bg,
-        shape = self._private.shape,
-        shape_border_width = border_width,
-        shape_border_color = border_color,
-        widget = wibox.container.background,
+        id           = 'background_role',
+        bg           = bg,
+        shape        = self._private.shape,
+        border_width = border_width,
+        border_color = border_color,
+        widget       = wibox.container.background,
     }
     self.textbox = self.widget:get_children_by_id('text_role')[1]
     self.marginbox = self.widget:get_children_by_id('margin_role')[1]

--- a/lib/awful/widget/calendar_popup.lua
+++ b/lib/awful/widget/calendar_popup.lua
@@ -39,13 +39,11 @@ local calendar_popup = { offset = 0, mt = {} }
 local properties = { "markup", "fg_color", "bg_color", "shape", "padding", "border_width", "border_color", "opacity" }
 local styles = { "year", "month", "yearheader", "monthheader", "header", "weekday", "weeknumber", "normal", "focus" }
 
-
 --- The generic calendar style table.
 --
 -- Each table property can also be defined by `beautiful.calendar_[flag]_[property]=val`.
 -- @beautiful beautiful.calendar_style
 -- @tparam cell_properties table Table of cell style properties
-
 
 --- Cell properties.
 -- @field markup Markup function or format string
@@ -68,8 +66,6 @@ local styles = { "year", "month", "yearheader", "monthheader", "header", "weekda
 -- @field normal Normal day cell properties table
 -- @field focus Current day cell properties table
 -- @table cell_flags
-
-
 
 --- Create a container for the grid layout
 -- @tparam table tprops Table of calendar container properties.
@@ -98,19 +94,18 @@ local function embed(tprops)
                 margins = props.padding + props.border_width,
                 widget  = wibox.container.margin
             },
-            shape              = props.shape or gears.shape.rectangle,
-            shape_border_color = props.border_color,
-            shape_border_width = props.border_width,
-            fg                 = props.fg_color,
-            bg                 = props.bg_color,
-            opacity            = props.opacity,
-            widget             = wibox.container.background
+            shape        = props.shape or gears.shape.rectangle,
+            border_color = props.border_color,
+            border_width = props.border_width,
+            fg           = props.fg_color,
+            bg           = props.bg_color,
+            opacity      = props.opacity,
+            widget       = wibox.container.background
         }
         return out
     end
     return fn
 end
-
 
 --- Parse the properties of the cell type and set default values
 -- @tparam string cell The cell type
@@ -164,7 +159,6 @@ local function parse_all_options(args)
     end
     return props
 end
-
 
 --- Make the geometry of a wibox
 -- @tparam widget widget Calendar widget
@@ -236,13 +230,11 @@ function calendar_popup:call_calendar(offset, position, screen)
     return self
 end
 
-
 --- Toggle calendar visibility
 function calendar_popup:toggle()
     self:call_calendar(0)
     self.visible = not self.visible
 end
-
 
 --- Attach the calendar to a widget to display at a specific position.
 --
@@ -285,7 +277,6 @@ function calendar_popup:attach(widget, position, args)
     end
     return self
 end
-
 
 --- Return a new calendar wibox by type.
 --
@@ -384,7 +375,6 @@ end
 function calendar_popup.month(args)
     return get_cal_wibox("month", args)
 end
-
 
 --- A year calendar wibox.
 --

--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -161,6 +161,14 @@ function common.list_update(w, buttons, label, data, objects, args)
             cache.ibm:set_margins(0)
         end
 
+        if item_args.icon_size and cache.ib then
+            cache.ib.forced_height = item_args.icon_size
+            cache.ib.forced_width  = item_args.icon_size
+        elseif cache.ib then
+            cache.ib.forced_height = nil
+            cache.ib.forced_width  = nil
+        end
+
         w:add(cache.primary)
    end
 end

--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -116,6 +116,10 @@ function common.list_update(w, buttons, label, data, objects, args)
                 cache.create_callback(cache.primary, o, i, objects)
             end
 
+            if args and args.create_callback then
+                args.create_callback(cache.primary, o, i, objects)
+            end
+
             data[o] = cache
         elseif cache.update_callback then
             cache.update_callback(cache.primary, o, i, objects)

--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -91,6 +91,19 @@ local function default_template()
     }
 end
 
+-- Find all the childrens (without the hierarchy) and set a property.
+function common._set_common_property(widget, property, value)
+    if widget["set_"..property] then
+        widget["set_"..property](widget, value)
+    end
+
+    if widget.get_children then
+        for _, w in ipairs(widget:get_children()) do
+            common._set_common_property(w, property, value)
+        end
+    end
+end
+
 --- Common update method.
 -- @param w The widget.
 -- @tab buttons

--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -62,6 +62,7 @@ local function default_template()
     return custom_template {
         widget_template = {
             id = 'background_role',
+            border_strategy = 'inner',
             widget = wibox.container.background,
             {
                 widget = wibox.layout.fixed.horizontal,

--- a/lib/awful/widget/common.lua
+++ b/lib/awful/widget/common.lua
@@ -148,9 +148,9 @@ function common.list_update(w, buttons, label, data, objects, args)
                 })
             end
 
-            cache.bgb.shape              = item_args.shape
-            cache.bgb.shape_border_width = item_args.shape_border_width
-            cache.bgb.shape_border_color = item_args.shape_border_color
+            cache.bgb.shape        = item_args.shape
+            cache.bgb.border_width = item_args.shape_border_width
+            cache.bgb.border_color = item_args.shape_border_color
 
         end
 

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -386,6 +386,11 @@ function taglist.taglist_label(t, args)
     return text, bg_color, bg_image, not taglist_disable_icon and icon or nil, other_args
 end
 
+-- Remove some callback boilerplate from the user provided templates.
+local function create_callback(w, t)
+    common._set_common_property(w, "tag", t)
+end
+
 local function taglist_update(s, w, buttons, filter, data, style, update_function, args)
     local tags = {}
 
@@ -402,6 +407,7 @@ local function taglist_update(s, w, buttons, filter, data, style, update_functio
 
     update_function(w, buttons, label, data, tags, {
         widget_template = args.widget_template,
+        create_callback = create_callback,
     })
 end
 

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -261,6 +261,7 @@ function taglist.taglist_label(t, args)
     local shape              = args.shape or theme.taglist_shape
     local shape_border_width = args.shape_border_width or theme.taglist_shape_border_width
     local shape_border_color = args.shape_border_color or theme.taglist_shape_border_color
+    local icon_size = args.icon_size or theme.taglist_icon_size
     -- TODO: Re-implement bg_resize
     local bg_resize = false -- luacheck: ignore
     local is_selected = false
@@ -379,6 +380,7 @@ function taglist.taglist_label(t, args)
         shape              = shape,
         shape_border_width = shape_border_width,
         shape_border_color = shape_border_color,
+        icon_size          = icon_size,
     }
 
     return text, bg_color, bg_image, not taglist_disable_icon and icon or nil, other_args

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -400,7 +400,9 @@ local function taglist_update(s, w, buttons, filter, data, style, update_functio
 
     local function label(c) return taglist.taglist_label(c, style) end
 
-    update_function(w, buttons, label, data, tags, args)
+    update_function(w, buttons, label, data, tags, {
+        widget_template = args.widget_template,
+    })
 end
 
 --- Create a new taglist widget. The last two arguments (update_function

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -401,6 +401,11 @@ local function tasklist_label(c, args, tb)
     return text, bg, bg_image, not tasklist_disable_icon and c.icon or nil, other_args
 end
 
+-- Remove some callback boilerplate from the user provided templates.
+local function create_callback(w, t)
+    common._set_common_property(w, "client", t)
+end
+
 local function tasklist_update(s, w, buttons, filter, data, style, update_function, args)
     local clients = {}
 
@@ -419,6 +424,7 @@ local function tasklist_update(s, w, buttons, filter, data, style, update_functi
 
     update_function(w, buttons, label, data, clients, {
         widget_template = args.widget_template,
+        create_callback = create_callback,
     })
 end
 

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -87,7 +87,13 @@ local timer = require("gears.timer")
 local gcolor = require("gears.color")
 local gstring = require("gears.string")
 local gdebug = require("gears.debug")
+local dpi = require("beautiful").xresources.apply_dpi
 local base = require("wibox.widget.base")
+local wfixed = require("wibox.layout.fixed")
+local wmargin = require("wibox.container.margin")
+local wtextbox = require("wibox.widget.textbox")
+local clienticon = require("awful.widget.clienticon")
+local wbackground = require("wibox.container.background")
 
 local function get_screen(s)
     return s and screen[s]
@@ -246,6 +252,32 @@ local instances
 
 -- Public structures
 tasklist.filter, tasklist.source = {}, {}
+
+-- This is the same template as awful.widget.common, but with an clienticon widget
+local default_template = {
+    {
+        {
+            clienticon,
+            id     = "icon_margin_role",
+            left   = dpi(4),
+            widget = wmargin
+        },
+        {
+            {
+                id     = "text_role",
+                widget = wtextbox,
+            },
+            id     = "text_margin_role",
+            left   = dpi(4),
+            right  = dpi(4),
+            widget = wmargin
+        },
+        fill_space = true,
+        layout     = wfixed.horizontal
+    },
+    id     = "background_role",
+    widget = wbackground
+}
 
 local function tasklist_label(c, args, tb)
     if not args then args = {} end
@@ -423,7 +455,7 @@ local function tasklist_update(s, w, buttons, filter, data, style, update_functi
     local function label(c, tb) return tasklist_label(c, style, tb) end
 
     update_function(w, buttons, label, data, clients, {
-        widget_template = args.widget_template,
+        widget_template = args.widget_template or default_template,
         create_callback = create_callback,
     })
 end

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -279,6 +279,7 @@ local function tasklist_label(c, args, tb)
     local shape              = args.shape or theme.tasklist_shape
     local shape_border_width = args.shape_border_width or theme.tasklist_shape_border_width
     local shape_border_color = args.shape_border_color or theme.tasklist_shape_border_color
+    local icon_size = args.icon_size or theme.tasklist_icon_size
 
     -- symbol to use to indicate certain client properties
     local sticky = args.sticky or theme.tasklist_sticky or "▪"
@@ -394,6 +395,7 @@ local function tasklist_label(c, args, tb)
         shape              = shape,
         shape_border_width = shape_border_width,
         shape_border_color = shape_border_color,
+        icon_size          = icon_size,
     }
 
     return text, bg, bg_image, not tasklist_disable_icon and c.icon or nil, other_args
@@ -451,6 +453,7 @@ end
 -- @tparam[opt=nil] string args.style.bg_image_urgent
 -- @tparam[opt=nil] string args.style.bg_image_minimize
 -- @tparam[opt=nil] boolean args.style.tasklist_disable_icon
+-- @tparam[opt=nil] number args.style.icon_size The size of the icon
 -- @tparam[opt=false] boolean args.style.disable_task_name
 -- @tparam[opt=nil] string args.style.font
 -- @tparam[opt=left] string args.style.align *left*, *right* or *center*

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -417,7 +417,9 @@ local function tasklist_update(s, w, buttons, filter, data, style, update_functi
 
     local function label(c, tb) return tasklist_label(c, style, tb) end
 
-    update_function(w, buttons, label, data, clients, args)
+    update_function(w, buttons, label, data, clients, {
+        widget_template = args.widget_template,
+    })
 end
 
 --- Create a new tasklist widget.

--- a/lib/naughty/layout/legacy.lua
+++ b/lib/naughty/layout/legacy.lua
@@ -241,10 +241,6 @@ local function set_escaped_text(self)
     if self.size_info then update_size(self) end
 end
 
-naughty.connect_signal("property::text" ,set_escaped_text)
-naughty.connect_signal("property::title",set_escaped_text)
-
-
 local function cleanup(self, _ --[[reason]], keep_visible)
     -- It is not a legacy notification
     if not self.box then return end

--- a/lib/wibox/container/background.lua
+++ b/lib/wibox/container/background.lua
@@ -15,6 +15,7 @@ local beautiful = require("beautiful")
 local cairo = require("lgi").cairo
 local gtable = require("gears.table")
 local gshape = require("gears.shape")
+local gdebug = require("gears.debug")
 local setmetatable = setmetatable
 local type = type
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
@@ -282,8 +283,19 @@ function background:get_border_width()
     return self._private.shape_border_width
 end
 
-background.get_shape_border_width = background.get_border_width
-background.set_shape_border_width = background.set_border_width
+function background.get_shape_border_width(...)
+    gdebug.deprecate("Use `border_width` instead of `shape_border_width`",
+        {deprecated_in=5})
+
+    return background.get_border_width(...)
+end
+
+function background.set_shape_border_width(...)
+    gdebug.deprecate("Use `border_width` instead of `shape_border_width`",
+        {deprecated_in=5})
+
+    background.set_border_width(...)
+end
 
 --- When a `shape` is set, also draw a border.
 --
@@ -312,8 +324,19 @@ function background:get_border_color()
     return self._private.shape_border_color
 end
 
-background.get_shape_border_color = background.get_border_color
-background.set_shape_border_color = background.set_border_color
+function background.get_shape_border_color(...)
+    gdebug.deprecate("Use `border_color` instead of `shape_border_color`",
+        {deprecated_in=5})
+
+    return background.get_border_color(...)
+end
+
+function background.set_shape_border_color(...)
+    gdebug.deprecate("Use `border_color` instead of `shape_border_color`",
+        {deprecated_in=5})
+
+    background.set_border_color(...)
+end
 
 function background:set_shape_clip(value)
     if value then return end

--- a/lib/wibox/container/background.lua
+++ b/lib/wibox/container/background.lua
@@ -14,6 +14,7 @@ local surface = require("gears.surface")
 local beautiful = require("beautiful")
 local cairo = require("lgi").cairo
 local gtable = require("gears.table")
+local gshape = require("gears.shape")
 local setmetatable = setmetatable
 local type = type
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
@@ -30,8 +31,11 @@ end
 
 -- Prepare drawing the children of this widget
 function background:before_draw_children(context, cr, width, height)
+    local bw    = self._private.shape_border_width or 0
+    local shape = self._private.shape or (bw > 0 and gshape.rectangle or nil)
+
     -- Redirect drawing to a temporary surface if there is a shape
-    if self._private.shape then
+    if shape then
         cr:push_group_with_content(cairo.Content.COLOR_ALPHA)
     end
 
@@ -63,15 +67,17 @@ end
 
 -- Draw the border
 function background:after_draw_children(_, cr, width, height)
-    if not self._private.shape then
+    local bw    = self._private.shape_border_width or 0
+    local shape = self._private.shape or (bw > 0 and gshape.rectangle or nil)
+
+    if not shape then
         return
     end
 
     -- Okay, there is a shape. Get it as a path.
-    local bw = self._private.shape_border_width or 0
 
     cr:translate(bw, bw)
-    self._private.shape(cr, width - 2*bw, height - 2*bw, unpack(self._private.shape_args or {}))
+    shape(cr, width - 2*bw, height - 2*bw, unpack(self._private.shape_args or {}))
     cr:translate(-bw, -bw)
 
     if bw > 0 then
@@ -126,7 +132,12 @@ end
 -- Layout this widget
 function background:layout(_, width, height)
     if self._private.widget then
-        return { base.place_widget_at(self._private.widget, 0, 0, width, height) }
+        local bw = self._private.border_strategy == "inner" and
+            self._private.shape_border_width or 0
+
+        return { base.place_widget_at(
+            self._private.widget, bw, bw, width-2*bw, height-2*bw
+        ) }
     end
 end
 
@@ -136,7 +147,14 @@ function background:fit(context, width, height)
         return 0, 0
     end
 
-    return base.fit_widget(self, context, self._private.widget, width, height)
+    local bw = self._private.border_strategy == "inner" and
+        self._private.shape_border_width or 0
+
+    local w, h = base.fit_widget(
+        self, context, self._private.widget, width - 2*bw, height - 2*bw
+    )
+
+    return w+2*bw, h+2*bw
 end
 
 --- The widget displayed in the background widget.
@@ -207,7 +225,7 @@ function background:get_fg()
     return self._private.foreground
 end
 
---- The background shap     e.
+--- The background shape.
 --
 -- Use `set_shape` to set additional shape paramaters.
 --
@@ -240,37 +258,62 @@ end
 --- When a `shape` is set, also draw a border.
 --
 -- See `wibox.container.background.shape` for an usage example.
--- @property shape_border_width
+-- @deprecatedproperty shape_border_width
 -- @tparam number width The border width
+-- @see border_width
 
-function background:set_shape_border_width(width)
+--- Add a border of a specific width.
+--
+-- If the shape is set, the border will also be shaped.
+--
+-- See `wibox.container.background.shape` for an usage example.
+-- @property border_width
+-- @tparam[opt=0] number width The border width.
+-- @see border_color
+
+function background:set_border_width(width)
     if self._private.shape_border_width == width then return end
 
     self._private.shape_border_width = width
     self:emit_signal("widget::redraw_needed")
 end
 
-function background:get_shape_border_width()
+function background:get_border_width()
     return self._private.shape_border_width
 end
+
+background.get_shape_border_width = background.get_border_width
+background.set_shape_border_width = background.set_border_width
 
 --- When a `shape` is set, also draw a border.
 --
 -- See `wibox.container.background.shape` for an usage example.
--- @property shape_border_color
+-- @deprecatedproperty shape_border_color
 -- @param[opt=self._private.foreground] fg The border color, pattern or gradient
 -- @see gears.color
+-- @see border_color
 
-function background:set_shape_border_color(fg)
+--- Set the color for the border.
+--
+-- See `wibox.container.background.shape` for an usage example.
+-- @property border_color
+-- @param[opt=self._private.foreground] fg The border color, pattern or gradient
+-- @see gears.color
+-- @see border_width
+
+function background:set_border_color(fg)
     if self._private.shape_border_color == fg then return end
 
     self._private.shape_border_color = fg
     self:emit_signal("widget::redraw_needed")
 end
 
-function background:get_shape_border_color()
+function background:get_border_color()
     return self._private.shape_border_color
 end
+
+background.get_shape_border_color = background.get_border_color
+background.set_shape_border_color = background.set_border_color
 
 function background:set_shape_clip(value)
     if value then return end
@@ -282,6 +325,21 @@ function background:get_shape_clip()
     require("gears.debug").print_warning("shape_clip property of background container was removed."
         .. " Use wibox.layout.stack instead if you want shape_clip=false.")
     return true
+end
+
+--- How the border width affects the contained widget.
+--
+-- The valid values are:
+--
+-- * *none*: Just apply the border, do not affect the content size (default).
+-- * *inner*: Squeeze the size of the content by the border width.
+--
+-- @property border_strategy
+-- @param[opt="none"] string
+
+function background:set_border_strategy(value)
+    self._private.border_strategy = value
+    self:emit_signal("widget::layout_changed")
 end
 
 --- The background image to use

--- a/lib/wibox/container/margin.lua
+++ b/lib/wibox/container/margin.lua
@@ -95,20 +95,30 @@ end
 
 --- Set all the margins to val.
 -- @property margins
--- @tparam number val The margin value
+-- @tparam number|table val The margin value. It can be a number or a table with
+--  the *left*/*right*/*top*/*bottom* keys.
 
 function margin:set_margins(val)
-    if self._private.left   == val and
-       self._private.right  == val and
-       self._private.top    == val and
-       self._private.bottom == val then
-        return
+
+    if type(val) == "number" or not val then
+        if self._private.left   == val and
+           self._private.right  == val and
+           self._private.top    == val and
+           self._private.bottom == val then
+            return
+        end
+
+        self._private.left   = val
+        self._private.right  = val
+        self._private.top    = val
+        self._private.bottom = val
+    elseif type(val) == "table" then
+        self._private.left   = val.left   or self._private.left
+        self._private.right  = val.right  or self._private.right
+        self._private.top    = val.top    or self._private.top
+        self._private.bottom = val.bottom or self._private.bottom
     end
 
-    self._private.left = val
-    self._private.right = val
-    self._private.top = val
-    self._private.bottom = val
     self:emit_signal("widget::layout_changed")
 end
 

--- a/tests/examples/awful/notification/corner.lua
+++ b/tests/examples/awful/notification/corner.lua
@@ -1,0 +1,20 @@
+--DOC_HIDE_ALL
+local naughty = require("naughty") --DOC_HIDE
+
+for _, pos in ipairs {
+    "top_left",
+    "top_middle",
+    "top_right",
+    "bottom_left",
+    "bottom_middle",
+    "bottom_right",
+} do
+    naughty.notify {
+        title    = pos,
+        position = pos,
+        text     = "",
+    }
+end
+
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/awful/popup/wiboxtypes.lua
+++ b/tests/examples/awful/popup/wiboxtypes.lua
@@ -198,8 +198,8 @@ local function create_info(text, x, y, width, height)
         forced_width  = width,
         forced_height = height,
         shape = gears.shape.rectangle,
-        shape_border_width = 1,
-        shape_border_color = beautiful.border_color,
+        border_width = 1,
+        border_color = beautiful.border_color,
         bg = "#ffff0055",
         widget = wibox.container.background
     }, {x = x, y = y})

--- a/tests/examples/awful/popup/wiboxtypes.lua
+++ b/tests/examples/awful/popup/wiboxtypes.lua
@@ -1,11 +1,13 @@
 --DOC_GEN_IMAGE
 --DOC_HIDE_ALL
 --DOC_NO_USAGE
+--DOC_NO_DASH
 require("_date")
 local awful     = require("awful")
 local gears     = require("gears")
 local wibox     = require("wibox")
 local beautiful = require("beautiful") --DOC_HIDE
+local look      = require("_default_look")
 
 screen[1]._resize {width = 640, height = 480}
 
@@ -22,36 +24,6 @@ c:geometry {
 }
 c._old_geo = {c:geometry()}
 c:set_label("A client")
-
-local wb = awful.wibar {
-    position = "top",
-}
-
--- Create the same number of tags as the default config
-awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, screen[1], awful.layout.layouts[1])
-
--- Only bother with widgets that are visible by default
-local mykeyboardlayout = awful.widget.keyboardlayout()
-local mytextclock = wibox.widget.textclock()
-local mylayoutbox = awful.widget.layoutbox(screen[1])
-local mytaglist = awful.widget.taglist(screen[1], awful.widget.taglist.filter.all, {})
-local mytasklist = awful.widget.tasklist(screen[1], awful.widget.tasklist.filter.currenttags, {})
-
-wb:setup {
-    layout = wibox.layout.align.horizontal,
-    { -- Left widgets
-        layout = wibox.layout.fixed.horizontal,
-        awful.titlebar.widget.iconwidget(c), --looks close enough
-        mytaglist,
-    },
-    mytasklist, -- Middle widget
-    { -- Right widgets
-        layout = wibox.layout.fixed.horizontal,
-        mykeyboardlayout,
-        mytextclock,
-        mylayoutbox,
-    },
-}
 
 -- The popup
 awful.popup {
@@ -112,37 +84,11 @@ local p10 = awful.popup {
 }
 
 require("gears.timer").run_delayed_calls_now()
-p10:bind_to_widget(mytextclock)
+p10:bind_to_widget(look.mytextclock)
 
 -- The titlebar
 
-local top_titlebar = awful.titlebar(c, {
-    height    = 20,
-    bg_normal = "#ff0000",
-})
-
-top_titlebar : setup {
-    { -- Left
-        awful.titlebar.widget.iconwidget(c),
-        layout  = wibox.layout.fixed.horizontal
-    },
-    { -- Middle
-        { -- Title
-            align  = "center",
-            widget = awful.titlebar.widget.titlewidget(c)
-        },
-        layout  = wibox.layout.flex.horizontal
-    },
-    { -- Right
-        awful.titlebar.widget.floatingbutton (c),
-        awful.titlebar.widget.maximizedbutton(c),
-        awful.titlebar.widget.stickybutton   (c),
-        awful.titlebar.widget.ontopbutton    (c),
-        awful.titlebar.widget.closebutton    (c),
-        layout = wibox.layout.fixed.horizontal()
-    },
-    layout = wibox.layout.align.horizontal
-}
+c:emit_signal("request::titlebars", "rules", {})--DOC_HIDE
 
 -- Normal wiboxes
 
@@ -228,7 +174,7 @@ create_info("awful.wibar", 200, 50, 100, 30)
 create_info("awful.titlebar", 250, 350, 100, 30)
 create_info("awful.tooltip", 30, 130, 100, 30)
 create_info("awful.popup", 450, 240, 100, 30)
-create_info("Standard `wibox1`", 420, 420, 130, 30)
+create_info("Standard `wibox`", 420, 420, 130, 30)
 
 create_line(250, 10, 250, 55)
 create_line(75, 100, 75, 135)

--- a/tests/examples/awful/template.lua
+++ b/tests/examples/awful/template.lua
@@ -141,12 +141,12 @@ local function client_widget(c, col, label)
             },
             layout = wibox.layout.stack
         },
-        shape_border_width = bw,
-        shape_border_color = beautiful.border_color,
-        shape_clip         = true,
-        fg                 = beautiful.fg_normal or "#000000",
-        bg                 = col,
-        shape              = function(cr2, w, h)
+        border_width = bw,
+        border_color = beautiful.border_color,
+        shape_clip   = true,
+        fg           = beautiful.fg_normal or "#000000",
+        bg           = col,
+        shape        = function(cr2, w, h)
             return shape.rounded_rect(cr2, w, h, args.radius or 5)
         end,
 

--- a/tests/examples/naughty/actions.lua
+++ b/tests/examples/naughty/actions.lua
@@ -1,0 +1,19 @@
+--DOC_NO_USAGE
+--DOC_HIDE_ALL
+-- local naughty = require("naughty")
+
+dbus.notify_send(
+    --[[data]] {
+        member = "Notify",
+    },
+    --[[app_name]]    "Notification demo",
+    --[[replaces_id]] nil,
+    --[[icon]] "",
+    --[[title]] "You got a message!",
+    --[[text]] "This is a message from above.\nAwesomeWM is your faith.",
+    {"Accept", "Dismiss", "Forward"},
+    --[[hints]] {},
+    --[[expire]] 5
+)
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/colors.lua
+++ b/tests/examples/naughty/colors.lua
@@ -1,0 +1,19 @@
+
+local beautiful = require("beautiful") --DOC_HIDE
+
+local text = [[An <b>important</b>
+<i>notification</i>
+]]
+
+require("naughty").notify {
+    title        = "Hello world!",
+    text         = text,
+    icon         = beautiful.icon,
+    bg           = "#0000ff",
+    fg           = "#ff0000",
+    font         = "verdana 14",
+    border_width = 1,
+    border_color = "#ff0000"
+}
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/helloworld.lua
+++ b/tests/examples/naughty/helloworld.lua
@@ -1,0 +1,18 @@
+--DOC_HIDE_ALL
+-- local naughty = require("naughty")
+
+dbus.notify_send(
+    --[[data]] {
+        member = "Notify",
+    },
+    --[[app_name]]    "Notification demo",
+    --[[replaces_id]] nil,
+    --[[icon]] "",
+    --[[title]] "Hello world!",
+    --[[text]] "The notification content",
+    --[[actions]] {},
+    --[[hints]] {},
+    --[[expire]] 5
+)
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/shape.lua
+++ b/tests/examples/naughty/shape.lua
@@ -1,0 +1,31 @@
+
+local beautiful = require("beautiful") --DOC_HIDE
+local gears     = {shape=require("gears.shape")} --DOC_HIDE
+local naughty   = require("naughty") --DOC_HIDE
+
+local text = [[An <b>important</b>
+<i>notification</i>
+]]
+
+local shapes = {
+    gears.shape.rounded_rect,
+    gears.shape.hexagon,
+    gears.shape.octogon,
+    function(cr, w, h)
+        return gears.shape.infobubble(cr, w, h, 20, 10, w/2 - 10)
+    end
+}
+
+for _, s in ipairs(shapes) do
+    naughty.notify {
+        title        = "Hello world!",
+        text         = text,
+        icon         = beautiful.icon,
+        shape        = s,
+        border_width = 3,
+        border_color = beautiful.bg_highlight,
+        margin       = 15,
+    }
+end
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/naughty/template.lua
+++ b/tests/examples/naughty/template.lua
@@ -1,0 +1,55 @@
+local file_path, image_path = ...
+require("_common_template")(...)
+local wibox = require("wibox")
+
+-- For the connections
+require("naughty")
+
+-- Create a screen
+screen[1]._resize {x = 0, width = 800, height = 600}
+
+-- Let the test request a size and file format
+loadfile(file_path)()
+
+-- Emulate the event loop for 10 iterations
+for _ = 1, 10 do
+    awesome:emit_signal("refresh")
+end
+
+local rect = {x1 = math.huge ,y1 = math.huge , x2 = -math.huge , y2 = -math.huge}
+
+-- Get the region with wiboxes
+for _, d in ipairs(drawin.get()) do
+    local w = d.get_wibox and d:get_wibox() or nil
+    if w then
+        local geo = w:geometry()
+        rect.x1 = math.min(rect.x1, geo.x                                )
+        rect.y1 = math.min(rect.y1, geo.y                                )
+        rect.x2 = math.max(rect.x2, geo.x + geo.width  + 2*w.border_width)
+        rect.y2 = math.max(rect.y2, geo.y + geo.height + 2*w.border_width)
+    end
+end
+
+-- Get rid of invalid drawins. The shims are very permissive and wont deny this.
+if rect.x1 == rect.x2 or rect.y1 == rect.y2 then return end
+
+local multi = wibox.layout {
+    forced_width  = rect.x2 - rect.x1,
+    forced_height = rect.y2 - rect.y1,
+    layout        = wibox.layout.manual
+}
+
+-- Draw all normal wiboxes
+for _, d in ipairs(drawin.get()) do
+    local w = d.get_wibox and d:get_wibox() or nil
+    if w then
+        local geo = w:geometry()
+        multi:add_at(w:to_widget(), {x = geo.x - rect.x1, y = geo.y - rect.y1})
+    end
+end
+
+wibox.widget.draw_to_svg_file(
+    multi, image_path..".svg", multi.forced_width, multi.forced_height
+)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/shims/_default_look.lua
+++ b/tests/examples/shims/_default_look.lua
@@ -1,0 +1,74 @@
+local awful     = require("awful")
+local wibox     = require("wibox")
+local beautiful = require("beautiful")
+require("_date")
+
+-- Create the same number of tags as the default config
+awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, screen[1], awful.layout.layouts[1])
+local mykeyboardlayout = awful.widget.keyboardlayout()
+local mytextclock = wibox.widget.textclock()
+local mylayoutbox = awful.widget.layoutbox(screen[1])
+local mytaglist = awful.widget.taglist(screen[1], awful.widget.taglist.filter.all, {})
+local mytasklist = awful.widget.tasklist(screen[1], awful.widget.tasklist.filter.currenttags, {})
+
+local wb = awful.wibar { position = "top" }
+wb:setup {
+    layout = wibox.layout.align.horizontal,
+    {
+        layout = wibox.layout.fixed.horizontal,
+        {
+            image  = beautiful.awesome_icon,
+            widget = wibox.widget.imagebox,
+        },
+        mytaglist,
+    },
+    mytasklist,
+    {
+        layout = wibox.layout.fixed.horizontal,
+        mykeyboardlayout,
+        mytextclock,
+        mylayoutbox,
+    },
+}
+
+
+client.connect_signal("request::titlebars", function(c)
+    local top_titlebar = awful.titlebar(c, {
+        height    = 20,
+        bg_normal = beautiful.bg_normal,
+    })
+
+    top_titlebar : setup {
+        { -- Left
+            awful.titlebar.widget.iconwidget(c),
+            layout  = wibox.layout.fixed.horizontal
+        },
+        { -- Middle
+            { -- Title
+                align  = "center",
+                widget = awful.titlebar.widget.titlewidget(c)
+            },
+            layout  = wibox.layout.flex.horizontal
+        },
+        { -- Right
+            awful.titlebar.widget.floatingbutton (c),
+            awful.titlebar.widget.maximizedbutton(c),
+            awful.titlebar.widget.stickybutton   (c),
+            awful.titlebar.widget.ontopbutton    (c),
+            awful.titlebar.widget.closebutton    (c),
+            layout = wibox.layout.fixed.horizontal()
+        },
+        layout = wibox.layout.align.horizontal
+    }
+end)
+
+require("gears.timer").run_delayed_calls_now()
+
+return {
+    mykeyboardlayout = mykeyboardlayout,
+    mytextclock      = mytextclock     ,
+    mylayoutbox      = mylayoutbox     ,
+    mytaglist        = mytaglist       ,
+    mytasklist       = mytasklist      ,
+    mywibox          = wb,
+}

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -42,8 +42,18 @@ local function _shim_fake_class()
     return obj, meta
 end
 
+local function forward_class(obj, class)
+    assert(obj.emit_signal)
+    local es = obj.emit_signal
+    function obj:emit_signal(name, ...)
+        es(obj, name, ...)
+        class.emit_signal(name, obj, ...)
+    end
+end
+
 local awesome = _shim_fake_class()
 awesome._shim_fake_class = _shim_fake_class
+awesome._forward_class = forward_class
 
 -- Avoid c.screen = acreen.focused() to be called, all tests will fail
 awesome.startup = true

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -13,10 +13,15 @@ local function _shim_fake_class()
         __newindex = function()end,
     }
 
-    obj._connect_signal = obj.connect_signal
+    obj._connect_signal    = obj.connect_signal
+    obj._disconnect_signal = obj.disconnect_signal
 
     function obj.connect_signal(name, func)
         return obj._connect_signal(obj, name, func)
+    end
+
+    function obj.disconnect_signal(name, func)
+        return obj._disconnect_signal(obj, name, func)
     end
 
     function obj.set_index_miss_handler(handler)

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -25,6 +25,8 @@ end
 -- Create fake clients to move around
 function client.gen_fake(args)
     local ret = gears_obj()
+    awesome._forward_class(ret, client)
+
     ret.data = {}
     ret.type = "normal"
     ret.valid = true

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -140,13 +140,15 @@ function client.gen_fake(args)
 
     client.focus = ret
 
+    setmetatable(ret, {
+        __index     = function(...) return meta.__index(...) end,
+        __newindex = function(...) return meta.__newindex(...) end
+    })
+
     client.emit_signal("manage", ret)
     assert(not args.screen or (args.screen == ret.screen))
 
-    return setmetatable(ret, {
-                        __index     = function(...) return meta.__index(...) end,
-                        __newindex = function(...) return meta.__newindex(...) end
-                    })
+    return ret
 end
 
 function client.get(s)

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -33,6 +33,12 @@ function client.gen_fake(args)
     ret.icon_sizes = {{16,16}}
     ret.name = "Example Client"
 
+    -- This is a hack because there's a `:is_transient_for(c2)` method
+    -- and a `transient_for` property. It will cause a stack overflow
+    -- since the auto-alias will kick in if the property is allowed to
+    -- be `nil`.
+    ret.transient_for = false
+
     -- Apply all properties
     for k,v in pairs(args or {}) do
         ret[k] = v

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -5,6 +5,8 @@ screen._count = 0
 
 local function create_screen(args)
     local s = gears_obj()
+    awesome._forward_class(s, screen)
+
     s.data = {}
     s.valid = true
 

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -19,10 +19,12 @@ local function create_screen(args)
     }
 
     function s._resize(args2)
+        local old  = s.geometry
         geo.x      = args2.x      or geo.x
         geo.y      = args2.y      or geo.y
         geo.width  = args2.width  or geo.width
         geo.height = args2.height or geo.height
+        s:emit_signal("property::geometry", old)
     end
 
     s.outputs = { ["LVDS1"] = {

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -136,6 +136,7 @@ screen._add_screen {width=320, height=240}
 screen._grid_vertical_margin = 10
 screen._grid_horizontal_margin = 10
 
+screen.primary = screen[1]
 
 function screen.count()
     return screen._count

--- a/tests/examples/shims/tag.lua
+++ b/tests/examples/shims/tag.lua
@@ -13,6 +13,7 @@ end
 
 local function new_tag(_, args)
     local ret = gears_obj()
+    awesome._forward_class(ret, tag)
 
     ret.data = {}
     ret.name = args.name or "test"

--- a/tests/examples/shims/tag.lua
+++ b/tests/examples/shims/tag.lua
@@ -2,13 +2,22 @@ local gears_obj = require("gears.object")
 
 local tag, meta = awesome._shim_fake_class()
 
+local function has_selected_tag(s)
+    for _, t in ipairs(root._tags) do
+        if t.selected and ((not s) or s == t.screen) then
+            return true
+        end
+    end
+    return false
+end
+
 local function new_tag(_, args)
     local ret = gears_obj()
 
     ret.data = {}
     ret.name = args.name or "test"
     ret.activated = true
-    ret.selected = true
+    ret.selected = not has_selected_tag(args.screen)
 
     function ret:clients(_) --TODO handle new
         local list = {}

--- a/tests/examples/wibox/awidget/tasklist/rounded.lua
+++ b/tests/examples/wibox/awidget/tasklist/rounded.lua
@@ -26,9 +26,9 @@ end --DOC_HIDE
         filter   = awful.widget.tasklist.filter.currenttags,
         buttons  = tasklist_buttons,
         style    = {
-            shape_border_width = 1,
-            shape_border_color = "#777777",
-            shape  = gears.shape.rounded_bar,
+            border_width = 1,
+            border_color = "#777777",
+            shape        = gears.shape.rounded_bar,
         },
         layout   = {
             spacing = 10,

--- a/tests/examples/wibox/awidget/tasklist/windows10.lua
+++ b/tests/examples/wibox/awidget/tasklist/windows10.lua
@@ -52,17 +52,11 @@ end --DOC_HIDE
                 widget        = wibox.container.background,
             },
             {
-                {
-                    id     = "clienticon",
-                    widget = awful.widget.clienticon,
-                },
+                awful.widget.clienticon,
                 margins = 5,
                 widget  = wibox.container.margin
             },
             nil,
-            create_callback = function(self, c, index, objects) --luacheck: no unused args
-                self:get_children_by_id("clienticon")[1].client = c
-            end,
             layout = wibox.layout.align.vertical,
         },
     }

--- a/tests/examples/wibox/container/background/shape.lua
+++ b/tests/examples/wibox/container/background/shape.lua
@@ -30,11 +30,11 @@ parent : setup {
             bottom = 3,
             widget = wibox.container.margin
         },
-        shape              = gears.shape.hexagon,
-        bg                 = beautiful.bg_normal,
-        shape_border_color = beautiful.border_color,
-        shape_border_width = beautiful.border_width,
-        widget             = wibox.container.background
+        shape        = gears.shape.hexagon,
+        bg           = beautiful.bg_normal,
+        border_color = beautiful.border_color,
+        border_width = beautiful.border_width,
+        widget       = wibox.container.background
     },
     spacing = 10,
     layout  = wibox.layout.fixed.vertical

--- a/tests/examples/wibox/container/defaults/background.lua
+++ b/tests/examples/wibox/container/defaults/background.lua
@@ -17,11 +17,11 @@ return {
         valign = "center",
         widget = wibox.widget.textbox,
     },
-    shape              = gears.shape.circle,
-    shape_border_width = 5,
-    shape_border_color = "#ff0000",
-    bg                 = beautiful.bg_highlight,
-    widget             = wibox.container.background
+    shape        = gears.shape.circle,
+    border_width = 5,
+    border_color = "#ff0000",
+    bg           = beautiful.bg_highlight,
+    widget       = wibox.container.background
 }
 
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/container/defaults/template.lua
+++ b/tests/examples/wibox/container/defaults/template.lua
@@ -13,10 +13,10 @@ local container = wibox.widget {
         {
             {
                 before,
-                shape_border_color = beautiful.border_color,
-                shape_border_width = beautiful.border_width,
-                shape              = shape.rounded_rect,
-                widget             = wibox.container.background,
+                border_color = beautiful.border_color,
+                border_width = beautiful.border_width,
+                shape        = shape.rounded_rect,
+                widget       = wibox.container.background,
             },
             strategy = 'exact',
             width    = 70,
@@ -29,11 +29,11 @@ local container = wibox.widget {
                     text   = " ",
                     widget = wibox.widget.textbox,
                 },
-                bg                 = beautiful.bg_normal,
-                shape_border_color = beautiful.border_color,
-                shape_border_width = beautiful.border_width,
-                widget             = wibox.container.background,
-                shape              = shape.transform(shape.arrow)
+                bg           = beautiful.bg_normal,
+                border_color = beautiful.border_color,
+                border_width = beautiful.border_width,
+                widget       = wibox.container.background,
+                shape        = shape.transform(shape.arrow)
                 : rotate_at(15,15,math.pi/2)
                 : translate(0,-8)
                 : scale(0.9, 0.9),
@@ -46,10 +46,10 @@ local container = wibox.widget {
         {
             {
                 after,
-                shape_border_color = beautiful.border_color,
-                shape_border_width = beautiful.border_width,
-                shape              = shape.rounded_rect,
-                widget             = wibox.container.background,
+                border_color = beautiful.border_color,
+                border_width = beautiful.border_width,
+                shape        = shape.rounded_rect,
+                widget       = wibox.container.background,
             },
             strategy = 'exact',
             width    = 70,

--- a/tests/examples/wibox/container/rotate/angle.lua
+++ b/tests/examples/wibox/container/rotate/angle.lua
@@ -4,27 +4,27 @@ local wibox     = require("wibox") --DOC_HIDE
 local gears     = {shape = require("gears.shape")} --DOC_HIDE
 local beautiful = require("beautiful") --DOC_HIDE
 
-local function create_arrow(text)                           --DOC_HIDE
-    return {                                                --DOC_HIDE
-        {                                                   --DOC_HIDE
-            {                                               --DOC_HIDE
-                text   = text,                              --DOC_HIDE
-                align  = "center",                          --DOC_HIDE
-                valign = "center",                          --DOC_HIDE
-                widget = wibox.widget.textbox,              --DOC_HIDE
-            },                                              --DOC_HIDE
-            shape              = gears.shape.arrow,         --DOC_HIDE
-            bg                 = beautiful.bg_normal,       --DOC_HIDE
-            shape_border_color = beautiful.border_color,    --DOC_HIDE
-            shape_border_width = beautiful.border_width,    --DOC_HIDE
-            widget             = wibox.container.background --DOC_HIDE
-        },                                                  --DOC_HIDE
-        strategy = 'exact',                                 --DOC_HIDE
-        width    = 70,                                      --DOC_HIDE
-        height   = 70,                                      --DOC_HIDE
-        widget   = wibox.container.constraint               --DOC_HIDE
-    }                                                       --DOC_HIDE
-end                                                         --DOC_HIDE
+local function create_arrow(text)                     --DOC_HIDE
+    return {                                          --DOC_HIDE
+        {                                             --DOC_HIDE
+            {                                         --DOC_HIDE
+                text   = text,                        --DOC_HIDE
+                align  = "center",                    --DOC_HIDE
+                valign = "center",                    --DOC_HIDE
+                widget = wibox.widget.textbox,        --DOC_HIDE
+            },                                        --DOC_HIDE
+            shape        = gears.shape.arrow,         --DOC_HIDE
+            bg           = beautiful.bg_normal,       --DOC_HIDE
+            border_color = beautiful.border_color,    --DOC_HIDE
+            border_width = beautiful.border_width,    --DOC_HIDE
+            widget       = wibox.container.background --DOC_HIDE
+        },                                            --DOC_HIDE
+        strategy = 'exact',                           --DOC_HIDE
+        width    = 70,                                --DOC_HIDE
+        height   = 70,                                --DOC_HIDE
+        widget   = wibox.container.constraint         --DOC_HIDE
+    }                                                 --DOC_HIDE
+end                                                   --DOC_HIDE
 
 local normal = create_arrow("Normal")
 

--- a/tests/examples/wibox/widget/calendar/fn_embed_cell.lua
+++ b/tests/examples/wibox/widget/calendar/fn_embed_cell.lua
@@ -67,12 +67,12 @@ beautiful.bg_focus = "#b9214f" --DOC_HIDE
                 margins = (props.padding or 2) + (props.border_width or 0),
                 widget  = wibox.container.margin
             },
-            shape              = props.shape,
-            shape_border_color = props.border_color or "#b9214f",
-            shape_border_width = props.border_width or 0,
-            fg                 = props.fg_color or "#999999",
-            bg                 = props.bg_color or default_bg,
-            widget             = wibox.container.background
+            shape        = props.shape,
+            border_color = props.border_color or "#b9214f",
+            border_width = props.border_width or 0,
+            fg           = props.fg_color or "#999999",
+            bg           = props.bg_color or default_bg,
+            widget       = wibox.container.background
         }
         return ret
     end

--- a/tests/test-awful-widget-button.lua
+++ b/tests/test-awful-widget-button.lua
@@ -69,7 +69,7 @@ table.insert(steps, function()
         awful.button({}, 1, nil, function ()
             button:emit_signal_recursive("test::recursive")
         end)
-))
+    ))
 
     layout:connect_signal("test::recursive", function()
         got_called = true
@@ -89,7 +89,7 @@ table.insert(steps, function()
 end)
 
 table.insert(steps, function()
-    assert(button._private.image ~= img)
+    if button._private.image == img then return end
 
     return true
 end)
@@ -115,30 +115,30 @@ table.insert(steps, function()
 end)
 
 table.insert(steps, function()
-assert(button._private.image ~= img)
+    if button._private.image == img then return end
 
-return true
+    return true
 end)
 
 table.insert(steps, function()
--- just make sure the button is not released for nothing
-assert(button._private.image ~= img)
+    -- just make sure the button is not released for nothing
+    assert(button._private.image ~= img)
 
--- test if the button is released when the mouse move out
-awful.placement.right(mouse--[[, {parent = w}]])
-root.fake_input("button_release", 1)
-awesome.sync()
+    -- test if the button is released when the mouse move out
+    awful.placement.right(mouse--[[, {parent = w}]])
+    root.fake_input("button_release", 1)
+    awesome.sync()
 
-return true
+    return true
 end)
 
 table.insert(steps, function()
-assert(button._private.image == img)
+    assert(button._private.image == img)
 
--- The button had plenty of clicks by now. Make sure everything worked
-assert(got_called)
+    -- The button had plenty of clicks by now. Make sure everything worked
+    assert(got_called)
 
-return true
+    return true
 end)
 
 runner.run_steps(steps)


### PR DESCRIPTION
These commits are (mostly) the reviewed ones plus the taglist/tasklist ones and the one to update the NEWS.

The other pull request is so large it time out in the CI (and has some luacheck issues in some commits). This has half the commits, so it will greatly reduce the number of commits of the other pull requests once merged.

edit: I added 3 more commit to fix some CI issues. One of them seems to be in an existing test suite while the other 2 are the consequences of deprecating `wibox.container.background.shape_border_width`.