### PR TITLE
naughty: Undocument naughty.notification.replaces_id.

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -126,9 +126,18 @@ gtable.crush(naughty, require("naughty.constants"))
 -- @property has_display_handler
 -- @param boolean
 
+--- If the timeout needs to be reset when a property changes.
+--
+-- This is the global variant of the `naughty.notification` `auto_reset_timeout`
+-- property.
+--
+-- @property auto_reset_timeout
+-- @tparam[opt=true] boolean auto_reset_timeout
+
 local properties = {
     suspended         = false,
-    expiration_paused = false
+    expiration_paused = false,
+    auto_reset_timeout= true,
 }
 
 --TODO v5 Deprecate the public `naughty.notifications` (to make it private)

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -236,6 +236,9 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
                 if k == "destroy" then k = "destroy_cb" end
                 notification[k] = v
             end
+
+            -- Even if no property changed, restart the timeout.
+            notification:reset_timeout()
         else
             notification = nnotif(args)
         end

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -267,6 +267,14 @@ local notification = {}
 -- @param boolean
 -- @see naughty.expiration_paused
 
+--- If the timeout needs to be reset when a property changes.
+--
+-- By default it fallsback to `naughty.auto_reset_timeout`, which itself is
+-- true by default.
+--
+-- @property auto_reset_timeout
+-- @tparam[opt=true] boolean auto_reset_timeout
+
 --- Emitted when the notification is destroyed.
 -- @signal destroyed
 -- @tparam number reason Why it was destroyed
@@ -391,7 +399,7 @@ local properties = {
     "fg"      , "bg"      , "height"  , "border_color"  ,
     "shape"   , "opacity" , "margin"  , "ignore_suspend",
     "destroy" , "preset"  , "callback", "actions"       ,
-    "run"     , "id"      , "ignore",
+    "run"     , "id"      , "ignore"  , "auto_reset_timeout"
 }
 
 for _, prop in ipairs(properties) do
@@ -408,6 +416,17 @@ for _, prop in ipairs(properties) do
     notification["set_"..prop] = notification["set_"..prop] or function(self, value)
         self._private[prop] = value
         self:emit_signal("property::"..prop, value)
+
+        -- When a notification is updated over dbus or by setting a property,
+        -- it is usually convenient to reset the timeout.
+        local reset = ((not self.suspended)
+            and self.auto_reset_timeout ~= false
+            and naughty.auto_reset_timeout)
+
+        if reset then
+            self:reset_timeout()
+        end
+
         return
     end
 

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -235,10 +235,6 @@ local notification = {}
 -- @property preset
 -- @param table
 
---- Replace the notification with the given ID.
--- @property replaces_id
--- @param number
-
 --- Function that will be called with all arguments.
 --   The notification will only be displayed if the function returns true.
 --   Note: this function is only relevant to notifications sent via dbus.
@@ -394,8 +390,8 @@ local properties = {
     "width"   , "font"    , "icon"    , "icon_size"     ,
     "fg"      , "bg"      , "height"  , "border_color"  ,
     "shape"   , "opacity" , "margin"  , "ignore_suspend",
-    "destroy" , "preset"  , "callback", "replaces_id"   ,
-    "actions" , "run"     , "id"      , "ignore"        ,
+    "destroy" , "preset"  , "callback", "actions"       ,
+    "run"     , "id"      , "ignore",
 }
 
 for _, prop in ipairs(properties) do
@@ -496,7 +492,6 @@ end
 -- @tparam[opt] table args.preset Table with any of the above parameters.
 --   Note: Any parameters specified directly in args will override ones defined
 --   in the preset.
--- @tparam[opt] int args.replaces_id Replace the notification with the given ID.
 -- @tparam[opt] func args.callback Function that will be called with all arguments.
 --   The notification will only be displayed if the function returns true.
 --   Note: this function is only relevant to notifications sent via dbus.


### PR DESCRIPTION
It doesn't and cannot exists within `naughty.notification()` since it is a constructor and that's way too late. The property was documented (because copy pasted from the original `naughty.notify` property list) but it has no code attached to it.

Ref #2816