### PR TITLE
Fix negative sizes with the margin container

### DIFF
--- a/lib/wibox/container/margin.lua
+++ b/lib/wibox/container/margin.lua
@@ -44,7 +44,12 @@ function margin:layout(_, width, height)
         local w = self._private.right
         local h = self._private.bottom
 
-        return { base.place_widget_at(self._private.widget, x, y, width - x - w, height - y - h) }
+        local resulting_width = width - x - w
+        local resulting_height = height - y - h
+
+        if resulting_width > 0 and resulting_height > 0 then
+            return { base.place_widget_at(self._private.widget, x, y, resulting_width, resulting_height) }
+        end
     end
 end
 

--- a/lib/wibox/hierarchy.lua
+++ b/lib/wibox/hierarchy.lua
@@ -304,8 +304,8 @@ end
 
 --- Does the given cairo context have an empty clip (aka "no drawing possible")?
 local function empty_clip(cr)
-    local _, _, width, height = cr:clip_extents()
-    return width == 0 or height == 0
+    local x1, y1, x2, y2 = cr:clip_extents()
+    return x2 - x1 == 0 or y2 - y1 == 0
 end
 
 --- Draw a hierarchy to some cairo context.

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -397,6 +397,8 @@ end
 -- @treturn table An opaque object that can be returned from `:layout()`.
 -- @staticfct wibox.widget.base.place_widget_via_matrix
 function base.place_widget_via_matrix(widget, mat, width, height)
+    assert(width >= 0, "A widget's width cannot be negative: " ..  tostring(width))
+    assert(height >= 0, "A widget's height cannot be negative: " ..  tostring(height))
     return {
         _widget = widget,
         _width = width,


### PR DESCRIPTION
This fixes #2799: With `draw_empty=false`, the margin container produced negative widths and heights for its inner widget. The first commit in here fixes that.

The second commit adds assertions to catch negative widget sizes early. Any code that gets broken by this change was most likely already broken before. And due to the many `pcall`s in the widget layout code, this error will be contained and will not "break everything".

The last commit fixes the `empty_clip` function to actually work. However, for reasons that I do not really understand, this does not have much of an effect on `test-benchmark.lua`.
Master:
```
   create&draw wibox: 0.0140362  sec/iter ( 73 iters, 1.6 sec for benchmark)
    update textclock: 2.68101e-06 sec/iter (428868 iters, 1.383 sec for benchmark)
  relayout textclock: 1.70189e-06 sec/iter (808534 iters, 1.582 sec for benchmark)
    redraw textclock: 8.05295e-07 sec/iter (1260045 iters, 3.085 sec for benchmark)
          tag switch: 0.0054088  sec/iter (185 iters, 1.674 sec for benchmark)
```
With this change:
```
   create&draw wibox: 0.0140465  sec/iter ( 73 iters, 1.59 sec for benchmark)
    update textclock: 2.68279e-06 sec/iter (428028 iters, 1.343 sec for benchmark)
  relayout textclock: 1.73115e-06 sec/iter (797147 iters, 1.631 sec for benchmark)
    redraw textclock: 7.87591e-07 sec/iter (1289767 iters, 3.115 sec for benchmark)
          tag switch: 0.00541387 sec/iter (186 iters, 2.68 sec for benchmark)
```