### PR TITLE
Allow the screens to be fully managed by Lua

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -937,11 +937,12 @@ require("awful.screen.dpi")(screen, data)
 
 -- Set the wallpaper(s) and create the bar(s) for new screens
 
-capi.screen.connect_signal("added", function(s)
+capi.screen.connect_signal("_added", function(s)
     -- If it was emited from here when screens are created with fake_add,
     -- the Lua code would not have an opportunity to polutate the screen
     -- metadata. Thus, the DPI may be wrong when setting the wallpaper.
     if s._managed ~= "Lua" then
+        s:emit_signal("added")
         s:emit_signal("request::desktop_decoration")
         s:emit_signal("request::wallpaper")
     end

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -740,6 +740,26 @@ end
 -- @property preferred_dpi
 -- @param number the DPI value.
 
+--- The maximum diagonal size in millimeters.
+--
+-- @property mm_maximum_size
+-- @param number
+
+--- The minimum diagonal size in millimeters.
+--
+-- @property mm_minimum_size
+-- @param number
+
+--- The maximum diagonal size in inches.
+--
+-- @property inch_maximum_size
+-- @param number
+
+--- The minimum diagonal size in inches.
+--
+-- @property inch_minimum_size
+-- @param number
+
 --- Emitted when a new screen is added.
 --
 -- The handler(s) of this signal are responsible of adding elements such as

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -13,6 +13,7 @@ local capi =
     screen = screen,
     client = client,
     awesome = awesome,
+    root = root,
 }
 local gdebug = require("gears.debug")
 local gmath = require("gears.math")
@@ -260,6 +261,58 @@ function screen.object.set_padding(self, padding)
     end
 end
 
+--- A list of outputs for this screen with their size in mm.
+--
+-- Please note that the table content may vary. In some case, it might also be
+-- empty.
+--
+-- An easy way to check if a screen is the laptop screen is usually:
+--
+--    if s.outputs["LVDS-1"] then
+--        -- do something
+--    end
+--
+-- **Signal:**
+--
+--  * *property::outputs*
+--
+-- **Immutable:** true
+-- @property outputs
+-- @param table
+-- @tfield table table.name A table with the screen name as key (like `eDP1` on a laptop)
+-- @tfield integer table.mm_width The screen physical width.
+-- @tfield integer table.mm_height The screen physical height.
+-- @tfield integer table.name The output name.
+-- @tfield integer table.viewport_id The identifier of the viewport this output
+--  corresponds to.
+
+function screen.object.get_outputs(s)
+    local ret = {}
+
+    local outputs = s._custom_outputs
+        or (s.data.viewport and s.data.viewport.outputs or s._outputs)
+
+    -- The reason this exists is because output with name as keys is very
+    -- convenient for quick name lookup by the users, but inconvenient in
+    -- the lower layers since knowing the output count (using #) is better.
+    for k, v in ipairs(outputs) do
+        ret[v.name or k] = v
+    end
+
+    return ret
+end
+
+function screen.object.set_outputs(self, outputs)
+    self._custom_outputs = outputs
+    self:emit_signal("property::outputs", screen.object.get_outputs(self))
+end
+
+capi.screen.connect_signal("property::_outputs", function(s)
+    if not s._custom_outputs then
+        s:emit_signal("property::outputs", screen.object.get_outputs(s))
+    end
+end)
+
 --- Get the preferred screen in the context of a client.
 --
 -- This is exactly the same as `awful.screen.focused` except that it avoids
@@ -486,7 +539,7 @@ end
 function screen.object.get_tags(s, unordered)
     local tags = {}
 
-    for _, t in ipairs(root.tags()) do
+    for _, t in ipairs(capi.root.tags()) do
         if get_screen(t.screen) == s then
             table.insert(tags, t)
         end
@@ -560,75 +613,32 @@ function screen.set_auto_dpi_enabled(enabled)
     data.autodpi = enabled
 end
 
-
 --- The number of pixels per inch of the screen.
+--
+-- The default DPI comes from the X11 server. In most case, it will be 96. If
+-- `autodpi` is set to `true` on the screen, it will use the least dense dpi
+-- from the screen outputs. Most of the time, screens only have a single output,
+-- however it will have two (or more) when "clone mode" is used (eg, when a
+-- screen is duplicated on a projector).
+--
 -- @property dpi
 -- @param number the DPI value.
 
-local xft_dpi, fallback_dpi
+--- The lowest density DPI from all of the (physical) outputs.
+-- @property minimum_dpi
+-- @param number the DPI value.
 
-local function get_fallback()
-    local mm_per_inch = 25.4
+--- The highest density DPI from all of the (physical) outputs.
+-- @property maximum_dpi
+-- @param number the DPI value.
 
-    -- Following Keith Packard's whitepaper on Xft,
-    -- https://keithp.com/~keithp/talks/xtc2001/paper/xft.html#sec-editing
-    -- the proper fallback for Xft.dpi is the vertical DPI reported by
-    -- the X server. This will generally be 96 on Xorg, unless the user
-    -- has configured it differently
-    if root and not fallback_dpi then
-        local _, h = root.size()
-        local _, hmm = root.size_mm()
-        fallback_dpi = hmm ~= 0 and h * mm_per_inch / hmm
-    end
-
-    return fallback_dpi or 96
-end
-
-function screen.object.get_dpi(s)
-    local mm_per_inch = 25.4
-
-    if s.data.dpi or s.data.dpi_cache then
-        return s.data.dpi or s.data.dpi_cache
-    end
-
-    -- Xft.dpi is explicit user configuration, so honor it
-    if not xft_dpi and awesome and awesome.xrdb_get_value then
-        xft_dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi")) or false
-    end
-
-    if xft_dpi then
-        s.data.dpi_cache = xft_dpi
-        return s.data.dpi_cache
-    end
-
-    if not data.autodpi then
-        s.data.dpi_cache = get_fallback()
-        return s.data.dpi_cache
-    end
-
-    -- Try to compute DPI based on outputs (use the minimum)
-    local dpi = nil
-    local geo = s.geometry
-    for _, o in pairs(s.outputs) do
-        -- Ignore outputs with width/height 0
-        if o.mm_width ~= 0 and o.mm_height ~= 0 then
-            local dpix = geo.width * mm_per_inch / o.mm_width
-            local dpiy = geo.height * mm_per_inch / o.mm_height
-            dpi = math.min(dpix, dpiy, dpi or dpix)
-        end
-    end
-    if dpi then
-        s.data.dpi_cache = dpi
-        return dpi
-    end
-
-    s.data.dpi_cache = get_fallback()
-    return s.data.dpi_cache
-end
-
-function screen.object.set_dpi(s, dpi)
-    s.data.dpi = dpi
-end
+--- The preferred DPI from all of the (physical) outputs.
+--
+-- This is computed by normalizing all output to fill the area, then picking
+-- the lowest of the resulting virtual DPIs.
+--
+-- @property preferred_dpi
+-- @param number the DPI value.
 
 --- Emitted when a new screen is added.
 --
@@ -651,6 +661,177 @@ end
 --
 -- @signal request::wallpaper
 -- @tparam screen s The screen object.
+
+--- When a new (physical) screen area has been added.
+--
+-- Important: This only exists when Awesome is started with `--screen off`.
+-- Please also note that this doesn't mean it will appear when a screen is
+-- physically plugged. Depending on the configuration a tool like `arandr` or
+-- the `xrandr` command is needed.
+--
+-- The default handler will create a screen that fills the area.
+--
+-- To disconnect the default handler, use:
+--
+--    screen.disconnect_signal(
+--        "request::create", awful.screen.create_screen_handler
+--    )
+--
+-- @signal request::create
+-- @tparam table viewport
+-- @tparam table viewport.geometry A table with `x`, `y`, `width` and `height`
+--  keys.
+-- @tparam table viewport.outputs A table with the monitor name and possibly the
+--  `mm_width` and `mm_height` values if they are available.
+-- @tparam number viewport.id An identifier for this viewport (by pixel
+--  resolution). It
+--  will not change when outputs are modified, but will change when the
+--  resolution changes. Note that if it fully disappear, the next time an
+--  viewport with the same resolution appears, it will have a different `id`.
+-- @tparam number viewport.minimum_dpi The least dense DPI.
+-- @tparam number viewport.maximum_dpi The most dense DPI.
+-- @tparam number viewport.preferred_dpi The relative least dense DPI.
+-- @tparam table args
+-- @tparam string args.context Why was this signal sent.
+-- @see outputs
+-- @see awful.screen.create_screen_handler
+
+--- When a physical monitor viewport has been removed.
+--
+-- Important: This only exists when Awesome is started with `--screen off`.
+--
+-- If you replace the default handler, it is up to you to find the screen(s)
+-- associated with this viewport.
+--
+-- To disconnect the default handler, use:
+--
+--    screen.disconnect_signal(
+--        "request::remove", awful.screen.remove_screen_handler
+--    )
+--
+-- @signal request::remove
+-- @tparam table viewport
+-- @tparam table viewport.geometry A table with `x`, `y`, `width` and `height`
+--  keys.
+-- @tparam table viewport.outputs A table with the monitor name and possibly the
+--  `mm_width` and `mm_height` values if they are available.
+-- @tparam number viewport.id An identifier for this viewport (by pixel
+--  resolution). It will not change when outputs are modified, but will change
+--  when the resolution changes. Note that if it fully disappear, the next time
+--  an viewport with the same resolution appears, it will have a different `id`.
+-- @tparam number viewport.minimum_dpi The least dense DPI.
+-- @tparam number viewport.maximum_dpi The most dense DPI.
+-- @tparam number viewport.preferred_dpi The relative least dense DPI.
+-- @tparam table args
+-- @tparam string args.context Why was this signal sent.
+-- @see awful.screen.remove_screen_handler
+
+--- When a physical viewport resolution has changed or it has been replaced.
+--
+-- Important: This only exists when Awesome is started with `--screen off`.
+--
+-- Note that given the viewports are not the same, the `id` wont be the same.
+-- Also note that if multiple new viewports fit within a single "old" viewport,
+-- the resized screen will be the one with the largest total overlapping
+-- viewport (`intersection.width*intersection.height`), regardless of the
+-- outputs names.
+--
+-- To disconnect the default handler, use:
+--
+--    screen.disconnect_signal(
+--        "request::resize", awful.screen.resize_screen_handler
+--    )
+--
+-- @signal request::resize
+-- @tparam table old_viewport
+-- @tparam table old_viewport.geometry A table with `x`, `y`, `width` and
+--  `height` keys.
+-- @tparam table old_viewport.outputs A table with the monitor name and
+--  possibly the `mm_width` and `mm_height` values if they are available.
+-- @tparam number old_viewport.id An identifier for this viewport (by pixel
+--  resolution). It will not change when outputs are modified, but will change
+--  when the resolution changes. Note that if it fully disappear, the next
+--  time an viewport with the same resolution appears, it will have a different
+--  `id`.
+-- @tparam number old_viewport.minimum_dpi The least dense DPI.
+-- @tparam number old_viewport.maximum_dpi The most dense DPI.
+-- @tparam number old_viewport.preferred_dpi The relative least dense DPI.
+-- @tparam table new_viewport
+-- @tparam table new_viewport.geometry A table with `x`, `y`, `width` and
+--  `height` keys.
+-- @tparam table new_viewport.outputs A table with the monitor name and
+--  possibly the
+--  `mm_width` and `mm_height` values if they are available.
+-- @tparam number new_viewport.id An identifier for this viewport (by pixel
+--  resolution). It will not change when outputs are modified, but will change
+--  when the  resolution changes. Note that if it fully disappear, the next time
+--  an viewport with the same resolution appears, it will have a different `id`.
+-- @tparam number new_viewport.minimum_dpi The least dense DPI.
+-- @tparam number new_viewport.maximum_dpi The most dense DPI.
+-- @tparam number new_viewport.preferred_dpi The relative least dense DPI.
+-- @tparam table args
+-- @tparam string args.context Why was this signal sent.
+-- @see awful.screen.resize_screen_handler
+
+--- Default handler for `request::create`.
+--
+-- Important: This only exists when Awesome is started with `--screen off`.
+--
+-- A simplified implementation looks like:
+--
+--    function(viewport --[[, args]])
+--        local geo = viewport.geometry
+--        local s = screen.fake_add(geo.x, geo.y, geo.width, geo.height)
+--    end
+--
+-- If you implement this by hand, you must also implement handler for the
+-- `request::remove` and `request::resize`.
+--
+-- @signalhandler awful.screen.create_screen_handler
+-- @see request::create
+
+--- Default handler for `request::remove`.
+--
+-- Important: This only exists when Awesome is started with `--screen off`.
+--
+-- A simplified version of the logic is:
+--
+--    function (viewport --[[, args]])
+--        local geo = viewport.geometry
+--        for s in screen do
+--            if gears.geometry.rectangle.are_equal(geo, s.geometry) then
+--                s:fake_remove()
+--                return
+--            end
+--        end
+--    end
+--
+-- @signalhandler awful.screen.remove_screen_handler
+-- @see request::remove
+
+--- Default handler for `request::resize`.
+--
+-- Important: This only exists when Awesome is started with `--screen off`.
+--
+-- A simplified version of the logic is:
+--
+--    function (old_viewport, new_viewport --[[, args]])
+--        local old_geo, new_geo = old_viewport.geometry, new_viewport.geometry
+--        for s in screen do
+--            local sgeo = new_viewport.geometry
+--            if gears.geometry.rectangle.are_equal(old_geo, s.geometry) then
+--                s:fake_resize(
+--                    sgeo.x, sgeo.y, sgeo.width, sgeo.height
+--                )
+--            end
+--        end
+--    end
+--
+-- @signalhandler awful.screen.resize_screen_handler
+-- @see request::resize
+
+-- Add the DPI properties.
+require("awful.screen.dpi")(screen, data)
 
 -- Set the wallpaper(s) and create the bar(s) for new screens
 capi.screen.connect_signal("added", function(s)
@@ -676,30 +857,6 @@ end)
 capi.screen.connect_signal("request::wallpaper::connected", function(new_handler)
     for s in capi.screen do
         new_handler(s)
-    end
-end)
-
--- Create some screens when none exist. This can happen when AwesomeWM is
--- started with `--screen off` and no handler is used.
-capi.screen.connect_signal("scanned", function()
-    if capi.screen.count() == 0 then
-        -- Private API to scan for screens now.
-        if #capi.screen._viewports() == 0 then
-            capi.screen._scan_quiet()
-        end
-
-        local viewports = capi.screen._viewports()
-
-        if #viewports > 0 then
-            for _, area in ipairs(viewports) do
-                local geo = area.geometry
-                capi.screen.fake_add(geo.x, geo.y, geo.width, geo.height)
-            end
-        else
-            capi.screen.fake_add(0, 0, 640, 480)
-        end
-
-        assert(capi.screen.count() > 0, "Creating screens failed")
     end
 end)
 

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -882,6 +882,8 @@ end
 --    function(viewport --[[, args]])
 --        local geo = viewport.geometry
 --        local s = screen.fake_add(geo.x, geo.y, geo.width, geo.height)
+--        s:emit_signal("request::desktop_decoration")
+--        s:emit_signal("request::wallpaper")
 --    end
 --
 -- If you implement this by hand, you must also implement handler for the
@@ -934,9 +936,15 @@ end
 require("awful.screen.dpi")(screen, data)
 
 -- Set the wallpaper(s) and create the bar(s) for new screens
+
 capi.screen.connect_signal("added", function(s)
+    -- If it was emited from here when screens are created with fake_add,
+    -- the Lua code would not have an opportunity to polutate the screen
+    -- metadata. Thus, the DPI may be wrong when setting the wallpaper.
+    --if capi.screen.automatic_factory then
     s:emit_signal("request::desktop_decoration")
     s:emit_signal("request::wallpaper")
+    --end
 end)
 
 -- Resize the wallpaper(s)
@@ -948,15 +956,19 @@ end
 
 -- Create the bar for existing screens when an handler is added
 capi.screen.connect_signal("request::desktop_decoration::connected", function(new_handler)
-    for s in capi.screen do
-        new_handler(s)
+    if capi.screen.automatic_factory then
+        for s in capi.screen do
+            new_handler(s)
+        end
     end
 end)
 
 -- Set the wallpaper when an handler is added.
 capi.screen.connect_signal("request::wallpaper::connected", function(new_handler)
-    for s in capi.screen do
-        new_handler(s)
+    if capi.screen.automatic_factory then
+        for s in capi.screen do
+            new_handler(s)
+        end
     end
 end)
 

--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -941,10 +941,10 @@ capi.screen.connect_signal("added", function(s)
     -- If it was emited from here when screens are created with fake_add,
     -- the Lua code would not have an opportunity to polutate the screen
     -- metadata. Thus, the DPI may be wrong when setting the wallpaper.
-    --if capi.screen.automatic_factory then
-    s:emit_signal("request::desktop_decoration")
-    s:emit_signal("request::wallpaper")
-    --end
+    if s._managed ~= "Lua" then
+        s:emit_signal("request::desktop_decoration")
+        s:emit_signal("request::wallpaper")
+    end
 end)
 
 -- Resize the wallpaper(s)

--- a/lib/awful/screen/dpi.lua
+++ b/lib/awful/screen/dpi.lua
@@ -152,13 +152,14 @@ function module.create_screen_handler(viewport)
         geo.x,
         geo.y,
         geo.width,
-        geo.height
+        geo.height,
+        {_managed = true}
     )
 
     update_screen_viewport(s)
 
-    --s:emit_signal("request::desktop_decoration")
-    --s:emit_signal("request::wallpaper")
+    s:emit_signal("request::desktop_decoration")
+    s:emit_signal("request::wallpaper")
 end
 
 function module.remove_screen_handler(viewport)

--- a/lib/awful/screen/dpi.lua
+++ b/lib/awful/screen/dpi.lua
@@ -160,6 +160,9 @@ function module.create_screen_handler(viewport)
 
     s:emit_signal("request::desktop_decoration")
     s:emit_signal("request::wallpaper")
+
+    -- Will call all `connect_for_each_screen`.
+    s:emit_signal("added")
 end
 
 function module.remove_screen_handler(viewport)

--- a/lib/awful/screen/dpi.lua
+++ b/lib/awful/screen/dpi.lua
@@ -156,6 +156,9 @@ function module.create_screen_handler(viewport)
     )
 
     update_screen_viewport(s)
