### PR TITLE
Fix instance existing check for application spawn

### DIFF
--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -547,16 +547,16 @@ local function is_running(hash, matcher)
     local status = spawn.single_instance_manager.by_uid[hash]
     if not status then return false end
 
-    if #status.instances == 0 then return false end
-
-    for _, c in ipairs(status.instances) do
-        if c.valid then return true end
-    end
-
     if matcher then
         for _, c in ipairs(client.get()) do
             if matcher(c) then return true end
         end
+    end
+
+    if #status.instances == 0 then return false end
+
+    for _, c in ipairs(status.instances) do
+        if c.valid then return true end
     end
 
     return false


### PR DESCRIPTION
Matcher argument for `spawn.once` and others was ignored in most cases during instance existence check. Now it has higher priority against `startup_id` and should work according docs.