### PR TITLE
Improve the shims

### DIFF
--- a/tests/examples/awful/template.lua
+++ b/tests/examples/awful/template.lua
@@ -35,8 +35,8 @@ local function draw_mouse(x, y)
 end
 
 -- Print an outline for the screens
-if not screen.no_outline then
-    for _, s in ipairs(screen) do
+if not rawget(screen, "no_outline") then
+    for s in screen do
         cr:save()
         -- Draw the screen outline
         cr:set_source(color("#00000044"))

--- a/tests/examples/shims/awesome.lua
+++ b/tests/examples/shims/awesome.lua
@@ -75,6 +75,10 @@ function awesome.pixbuf_to_surface(_, path)
     return awesome.load_image(path)
 end
 
+function awesome.xrdb_get_value()
+    return nil
+end
+
 -- Always show deprecated messages
 awesome.version = "v9999"
 

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -34,6 +34,7 @@ function client.gen_fake(args)
     ret.border_width = 1
     ret.icon_sizes = {{16,16}}
     ret.name = "Example Client"
+    ret.data._struts = { top = 0, right = 0, left = 0, bottom = 0 }
 
     -- This is a hack because there's a `:is_transient_for(c2)` method
     -- and a `transient_for` property. It will cause a stack overflow
@@ -140,6 +141,14 @@ function client.gen_fake(args)
         end
 
         return {}
+    end
+
+    function ret:struts(new)
+        for k, v in pairs(new or {}) do
+            ret.data._struts[k] = v
+        end
+
+        return ret.data._struts
     end
 
     -- Record the geometry

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -151,6 +151,14 @@ function client.gen_fake(args)
         return ret.data._struts
     end
 
+    function ret:struts(new)
+        for k, v in pairs(new or {}) do
+            ret.data._struts[k] = v
+        end
+
+        return ret.data._struts
+    end
+
     -- Record the geometry
     ret._old_geo = {}
     push_geometry(ret)

--- a/tests/examples/shims/client.lua
+++ b/tests/examples/shims/client.lua
@@ -101,6 +101,27 @@ function client.gen_fake(args)
         --TODO
     end
 
+    function ret:kill()
+        local old_tags = ret:tags() or {}
+
+        for k, c in ipairs(clients) do
+            if c == ret then
+                ret:emit_signal("unmanaged", c)
+                ret.valid = false
+                table.remove(clients, k)
+                break
+            end
+        end
+
+        ret._tags = {}
+
+        for _, t in ipairs(old_tags) do
+            ret:emit_signal("untagged", t)
+            t:emit_signal("property::tags")
+        end
+
+        assert(not ret.valid)
+    end
     titlebar_meta(ret)
 
     function ret:tags(new) --FIXME

--- a/tests/examples/shims/drawin.lua
+++ b/tests/examples/shims/drawin.lua
@@ -35,9 +35,18 @@ local function new_drawin(_, args)
     ret.data.drawable.surface  = cairo.ImageSurface(cairo.Format.ARGB32, 0, 0)
     ret.data.drawable.geometry = ret.geometry
     ret.data.drawable.refresh  = function() end
+    ret.data._struts           = { top = 0, right = 0, left = 0, bottom = 0 }
 
-    for _, k in pairs{ "buttons", "struts", "get_xproperty", "set_xproperty" } do
+    for _, k in pairs{ "buttons", "get_xproperty", "set_xproperty" } do
         ret[k] = function() end