+
+    --s:emit_signal("request::desktop_decoration")
+    --s:emit_signal("request::wallpaper")
 end
 
 function module.remove_screen_handler(viewport)

--- a/lib/awful/screen/dpi.lua
+++ b/lib/awful/screen/dpi.lua
@@ -1,0 +1,333 @@
+---------------------------------------------------------------------------
+--                          DPI detection code.                          --
+---------------------------------------------------------------------------
+
+local capi    = {screen = screen}
+local gtable  = require("gears.table")
+local grect   = require("gears.geometry").rectangle
+local gdebug  = require("gears.debug")
+
+local module = {}
+
+local ascreen, data = nil, nil
+
+-- Metric to Imperial conversion constant.
+local mm_per_inch = 25.4
+
+local xft_dpi, fallback_dpi
+
+local function get_fallback_dpi()
+    -- Following Keith Packard's whitepaper on Xft,
+    -- https://keithp.com/~keithp/talks/xtc2001/paper/xft.html#sec-editing
+    -- the proper fallback for Xft.dpi is the vertical DPI reported by
+    -- the X server. This will generally be 96 on Xorg, unless the user
+    -- has configured it differently
+    if not fallback_dpi then
+        local _, h = root.size()
+        local _, hmm = root.size_mm()
+        fallback_dpi = hmm ~= 0 and h * mm_per_inch / hmm
+    end
+
+    return fallback_dpi or 96
+end
+
+local function dpi_for_output(viewport, output)
+    local dpi = nil
+    local geo = viewport.geometry
+
+    -- Ignore outputs with width/height 0
+    if output.mm_width ~= 0 and output.mm_height ~= 0 then
+        local dpix = geo.width * mm_per_inch / output.mm_width
+        local dpiy = geo.height * mm_per_inch / output.mm_height
+        dpi = math.min(dpix, dpiy, dpi or dpix)
+    elseif ascreen._get_xft_dpi() then
+        dpi = ascreen._get_xft_dpi()
+    end
+
+    return dpi or get_fallback_dpi()
+end
+
+local function dpis_for_outputs(viewport)
+    local max, min = 0, math.huge
+
+    for _, o in pairs(viewport.outputs) do
+        local dpi = dpi_for_output(viewport, o)
+        o.dpi = dpi
+        max = math.max(max, dpi)
+        min = math.min(min, dpi)
+    end
+
+    -- When there is no output.
+    if min == math.huge then
+        min = get_fallback_dpi()
+        max = min
+    end
+
+    --TODO Some output may have a lower resolution than the viewport, so their
+    -- DPI is currently wrong. Once fixed, the preferred DPI can become
+    -- different from the minimum one.
+    local pref = min
+
+    viewport.minimum_dpi, viewport.maximum_dpi, viewport.preferred_dpi = min, max, pref
+
+    return max, min, pref
+end
+
+local function update_outputs(old_viewport, new_viewport)
+    gtable.diff_merge(
+        old_viewport.outputs,
+        new_viewport.outputs,
+        function(o)
+            return o.name or (
+                (o.mm_height or -7)*9999 * (o.mm_width or 5)*123
+            )
+        end,
+        gtable.crush
+    )
+end
+
+-- Fetch the current viewports and compare them to the caches ones.
+--
+-- The idea is to keep whatever metadata kept within the existing ones and know
+-- what is added and removed.
+local function update_viewports(force)
+    if #ascreen._viewports > 0 and not force then return ascreen._viewports end
+
+    local new = ascreen._get_viewports()
+
+    local _, add, rem = gtable.diff_merge(
+        ascreen._viewports,
+        new,
+        function(a) return a.id end,
+        update_outputs
+    )
+
+    for _, viewport in ipairs(ascreen._viewports) do
+        dpis_for_outputs(viewport)
+    end
+
+    assert(#ascreen._viewports > 0 or #new == 0)
+
+    return ascreen._viewports, add, rem
+end
+
+-- Compute more useful viewport metadata frrom_sparse(add)om the list of output.
+-- @treturn table An viewport with more information.
+local function update_screen_viewport(s)
+    local viewport = s.data.viewport
+
+    if #ascreen._viewports == 0 then
+        ascreen._viewports = update_viewports(false)
+    end
+
+    -- The maximum is equal to the screen viewport, so no need for many loops.
+    if not viewport then
+        local big_a, i_size = nil, 0
+
+        for _, a in ipairs(ascreen._viewports) do
+            local int = grect.get_intersection(a.geometry, s.geometry)
+
+            if int.width*int.height > i_size then
+                big_a, i_size = a, int.width*int.height
+            end
+
+            if i_size == s.geometry.width*s.geometry.height then break end
+        end
+
+        if big_a then
+            viewport, s.data.viewport = big_a, big_a
+        end
+    end
+
+    if not viewport then
+        gdebug.print_warning("Screen "..tostring(s)..
+            " doesn't overlap a known physical monitor")
+    end
+end
+
+function module.create_screen_handler(viewport)
+    local geo = viewport.geometry
+
+    local s = capi.screen.fake_add(
+        geo.x,
+        geo.y,
+        geo.width,
+        geo.height
+    )
+
+    update_screen_viewport(s)
+end
+
+function module.remove_screen_handler(viewport)
+    for s in capi.screen do
+        if s.data.viewport and s.data.viewport.id == viewport.id then
+            s:fake_remove()
+            return
+        end
+    end
+end
+
+function module.resize_screen_handler(old_viewport, new_viewport)
+    for s in capi.screen do
+        if s.data.viewport and s.data.viewport.id == old_viewport.id then
+            local ngeo = new_viewport.geometry
+            s:fake_resize(
+                ngeo.x, ngeo.y, ngeo.width, ngeo.height
+            )
+            s.data.viewport = new_viewport
+            return
+        end
+    end
+end
+
+-- Xft.dpi is explicit user configuration, so honor it.
+-- (It isn't a local function to allow the tests to replace it)
+function module._get_xft_dpi()
+    if not xft_dpi then
+        xft_dpi = tonumber(awesome.xrdb_get_value("", "Xft.dpi")) or false
+    end
+
+    return xft_dpi
+end
+
+-- Provide a way for the tests to replace `capi.screen._viewports`.
+function module._get_viewports()
+    assert(type(capi.screen._viewports()) == "table")
+    return capi.screen._viewports()
+end
+
+local function get_dpi(s)
+    if s.data.dpi or s.data.dpi_cache then
+        return s.data.dpi or s.data.dpi_cache
+    end
+
+    if not s.data.viewport then
+        update_screen_viewport(s)
+    end
+
+    -- Pick a DPI (from best to worst).
+    local dpi = ascreen._get_xft_dpi()
+        or (s.data.viewport and s.data.viewport.preferred_dpi or nil)
+        or get_fallback_dpi()
+
+    -- Pick the screen DPI depending on the `autodpi` settings.
+    -- Historically, AwesomeWM size unit was the pixel. This assumption is
+    -- present in a lot, if not most, user config and is why this cannot be
+    -- enable by default for existing users.
+    s.data.dpi_cache = data.autodpi and dpi
+        or ascreen._get_xft_dpi()
+        or get_fallback_dpi()
+
+    return s.data.dpi_cache
+end
+
+local function set_dpi(s, dpi)
+    s.data.dpi = dpi
+end
+
+screen.connect_signal("request::create", module.create_screen_handler)
+screen.connect_signal("request::remove", module.remove_screen_handler)
+screen.connect_signal("request::resize", module.resize_screen_handler)
+
+-- Create some screens when none exist. This can happen when AwesomeWM is
+-- started with `--screen manual` and no handler is used.
+capi.screen.connect_signal("scanned", function()
+    if capi.screen.count() == 0 then
+        -- Private API to scan for screens now.
+        if #ascreen._get_viewports() == 0 then
+            capi.screen._scan_quiet()
+        end
+
+        local cur_viewports = ascreen._get_viewports()
+
+        if #cur_viewports > 0 then
+            for _, viewport in ipairs(cur_viewports) do
+                module.create_screen_handler(viewport)
+            end
+        else
+            capi.screen.fake_add(0, 0, 640, 480)
+        end
+
+        assert(capi.screen.count() > 0, "Creating screens failed")
+    end
+end)
+
+-- This is the (undocumented) signal sent by capi.
+capi.screen.connect_signal("property::_viewports", function(a)
+    if capi.screen.automatic_factory then return end
+
+    assert(#a > 0)
+
+    local _, added, removed = update_viewports(true)
+
+    local resized = {}
+
+    -- Try to detect viewports being replaced or resized.
+    for k2, viewport in ipairs(removed) do
+        local candidate, best_size, best_idx = {}, 0, nil
+
+        for k, viewport2 in ipairs(added) do
+            local int = grect.get_intersection(viewport.geometry, viewport2.geometry)
+
+            if (int.width*int.height) > best_size then
+                best_size, best_idx, candidate = (int.width*int.height), k, viewport2
+            end
+        end
+
+        if candidate and best_size > 0 then
+            table.insert(resized, {removed[k2], added[best_idx]})
+            removed[k2] = nil
+            table.remove(added  , best_idx)
+        end
+    end
+
+    gtable.from_sparse(removed)
+
+    -- Drop the cache.
+    for s in capi.screen do
+        s.data.dpi_cache = nil
+    end
+
+    capi.screen.emit_signal("property::viewports", ascreen._get_viewports())
+
+    -- First, ask for screens for these new viewport.
+    for _, viewport in ipairs(added) do
+        capi.screen.emit_signal("request::create", viewport, {context="viewports_changed"})
+    end
+
+    -- Before removing anything, make sure to resize existing screen as it may
+    -- affect where clients will go when the screens are removed.
+    for _, p in ipairs(resized) do
+        capi.screen.emit_signal("request::resize", p[1], p[2], {context="viewports_changed"})
+    end
+
+    -- Remove the now out-of-view screens.
+    for _, viewport in ipairs(removed) do
+        capi.screen.emit_signal("request::remove", viewport, {context="viewports_changed"})
+    end
+
+end)
+
+-- Add the DPI related properties
+return function(screen, d)
+    ascreen, data = screen, d
+
+    -- "Lua" copy of the CAPI viewports. It has more metadata.
+    ascreen._viewports = {}
+    gtable.crush(ascreen, module, true)
+
+    ascreen.object.set_dpi = set_dpi
+    ascreen.object.get_dpi = get_dpi
+
+    for _, prop in ipairs {"minimum", "maximum", "preferred" } do
+        screen.object["get_"..prop.."_dpi"] = function(s)
+            if not s.data.viewport then
+                update_screen_viewport(s)
+            end
+
+            local a = s.data.viewport or {}
+
+            return a[prop.."_dpi"] or nil
+        end
+    end
+end

--- a/lib/naughty/init.lua
+++ b/lib/naughty/init.lua
@@ -6,7 +6,7 @@
 
 local naughty = require("naughty.core")
 local gdebug = require("gears.debug")
-local capi = {awesome = awesome}
+local capi = {awesome = awesome, screen = screen}
 if dbus then
     naughty.dbus = require("naughty.dbus")
 end
@@ -31,7 +31,7 @@ naughty.notification = require("naughty.notification")
 --    screen.connect_signal("scanned", function() foobar() end)
 --
 local function screen_fallback()
-    if screen.count() == 0 then
+    if capi.screen.count() == 0 then
         gdebug.print_warning("An error occurred before a scrren was added")
 
         -- Private API to scan for screens now.
@@ -44,10 +44,11 @@ local function screen_fallback()
         if #viewports > 0 then
             for _, viewport in ipairs(viewports) do
                 local geo = viewport.geometry
-                screen.fake_add(geo.x, geo.y, geo.width, geo.height)
+                local s = capi.screen.fake_add(geo.x, geo.y, geo.width, geo.height)
+                s.outputs = viewport.outputs
             end
         else
-            screen.fake_add(0, 0, 640, 480)
+            capi.screen.fake_add(0, 0, 640, 480)
         end
     end
 end

--- a/manpages/awesome.1.fr.txt
+++ b/manpages/awesome.1.fr.txt
@@ -48,7 +48,7 @@ OPTIONS
 *-a*, *--no-argb*::
     N'utilise pas le codage ARGB.
 *-m*, *--screen*:: 'off' ou 'on'::
-    Utiliser "manual" pour exécuter rc.lua avant de créer les écrans.
+    Utiliser "off" pour exécuter le fichier rc.lua avant de créer les écrans.
 *-r*, *--replace*::
     Remplace le gestionnaire de fenêtres existant.
 

--- a/manpages/awesome.1.txt
+++ b/manpages/awesome.1.txt
@@ -47,7 +47,7 @@ OPTIONS
 *-a*, *--no-argb*::
     Don't use ARGB visuals.
 *-m*, *--screen*:: 'off' or 'on'::
-    Use "off" to execute rc.lua before creating the screens.
+    Use "off" to execute rc.lua before creating screens.
 *-r*, *--replace*::
     Replace an existing window manager.
 

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1644,6 +1644,11 @@ luaA_screen_fake_add(lua_State *L)
     luaA_class_emit_signal(L, &screen_class, "list", 0);
     luaA_object_push(L, s);
 
+    foreach(c, globalconf.clients) {
+        screen_client_moveto(*c, screen_getbycoord(
+                    (*c)->geometry.x, (*c)->geometry.y), false);
+    }
+
     return 1;
 }
 
@@ -1701,6 +1706,11 @@ luaA_screen_fake_resize(lua_State *L)
 
     luaA_pusharea(L, old_geometry);
     luaA_object_emit_signal(L, 1, "property::geometry", 1);
+
+    /* Note: calling `screen_client_moveto` from here will create more issues
+     * than it would fix. Keep in mind that it means `c.screen` will be wrong
+     * until Lua it `fake_add` fixes it.
+     */
 
     return 0;
 }

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -130,8 +130,16 @@
  * Each viewport in the list corresponds to a **physical** screen rectangle, which
  * is **not** the `viewports` property of the `screen` objects.
  *
+ * Each entry in the `viewports` entry has the following keys:
+ *
+ * * `geometry` *(table)*: A table with an `x`, `y`, `width` and `height` keys.
+ * * `outputs` *(table)*: All outputs sharing this viewport.
+ * * `maximum_dpi` *(number)*: The DPI of the most dense output.
+ * * `minimum_dpi` *(number)*: The DPI of the least dense output.
+ * * `preferred_dpi` *(number)*: The optimal DPI.
+ *
  * @signal property::viewports
- * @tparam table viewports
+ * @tparam table viewports A table containing all physical viewports.
  * @see automatic_factory
  */
 
@@ -200,24 +208,6 @@
  * @property index
  * @param integer
  * @see screen
- */
-
-/**
- * If RANDR information is available, a list of outputs
- *   for this screen and their size in mm.
- *
- * Please note that the table content may vary.
- *
- * **Signal:**
- *
- *  * *property::outputs*
- *
- * **Immutable:** true
- * @property outputs
- * @param table
- * @tfield table table.name A table with the screen name as key (like `eDP1` on a laptop)
- * @tfield integer table.name.mm_width The screen physical width
- * @tfield integer table.name.mm_height The screen physical height
  */
 
 /**
@@ -413,6 +403,10 @@ luaA_viewport_get_outputs(lua_State *L, viewport_t *a)
         lua_pushstring(L, output->name);
         lua_settable(L, -3);
 
+        lua_pushstring(L, "viewport_id");
+        lua_pushinteger(L, a->id);
+        lua_settable(L, -3);
+
         /* Add to the outputs */
         lua_rawseti(L, -2, count++);
     }
