### PR TITLE
wibox.hierarchy:draw: Clear paths after .draw

### DIFF
--- a/lib/wibox/hierarchy.lua
+++ b/lib/wibox/hierarchy.lua
@@ -350,6 +350,8 @@ function hierarchy:draw(context, cr)
         cr:clip()
         call(widget.draw)
         cr:restore()
+        -- Clear any path that the widget might have left
+        cr:new_path()
 
         -- Draw its children (We already clipped to the draw extents above)
         call(widget.before_draw_children)
@@ -359,6 +361,8 @@ function hierarchy:draw(context, cr)
             call(widget.after_draw_child, i, wi:get_widget())
         end
         call(widget.after_draw_children)
+        -- Clear any path that the widget might have left
+        cr:new_path()
 
         -- Apply opacity
         if opacity ~= 1 then


### PR DESCRIPTION
Cairo's save/restore methods handle all properties except for the
current path. The path is just left as-is.

A widget's draw method could create some path without consuming it. This
path would then interfere with random things later which did not expect
a path to already exist.

This commits adds calls to cairo_new_path() in the relevant positions to
clean things up.

This not only applies to a widget's draw method, but also
{before,after}_draw_{child,children}. However, these methods could (for
whatever reason) create paths that are to be consumed in one of the
other methods. To keep this working, the path is only cleared after all
of these methods ran.

I do not expect this commit to break anything, because a widget cannot
really assume much about what widget is drawn after it. Especially so,
because partial redraws could mean that some later widget is skipped and
not redrawn.

This should fix the issue reported at
https://github.com/awesomeWM/awesome/pull/2804.

Signed-off-by: Uli Schlachter <psychon@znc.in>

Edit: Travis build failed due to https://github.com/Olivine-Labs/busted/issues/602.