### PR TITLE
Use GLib idle sources for lots of house keeping

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -727,7 +727,7 @@ main(int argc, char **argv)
     sigaction(SIGCHLD, &sa, 0);
 
     /* We have no clue where the input focus is right now */
-    globalconf.focus.need_update = true;
+    client_focus_need_update();
 
     /* set the default preferred icon size */
     globalconf.preferred_icon_size = 0;

--- a/banning.h
+++ b/banning.h
@@ -23,7 +23,6 @@
 #define AWESOME_BANNING_H
 
 void banning_need_update(void);
-void banning_refresh(void);
 
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/event.c
+++ b/event.c
@@ -686,7 +686,7 @@ event_handle_enternotify(xcb_enter_notify_event_t *ev)
         /* When there are multiple X screens with awesome running separate
          * instances, reset focus.
          */
-        globalconf.focus.need_update = true;
+        client_focus_need_update();
     }
 }
 

--- a/event.h
+++ b/event.h
@@ -31,9 +31,6 @@
 /* luaa.c */
 void luaA_emit_refresh(void);
 
-/* objects/drawin.c */
-void drawin_refresh(void);
-
 /* objects/client.c */
 void client_refresh(void);
 void client_focus_refresh(void);
@@ -43,7 +40,6 @@ static inline int
 awesome_refresh(void)
 {
     luaA_emit_refresh();
-    drawin_refresh();
     client_refresh();
     banning_refresh();
     stack_refresh();

--- a/event.h
+++ b/event.h
@@ -34,14 +34,12 @@ void luaA_emit_refresh(void);
 /* objects/client.c */
 void client_refresh(void);
 void client_focus_refresh(void);
-void client_destroy_later(void);
 
 static inline int
 awesome_refresh(void)
 {
     luaA_emit_refresh();
     client_refresh();
-    client_destroy_later();
     return xcb_flush(globalconf.connection);
 }
 

--- a/event.h
+++ b/event.h
@@ -41,7 +41,6 @@ awesome_refresh(void)
 {
     luaA_emit_refresh();
     client_refresh();
-    banning_refresh();
     stack_refresh();
     client_destroy_later();
     return xcb_flush(globalconf.connection);

--- a/event.h
+++ b/event.h
@@ -41,7 +41,6 @@ awesome_refresh(void)
 {
     luaA_emit_refresh();
     client_refresh();
-    stack_refresh();
     client_destroy_later();
     return xcb_flush(globalconf.connection);
 }

--- a/globalconf.h
+++ b/globalconf.h
@@ -151,7 +151,7 @@ typedef struct
         /** Focused client */
         client_t *client;
         /** Is there a focus change pending? */
-        bool need_update;
+        guint source_id;
         /** When nothing has the input focus, this window actually is focused */
         xcb_window_t window_no_focus;
     } focus;

--- a/globalconf.h
+++ b/globalconf.h
@@ -190,6 +190,8 @@ typedef struct
     xcb_colormap_t default_cmap;
     /** Do we have to reban clients? */
     guint banning_update_id;
+    /** Do we have to update the stacking order? */
+    guint stacking_update_id;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/globalconf.h
+++ b/globalconf.h
@@ -189,7 +189,7 @@ typedef struct
     /** Our default color map */
     xcb_colormap_t default_cmap;
     /** Do we have to reban clients? */
-    bool need_lazy_banning;
+    guint banning_update_id;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/objects/client.c
+++ b/objects/client.c
@@ -1345,13 +1345,6 @@ client_focus_refresh(void)
 }
 
 static void
-client_border_refresh(void)
-{
-    foreach(c, globalconf.clients)
-        window_border_refresh((window_t *) *c);
-}
-
-static void
 client_geometry_refresh(void)
 {
     bool ignored_enterleave = false;
@@ -1413,8 +1406,8 @@ client_geometry_refresh(void)
         }
 
         xcb_configure_window(globalconf.connection, c->frame_window,
-                XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
-                (uint32_t[]) { geometry.x, geometry.y, geometry.width, geometry.height });
+                XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT | XCB_CONFIG_WINDOW_BORDER_WIDTH,
+                (uint32_t[]) { geometry.x, geometry.y, geometry.width, geometry.height, c->border_width });
         xcb_configure_window(globalconf.connection, c->window,
                 XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
                 (uint32_t[]) { real_geometry.x, real_geometry.y, real_geometry.width, real_geometry.height });
@@ -1434,7 +1427,6 @@ void
 client_refresh(void)
 {
     client_geometry_refresh();
-    client_border_refresh();
     client_focus_refresh();
 }
 
@@ -2372,6 +2364,7 @@ client_unmanage(client_t *c, bool window_valid)
     if (c->nofocus_window != XCB_NONE)
         window_array_append(&globalconf.destroy_later_windows, c->nofocus_window);
     window_array_append(&globalconf.destroy_later_windows, c->frame_window);
