### PR TITLE
Fix 4 "new API" notification bugs

### DIFF
--- a/lib/naughty/action.lua
+++ b/lib/naughty/action.lua
@@ -44,6 +44,9 @@ local action = {}
 -- @tparam gears.surface|string icon
 
 --- If the action should hide the label and only display the icon.
+--
+-- @DOC_wibox_nwidget_actionlist_icon_only_EXAMPLE@
+--
 -- @property icon_only
 -- @param[opt=false] boolean
 
@@ -125,9 +128,12 @@ local function new(_, args)
         position     = args.position,
         icon         = args.icon,
         notification = args.notification,
+        icon_only    = args.icon_only or false,
     }
 
     rawset(ret, "_private", default)
+
+    gtable.crush(ret, args)
 
     return ret
 end

--- a/lib/naughty/action.lua
+++ b/lib/naughty/action.lua
@@ -103,6 +103,16 @@ for _, prop in ipairs { "name", "icon", "notification", "icon_only" } do
     end
 end
 
+local set_notif = action.set_notification
+
+function action.set_notification(self, value)
+    local old = self._private.notification
+    set_notif(self, value)
+    if old then
+        old:emit_signal("property::actions")
+    end
+end
+
 --- Execute this action.
 --
 -- This only emits the `invoked` signal.

--- a/lib/naughty/container/background.lua
+++ b/lib/naughty/container/background.lua
@@ -48,13 +48,13 @@ function background:set_notification(notif)
     if self._private.notification == notif then return end
 
     if self._private.notification then