@@ -482,7 +476,7 @@ viewports_notify(lua_State *L)
 
     luaA_viewports(L);
 
-    luaA_class_emit_signal(L, &screen_class, "property::viewports", 1);
+    luaA_class_emit_signal(L, &screen_class, "property::_viewports", 1);
 }
 
 static viewport_t *
@@ -1084,7 +1078,7 @@ screen_modified(screen_t *existing_screen, screen_t *other_screen)
 
         if(outputs_changed) {
             luaA_object_push(L, existing_screen);
-            luaA_object_emit_signal(L, -1, "property::outputs", 0);
+            luaA_object_emit_signal(L, -1, "property::_outputs", 0);
             lua_pop(L, 1);
         }
     }
@@ -1795,7 +1789,7 @@ screen_class_setup(lua_State *L)
                             NULL,
                             (lua_class_propfunc_t) luaA_screen_get_index,
                             NULL);
-    luaA_class_add_property(&screen_class, "outputs",
+    luaA_class_add_property(&screen_class, "_outputs",
                             NULL,
                             (lua_class_propfunc_t) luaA_screen_get_outputs,
                             NULL);

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -949,7 +949,7 @@ screen_added(lua_State *L, screen_t *screen)
     screen->workarea = screen->geometry;
     screen->valid = true;
     luaA_object_push(L, screen);
-    luaA_object_emit_signal(L, -1, "added", 0);
+    luaA_object_emit_signal(L, -1, "_added", 0);
     lua_pop(L, 1);
 }
 

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -378,6 +378,7 @@ typedef struct viewport_t
     int y;
     int width;
     int height;
