### PR TITLE
 awful.placement: Fix no_overlap with unselected tags

### DIFF
--- a/tests/test-awful-placement.lua
+++ b/tests/test-awful-placement.lua
@@ -78,110 +78,111 @@ end
 -- Repeat testing 3 times.
 for _, _ in ipairs{1, 2, 3} do
 
--- The first 100x100 window should be placed at the top left corner.
-add_client {
-    geometry = function(wa)
-        return {
-            width       = 100,
-            height      = 100,
-            expected_x  = wa.x,
-            expected_y  = wa.y
-        }
-    end
-}
+    -- The first 100x100 window should be placed at the top left corner.
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = 100,
+                height      = 100,
+                expected_x  = wa.x,
+                expected_y  = wa.y
+            }
+        end
+    }
 
--- The second 100x100 window should be placed to the right of the first window.
--- Note that this assumption fails if the screen is in the portrait orientation
--- (e.g., the test succeeds with a 600x703 screen and fails with 600x704).
-add_client {
-    geometry = function(wa)
-        return {
-            width       = 100,
-            height      = 100,
-            expected_x  = wa.x + 100 + 2*border_width,
-            expected_y  = wa.y
-        }
-    end
-}
+    -- The second 100x100 window should be placed to the right of the first
+    -- window.  Note that this assumption fails if the screen is in the portrait
+    -- orientation (e.g., the test succeeds with a 600x703 screen and fails with
+    -- 600x704).
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = 100,
+                height      = 100,
+                expected_x  = wa.x + 100 + 2*border_width,
+                expected_y  = wa.y
+            }
+        end
+    }
 
--- The wide window should be placed below the two 100x100 windows.
-add_client {
-    geometry = function(wa)
-        return {
-            width       = wa.width - 50,
-            height      = 100,
-            expected_x  = wa.x,
-            expected_y  = wa.y + tb_height + 2*border_width + 100
-        }
-    end
-}
+    -- The wide window should be placed below the two 100x100 windows.
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = wa.width - 50,
+                height      = 100,
+                expected_x  = wa.x,
+                expected_y  = wa.y + tb_height + 2*border_width + 100
+            }
+        end
+    }
 
--- The first large window which does not completely fit in any free area should
--- be placed at the bottom left corner (no_overlap should place it below the
--- wide window, and then no_offscreen should shift it up so that it would be
--- completely inside the workarea).
-add_client {
-    geometry = function(wa)
-        return {
-            width       = wa.width - 10,
-            height      = wa.height - 50,
-            expected_x  = wa.x,
-            expected_y  = wa.y + 50 - 2*border_width - tb_height
-        }
-    end
-}
+    -- The first large window which does not completely fit in any free area
+    -- should be placed at the bottom left corner (no_overlap should place it
+    -- below the wide window, and then no_offscreen should shift it up so that
+    -- it would be completely inside the workarea).
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = wa.width - 10,
+                height      = wa.height - 50,
+                expected_x  = wa.x,
+                expected_y  = wa.y + 50 - 2*border_width - tb_height
+            }
+        end
+    }
 
--- The second large window should be placed at the top right corner.
-add_client {
-    geometry = function(wa)
-        return {
-            width       = wa.width - 10,
-            height      = wa.height - 50,
-            expected_x  = wa.x + 10 - 2*border_width,
-            expected_y  = wa.y
-        }
-    end
-}
+    -- The second large window should be placed at the top right corner.
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = wa.width - 10,
+                height      = wa.height - 50,
+                expected_x  = wa.x + 10 - 2*border_width,
+                expected_y  = wa.y
+            }
+        end
+    }
 
--- The third large window should be placed at the bottom right corner.
-add_client {
-    geometry = function(wa)
-        return {
-            width       = wa.width - 10,
-            height      = wa.height - 50,
-            expected_x  = wa.x + 10 - 2*border_width,
-            expected_y  = wa.y + 50 - 2*border_width - tb_height
-        }
-    end
-}
+    -- The third large window should be placed at the bottom right corner.
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = wa.width - 10,
+                height      = wa.height - 50,
+                expected_x  = wa.x + 10 - 2*border_width,
+                expected_y  = wa.y + 50 - 2*border_width - tb_height
+            }
+        end
+    }
 
--- The fourth large window should be placed at the top left corner (the whole
--- workarea is occupied now).
-add_client {
-    geometry = function(wa)
-        return {
-            width       = wa.width - 50,
-            height      = wa.height - 50,
-            expected_x  = wa.x,
-            expected_y  = wa.y
-        }
-    end
-}
+    -- The fourth large window should be placed at the top left corner (the
+    -- whole workarea is occupied now).
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = wa.width - 50,
+                height      = wa.height - 50,
+                expected_x  = wa.x,
+                expected_y  = wa.y
+            }
+        end
+    }
 
--- Kill test clients to prepare for the next iteration.
-table.insert(tests, function(count)
-    if count <= 1 then
-        for _, data in ipairs(client_data) do
-            if data.c then
-                data.c:kill()
-                data.c = nil
+    -- Kill test clients to prepare for the next iteration.
+    table.insert(tests, function(count)
+        if count <= 1 then
+            for _, data in ipairs(client_data) do
+                if data.c then
+                    data.c:kill()
+                    data.c = nil
+                end
             end
         end
-    end
-    if #client.get() == 0 then
-        return true
-    end
-end)
+        if #client.get() == 0 then
+            return true
+        end
+    end)
 
 end
 

