### PR TITLE
Fix index handling in a taglist example

### DIFF
--- a/tests/examples/wibox/awidget/taglist/indexed.lua
+++ b/tests/examples/wibox/awidget/taglist/indexed.lua
@@ -79,7 +79,7 @@ c2:tags(tags[1]) --DOC_HIDE
 
             -- Add support for hover colors and an index label
             create_callback = function(self, c3, index, objects) --luacheck: no unused args
-                self:get_children_by_id("index_role")[1].markup = "<b> "..index.." </b>"
+                self:get_children_by_id("index_role")[1].markup = "<b> "..c3.index.." </b>"
 
                 self:connect_signal("mouse::enter", function()
                     if self.bg ~= "#ff0000" then
@@ -94,7 +94,7 @@ c2:tags(tags[1]) --DOC_HIDE
                 end)
             end,
             update_callback = function(self, c3, index, objects) --luacheck: no unused args
-                self:get_children_by_id("index_role")[1].markup = "<b> "..index.." </b>"
+                self:get_children_by_id("index_role")[1].markup = "<b> "..c3.index.." </b>"
             end,
         },
         buttons = taglist_buttons


### PR DESCRIPTION
Quote (with some minor changes) from [1]:

  I'd like to use the code presented at the top of the documentation
  page for the taglist widget [2]. However, I prefer my taglist to be
  filtered and display only noempty tags BUT to keep the numbering so
  that pressing Mod+3 always shows the same tag.

  If I only update the

      filter  = awful.widget.taglist.filter.all,

  so that it reads

      filter  = awful.widget.taglist.filter.noempty,

  then my tags are displayed with a wrong number, since the index
  parameter in the callback function (a few lines below) is based on the
  list of selected_tags and not the global list of tags.

The answers by Veratil are:

  Prefix index with c3. so that it becomes c3.index in the
  update_callback.

  Thanks for pointing this out, I can make a PR to fix it.

and

  Maybe update the one in create_callback as well.

I just reproduced the problem and tested that the proposed change makes
things work as expected. Since the comments were written two months ago
and nothing happened yet, I am just turning this into a PR. The idea is
that the PR is only accepted if someone who understands this code
decides that this change is correct. Let's see if that works out...

[1]: https://www.reddit.com/r/awesomewm/comments/bhmgd1/tag_list_with_indexes_and_filternoempty/
[2]: https://awesomewm.org/doc/api/classes/awful.widget.taglist.html

Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @Veratil 