### PR TITLE
Fix nil pending_wallpaper error

### DIFF
--- a/lib/gears/wallpaper.lua
+++ b/lib/gears/wallpaper.lua
@@ -66,10 +66,12 @@ function wallpaper.prepare_context(s)
 
         -- Set the wallpaper (delayed)
         timer.delayed_call(function()
-            local paper = pending_wallpaper
-            pending_wallpaper = nil
-            wallpaper.set(paper.surface)
-            paper.surface:finish()
+            if pending_wallpaper then
+                local paper = pending_wallpaper
+                pending_wallpaper = nil
+                wallpaper.set(paper.surface)
+                paper.surface:finish()
+            end
         end)
     elseif root_width > pending_wallpaper.width or root_height > pending_wallpaper.height then
         -- The root window was resized while a wallpaper is pending


### PR DESCRIPTION
See https://github.com/awesomeWM/awesome/issues/2835

Under certain circumstances, the delayed_call  callback is run when pending_wallpaper is nil. Specifically, adding local lgi async contexts changed the call order so this could occur. 

The wallpaper.maximized function continues to work fine on 2 screens despite pending_wallpaper being nil at the time of the delayed_call.