+    window_cancel_border_refresh((window_t *) c);
 
     if(window_valid)
     {

--- a/objects/client.c
+++ b/objects/client.c
@@ -1450,8 +1450,8 @@ client_refresh(void)
     client_geometry_refresh();
 }
 
-void
-client_destroy_later(void)
+static gboolean
+client_destroy_later_callback(gpointer unused)
 {
     bool ignored_enterleave = false;
     foreach(window, globalconf.destroy_later_windows)
@@ -1467,6 +1467,8 @@ client_destroy_later(void)
 
     /* Everything's done, clear the list */
     globalconf.destroy_later_windows.len = 0;
+
+    return G_SOURCE_REMOVE;
 }
 
 static void
@@ -2395,6 +2397,7 @@ client_unmanage(client_t *c, bool window_valid)
     if (c->nofocus_window != XCB_NONE)
         window_array_append(&globalconf.destroy_later_windows, c->nofocus_window);
     window_array_append(&globalconf.destroy_later_windows, c->frame_window);
+    g_idle_add_full(G_PRIORITY_LOW, client_destroy_later_callback, NULL, NULL);
     window_cancel_border_refresh((window_t *) c);
 
     if(window_valid)

--- a/objects/client.h
+++ b/objects/client.h
@@ -237,6 +237,7 @@ void client_set_skip_taskbar(lua_State *, int, bool);
 void client_set_motif_wm_hints(lua_State *, int, motif_wm_hints_t);
 void client_focus(client_t *);
 bool client_focus_update(client_t *);
