### PR TITLE
Fix name of max layout in docs

### DIFF
--- a/lib/awful/layout/suit/max.lua
+++ b/lib/awful/layout/suit/max.lua
@@ -42,7 +42,7 @@ local function fmax(p, fs)
 end
 
 --- Maximized layout.
--- @clientlayout awful.layout.suit.max.name
+-- @clientlayout awful.layout.suit.max
 max.name = "max"
 function max.arrange(p)
     return fmax(p, false)


### PR DESCRIPTION
It is documented as `awful.layout.suit.max.name` but it's actually `awful.layout.suit.max`