-        self._private.notification:disconnect_signal("poperty::bg",
+        self._private.notification:disconnect_signal("property::bg",
             self._private.background_changed_callback)
-        self._private.notification:disconnect_signal("poperty::border_width",
+        self._private.notification:disconnect_signal("property::border_width",
             self._private.background_changed_callback)
-        self._private.notification:disconnect_signal("poperty::border_color",
+        self._private.notification:disconnect_signal("property::border_color",
             self._private.background_changed_callback)
-        self._private.notification:disconnect_signal("poperty::shape",
+        self._private.notification:disconnect_signal("property::shape",
             self._private.background_changed_callback)
     end
 
@@ -62,10 +62,10 @@ function background:set_notification(notif)
 
     self._private.notification = notif
 
-    notif:connect_signal("poperty::bg"          , self._private.background_changed_callback)
-    notif:connect_signal("poperty::border_width", self._private.background_changed_callback)
-    notif:connect_signal("poperty::border_color", self._private.background_changed_callback)
-    notif:connect_signal("poperty::shape"       , self._private.background_changed_callback)
+    notif:connect_signal("property::bg"          , self._private.background_changed_callback)
+    notif:connect_signal("property::border_width", self._private.background_changed_callback)
+    notif:connect_signal("property::border_color", self._private.background_changed_callback)
+    notif:connect_signal("property::shape"       , self._private.background_changed_callback)
 end
 
 --- Create a new naughty.container.background.

--- a/lib/naughty/layout/legacy.lua
+++ b/lib/naughty/layout/legacy.lua
@@ -266,14 +266,27 @@ local function set_escaped_text(self)
     if self.size_info then update_size(self) end
 end
 
+local function seek_and_destroy(n)
+    for _, positions in pairs(current_notifications) do
+         for _, pos in pairs(positions) do
+            for k, n2 in ipairs(pos) do
+                if n == n2 then
+                    table.remove(pos, k)
+                    return
+                end
+            end
+         end
+    end
+end
+
 local function cleanup(self, _ --[[reason]], keep_visible)
     -- It is not a legacy notification
     if not self.box then return end
 
     local scr = self.screen
 
-    assert(current_notifications[scr][self.position][self.idx] == self)
-    table.remove(current_notifications[scr][self.position], self.idx)
+    -- Brute force find it, the position could have been replaced.
+    seek_and_destroy(self)
 
     if (not keep_visible) or (not scr) then
         self.box.visible = false

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -580,6 +580,8 @@ local function create(args)
 
     gtable.crush(n, notification, true)
 
+    n.id = n.id or notification._gen_next_id()
+
     -- Allow extensions to create override the preset with custom data
     naughty.emit_signal("request::preset", n, args)
 
@@ -596,8 +598,6 @@ local function create(args)
     if n._private.timeout then
         n:set_timeout(n._private.timeout or n.preset.timeout)
     end
-
-    n.id = notification._gen_next_id()
 
     return n
 end

--- a/lib/naughty/widget/icon.lua
+++ b/lib/naughty/widget/icon.lua
@@ -89,7 +89,7 @@ function icon:set_notification(notif)
 
     self._private.notification = notif
 
-    notif:connect_signal("poperty::icon", self._private.icon_changed_callback)
+    notif:connect_signal("property::icon", self._private.icon_changed_callback)
 end
 
 local valid_strategies = {

--- a/lib/naughty/widget/message.lua
+++ b/lib/naughty/widget/message.lua
@@ -41,9 +41,9 @@ function message:set_notification(notif)
     if self._private.notification == notif then return end
 
     if self._private.notification then
-        self._private.notification:disconnect_signal("poperty::message",
+        self._private.notification:disconnect_signal("property::message",
             self._private.message_changed_callback)
-        self._private.notification:disconnect_signal("poperty::fg",
+        self._private.notification:disconnect_signal("property::fg",
             self._private.message_changed_callback)
     end
 
@@ -51,8 +51,8 @@ function message:set_notification(notif)
 
     self._private.notification = notif
 
-    notif:connect_signal("poperty::message", self._private.message_changed_callback)
-    notif:connect_signal("poperty::fg"     , self._private.message_changed_callback)
+    notif:connect_signal("property::message", self._private.message_changed_callback)
+    notif:connect_signal("property::fg"     , self._private.message_changed_callback)
 end
 
 --- Create a new naughty.widget.message.

--- a/lib/naughty/widget/title.lua
+++ b/lib/naughty/widget/title.lua
@@ -41,9 +41,9 @@ function title:set_notification(notif)
     if self._private.notification == notif then return end
 
     if self._private.notification then
-        self._private.notification:disconnect_signal("poperty::message",
+        self._private.notification:disconnect_signal("property::message",
             self._private.title_changed_callback)
-        self._private.notification:disconnect_signal("poperty::fg",
+        self._private.notification:disconnect_signal("property::fg",
             self._private.title_changed_callback)
     end
 
@@ -52,8 +52,8 @@ function title:set_notification(notif)
     self._private.notification = notif
     self._private.title_changed_callback()
 
-    notif:connect_signal("poperty::title", self._private.title_changed_callback)
-    notif:connect_signal("poperty::fg"   , self._private.title_changed_callback)
+    notif:connect_signal("property::title", self._private.title_changed_callback)
+    notif:connect_signal("property::fg"   , self._private.title_changed_callback)
 end
 
 --- Create a new naughty.widget.title.

--- a/tests/examples/wibox/nwidget/actionlist/icon_only.lua
+++ b/tests/examples/wibox/nwidget/actionlist/icon_only.lua
@@ -1,0 +1,40 @@
+--DOC_GEN_IMAGE
+local parent    = ... --DOC_HIDE --DOC_NO_USAGE
+local naughty = { --DOC_HIDE
+    list         = {actions = require("naughty.list.actions")}, --DOC_HIDE
+    notification = require("naughty.notification"), --DOC_HIDE
+    action       = require("naughty.action") --DOC_HIDE
+} --DOC_HIDE
+local wibox = require("wibox") --DOC_HIDE
+local beautiful = require("beautiful") --DOC_HIDE
+
+    local notif = naughty.notification {
+        title   = "A notification",
+        message = "This notification has actions!",
+        actions = {
+            naughty.action {
+                name = "Accept",
+                icon = beautiful.awesome_icon,
+                icon_only = true,
+            },
+            naughty.action {
+                name = "Refuse",
+                icon = beautiful.awesome_icon,
+                icon_only = true,
+            },
+            naughty.action {
+                name = "Ignore",
+                icon = beautiful.awesome_icon,
+                icon_only = true,
+            },
+        }
+    }
+
+--DOC_NEWLINE
+
+parent:add( wibox.container.background(--DOC_HIDE
+    wibox.widget {
+        notification = notif,
+        widget = naughty.list.actions,
+    }
+,beautiful.bg_normal)) --DOC_HIDE


### PR DESCRIPTION
Well, updating now works "better". Better as-in, I have zero apps that use this, but tested using some Lua scripts and it now works for me. 2 of the "fixes" are more for general robustness than major issues. The signal typo is quite a facepalm.

```lua
local Gio       = require("lgi"        ).Gio
local GLib      = require("lgi"        ).GLib
local main_loop = GLib.MainLoop()

local dbus_connection = assert(Gio.bus_get_sync(Gio.BusType.SESSION))

local counter = 1

local actions = { "1", "one", "2", "two", "3", "three" }

local function send_notify(app, id, icon, summary, body, actions, hints, timeout, callback)
    local parameters = GLib.Variant("(susssasa{sv}i)", {
        app, id, icon, summary, body, actions, hints, timeout
    })
    local reply_type = GLib.VariantType.new("(u)")

    local function invoke_callback(conn, result)
        local new_id = conn:call_finish(result).value[1]
        print("RESULT", new_id)
        counter = counter + 1

        if counter >= 5 then os.exit(0) end

        os.execute("sleep 3")

        send_notify("app", new_id, "", "one two three"..counter, "body"..counter, actions, {}, 25000)
    end

    print("CALL")

    dbus_connection:call("org.freedesktop.Notifications",
        "/org/freedesktop/Notifications", "org.freedesktop.Notifications",
        "Notify", parameters, reply_type, Gio.DBusCallFlags.NO_AUTO_START, -1,
        nil, invoke_callback)
end

GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, function()
    send_notify("app", 9999, "", "one two three", "body", actions, {}, 25000)
end)

main_loop:run()
```