### PR TITLE
Fix 2 more notification issues

### DIFF
--- a/lib/naughty/init.lua
+++ b/lib/naughty/init.lua
@@ -9,6 +9,7 @@ if dbus then
     naughty.dbus = require("naughty.dbus")
 end
 
+naughty.action = require("naughty.action")
 naughty.layout = require("naughty.layout")
 naughty.notification = require("naughty.notification")
 

--- a/lib/naughty/layout/legacy.lua
+++ b/lib/naughty/layout/legacy.lua
@@ -400,8 +400,8 @@ function naughty.default_notification_handler(notification, args)
             local action_width = w + 2 * margin
 
             actionmarginbox:buttons(gtable.join(
-                button({ }, 1, function() action:trigger() end),
-                button({ }, 3, function() action:trigger() end)
+                button({ }, 1, function() action:invoke() end),
+                button({ }, 3, function() action:invoke() end)
             ))
             actionslayout:add(actionmarginbox)
 


### PR DESCRIPTION
(and for the `naughty.constants`, it is already added by `core.lua`. Not having a `require` is "normal". It was split into a different file to avoid some circular `require`s).