+    int id;
     struct viewport_t *next;
     screen_t *screen;
     screen_output_array_t outputs;
@@ -385,6 +386,7 @@ typedef struct viewport_t
 
 static viewport_t *first_screen_viewport = NULL;
 static viewport_t *last_screen_viewport = NULL;
+static int screen_area_gid = 1;
 
 static void
 luaA_viewport_get_outputs(lua_State *L, viewport_t *a)
@@ -458,6 +460,11 @@ luaA_viewports(lua_State *L)
         luaA_viewport_get_outputs(L, a);
         lua_settable(L, -3);
 
+        /* Add an identifier to better detect when screens are removed */
+        lua_pushstring(L, "id");
+        lua_pushinteger(L, a->id);
+        lua_settable(L, -3);
+
         lua_rawseti(L, -2, count++);
     } while ((a = a->next));
 
@@ -499,6 +506,7 @@ viewport_add(lua_State *L, int x, int y, int w, int h)
     node->y      = y;
     node->width  = w;
     node->height = h;
+    node->id     = screen_area_gid++;
     node->next   = NULL;
     node->screen = NULL;
     node->marked = true;

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -30,16 +30,24 @@
 typedef struct screen_output_t screen_output_t;
 ARRAY_TYPE(screen_output_t, screen_output)
 
