### PR TITLE
awful.tooltip:show() - swap timer.started and timer_function call

### DIFF
--- a/lib/awful/tooltip.lua
+++ b/lib/awful/tooltip.lua
@@ -172,8 +172,8 @@ local function show(self)
     if self._private.visible then return end
     if self.timer then
         if not self.timer.started then
-            self:timer_function()
             self.timer:start()
+            self:timer_function()
         end
     end
     set_geometry(self)


### PR DESCRIPTION
This is needed because if async code is run inside of a tooltip timer func the started property may be true by the time we call timer:start().
The current version causes random spurious timer already started errors.
This fix should also result in more uniform timer behavior by making the timer fire on time regardless of if the timer_function has finished executing yet.