### PR TITLE
doc: Fix a rendering regression regarding backgrounds clipping changes

### DIFF
--- a/tests/examples/shims/_common_template.lua
+++ b/tests/examples/shims/_common_template.lua
@@ -26,6 +26,11 @@ return function(_, _)
 
     -- Silence debug warnings
     require("gears.debug").print_warning = function() end
+
+    -- Revert the background widget to something compatible with Cairo SVG
+    -- backend.
+    local bg = require("wibox.container.background")
+    bg._use_fallback_algorithm()
 end
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The way background are rendered changed to accomodate issues regarding
cliping and border. However this broke the documentation examples.

This commit fixes this in the least hacky way I found. @psychon if you have a better idea to solve:

 1) the rendering bug (which you reported upstream)
 2) the fact that it renders everything as base64 raster within a SVG container

Using raster images within SVG is probably what you expect from `cr:set_source_surface`, so I guess the current behavior is expected, but unwanted. This doesn't work well with matrices and render blurry results. There is probably issues/regressions in real wibox themselves when using such matrix. Is that a problem when nobody complains (yet)? Should the clipping change be reverted or should this PR be used? @actionless would be disappointed that the background border will regress *again*, but on the other hand the older code is simpler and has less side effects like this.

Fixes #2727