--- a/tests/test-awful-placement.lua
+++ b/tests/test-awful-placement.lua
@@ -54,7 +54,7 @@ local function add_client(args)
         if count <= 1 then
             data.prev_client_count = #client.get()
             local geometry = args.geometry(mouse.screen.workarea)
-            test_client(class, name, nil, nil, nil, {
+            test_client(class, name, args.sn_rules, nil, nil, {
                 size = {
                     width = geometry.width,
                     height = geometry.height
@@ -75,11 +75,40 @@ local function add_client(args)
     end)
 end
 
--- Repeat testing 3 times.
-for _, _ in ipairs{1, 2, 3} do
+-- Repeat testing 3 times, placing clients on different tags:
+--
+--   - Iteration 1 places clients on the tag 1, which is selected.
+--
+--   - Iteration 2 places clients on the tag 2, which is unselected; the
+--     selected tag 1 remains empty.
+--
+--   - Iteration 3 places clients on the tag 3, which is unselected; the
+--     selected tag 1 contains some clients.
+--
+for _, tag_num in ipairs{1, 2, 3} do
+
+    local sn_rules
+    if tag_num > 1 then
+        sn_rules = { tag = root.tags()[tag_num] }
+    end
+
+    -- Put a 100x100 client on the tag 1 before iteration 3.
+    if tag_num == 3 then
+        add_client {
+            geometry = function(wa)
+                return {
+                    width       = 100,
+                    height      = 100,
+                    expected_x  = wa.x,
+                    expected_y  = wa.y
+                }
+            end
+        }
+    end
 
     -- The first 100x100 client should be placed at the top left corner.
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = 100,
@@ -98,6 +127,7 @@ for _, _ in ipairs{1, 2, 3} do
     -- orientation (e.g., the test succeeds with a 600x703 screen and fails with
     -- 600x704).
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = 100,
@@ -120,6 +150,7 @@ for _, _ in ipairs{1, 2, 3} do
     -- Another 100x100 client should be placed to the right of the first client
     -- (the hidden client should be ignored during placement).
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = 100,
@@ -142,6 +173,7 @@ for _, _ in ipairs{1, 2, 3} do
     -- Another 100x100 client should be placed to the right of the first client
     -- (the minimized client should be ignored during placement).
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = 100,
@@ -165,6 +197,7 @@ for _, _ in ipairs{1, 2, 3} do
     -- Another 100x100 client should be placed to the right of the first client
     -- (the sticky client should be taken into account during placement).
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = 100,
@@ -190,6 +223,7 @@ for _, _ in ipairs{1, 2, 3} do
     -- (the sticky client should be taken into account during placement even if
     -- that client seems to be on an unselected tag).
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = 100,
@@ -202,6 +236,7 @@ for _, _ in ipairs{1, 2, 3} do
 
     -- The wide client should be placed below the two 100x100 client.
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = wa.width - 50,
@@ -217,6 +252,7 @@ for _, _ in ipairs{1, 2, 3} do
     -- below the wide client, and then no_offscreen should shift it up so that
     -- it would be completely inside the workarea).
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = wa.width - 10,
@@ -229,6 +265,7 @@ for _, _ in ipairs{1, 2, 3} do
 
     -- The second large client should be placed at the top right corner.
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = wa.width - 10,
@@ -241,6 +278,7 @@ for _, _ in ipairs{1, 2, 3} do
 
     -- The third large client should be placed at the bottom right corner.
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = wa.width - 10,
@@ -254,6 +292,7 @@ for _, _ in ipairs{1, 2, 3} do
     -- The fourth large client should be placed at the top left corner (the
     -- whole workarea is occupied now).
     add_client {
+        sn_rules = sn_rules,
         geometry = function(wa)
             return {
                 width       = wa.width - 50,

--- a/tests/test-awful-placement.lua
+++ b/tests/test-awful-placement.lua
@@ -78,7 +78,7 @@ end
 -- Repeat testing 3 times.
 for _, _ in ipairs{1, 2, 3} do
 
-    -- The first 100x100 window should be placed at the top left corner.
+    -- The first 100x100 client should be placed at the top left corner.
     add_client {
         geometry = function(wa)
             return {
@@ -93,8 +93,8 @@ for _, _ in ipairs{1, 2, 3} do
     -- Remember the first client data for the current iteration.
     local first_client_data = client_data[#client_data]
 
-    -- The second 100x100 window should be placed to the right of the first
-    -- window.  Note that this assumption fails if the screen is in the portrait
+    -- The second 100x100 client should be placed to the right of the first
+    -- client.  Note that this assumption fails if the screen is in the portrait
     -- orientation (e.g., the test succeeds with a 600x703 screen and fails with
     -- 600x704).
     add_client {
@@ -200,7 +200,7 @@ for _, _ in ipairs{1, 2, 3} do
         end
     }
 
-    -- The wide window should be placed below the two 100x100 windows.
+    -- The wide client should be placed below the two 100x100 client.
     add_client {
         geometry = function(wa)
             return {
@@ -212,9 +212,9 @@ for _, _ in ipairs{1, 2, 3} do
         end
     }
 
-    -- The first large window which does not completely fit in any free area
+    -- The first large client which does not completely fit in any free area
     -- should be placed at the bottom left corner (no_overlap should place it
-    -- below the wide window, and then no_offscreen should shift it up so that
+    -- below the wide client, and then no_offscreen should shift it up so that
     -- it would be completely inside the workarea).
     add_client {
         geometry = function(wa)
@@ -227,7 +227,7 @@ for _, _ in ipairs{1, 2, 3} do
         end
     }
 
-    -- The second large window should be placed at the top right corner.
+    -- The second large client should be placed at the top right corner.
     add_client {
         geometry = function(wa)
             return {
@@ -239,7 +239,7 @@ for _, _ in ipairs{1, 2, 3} do
         end
     }
 
-    -- The third large window should be placed at the bottom right corner.
+    -- The third large client should be placed at the bottom right corner.
     add_client {
         geometry = function(wa)
             return {
@@ -251,7 +251,7 @@ for _, _ in ipairs{1, 2, 3} do
         end
     }
 
-    -- The fourth large window should be placed at the top left corner (the
+    -- The fourth large client should be placed at the top left corner (the
     -- whole workarea is occupied now).
     add_client {
         geometry = function(wa)

--- a/tests/test-awful-placement.lua
+++ b/tests/test-awful-placement.lua
@@ -90,6 +90,9 @@ for _, _ in ipairs{1, 2, 3} do
         end
     }
 
+    -- Remember the first client data for the current iteration.
+    local first_client_data = client_data[#client_data]
+
     -- The second 100x100 window should be placed to the right of the first
     -- window.  Note that this assumption fails if the screen is in the portrait
     -- orientation (e.g., the test succeeds with a 600x703 screen and fails with
@@ -138,6 +141,54 @@ for _, _ in ipairs{1, 2, 3} do
 
     -- Another 100x100 client should be placed to the right of the first client
     -- (the minimized client should be ignored during placement).
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = 100,
+                height      = 100,
+                expected_x  = wa.x + 100 + 2*border_width,
+                expected_y  = wa.y
+            }
+        end
+    }
+
+    -- Hide last client, and make the first client sticky.
+    do
+        local data = client_data[#client_data]
+        table.insert(tests, function()
+            data.c.hidden = true
+            first_client_data.c.sticky = true
+            return true
+        end)
+    end
+
+    -- Another 100x100 client should be placed to the right of the first client
+    -- (the sticky client should be taken into account during placement).
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = 100,
+                height      = 100,
+                expected_x  = wa.x + 100 + 2*border_width,
+                expected_y  = wa.y
+            }
+        end
+    }
+
+    -- Hide last client, and put the first client on the tag 9 (because the
+    -- first client is sticky, it should remain visible).
+    do
+        local data = client_data[#client_data]
+        table.insert(tests, function()
+            data.c.hidden = true
+            first_client_data.c:tags{ root.tags()[9] }
+            return true
+        end)
+    end
+
+    -- Another 100x100 client should be placed to the right of the first client
+    -- (the sticky client should be taken into account during placement even if
+    -- that client seems to be on an unselected tag).
     add_client {
         geometry = function(wa)
             return {

--- a/tests/test-awful-placement.lua
+++ b/tests/test-awful-placement.lua
@@ -105,6 +105,50 @@ for _, _ in ipairs{1, 2, 3} do
         end
     }
 
+    -- Hide last client.
+    do
+        local data = client_data[#client_data]
+        table.insert(tests, function()
+            data.c.hidden = true
+            return true
+        end)
+    end
+
+    -- Another 100x100 client should be placed to the right of the first client
+    -- (the hidden client should be ignored during placement).
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = 100,
+                height      = 100,
+                expected_x  = wa.x + 100 + 2*border_width,
+                expected_y  = wa.y
+            }
+        end
+    }
+
+    -- Minimize last client.
+    do
+        local data = client_data[#client_data]
+        table.insert(tests, function()
+            data.c.minimized = true
+            return true
+        end)
+    end
+
+    -- Another 100x100 client should be placed to the right of the first client
+    -- (the minimized client should be ignored during placement).
+    add_client {
+        geometry = function(wa)
+            return {
+                width       = 100,
+                height      = 100,
+                expected_x  = wa.x + 100 + 2*border_width,
+                expected_y  = wa.y
+            }
+        end
+    }
+
     -- The wide window should be placed below the two 100x100 windows.
     add_client {
         geometry = function(wa)


### PR DESCRIPTION
Fix #2809: make `awful.placement.no_overlap` place clients on unselected tags as if those tags were selected.

The `client_on_selected_tags` function can be removed and replaced with `c:isvisible()`, but that potentially can change the behavior if someone tries to place a client which is initially hidden or minimized, and at the same time the set of selected tags is different from the set of tags assigned to the client being placed.