+void client_focus_need_update(void);
 bool client_hasproto(client_t *, xcb_atom_t);
 void client_ignore_enterleave_events(void);
 void client_restore_enterleave_events(void);

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -176,6 +176,7 @@ drawin_wipe(drawin_t *w)
 {
     /* The drawin must already be unmapped, else it
      * couldn't be garbage collected -> no unmap needed */
+    window_cancel_border_refresh((window_t *) w);
     if(w->geometry_dirty_id != 0)
     {
         g_source_remove(w->geometry_dirty_id);
@@ -254,15 +255,6 @@ drawin_set_geometry_dirty(drawin_t *w)
     if (w->geometry_dirty_id != 0)
         return;
     w->geometry_dirty_id = g_idle_add(drawin_apply_moveresize_callback, w);
-}
-
-void
-drawin_refresh(void)
-{
-    foreach(item, globalconf.drawins)
-    {
-        window_border_refresh((window_t *) *item);
-    }
 }
 
 /** Get all drawins into a table.

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -176,6 +176,11 @@ drawin_wipe(drawin_t *w)
 {
     /* The drawin must already be unmapped, else it
      * couldn't be garbage collected -> no unmap needed */
+    if(w->geometry_dirty_id != 0)
+    {
+        g_source_remove(w->geometry_dirty_id);
+        w->geometry_dirty_id = 0;
+    }
     p_delete(&w->cursor);
     if(w->window)
     {
@@ -207,12 +212,8 @@ drawin_refresh_pixmap(drawin_t *w)
 }
 
 static void
-drawin_apply_moveresize(drawin_t *w)
+drawin_apply_moveresize_internal(drawin_t *w)
 {
-    if (!w->geometry_dirty)
-        return;
-
-    w->geometry_dirty = false;
     client_ignore_enterleave_events();
     xcb_configure_window(globalconf.connection, w->window,
                          XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y
@@ -227,12 +228,39 @@ drawin_apply_moveresize(drawin_t *w)
     client_restore_enterleave_events();
 }
 
+static void
+drawin_apply_moveresize_now(drawin_t *w)
+{
+    if (w->geometry_dirty_id == 0)
+        return;
+    g_source_remove(w->geometry_dirty_id);
+    w->geometry_dirty_id = 0;
+    drawin_apply_moveresize_internal(w);
+}
+
+static gboolean
+drawin_apply_moveresize_callback(gpointer user_data)
+{
+    drawin_t *w = user_data;
+    assert(w->geometry_dirty_id != 0);
+    drawin_apply_moveresize_internal(w);
+    w->geometry_dirty_id = 0;
+    return G_SOURCE_REMOVE;
+}
+
+static void
+drawin_set_geometry_dirty(drawin_t *w)
+{
+    if (w->geometry_dirty_id != 0)
+        return;
+    w->geometry_dirty_id = g_idle_add(drawin_apply_moveresize_callback, w);
+}
+
 void
 drawin_refresh(void)
 {
     foreach(item, globalconf.drawins)
     {
-        drawin_apply_moveresize(*item);
         window_border_refresh((window_t *) *item);
     }
 }
@@ -273,7 +301,7 @@ drawin_moveresize(lua_State *L, int udx, area_t geometry)
     if(w->geometry.height <= 0)
         w->geometry.height = old_geometry.height;
 
-    w->geometry_dirty = true;
+    drawin_set_geometry_dirty(w);
     drawin_update_drawing(L, udx);
 
     if (!AREA_EQUAL(old_geometry, w->geometry))
@@ -312,7 +340,7 @@ drawin_refresh_pixmap_partial(drawin_t *drawin,
         return;
 
     /* Make sure it really has the size it should have */
-    drawin_apply_moveresize(drawin);
+    drawin_apply_moveresize_now(drawin);
 
     /* Make cairo do all pending drawing */
     cairo_surface_flush(drawin->drawable->surface);
@@ -326,7 +354,7 @@ drawin_map(lua_State *L, int widx)
 {
     drawin_t *drawin = luaA_checkudata(L, widx, &drawin_class);
     /* Apply any pending changes */
-    drawin_apply_moveresize(drawin);
+    drawin_apply_moveresize_now(drawin);
     /* Activate BMA */
     client_ignore_enterleave_events();
     /* Map the drawin */
@@ -421,7 +449,7 @@ drawin_allocator(lua_State *L)
     w->cursor = a_strdup("left_ptr");
     w->geometry.width = 1;
     w->geometry.height = 1;
-    w->geometry_dirty = false;
+    w->geometry_dirty_id = 0;
     w->type = _NET_WM_WINDOW_TYPE_NORMAL;
 
     drawable_allocator(L, (drawable_refresh_callback *) drawin_refresh_pixmap, w);
@@ -672,7 +700,7 @@ luaA_drawin_set_shape_bounding(lua_State *L, drawin_t *drawin)
         surf = (cairo_surface_t *)lua_touserdata(L, -1);
 
     /* The drawin might have been resized to a larger size. Apply that. */
-    drawin_apply_moveresize(drawin);
+    drawin_apply_moveresize_now(drawin);
 
     xwindow_set_shape(drawin->window,
             drawin->geometry.width + 2*drawin->border_width,
@@ -711,7 +739,7 @@ luaA_drawin_set_shape_clip(lua_State *L, drawin_t *drawin)
         surf = (cairo_surface_t *)lua_touserdata(L, -1);
 
     /* The drawin might have been resized to a larger size. Apply that. */
-    drawin_apply_moveresize(drawin);
+    drawin_apply_moveresize_now(drawin);
 
     xwindow_set_shape(drawin->window, drawin->geometry.width, drawin->geometry.height,
             XCB_SHAPE_SK_CLIP, surf, 0);
@@ -748,7 +776,7 @@ luaA_drawin_set_shape_input(lua_State *L, drawin_t *drawin)
         surf = (cairo_surface_t *)lua_touserdata(L, -1);
 
     /* The drawin might have been resized to a larger size. Apply that. */
-    drawin_apply_moveresize(drawin);
+    drawin_apply_moveresize_now(drawin);
 
     xwindow_set_shape(drawin->window,
             drawin->geometry.width + 2*drawin->border_width,

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -41,7 +41,7 @@ struct drawin_t
     /** The window geometry. */
     area_t geometry;
     /** Do we have a pending geometry change that still needs to be applied? */
-    bool geometry_dirty;
+    guint geometry_dirty_id;
 };
 
 ARRAY_FUNCS(drawin_t *, drawin, DO_NOTHING)

--- a/objects/window.h
+++ b/objects/window.h
@@ -64,7 +64,7 @@ typedef enum
     /** Button bindings */ \
     button_array_t buttons; \
     /** Do we have pending border changes? */ \
-    bool border_need_update; \
+    guint border_update_id; \
     /** Border color */ \
     color_t border_color; \
     /** Border width */ \
@@ -86,7 +86,7 @@ void window_class_setup(lua_State *);
 
 void window_set_opacity(lua_State *, int, double);
 void window_set_border_width(lua_State *, int, int);
-void window_border_refresh(window_t *);
+void window_cancel_border_refresh(window_t *);
 int luaA_window_get_type(lua_State *, window_t *);
 int luaA_window_set_type(lua_State *, window_t *);
 uint32_t window_translate_type(window_type_t);

--- a/stack.h
+++ b/stack.h
@@ -28,7 +28,6 @@ void stack_client_remove(client_t *);
 void stack_client_push(client_t *);
 void stack_client_append(client_t *);
 void stack_windows(void);
-void stack_refresh(void);
 
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This is loosely related to #2832. It does not help with that issue, but it reduces the amount of code that is "hidden" from the main loop. CC @DorianGray

These commits can easily break user configs. If you have a timer with timeout 0, it fires all the time. Timers have the GLib default priority (0) which is a higher priority than the default priority for idle callbacks (which is 200). Thus, a timer with timeout 0 will prevent all of this from running. I'd be tempted to tell anyone affected not to start a timer with a timeout of 0, even though I am guilty of writing such code myself once.
Also, any code that uses a timer with a timeout of 0 to get to a point where the main loop "did its thing" and all the lazily done stuff is, well, done, will now actively prevent such progress...

Long-term, I want to get rid of all the code in `a_glib_poll()` and `awesome_refresh()`, but this PR only handles the easy part. The hard parts (like the `refresh` signal) are still left.

Side note: At one point I had `test-gravity` break while writing this. I might have found the bug that prevents #2323 from being merged...