+    end
+
+    function ret:struts(new)
+        for k, v in pairs(new or {}) do
+            ret.data._struts[k] = v
+        end
+
+        return ret.data._struts
     end
 
     local md = setmetatable(ret, {

--- a/tests/examples/shims/mouse.lua
+++ b/tests/examples/shims/mouse.lua
@@ -53,9 +53,14 @@ function mouse.push_history()
     mouse.history = {}
 end
 
+local forced_screen = nil
+
 return setmetatable(mouse, {
     __index = function(self, key)
         if key == "screen" then
+            if forced_screen and screen._deleted[forced_screen] then
+                forced_screen = nil
+            end
             return screen[1]
         end
         local h = rawget(mouse,"_i_handler")
@@ -63,10 +68,13 @@ return setmetatable(mouse, {
             return h(self, key)
         end
     end,
-    __newindex = function(...)
+    __newindex = function(_, k, v)
         local h = rawget(mouse,"_ni_handler")
-        if h then
-            h(...)
+        if k == "screen" then
+            -- This will assert if the screen is invalid
+            forced_screen = v and screen[v] or nil
+        elseif h then
+            h(_, k, v)
         end
     end,
 })

--- a/tests/examples/shims/mouse.lua
+++ b/tests/examples/shims/mouse.lua
@@ -61,7 +61,14 @@ return setmetatable(mouse, {
             if forced_screen and screen._deleted[forced_screen] then
                 forced_screen = nil
             end
-            return screen[1]
+
+            -- Using capi.mouse.screen is *not* supported when there is zero
+            -- screen. Nearly all the code uses `mouse.screen` as its ultimate
+            -- fallback. Having no screens is tolerated during early
+            -- initialization and that's it.
+            return screen.count() > 0 and screen[1] or assert(
+                false, "Calling `mouse.screen` without screens isn't supported"
+            )
         end
         local h = rawget(mouse,"_i_handler")
         if h then

--- a/tests/examples/shims/mouse.lua
+++ b/tests/examples/shims/mouse.lua
@@ -62,6 +62,13 @@ return setmetatable(mouse, {
                 forced_screen = nil
             end
 
+            for s in screen do
+                if coords.x > s.geometry.x and coords.x < s.geometry.x +s.geometry.width
+                  and coords.y > s.geometry.y and coords.y < s.geometry.y +s.geometry.height then
+                    return s
+                end
+            end
+
             -- Using capi.mouse.screen is *not* supported when there is zero
             -- screen. Nearly all the code uses `mouse.screen` as its ultimate
             -- fallback. Having no screens is tolerated during early

--- a/tests/examples/shims/root.lua
+++ b/tests/examples/shims/root.lua
@@ -8,12 +8,22 @@ function root:tags()
     return root._tags
 end
 
-function root:size() --TODO use the screens
-    return 0, 0
+function root.size()
+    local geo = {x1 = math.huge, y1 = math.huge, x2 = 0, y2 = 0}
+
+    for s in screen do
+        geo.x1 = math.min( geo.x1, s.geometry.x                   )
+        geo.y1 = math.min( geo.y1, s.geometry.y                   )
+        geo.x2 = math.max( geo.x2, s.geometry.x+s.geometry.width  )
+        geo.y2 = math.max( geo.y2, s.geometry.y+s.geometry.height )
+    end
+
+    return math.max(0, geo.x2-geo.x1), math.max(0, geo.y2 - geo.y1)
 end
 
-function root:size_mm()
-    return 0, 0
+function root.size_mm()
+    local w, h = root.size()
+    return (w/96)*25.4, (h/96)*25.4
 end
 
 function root.cursor() end

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -35,12 +35,6 @@ local function create_screen(args)
 
     local wa = args.workarea_sides or 10
 
-    -- This will happen if `clear()` is called
-    if mouse and (screen.count() > 0 and not mouse.screen) then
-        screen[s] = s
-        mouse.screen = s
-    end
-
     return setmetatable(s,{ __index = function(_, key)
             assert(s.valid)
 

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -78,7 +78,7 @@ end
 
 function screen._get_extents()
     local xmax, ymax
-    for _, v in ipairs(screen) do
+    for v in screen do
         if not xmax or v.geometry.x+v.geometry.width > xmax.geometry.x+xmax.geometry.width then
             xmax = v
         end

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -35,7 +35,8 @@ local function create_screen(args)
     local wa = args.workarea_sides or 10
 
     -- This will happen if `clear()` is called
-    if mouse and not mouse.screen then
+    if mouse and (screen.count() > 0 and not mouse.screen) then
+        screen[s] = s
         mouse.screen = s
     end
 

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -1,4 +1,5 @@
 local gears_obj = require("gears.object")
+local gears_tab = require("gears.table")
 
 local screen, meta = awesome._shim_fake_class()
 screen._count, screen._deleted = 0, {}
@@ -19,7 +20,7 @@ local function create_screen(args)
     }
 
     function s._resize(args2)
-        local old  = s.geometry
+        local old  = gears_tab.clone(s.geometry)
         geo.x      = args2.x      or geo.x
         geo.y      = args2.y      or geo.y
         geo.width  = args2.width  or geo.width

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -40,26 +40,26 @@ local function create_screen(args)
     end
 
     return setmetatable(s,{ __index = function(_, key)
-        if key == "geometry" then
-            return {
-                x      = geo.x or 0,
-                y      = geo.y or 0,
-                width  = geo.width ,
-                height = geo.height,
-            }
-        elseif key == "workarea" then
-            return {
-                x      = (geo.x or 0) + wa  ,
-                y      = (geo.y or 0) + wa  ,
-                width  = geo.width    - 2*wa,
-                height = geo.height   - 2*wa,
-            }
-        else
-            return meta.__index(_, key)
-        end
-    end,
-    __newindex = function(...) return meta.__newindex(...) end
-})
+            if key == "geometry" then
+                return {
+                    x      = geo.x or 0,
+                    y      = geo.y or 0,
+                    width  = geo.width ,
+                    height = geo.height,
+                }
+            elseif key == "workarea" then
+                return {
+                    x      = (geo.x or 0) + wa  ,
+                    y      = (geo.y or 0) + wa  ,
+                    width  = geo.width    - 2*wa,
+                    height = geo.height   - 2*wa,
+                }
+            else
+                return meta.__index(_, key)
+            end
+        end,
+        __newindex = function(...) return meta.__newindex(...) end
+    })
 end
 
 local screens = {}

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -4,6 +4,29 @@ local gears_tab = require("gears.table")
 local screen, meta = awesome._shim_fake_class()
 screen._count, screen._deleted = 0, {}
 
+local function compute_workarea(s)
+    local struts = {top=0,bottom=0,left=0,right=0}
+
+    for _, c in ipairs(drawin.get()) do
+        for k,v in pairs(struts) do
+            struts[k] = v + (c:struts()[k] or 0)
+        end
+    end
+
+    for _, c in ipairs(client.get()) do
+        for k,v in pairs(struts) do
+            struts[k] = v + (c:struts()[k] or 0)
+        end
+    end
+
+    return {
+        x      = s.geometry.x      + struts.left,
+        y      = s.geometry.y      + struts.top ,
+        width  = s.geometry.width  - struts.left - struts.right ,
+        height = s.geometry.height - struts.top  - struts.bottom,
+    }
+end
+
 local function create_screen(args)
     local s = gears_obj()
     awesome._forward_class(s, screen)
@@ -28,9 +51,40 @@ local function create_screen(args)
         s:emit_signal("property::geometry", old)
     end
 
-    s.outputs = { ["LVDS1"] = {
-        mm_width  = 0,
-        mm_height = 0,
+    function s.fake_resize(self, x, y, width, height)
+        self._resize {
+            x=x,y=y,width=width,height=height
+        }
+    end
+
+    function s:fake_remove()
+        local i = s.index
+        table.remove(screen, i)
+        screen._deleted[s] = true
+        s:emit_signal("removed")
+        screen[screen[i]] = nil
+        s.valid = false
+    end
+
+    function s:swap(other_s)
+        local s1geo = gears_tab.clone(s.geometry)
+        local s2geo = gears_tab.clone(other_s.geometry)
+
+        s:fake_resize(
+            s2geo.x, s2geo.y, s2geo.width, s2geo.height
+        )
+        other_s:fake_resize(
+            s1geo.x, s1geo.y, s1geo.width, s1geo.height
+        )
+
+        s:emit_signal("swapped",other_s)
+        other_s:emit_signal("swapped",s)
+    end
+
+    s.outputs = { LVDS1 ={
+        name      = "LVDS1",
+        mm_width  = (geo.width /96)*25.4,
+        mm_height = (geo.height/96)*25.4,
     }}
 
     local wa = args.workarea_sides or 10
@@ -46,12 +100,16 @@ local function create_screen(args)
                     height = geo.height,
                 }
             elseif key == "workarea" then
-                return {
-                    x      = (geo.x or 0) + wa  ,
-                    y      = (geo.y or 0) + wa  ,
-                    width  = geo.width    - 2*wa,
-                    height = geo.height   - 2*wa,
-                }
+                if screen._track_workarea then
+                    return compute_workarea(s)
+                else
+                    return {
+                        x      = (geo.x or 0) + wa  ,
+                        y      = (geo.y or 0) + wa  ,
+                        width  = geo.width    - 2*wa,
+                        height = geo.height   - 2*wa,
+                    }
+                end
             else
                 return meta.__index(_, key)
             end
@@ -72,6 +130,8 @@ function screen._add_screen(args)
     screen[#screen+1] = s
     screen[s] = s
     screen._count = screen._count + 1
+
+    return s
 end
 
 function screen._get_extents()
@@ -92,7 +152,18 @@ end
 -- problematic since it can cause invalid screens to be "resurrected".
 local function catch_invalid(_, s)
     -- The CAPI implementation allows `nil`
-    if s == nil or type(s) == "string" then return end
+    if s == nil then return end
+
+    -- Try to get the screens by output name.
+    if type(s) == "string" then
+        for s2 in screen do
+            for out in pairs(s2.outputs or {}) do
+                if out == s then
+                    return s2
+                end
+            end
+        end
+    end
 
     assert(screen ~= s, "Some code tried (and failed) to shadow the global `screen`")
 
@@ -152,9 +223,19 @@ local function iter_scr(_, _, s)
 
     local i = s.index
 
-    if i + 1 < #screen then
+    if i < #screen then
         return screen[i+1], i+1
     end
+end
+
+function screen._areas()
+    return {}
+end
+
+function screen.fake_add(x,y,width,height)
+    return screen._add_screen {
+        x=x,y=y,width=width,height=height
+    }
 end
 
 screen._add_screen {width=320, height=240}
@@ -163,6 +244,8 @@ screen._grid_vertical_margin = 10
 screen._grid_horizontal_margin = 10
 
 screen.primary = screen[1]
+
+screen._track_workarea = false
 
 function screen.count()
     return screen._count

--- a/tests/examples/shims/tag.lua
+++ b/tests/examples/shims/tag.lua
@@ -16,15 +16,19 @@ local function new_tag(_, args)
     awesome._forward_class(ret, tag)
 
     ret.data = {}
-    ret.name = args.name or "test"
+    ret.name = tostring(args.name) or "test"
     ret.activated = true
     ret.selected = not has_selected_tag(args.screen)
 
     function ret:clients(_) --TODO handle new
         local list = {}
         for _, c in ipairs(client.get()) do
-            if c.screen == (ret.screen or screen[1]) then
-                table.insert(list, c)
+            if #c:tags() > 0 then
+                for _, t in ipairs(c:tags()) do
+                    if t == ret then
+                        table.insert(list, c)
+                    end
+                end
             end
         end
 


### PR DESCRIPTION
I was rebasing some of my branches and some "regressions" due to various merged changes were easier to debug with this little change. It catches attempts to use invalid screens. It's useful for documentation tests that add and remove screens.