### PR TITLE
Add libRSVG to the list of optional dependencies

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -104,6 +104,8 @@ Additionally, the following optional dependencies exist:
 - [GTK+ >= 3.10](https://www.gtk.org/) for `./themes/gtk/`
 - [xcb-errors](https://gitlab.freedesktop.org/xorg/lib/libxcb-errors) for
   pretty-printing of X11 errors
+- [libRSVG](https://wiki.gnome.org/action/show/Projects/LibRsvg) for displaying
+  SVG files without scaling artifacts
 
 ## Running Awesome
 


### PR DESCRIPTION
Since commit 3295e9f33d33067838, the imagebox tries to use libRSVG via
lgi.Rsvg to load SVG files without rasterising them immediately.
Instead, they are directly drawn at the expected size.

Signed-off-by: Uli Schlachter <psychon@znc.in>