+/** Different ways to manage screens */
+typedef enum {
+    SCREEN_LIFECYCLE_USER =        0, /*!< Unmanaged (ei. from fake_add) */
+    SCREEN_LIFECYCLE_LUA  = 0x1 << 0, /*!< Is managed internally by Lua  */
+    SCREEN_LIFECYCLE_C    = 0x1 << 1, /*!< Is managed internally by C    */
+} screen_lifecycle_t;
+
 struct a_screen
 {
     LUA_OBJECT_HEADER
-    /** Is this screen still valid and may be used? */
     bool valid;
+    /** Who manages the screen lifecycle */
+    screen_lifecycle_t lifecycle;
     /** Screen geometry */
     area_t geometry;
     /** Screen workarea */
     area_t workarea;
-    /** Opaque pointer to the psysical geometry */
+    /** Opaque pointer to the viewport */
     struct viewport_t *viewport;
     /** Some XID identifying this screen */
     uint32_t xid;

--- a/objects/screen.h
+++ b/objects/screen.h
@@ -47,6 +47,8 @@ struct a_screen
     area_t geometry;
     /** Screen workarea */
     area_t workarea;
+    /** The name of the screen */
+    char *name;
     /** Opaque pointer to the viewport */
     struct viewport_t *viewport;
     /** Some XID identifying this screen */

--- a/tests/examples/awful/screen/split1.lua
+++ b/tests/examples/awful/screen/split1.lua
@@ -1,0 +1,9 @@
+--DOC_GEN_IMAGE --DOC_HIDE  --DOC_NO_USAGE
+
+require("awful.screen") --DOC_HIDE
+
+screen[1]._resize {x = 95, width = 256, height = 108} --DOC_HIDE
+
+    screen[1]:split({1/5, 3/5, 1/5})
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/awful/screen/split2.lua
+++ b/tests/examples/awful/screen/split2.lua
@@ -1,0 +1,9 @@
+--DOC_GEN_IMAGE --DOC_HIDE --DOC_NO_USAGE
+
+require("awful.screen") --DOC_HIDE
+
+screen[1]._resize {x = 175, width = 108, height = 198} --DOC_HIDE
+
+    screen[1]:split()
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -255,7 +255,7 @@ for f in $tests; do
     error="$(echo "$error" | grep -vE ".{19} W: awesome: (Can't read color .* from GTK)" || true)"
     if [[ $fail_on_warning ]]; then
         # Filter out ignored warnings.
-        error="$(echo "$error" | grep -vE ".{19} W: awesome: (a_glib_poll|Cannot reliably detect EOF|beautiful: can't get colorscheme from xrdb|Can't read color .* from GTK+3 theme|A notification|Notification)" || true)"
+        error="$(echo "$error" | grep -vE ".{19} W: awesome: (Removing last screen through fake_remove|a_glib_poll|Cannot reliably detect EOF|beautiful: can't get colorscheme from xrdb|Can't read color .* from GTK+3 theme|A notification|Notification)" || true)"
     fi
     if [[ -n "$error" ]]; then
         color_red

--- a/tests/test-awful-screen.lua
+++ b/tests/test-awful-screen.lua
@@ -68,6 +68,12 @@ local steps = {
     -- Make sure the error code still works when all screens are gone.
     function()
         while screen.count() > 0 do
+            -- Before removing them, check if `name` works.
+            assert(screen[1].name == "screen1")
+            screen[1].name = "foo"
+            assert(screen[1].name == "foo")
+            assert(screen.foo == screen[1])
+
             screen[1]:fake_remove()
         end
 

--- a/tests/test-dpi.lua
+++ b/tests/test-dpi.lua
@@ -1,0 +1,548 @@
+-- This testsuite intends to tests the delayed screen creation mode and it's
+-- automatic fallback when no screens are created.
+
+local runner = require("_runner")
+local ascreen = require("awful.screen")
+local gtable = require("gears.table")
+local grect = require("gears.geometry").rectangle
+
+local xft_dpi = 42
+
+local fake_viewports, max_id, allow_zero = screen._viewports(), 1, false
+local called = 0
+
+local saved_dpi1, saved_dpi2, saved_dpi3
+
+-- Make sure what is tested matches some criteria.
+-- Prevents silly errors when adding more test case.
+local function validate_viewports(viewports)
+    for _, a in ipairs(viewports) do
+        assert(type(a.id) == "number")
+        assert(a.id > max_id)
+        assert(type(a.outputs ) == "table")
+        assert(type(a.geometry) == "table")
+
+        for _, prop in ipairs {"x", "y", "width", "height"} do
+            assert(type(a.geometry[prop]) == "number")
+            assert(a.geometry[prop] >= 0)
+        end
+
+        max_id = a.id
+    end
+end
+
+local function fake_replace(viewports)
+    fake_viewports = viewports
+    screen.emit_signal("property::_viewports", fake_viewports)
+end
+
+-- Rollback the clock and replay the initialization.
+local function fake_replay(viewports)
+    if viewports then
+        validate_viewports(viewports)
+    end
+
+    viewports = viewports or fake_viewports
+
+    ascreen._viewports, fake_viewports = {}, viewports
+
+    while screen.count() > 0 do
+        screen[1]:fake_remove()
+    end
+
+    assert(screen.count() == 0)
+
+    screen.emit_signal("scanning")
+    screen.emit_signal("property::_viewports", fake_viewports)
+    screen.emit_signal("scanned")
+    assert(screen.count() == #viewports)
+
+    assert(type(ascreen._get_xft_dpi()) ~= "boolean")
+
+    -- Check of the viewports (+new metadata) is created.
+    for k, a in ipairs(viewports) do
+        local s = screen[k]
+
+        -- Check if the extra metadata are computed.
+        assert(s.data.viewport.maximum_dpi)
+        assert(s.data.viewport.minimum_dpi)
+        assert(s.data.viewport.preferred_dpi)
+        assert(s.dpi)
+        assert(s.maximum_dpi   == s.data.viewport.maximum_dpi  )
+        assert(s.minimum_dpi   == s.data.viewport.minimum_dpi  )
+        assert(s.preferred_dpi == s.data.viewport.preferred_dpi)
+
+        -- Make sure it enters either the main `if` or the fallback one.
+        assert(s.data.viewport.minimum_dpi   ~= math.huge)
+        assert(s.data.viewport.preferred_dpi ~= math.huge)
+
+        -- Check the range.
+        assert(s.data.viewport.maximum_dpi   >= s.data.viewport.minimum_dpi)
+        assert(s.data.viewport.preferred_dpi >= s.data.viewport.minimum_dpi)
+        assert(s.data.viewport.preferred_dpi <= s.data.viewport.maximum_dpi)
+
+        -- Check if the screen was created using the right viewport
+        -- (order *is* relevant).
+        assert(#s.data.viewport.outputs == #a.outputs)
+        assert(s.data.viewport and s.data.viewport.id == a.id)
+    end
+
+    -- The original shall not be modified, the CAPI for this is read-only.
+    for _, a in ipairs(fake_viewports) do
+        assert(not a.minimum_dpi  )
+        assert(not a.maximum_dpi  )
+        assert(not a.preferred_dpi)
+        assert(not a.dpi          )
+    end
+end
+
+local function remove_output(viewport, name)
+    for k, output in ipairs(viewport.outputs) do
+        if output.name == name then
+            table.remove(viewport.outputs, k)
+            screen.emit_signal("property::_viewports", fake_viewports)
+            return
+        end
+    end
+    assert(false)
+end
+
+local function add_output(viewport, output)
+    table.insert(viewport.outputs, output)
+    screen.emit_signal("property::_viewports", fake_viewports)
+end
+
+local function remove_viewport(id)
+    for k, a in ipairs(fake_viewports) do
+        if a.id == id then
+            table.remove(fake_viewports, k)
+            screen.emit_signal("property::_viewports", fake_viewports)
+            return
+        end
+    end
+    assert(false)
+end
+
+local function add_viewport(viewport)
+    assert(viewport.id)
+    assert(viewport.geometry)
+    assert(viewport.outputs)
+    table.insert(fake_viewports, viewport)
+    screen.emit_signal("property::_viewports", fake_viewports)
+end
+
+local steps = {
+
+-- Monkeypatch for the tests.
+function()
+    -- This should be true for all tests for.
+    assert(not screen.automatic_factory)
+
+    -- Avoids touching the real XRDB, the tests don't control it.
+    function ascreen._get_xft_dpi()
+        return xft_dpi
+    end
+
+    -- This testsuite needs to manipulate this.
+    function ascreen._get_viewports()
+        local clone = gtable.clone(fake_viewports, true)
+        assert(#clone > 0 or allow_zero)
+        return clone
+    end
+
+    return true
+end,
+
+-- Remove all the screens, which is **not** supported, but necessary to play
+-- with the initial screen creation code.
+function()
+    -- Simple scenario, a single screen.
+    fake_replay {
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 2,
+            geometry = { x = 0, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "leet", mm_width = 353, mm_height = 11 }},
+        },
+    }
+
+    -- It should honor the XFT DPI when set.
+    assert(xft_dpi == screen[1].dpi)
+
+    -- Now that we know it works, unset it for the other steps.
+    xft_dpi = nil
+
+    -- Check if the "normal" fallback works.
+    fake_replay()
+    assert(screen[1].dpi ~= 42)
+
+    return true
+end,
+
+-- Test with multiple outputs.
+function()
+    -- Simple scenario, a single screen.
+    fake_replay {
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 3,
+            geometry = { x = 0, y = 0, width = 1337, height = 42 },
+            outputs  = {
+                { name = "leet", mm_width = 353  , mm_height = 11   },
+                { name = "leet", mm_width = 353/2, mm_height = 11/2 },
+                { name = "leet", mm_width = 353/3, mm_height = 11/3 },
+            },
+        },
+    }
+
+    assert(screen[1].maximum_dpi   == screen[1].minimum_dpi*3)
+    assert(screen[1].preferred_dpi == screen[1].minimum_dpi  )
+
+    return true
+end,
+
+-- Test with zero outputs.
+function()
+    -- Simple scenario, a single screen.
+    fake_replay {
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 4,
+            geometry = { x = 0, y = 0, width = 1337, height = 42 },
+            outputs  = {},
+        },
+    }
+
+    assert(screen[1].maximum_dpi   == screen[1].minimum_dpi)
+    assert(screen[1].preferred_dpi == screen[1].minimum_dpi)
+
+    return true
+end,
+
+-- Test with 2 screens.
+function()
+    fake_replay {
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 5,
+            geometry = { x = 0, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "0x1ee7", mm_width = 353, mm_height = 11 }},
+        },
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 6,
+            geometry = { x = 1337, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "3leet", mm_width = 353, mm_height = 11 }},
+        },
+    }
+
+    saved_dpi1 = screen[1].preferred_dpi
+
+    return true
+end,
+
+-- Test with 2 screens with twice the density.
+function()
+    -- Simple scenario, a single screen.
+    fake_replay {
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 7,
+            geometry = { x = 0, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "0x1ee7", mm_width = 353/2, mm_height = 11/2 }},
+        },
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 8,
+            geometry = { x = 1337, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "3leet", mm_width = 353/3, mm_height = 11/3 }},
+        },
+    }
+
+    -- Test if scaling works as expected.
+    assert(saved_dpi1*2 == screen[1].preferred_dpi)
+    assert(saved_dpi1*3 == screen[2].preferred_dpi)
+
+    -- Revert to the previous settings if the DPI happens to accidentally match.
+    -- For the following tests, it has to be different from the fallback.
+    if screen[1].preferred_dpi == screen[1].dpi then
+        fake_replay {
+            {
+                -- 1 has already been consumed, this makes the test more future proof.
+                id       = 9,
+                geometry = { x = 0, y = 0, width = 1337, height = 42 },
+                outputs  = {{ name = "0x1ee7", mm_width = 353, mm_height = 11 }},
+            }
+        }
+    end
+
+    saved_dpi1 = screen[1].preferred_dpi
+
+    -- The next test requires a different value.
+    assert(saved_dpi1 ~= screen[1].dpi)
+
+    -- Enable autodpi.
+    ascreen.set_auto_dpi_enabled(true)
+
+    return true
+end,
+
+-- Test if autodpi does something.
+function()
+    -- Replay with the same settings.
+    fake_replay()
+
+    -- If this isn't true, then auto-dpi didn't do its job.
+    assert(screen[1].dpi == saved_dpi1)
+
+    -- Revert to a single viewport for the next tests.
+    fake_replay {
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 10,
+            geometry = { x = 0, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "leet", mm_width = 353, mm_height = 11 }},
+        },
+    }
+
+    saved_dpi1 = screen[1].dpi
+    saved_dpi2 = screen[1].maximum_dpi
+    saved_dpi3 = screen[1].minimum_dpi
+
+    return true
+end,
+
+-- Test adding an output.
+function()
+    local viewport = screen[1].data.viewport
+
+    add_output(fake_viewports[1], {
+        name      = "foobar",
+        mm_width  = 353/2,
+        mm_height = 11/2
+    })
+    add_output(fake_viewports[1], {
+        name      = "foobar2",
+        mm_width  = 353*2,
+        mm_height = 11*2
+    })
+
+    -- It should have been kept.
+    assert(viewport == screen[1].data.viewport)
+
+    -- If this isn't true, then auto-dpi didn't do its job.
+    assert(screen[1].dpi ~= saved_dpi1)
+
+    -- Now that there is multiple DPIs for the same viewport, the number
+    -- should double.
+    assert(#screen[1].data.viewport.outputs == 3)
+    assert(screen[1].maximum_dpi == saved_dpi2*2)
+    assert(screen[1].minimum_dpi == saved_dpi3/2)
+    assert(screen[1].dpi         == saved_dpi1/2)
+
+    remove_output(fake_viewports[1], "leet")
+    assert(#screen[1].data.viewport.outputs == 2)
+    remove_output(fake_viewports[1], "foobar")
+
+    -- At this point, only 1 DPI is left.
+    assert(#screen[1].data.viewport.outputs == 1)
+    assert(screen[1].maximum_dpi == saved_dpi1/2)
+    assert(screen[1].minimum_dpi == saved_dpi1/2)
+    assert(screen[1].dpi         == saved_dpi1/2)
+
+    return true
+end,
+
+-- Test adding/removing viewports.
+function()
+    assert(screen.count() == 1)
+
+    add_viewport {
+        id = 11,
+        geometry = { x = 1337, y = 0, width = 1337, height = 42 },
+        outputs = {{
+            name      = "foobar",
+            mm_width  = 353/2,
+            mm_height = 11/2
+        }}
+    }
+
+    assert(screen.count() == 2)
+    assert(screen[1].data.viewport.id == 10)
+    assert(screen[2].data.viewport.id == 11)
+    assert(grect.are_equal(screen[1].data.viewport.geometry, screen[1].geometry))
+    assert(grect.are_equal(screen[2].data.viewport.geometry, screen[2].geometry))
+    assert(#ascreen._viewports == 2)
+
+    remove_viewport(10)
+
+    assert(#ascreen._viewports == 1)
+    assert(screen.count() == 1)
+    assert(screen[1].data.viewport.id == 11)
+    assert(grect.are_equal(screen[1].data.viewport.geometry, screen[1].geometry))
+
+    return true
+end,
+
+-- Test resizing.
+function()
+    local s, sa = screen[1], screen[1].data.viewport
+    assert(screen.count() == 1)
+    assert(#ascreen._viewports == 1)
+
+    -- First, to the same size (replace internal screen with external screen).
+    -- It may or may not create a different viewport in practice, but it's possible
+    -- if the first screen is removed then the new one added in 2 steps.
+    fake_replace {
+        {
+            id = 12,
+            geometry = { x = 1337, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "foobar3", mm_width  = 353/2, mm_height = 11/2}}
+        }
+    }
+
+    assert(screen.count() == 1)
+    assert(s == screen[1])
+    assert(s.data.viewport ~= sa)
+    assert(s.data.viewport.id == 12)
+
+    -- Now 2 smaller (resolution) screens side by side to make sure it doesn't
+    -- go haywire with overlapping
+    fake_replace {
+        {
+            id = 13,
+            geometry = { x = 1337, y = 0, width = 680, height = 42 },
+            outputs  = {{ name = "foobar4", mm_width  = 353/2, mm_height = 11/2}}
+        },
+        {
+            id = 14,
+            geometry = { x = 1337+680, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "foobar5", mm_width  = 353/2, mm_height = 11/2}}
+        }
+    }
+
+    assert(screen.count() == 2)
+    assert(s == screen[1])
+    assert(s.data.viewport.id == 13)
+    assert(s.geometry.x == 1337)
+    assert(s.geometry.width == 680)
+
+    -- Disconnect the default handler to test the fallback.
+    screen.disconnect_signal("request::create", ascreen.create_screen_handler)
+    screen.disconnect_signal("request::remove", ascreen.remove_screen_handler)
+    screen.disconnect_signal("request::resize", ascreen.resize_screen_handler)
+
+    return true
+end,
+
+-- Test the fallback screen creation.
+function()
+    fake_replay {
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 15,
+            geometry = { x = 0, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "0x1ee7", mm_width = 353, mm_height = 11 }},
+        },
+        {
+            -- 1 has already been consumed, this makes the test more future proof.
+            id       = 16,
+            geometry = { x = 1337, y = 0, width = 1337, height = 42 },
+            outputs  = {{ name = "3leet", mm_width = 353, mm_height = 11 }},
+        },
+    }
+
+    assert(screen.count() == 2)
+    assert(screen[1].data.viewport.id == 15)
+    assert(screen[2].data.viewport.id == 16)
+
+    -- Connect custom handler and see if the internals accidently depend on
+    -- implementation details.
+    screen.connect_signal("request::create", function(viewport)
+        assert(viewport.minimum_dpi)
+        assert(viewport.maximum_dpi)
+        assert(viewport.preferred_dpi)
+        local geo = viewport.geometry
+        local s = screen.fake_add(geo.x, geo.y, geo.width, geo.height)
+        s.outputs = viewport.outputs
+        called = called + 1
+    end)
+    screen.connect_signal("request::remove", function(viewport)
+        local geo = viewport.geometry
+        for s in screen do
+            if grect.are_equal(geo, s.geometry) then
+                s:fake_remove()
+                called = called + 1
+                return
+            end
+        end
+    end)
+
+    return true
+end,
+
+-- Test if alternate implementations don't explode the internals.
+function()
+    ascreen._viewports = {}
+
+    while screen.count() > 0 do
+        screen[1]:fake_remove()
+    end
+
+    assert(screen.count() == 0)
+
+--     screen.emit_signal("scanning")
+    screen.emit_signal("property::_viewports", fake_viewports)
+    screen.emit_signal("scanned")
+    assert(screen.count() == 2)
+
+    assert(grect.are_equal(
+        screen[1].geometry, {x = 0, y = 0, width = 1337, height = 42}
+    ))
+    assert(grect.are_equal(
+        screen[2].geometry, {x = 1337, y = 0, width = 1337, height = 42}
+    ))
+
+    -- Call the DPI properties just to check it doesn't cause an error)
+    assert(screen[1].dpi           or true)
+    assert(screen[1].maximum_dpi   or true)
+    assert(screen[1].minimum_dpi   or true)
+    assert(screen[1].preferred_dpi or true)
+    assert(screen[2].dpi           or true)
+    assert(screen[2].maximum_dpi   or true)
+    assert(screen[2].minimum_dpi   or true)
+    assert(screen[2].preferred_dpi or true)
+    assert(called == 2)
+
+    -- Try adding an viewport.
+    table.insert(fake_viewports, {
+        -- 1 has already been consumed, this makes the test more future proof.
+        id       = 17,
+        geometry = { x = 1337, y = 42, width = 1337, height = 42 },
+        outputs  = {{ name = "last", mm_width = 353, mm_height = 11 }},
+    })
+    screen.emit_signal("property::_viewports", fake_viewports)
+    assert(screen.count() == 3)
+    assert(called == 3)
+    assert(grect.are_equal(
+        screen[3].geometry, {x = 1337, y = 42, width = 1337, height = 42}
+    ))
+
+    -- Remove the middle one.
+    table.remove(fake_viewports, 2)
+    screen.emit_signal("property::_viewports", fake_viewports)
+
+    assert(screen.count() == 2)
+    assert(called == 4)
+    assert(grect.are_equal(
+        screen[1].geometry, {x = 0, y = 0, width = 1337, height = 42}
+    ))
+    assert(grect.are_equal(
+        screen[2].geometry, {x = 1337, y = 42, width = 1337, height = 42}
+    ))
+
+    return true
+end
+}
+
+runner.run_steps(steps)


### PR DESCRIPTION
This pull request ~~publishes the draft commits to~~ allow AwesomeWM to be started without screens and let some Lua code add "fake" ones. This is hidden behind a command line option (`--screen off`) because it would otherwise break some configs. With this option enabled, `mouse.screen` can be nil for a short time and this isn't supported. With all the `request::` sections I am promoting for a more modular `rc.lua`, this is less of an issue because less code runs in the `_G` context and more within callbacks (which are unaffected).

The commits also add some new signals and method to fetch the rectangle areas used by physical screens without creating the screen objects. ~~So far, it doesn't fetch the outputs, which is a problem. There is some memory leaks and this is actually untested with multiple "real" screens. It also has an obsolete/unused data structure in the diff because I am lazy.~~

The reason I publish this now (the older parts are from 2017) is because of my ongoing effort to add an `awful.rules` like API to all core objects. Screens are core objects and the only way to integrate them with the rules is for Lua to manage them. I will also need to use multiple/changing screens again for my new job, so better work on this now.

~~So this PR is mostly for opinions and feedback about the design and initialization sequence. The code isn't so great (yet).~~

The most basic Lua implementation is 

```lua
screen.connect_signal("scanning", function()
    screen.automatic_factory = false
end)

client.connect_signal("property::viewports", function()
    for _, viewport in ipairs(screen.viewports()) do
       if not find_existing_screen_function(viewport) then
            local geo = viewport.geometry
            screen.fake_add(geo.x, geo.y, geo.width, geo.height)
        end
    end

    --TODO Check for dead screens.
end)

-- Should never happen, but just in case.
screen.connect_signal("scanned", function()
    if screen.count() == 0 then
       screen.fake_add(0, 0, 640, 480)
    end
end)
```

Fixes #1382