### PR TITLE
Add the notification rules.

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -382,21 +382,25 @@ add_custom_command(
             ${SOURCE_DIR}/docs/_parser.lua
 )
 
-add_custom_command(
-        OUTPUT ${BUILD_DIR}/docs/common/rules_index.ldoc
+foreach(RULE_TYPE client tag screen notification)
+    add_custom_command(
+        OUTPUT ${BUILD_DIR}/docs/common/${RULE_TYPE}_rules_index.ldoc
         COMMAND lua ${SOURCE_DIR}/docs/build_rules_index.lua
-            ${BUILD_DIR}/docs/common/rules_index.ldoc
+            ${BUILD_DIR}/docs/common/${RULE_TYPE}_rules_index.ldoc
+            ${RULE_TYPE}
 
         # Cheap trick until the ldoc `configure_file` is ported to be a build
         # step rather than part of cmake.
-        COMMAND ${CMAKE_COMMAND} -E copy ${BUILD_DIR}/docs/common/rules_index.ldoc
-            ${SOURCE_DIR}/docs/common/rules_index.ldoc
+        COMMAND ${CMAKE_COMMAND} -E
+            copy ${BUILD_DIR}/docs/common/${RULE_TYPE}_rules_index.ldoc
+                 ${SOURCE_DIR}/docs/common/${RULE_TYPE}_rules_index.ldoc
 
         DEPENDS
             lgi-check-run
             ${SOURCE_DIR}/docs/build_rules_index.lua
             ${SOURCE_DIR}/docs/_parser.lua
-)
+    )
+endforeach()
 
 add_custom_command(
         OUTPUT ${BUILD_DIR}/awesomerc.lua ${BUILD_DIR}/docs/05-awesomerc.md
@@ -423,7 +427,10 @@ add_custom_target(generate_awesomerc DEPENDS
     ${BUILD_DIR}/docs/06-appearance.md
     ${SOURCE_DIR}/docs/05-awesomerc.md.lua
     ${SOURCE_DIR}/docs/build_rules_index.lua
-    ${BUILD_DIR}/docs/common/rules_index.ldoc
+    ${BUILD_DIR}/docs/common/client_rules_index.ldoc
+    ${BUILD_DIR}/docs/common/tag_rules_index.ldoc
+    ${BUILD_DIR}/docs/common/screen_rules_index.ldoc
+    ${BUILD_DIR}/docs/common/notification_rules_index.ldoc
     ${SOURCE_DIR}/docs/sample_theme.lua
     ${SOURCE_DIR}/docs/sample_files.lua
     ${SOURCE_DIR}/awesomerc.lua

--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -537,6 +537,24 @@ client.connect_signal("request::titlebars", function(c)
         layout = wibox.layout.align.horizontal
     }
 end)
+
+-- {{{ Notifications
+
+ruled.notification.connect_signal('request::rules', function()
+    -- All notifications will match this rule.
+    ruled.notification.append_rule {
+        rule       = { },
+        properties = {
+            screen           = awful.screen.preferred,
+            implicit_timeout = 5,
+        }
+    }
+end)
+
+naughty.connect_signal("request::display", function(n)
+    naughty.layout.box { notification = n }
+end)
+
 -- }}}
 
 -- Enable sloppy focus, so that focus follows mouse.

--- a/docs/_parser.lua
+++ b/docs/_parser.lua
@@ -131,47 +131,51 @@ local function parse_files(paths, property_name, matcher, name_matcher)
 
         local buffer = ""
 
-        for line in f:lines() do
+        if f then
+            for line in f and f:lines() do
 
-            local var = line:gmatch(exp1)()
+                local var = line:gmatch(exp1)()
 
-            -- There is no backward/forward pattern in lua
-            if #line <= 1 then
-                buffer = ""
-            elseif #buffer and not var then
-                buffer = buffer.."\n"..line
-            elseif line:sub(1,3) == "---" or line:sub(1,3) == "/**" then
-                buffer = line
-            end
+                -- There is no backward/forward pattern in lua
+                if #line <= 1 then
+                    buffer = ""
+                elseif #buffer and not var then
+                    buffer = buffer.."\n"..line
+                elseif line:sub(1,3) == "---" or line:sub(1,3) == "/**" then
+                    buffer = line
+                end
 
-            if var then
-                -- Get the @param, @see and @usage
-                local params = ""
-                for line in f:lines() do
-                    if line:sub(1,2) ~= "--" and line:sub(1,2) ~= " *" then
-                        break
-                    else
-                        params = params.."\n"..line
+                if var then
+                    -- Get the @param, @see and @usage
+                    local params = ""
+                    for line in f:lines() do
+                        if line:sub(1,2) ~= "--" and line:sub(1,2) ~= " *" then
+                            break
+                        else
+                            params = params.."\n"..line
+                        end
                     end
-                end
 
-                local name = var:gmatch(exp2)()
-                if not name then
-                    print("WARNING:", var,
-                        "seems to be misformatted. Use `beautiful.namespace_name`"
-                    )
-                else
-                    table.insert(ret, {
-                        file = file,
-                        name = name:gsub("_", "\\_"),
-                        link = get_link(file, var, var:match(exp3):gsub("_", "\\_")),
-                        desc = buffer:gmatch("[-*/ \n]+([^\n.]*)")() or "",
-                        mod  = path_to_module(file),
-                    })
-                end
+                    local name = var:gmatch(exp2)()
+                    if not name then
+                        print("WARNING:", var,
+                            "seems to be misformatted. Use `beautiful.namespace_name`"
+                        )
+                    else
+                        table.insert(ret, {
+                            file = file,
+                            name = name:gsub("_", "_"),
+                            link = get_link(file, var, var:match(exp3):gsub("_", "\\_")),
+                            desc = buffer:gmatch("[-*/ \n]+([^\n.]*)")() or "",
+                            mod  = path_to_module(file),
+                        })
+                    end
 
-                buffer = ""
+                    buffer = ""
+                end
             end
+
+            f:close()
         end
     end
 

--- a/docs/build_rules_index.lua
+++ b/docs/build_rules_index.lua
@@ -1,15 +1,23 @@
 #! /usr/bin/lua
 local args = {...}
+local typename = args[2]
 local parser = require("docs._parser")
 
-local files = {"./objects/client.c", "./lib/awful/client.lua"}
+assert(typename)
+
+local files = {
+    "./objects/"..typename..".c",
+    "./lib/awful/"..typename..".lua",
+    "./lib/naughty/"..typename..".lua"
+}
+
 local matcher, matcher2 = "(.*)", ".*"
 
 -- The client function comes from 5 different files, but all of those are
 -- merged into one documentation page (aka, awful.client doesn't have content
 -- anymore). This override the path so the parser doesn't have to be aware of it
 function parser.path_to_html()
-    return "../core_components/client.html#"
+    return "../core_components/"..typename..".html#"
 end
 
 local clientruleproperty = parser.parse_files(files, "clientruleproperty", matcher, matcher2)

--- a/docs/common/notification_rules_index.ldoc
+++ b/docs/common/notification_rules_index.ldoc
@@ -1,0 +1,42 @@
+--<table class='widget_list' border=1>
+-- <tr>
+--  <th align='center'>Name</th>
+--  <th align='center'>Description</th>
+-- </tr>
+--   <tr><td><a href='../core_components/notification.html#id'>id</a></td><td>Unique identifier of the notification</td></tr>
+--   <tr><td><a href='../core_components/notification.html#title'>title</a></td><td>Title of the notification</td></tr>
+--   <tr><td><a href='../core_components/notification.html#timeout'>timeout</a></td><td>Time in seconds after which popup expires</td></tr>
+--   <tr><td><a href='../core_components/notification.html#urgency'>urgency</a></td><td>The notification urgency level</td></tr>
+--   <tr><td><a href='../core_components/notification.html#category'>category</a></td><td>The notification category</td></tr>
+--   <tr><td><a href='../core_components/notification.html#resident'>resident</a></td><td>True if the notification should be kept when an action is pressed</td></tr>
+--   <tr><td><a href='../core_components/notification.html#hover_timeout'>hover\_timeout</a></td><td>Delay in seconds after which hovered popup disappears</td></tr>
+--   <tr><td><a href='../core_components/notification.html#screen'>screen</a></td><td>Target screen for the notification</td></tr>
+--   <tr><td><a href='../core_components/notification.html#position'>position</a></td><td>Corner of the workarea displaying the popups</td></tr>
+--   <tr><td><a href='../core_components/notification.html#ontop'>ontop</a></td><td>Boolean forcing popups to display on top</td></tr>
+--   <tr><td><a href='../core_components/notification.html#height'>height</a></td><td>Popup height</td></tr>
+--   <tr><td><a href='../core_components/notification.html#width'>width</a></td><td>Popup width</td></tr>
+--   <tr><td><a href='../core_components/notification.html#font'>font</a></td><td>Notification font</td></tr>
+--   <tr><td><a href='../core_components/notification.html#icon'>icon</a></td><td>"All in one" way to access the default image or icon</td></tr>
+--   <tr><td><a href='../core_components/notification.html#icon_size'>icon\_size</a></td><td>Desired icon size in px</td></tr>
+--   <tr><td><a href='../core_components/notification.html#app_icon'>app\_icon</a></td><td>The icon provided in the `app_icon` field of the DBus notification</td></tr>
+--   <tr><td><a href='../core_components/notification.html#image'>image</a></td><td>The notification image</td></tr>
+--   <tr><td><a href='../core_components/notification.html#images'>images</a></td><td>The notification (animated) images</td></tr>
+--   <tr><td><a href='../core_components/notification.html#fg'>fg</a></td><td>Foreground color</td></tr>
+--   <tr><td><a href='../core_components/notification.html#bg'>bg</a></td><td>Background color</td></tr>
+--   <tr><td><a href='../core_components/notification.html#border_width'>border\_width</a></td><td>Border width</td></tr>
+--   <tr><td><a href='../core_components/notification.html#border_color'>border\_color</a></td><td>Border color</td></tr>
+--   <tr><td><a href='../core_components/notification.html#shape'>shape</a></td><td>Widget shape</td></tr>
+--   <tr><td><a href='../core_components/notification.html#opacity'>opacity</a></td><td>Widget opacity</td></tr>
+--   <tr><td><a href='../core_components/notification.html#margin'>margin</a></td><td>Widget margin</td></tr>
+--   <tr><td><a href='../core_components/notification.html#preset'>preset</a></td><td>Table with any of the above parameters</td></tr>
+--   <tr><td><a href='../core_components/notification.html#callback'>callback</a></td><td>Function that will be called with all arguments</td></tr>
+--   <tr><td><a href='../core_components/notification.html#actions'>actions</a></td><td>A table containing strings that represents actions to buttons</td></tr>
+--   <tr><td><a href='../core_components/notification.html#ignore'>ignore</a></td><td>Ignore this notification, do not display</td></tr>
+--   <tr><td><a href='../core_components/notification.html#suspended'>suspended</a></td><td>Tell if the notification is currently suspended (read only)</td></tr>
+--   <tr><td><a href='../core_components/notification.html#is_expired'>is\_expired</a></td><td>If the notification is expired</td></tr>
+--   <tr><td><a href='../core_components/notification.html#auto_reset_timeout'>auto\_reset\_timeout</a></td><td>If the timeout needs to be reset when a property changes</td></tr>
+--   <tr><td><a href='../core_components/notification.html#ignore_suspend'>ignore\_suspend</a></td><td></td></tr>
+--   <tr><td><a href='../core_components/notification.html#clients'>clients</a></td><td>A list of clients associated with this notification</td></tr>
+--   <tr><td><a href='../core_components/notification.html#app_name'>app\_name</a></td><td>The application name specified by the notification</td></tr>
+--   <tr><td><a href='../core_components/notification.html#widget_template'>widget\_template</a></td><td>The widget template used to represent the notification</td></tr>
+-- </table>

--- a/docs/common/signals.ldoc
+++ b/docs/common/signals.ldoc
@@ -1,0 +1,27 @@
+
+
+--- Connect a global signal on the module.
+--
+-- Functions connected to this signal source will be executed when any
+-- module object emits the signal.
+--
+-- It is also used for some generic module signals such as
+-- `request::display`.
+--
+-- @tparam string name The name of the signal
+-- @tparam function func The function to attach
+-- @function naughty.connect_signal
+-- @usage naughty.connect_signal("added", function(notif)
+--    -- do something
+-- end)
+
+--- Emit a module signal.
+-- @tparam string name The signal name.
+-- @param ... The signal callback arguments
+-- @function naughty.emit_signal
+
+--- Disconnect a signal from a source.
+-- @tparam string name The name of the signal
+-- @tparam function func The attached function
+-- @function naughty.disconnect_signal
+-- @treturn boolean If the disconnection was successful

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -276,32 +276,6 @@ end
 
 local conns = gobject._setup_class_signals(naughty)
 
---- Connect a global signal on the notification engine.
---
--- Functions connected to this signal source will be executed when any
--- notification object emits the signal.
---
--- It is also used for some generic notification signals such as
--- `request::display`.
---
--- @tparam string name The name of the signal
--- @tparam function func The function to attach
--- @staticfct naughty.connect_signal
--- @usage naughty.connect_signal("added", function(notif)
---    -- do something
--- end)
-
---- Emit a notification signal.
--- @tparam string name The signal name.
--- @param ... The signal callback arguments
--- @staticfct naughty.emit_signal
-
---- Disconnect a signal from a source.
--- @tparam string name The name of the signal
--- @tparam function func The attached function
--- @staticfct naughty.disconnect_signal
--- @treturn boolean If the disconnection was successful
-
 local function resume()
     properties.suspended = false
     for _, v in pairs(naughty.notifications.suspended) do
@@ -740,6 +714,8 @@ end
 
 naughty.connect_signal("property::screen"  , update_index)
 naughty.connect_signal("property::position", update_index)
+
+--@DOC_signals_COMMON@
 
 return setmetatable(naughty, {__index = index_miss, __newindex = set_index_miss})
 

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -284,7 +284,7 @@ local function resume()
         v._private.args = nil
 
         naughty.emit_signal("added", v, args)
-        naughty.emit_signal("request::display", v, args)
+        naughty.emit_signal("request::display", v, "resume", args)
         if v.timer then v.timer:start() end
     end
     naughty.notifications.suspended = { }
@@ -540,6 +540,7 @@ naughty.connect_signal("request::screen", naughty.default_screen_handler)
 --    end)
 --
 -- @tparam table notification The `naughty.notification` object.
+-- @tparam string context Why is the signal sent.
 -- @tparam table args Any arguments passed to the `naughty.notify` function,
 --  including, but not limited to, all `naughty.notification` properties.
 -- @signal request::display
@@ -547,6 +548,7 @@ naughty.connect_signal("request::screen", naughty.default_screen_handler)
 --- Emitted when a notification needs pre-display configuration.
 --
 -- @tparam table notification The `naughty.notification` object.
+-- @tparam string context Why is the signal sent.
 -- @tparam table args Any arguments passed to the `naughty.notify` function,
 --  including, but not limited to, all `naughty.notification` properties.
 -- @signal request::preset

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -942,13 +942,13 @@ local function create(args)
 
     -- The rules are attached to this.
     if naughty._has_preset_handler then
-        naughty.emit_signal("request::preset", n, args)
+        naughty.emit_signal("request::preset", n, "new", args)
     end
 
     -- Let all listeners handle the actual visual aspects
     if (not n.ignore) and ((not n.preset) or n.preset.ignore ~= true) then
-        naughty.emit_signal("request::display" , n, args)
-        naughty.emit_signal("request::fallback", n, args)
+        naughty.emit_signal("request::display" , n, "new", args)
+        naughty.emit_signal("request::fallback", n, "new", args)
     end
 
     -- Because otherwise the setter logic would not be executed

--- a/lib/ruled/init.lua
+++ b/lib/ruled/init.lua
@@ -1,3 +1,4 @@
 return {
-    client = require("ruled.client");
+    client       = require( "ruled.client"       ),
+    notification = require( "ruled.notification" ),
 }

--- a/lib/ruled/notification.lua
+++ b/lib/ruled/notification.lua
@@ -27,7 +27,6 @@ local capi = {screen = screen, client = client, awesome = awesome}
 local matcher = require("gears.matcher")
 local gtable  = require("gears.table")
 local gobject = require("gears.object")
-local naughty = require("naughty")
 
 --- The notification is attached to the focused client.
 --
@@ -206,7 +205,7 @@ capi.awesome.connect_signal("startup", function()
         module.emit_signal("request::rules")
 
         -- This will disable the legacy preset support.
-        naughty.connect_signal("request::preset", function(n)
+        require("naughty").connect_signal("request::preset", function(n)
             module.apply(n)
         end)
     end

--- a/lib/ruled/notification.lua
+++ b/lib/ruled/notification.lua
@@ -71,6 +71,10 @@ local gobject = require("gears.object")
 -- @clientruleproperty implicit_timeout
 -- @param number
 
+--- Do not let this notification timeout, even if it asks for it.
+-- @clientruleproperty never_timeout
+-- @param boolean
+
 local nrules = matcher()
 
 local function client_match_common(n, prop, value)
@@ -116,7 +120,20 @@ end)
 
 nrules:add_property_setter("implicit_timeout", function(n, value)
     -- Check if there is an explicit timeout.
-    if not n._private.timeout then
+    if (not n._private.timeout) and (not n._private.never_timeout) then
+        n.timeout = value
+    end
+end)
+
+nrules:add_property_setter("never_timeout", function(n, value)
+    if value then
+        n.timeout = 0
+    end
+end)
+
+nrules:add_property_setter("timeout", function(n, value)
+    -- `never_timeout` has an higher priority than `timeout`.
+    if not n._private.never_timeout then
         n.timeout = value
     end
 end)

--- a/lib/ruled/notification.lua
+++ b/lib/ruled/notification.lua
@@ -213,6 +213,15 @@ function module.add_rule_source(name, cb, ...)
     return nrules:add_matching_function(name, cb, ...)
 end
 
+-- Allow to clear the rules for testing purpose only.
+-- Because multiple modules might set their rules, it is a bad idea to let
+-- them be purged under their feet.
+function module._clear()
+    for k in pairs(nrules._matching_rules["ruled.notifications"]) do
+        nrules._matching_rules["ruled.notifications"][k] = nil
+    end
+end
+
 -- Add signals.
 local conns = gobject._setup_class_signals(module)
 

--- a/lib/ruled/notification.lua
+++ b/lib/ruled/notification.lua
@@ -1,0 +1,202 @@
+---------------------------------------------------------------------------
+--- Rules for notifications.
+--
+--@DOC_wibox_nwidget_rules_urgency_EXAMPLE@
+--
+-- In this example, we setup a different widget template for some music
+-- notifications:
+--
+--@DOC_wibox_nwidget_rules_widget_template_EXAMPLE@
+--
+-- In this example, we add action to a notification that originally lacked
+-- them:
+--
+--@DOC_wibox_nwidget_rules_add_actions_EXAMPLE@
+--
+-- Here is a list of all properties available in the `properties` section of
+-- a rule:
+--
+--@DOC_notification_rules_index_COMMON@
+--
+-- @author Emmanuel Lepage Vallee &lt;elv1313@gmail.com&gt;
+-- @copyright 2017-2019 Emmanuel Lepage Vallee
+-- @ruleslib ruled.notifications
+---------------------------------------------------------------------------
+
+local capi = {screen = screen, client = client, awesome = awesome}
+local matcher = require("gears.matcher")
+local gtable  = require("gears.table")
+local gobject = require("gears.object")
+local naughty = require("naughty")
+
+--- The notification is attached to the focused client.
+--
+-- This is useful, along with other matching properties and the `ignore`
+-- notification property, to prevent focused application from spamming with
+-- useless notifications.
+--
+--@DOC_wibox_nwidget_rules_has_focus_EXAMPLE@
+--
+-- @matchingproperty has_focus
+-- @param boolean
+
+--- The notification is attached to a client with this class.
+--
+--@DOC_wibox_nwidget_rules_has_class_EXAMPLE@
+--
+-- @matchingproperty has_class
+-- @param string
+-- @see has_instance
+
+--- The notification is attached to a client with this instance name.
+--
+--@DOC_wibox_nwidget_rules_has_instance_EXAMPLE@
+--
+-- @matchingproperty has_instance
+-- @param string
+-- @see has_class
+
+--- Append some actions to a notification.
+--
+-- Using `actions` directly is destructive since it will override existing
+-- actions.
+--
+-- @clientruleproperty append_actions
+-- @param table
+
+local nrules = matcher()
+
+local function client_match_common(n, prop, value)
+    local clients = n.clients
+
+    if #clients == 0 then return false end
+
+    for _, c in ipairs(clients) do
+        if c[prop] == value then
+            return true
+        end
+    end
+
+    return false
+end
+
+nrules:add_property_matcher("has_class", function(n, value)
+    return client_match_common(n, "class", value)
+end)
+
+nrules:add_property_matcher("has_instance", function(n, value)
+    return client_match_common(n, "instance", value)
+end)
+
+nrules:add_property_matcher("has_focus", function(n)
+    local clients = n.clients
+
+    if #clients == 0 then return false end
+
+    for _, c in ipairs(clients) do
+        if c == capi.client.focus then
+            return true
+        end
+    end
+
+    return false
+end)
+
+nrules:add_property_setter("append_actions", function(n, value)
+    local new_actions = gtable.clone(n.actions or {}, false)
+    n.actions = gtable.merge(new_actions, value)
+end)
+
+local module = {}
+
+gobject._setup_class_signals(module)
+
+--- Remove a source.
+-- @tparam string name The source name.
+-- @treturn boolean If the source was removed.
+-- @staticfct ruled.notification.remove_rule_source
+function module.remove_rule_source(name)
+    return nrules:remove_matching_source(name)
+end
+
+--- Apply the tag rules to a client.
+--
+-- This is useful when it is necessary to apply rules after a tag has been
+-- created. Many workflows can make use of "blank" tags which wont match any
+-- rules until later.
+--
+-- @tparam naughty.notification n The notification.
+-- @staticfct ruled.notification.apply
+function module.apply(n)
+    local callbacks, props = {}, {}
+    for _, v in ipairs(nrules._matching_source) do
+        v.callback(nrules, n, props, callbacks)
+    end
+
+    nrules:_execute(n, props, callbacks)
+end
+
+--- Add a new rule to the default set.
+-- @tparam table rule A valid rule.
+-- @staticfct ruled.notification.append_rule
+function module.append_rule(rule)
+    nrules:append_rule("ruled.notifications", rule)
+end
+
+--- Add a new rules to the default set.
+-- @tparam table rule A table with rules.
+-- @staticfct ruled.notification.append_rules
+function module.append_rules(rules)
+    nrules:append_rules("ruled.notifications", rules)
+end
+
+--- Remove a new rule to the default set.
+-- @tparam table rule A valid rule.
+-- @staticfct ruled.notification.remove_rule
+function module.remove_rule(rule)
+    nrules:remove_rule("ruled.notifications", rule)
+    module.emit_signal("rule::removed", rule)
+end
+
+--- Add a new rule source.
+--
+-- A rule source is a provider called when a client initially request tags. It
+-- allows to configure, select or create a tag (or many) to be attached to the
+-- client.
+--
+-- @tparam string name The provider name. It must be unique.
+-- @tparam function callback The callback that is called to produce properties.
+-- @tparam client callback.c The client
+-- @tparam table callback.properties The current properties. The callback should
+--  add to and overwrite properties in this table
+-- @tparam table callback.callbacks A table of all callbacks scheduled to be
+--  executed after the main properties are applied.
+-- @tparam[opt={}] table depends_on A list of names of sources this source depends on
+--  (sources that must be executed *before* `name`.
+-- @tparam[opt={}] table precede A list of names of sources this source have a
+--  priority over.
+-- @treturn boolean Returns false if a dependency conflict was found.
+-- @staticfct ruled.notifications.add_rule_source
+
+function module.add_rule_source(name, cb, ...)
+    return nrules:add_matching_function(name, cb, ...)
+end
+
+-- Add signals.
+local conns = gobject._setup_class_signals(module)
+
+-- First time getting a notification? Request some rules.
+capi.awesome.connect_signal("startup", function()
+    if conns["request::rules"] and #conns["request::rules"] > 0 then
+        module.emit_signal("request::rules")
+
+        -- This will disable the legacy preset support.
+        naughty.connect_signal("request::preset", function(n)
+            module.apply(n)
+        end)
+    end
+end)
+
+--@DOC_rule_COMMON@
+
+return module

--- a/lib/ruled/notification.lua
+++ b/lib/ruled/notification.lua
@@ -64,6 +64,14 @@ local naughty = require("naughty")
 -- @clientruleproperty append_actions
 -- @param table
 
+--- Set a fallback timeout the notification has no explicit timeout.
+--
+-- The value is in seconds. If none is specified, the default is 5 seconds. If
+-- the notification specifies its own timeout, this property will be skipped.
+--
+-- @clientruleproperty implicit_timeout
+-- @param number
+
 local nrules = matcher()
 
 local function client_match_common(n, prop, value)
@@ -105,6 +113,13 @@ end)
 nrules:add_property_setter("append_actions", function(n, value)
     local new_actions = gtable.clone(n.actions or {}, false)
     n.actions = gtable.merge(new_actions, value)
+end)
+
+nrules:add_property_setter("implicit_timeout", function(n, value)
+    -- Check if there is an explicit timeout.
+    if not n._private.timeout then
+        n.timeout = value
+    end
 end)
 
 local module = {}

--- a/lib/ruled/notification.lua
+++ b/lib/ruled/notification.lua
@@ -63,7 +63,7 @@ local gobject = require("gears.object")
 -- @clientruleproperty append_actions
 -- @param table
 
---- Set a fallback timeout the notification has no explicit timeout.
+--- Set a fallback timeout when the notification doesn't have an explicit timeout.
 --
 -- The value is in seconds. If none is specified, the default is 5 seconds. If
 -- the notification specifies its own timeout, this property will be skipped.

--- a/tests/examples/wibox/nwidget/rules/add_actions.lua
+++ b/tests/examples/wibox/nwidget/rules/add_actions.lua
@@ -1,0 +1,61 @@
+--DOC_GEN_IMAGE --DOC_NO_USAGE
+local parent    = ... --DOC_HIDE
+local naughty = require("naughty") --DOC_HIDE
+local ruled = {notification = require("ruled.notification")}--DOC_HIDE
+local wibox = require("wibox") --DOC_HIDE
+local beautiful = require("beautiful") --DOC_HIDE
+local def = require("naughty.widget._default") --DOC_HIDE
+local acommon = require("awful.widget.common") --DOC_HIDE
+
+beautiful.notification_bg = beautiful.bg_normal --DOC_HIDE
+
+   ruled.notification.connect_signal("request::rules", function()
+       -- Add a red background for urgent notifications.
+       ruled.notification.append_rule {
+           rule       = { }, -- Match everything.
+           properties = {
+               append_actions = {
+                  naughty.action {
+                      name = "Snooze (5m)",
+                  },
+                  naughty.action {
+                      name = "Snooze (15m)",
+                  },
+                  naughty.action {
+                      name = "Snooze (1h)",
+                  },
+               },
+           }
+       }
+   end)
+
+awesome.emit_signal("startup") --DOC_HIDE
+
+--DOC_NEWLINE
+
+   -- Create a normal notification.
+local notif =  --DOC_HIDE
+   naughty.notification {
+       title   = "A notification",
+       message = "This is very informative",
+       icon    = beautiful.awesome_icon,
+       actions = {
+           naughty.action { name = "Existing 1" },
+           naughty.action { name = "Existing 2" },
+       }
+   }
+
+local function show_notification(n) --DOC_HIDE
+    local default = wibox.widget(def) --DOC_HIDE
+    acommon._set_common_property(default, "notification", n) --DOC_HIDE
+
+    local w, h = default:fit({dpi=96}, 9999, 9999) --DOC_HIDE
+    default.forced_width = w + 250 --DOC_HIDE
+    default.forced_height = h --DOC_HIDE
+    parent.forced_width = w + 250 --DOC_HIDE
+
+    parent:add(default) --DOC_HIDE
+end --DOC_HIDE
+
+parent.spacing = 10 --DOC_HIDE
+show_notification(notif)  --DOC_HIDE

--- a/tests/examples/wibox/nwidget/rules/has_class.lua
+++ b/tests/examples/wibox/nwidget/rules/has_class.lua
@@ -1,0 +1,29 @@
+local naughty = require("naughty") --DOC_HIDE
+local ruled = {notification = require("ruled.notification")}--DOC_HIDE
+
+local function get_mpris_actions() end --DOC_HIDE
+local my_music_widget_template = nil --DOC_HIDE
+
+ruled.notification.connect_signal("request::rules", function() --DOC_HIDE
+   ruled.notification.append_rule {
+       rule       = { has_class = "amarok" },
+       properties = {
+           widget_template = my_music_widget_template,
+           actions         = get_mpris_actions(),
+           works           = true --DOC_HIDE
+       }
+   }
+end) --DOC_HIDE
+
+awesome.emit_signal("startup") --DOC_HIDE
+
+local c = client.gen_fake { class = "amarok" } --DOC_HIDE
+client.focus = c --DOC_HIDE
+assert(client.focus == c) --DOC_HIDE
+
+local notif = naughty.notification { --DOC_HIDE
+    message = "I am SPAM", --DOC_HIDE
+    clients = {c}, --DOC_HIDE note that this is undocumented
+} --DOC_HIDE
+
+assert(notif.works) --DOC_HIDE

--- a/tests/examples/wibox/nwidget/rules/has_focus.lua
+++ b/tests/examples/wibox/nwidget/rules/has_focus.lua
@@ -1,0 +1,24 @@
+local naughty = require("naughty") --DOC_HIDE
+local ruled = {notification = require("ruled.notification")}--DOC_HIDE
+
+ruled.notification.connect_signal("request::rules", function() --DOC_HIDE
+   -- Note that the the message is matched as a pattern.
+   ruled.notification.append_rule {
+       rule       = { message = "I am SPAM", has_focus = true },
+       properties = { ignore  = true}
+   }
+end) --DOC_HIDE
+
+awesome.emit_signal("startup") --DOC_HIDE
+
+local c = client.gen_fake { class = "xchat" } --DOC_HIDE
+client.focus = c --DOC_HIDE
+assert(client.focus == c) --DOC_HIDE
+
+local notif = naughty.notification { --DOC_HIDE
+    message = "I am SPAM", --DOC_HIDE
+    clients = {c}, --DOC_HIDE note that this is undocumented
+} --DOC_HIDE
+
+assert(#notif.clients == 1 and notif.clients[1] == client.focus) --DOC_HIDE
+assert(notif.ignore) --DOC_HIDE

--- a/tests/examples/wibox/nwidget/rules/has_instance.lua
+++ b/tests/examples/wibox/nwidget/rules/has_instance.lua
@@ -1,0 +1,30 @@
+local naughty = require("naughty") --DOC_HIDE
+local ruled = {notification = require("ruled.notification")}--DOC_HIDE
+
+local function get_mpris_actions() end --DOC_HIDE
+local my_music_widget_template = nil --DOC_HIDE
+
+ruled.notification.connect_signal("request::rules", function() --DOC_HIDE
+   ruled.notification.append_rule {
+       rule       = { has_instance = "amarok" },
+       properties = {
+           widget_template = my_music_widget_template,
+           actions         = get_mpris_actions(),
+           works           = true --DOC_HIDE
+       }
+   }
+end) --DOC_HIDE
+
+awesome.emit_signal("startup") --DOC_HIDE
+
+local c = client.gen_fake { instance = "amarok" } --DOC_HIDE
+assert(c.instance == "amarok") --DOC_HIDE
+client.focus = c --DOC_HIDE
+assert(client.focus == c) --DOC_HIDE
+
+local notif = naughty.notification { --DOC_HIDE
+    message = "I am SPAM", --DOC_HIDE
+    clients = {c}, --DOC_HIDE note that this is undocumented
+} --DOC_HIDE
+
+assert(notif.works) --DOC_HIDE

--- a/tests/examples/wibox/nwidget/rules/urgency.lua
+++ b/tests/examples/wibox/nwidget/rules/urgency.lua
@@ -1,0 +1,60 @@
+--DOC_GEN_IMAGE --DOC_NO_USAGE
+local parent    = ... --DOC_HIDE
+local naughty = require("naughty") --DOC_HIDE
+local ruled = {notification = require("ruled.notification")}--DOC_HIDE
+local wibox = require("wibox") --DOC_HIDE
+local beautiful = require("beautiful") --DOC_HIDE
+local def = require("naughty.widget._default") --DOC_HIDE
+local acommon = require("awful.widget.common") --DOC_HIDE
+
+beautiful.notification_bg = beautiful.bg_normal --DOC_HIDE
+
+   ruled.notification.connect_signal("request::rules", function()
+       -- Add a red background for urgent notifications.
+       ruled.notification.append_rule {
+           rule       = { urgency = "critical" },
+           properties = { bg = "#ff0000", fg = "#ffffff", timeout = 0 }
+       }
+
+       --DOC_NEWLINE
+
+       -- Or green background for normal ones.
+       ruled.notification.append_rule {
+           rule       = { urgency = "normal" },
+           properties = { bg      = "#00ff00", fg = "#000000"}
+       }
+   end)
+
+awesome.emit_signal("startup") --DOC_HIDE
+
+--DOC_NEWLINE
+
+   -- Create a normal notification.
+local notif =  --DOC_HIDE
+   naughty.notification {
+       title   = "A notification 1",
+       message = "This is very informative",
+       icon    = beautiful.awesome_icon,
+       urgency = "normal",
+   }
+
+--DOC_NEWLINE
+
+   -- Create a normal notification.
+local notif2 =  --DOC_HIDE
+   naughty.notification {
+       title   = "A notification 2",
+       message = "This is very informative",
+       icon    = beautiful.awesome_icon,
+       urgency = "critical",
+   }
+
+local function show_notification(n) --DOC_HIDE
+    local default = wibox.widget(def) --DOC_HIDE
+    acommon._set_common_property(default, "notification", n) --DOC_HIDE
+    parent:add(default) --DOC_HIDE
+end --DOC_HIDE
+
+parent.spacing = 10 --DOC_HIDE
+show_notification(notif)  --DOC_HIDE
+show_notification(notif2) --DOC_HIDE

--- a/tests/examples/wibox/nwidget/rules/widget_template.lua
+++ b/tests/examples/wibox/nwidget/rules/widget_template.lua
@@ -1,0 +1,91 @@
+--DOC_GEN_IMAGE --DOC_NO_USAGE
+local parent    = ... --DOC_HIDE
+local naughty = require("naughty") --DOC_HIDE
+local ruled = {notification = require("ruled.notification")}--DOC_HIDE
+local wibox = require("wibox") --DOC_HIDE
+local beautiful = require("beautiful") --DOC_HIDE
+
+local box = nil --DOC_HIDE
+beautiful.notification_bg = beautiful.bg_normal --DOC_HIDE
+
+   ruled.notification.connect_signal("request::rules", function()
+       -- Add a red background for urgent notifications.
+       ruled.notification.append_rule {
+           rule       = { app_name = "mdp" },
+           properties = {
+               widget_template = {
+                   {
+                       {
+                           {
+                               {
+                                   naughty.widget.icon,
+                                   forced_height = 48,
+                                   halign        = "center",
+                                   valign        = "center",
+                                   widget        = wibox.container.place
+                               },
+                               {
+                                   align  = "center",
+                                   widget = naughty.widget.title,
+                               },
+                               {
+                                   align  = "center",
+                                   widget = naughty.widget.message,
+                               },
+                               {
+                                   orientation   = "horizontal",
+                                   widget        = wibox.widget.separator,
+                                   forced_height = 1,
+                               },
+                               {
+                                   nil,
+                                   {
+                                       wibox.widget.textbox "⏪",
+                                       wibox.widget.textbox "⏸",
+                                       wibox.widget.textbox "⏩",
+                                       spacing = 20,
+                                       layout  = wibox.layout.fixed.horizontal,
+                                   },
+                                   expand = "outside",
+                                   nil,
+                                   layout = wibox.layout.align.horizontal,
+                               },
+                               spacing = 10,
+                               layout  = wibox.layout.fixed.vertical,
+                           },
+                           margins = beautiful.notification_margin,
+                           widget  = wibox.container.margin,
+                       },
+                       id     = "background_role",
+                       widget = naughty.container.background,
+                   },
+                   strategy = "max",
+                   width    = 160,
+                   widget   = wibox.container.constraint,
+               }
+           }
+       }
+   end)
+
+   naughty.connect_signal("request::display", function(n)
+       box = --DOC_HIDE
+       naughty.layout.box { notification = n }
+   end)
+
+awesome.emit_signal("startup") --DOC_HIDE
+
+local notif2 =  --DOC_HIDE
+   naughty.notification {  --DOC_HIDE
+       title     = "Daft Punk",  --DOC_HIDE
+       message   = "Harder, Better, Faster, Stronger",  --DOC_HIDE
+       icon      = beautiful.awesome_icon,
+       icon_size = 128,  --DOC_HIDE
+       app_name  = "mdp",  --DOC_HIDE
+   }  --DOC_HIDE
+
+assert(notif2.app_name == "mdp") --DOC_HIDE
+assert(box) --DOC_HIDE
+
+box.widget.forced_width = 250 --DOC_HIDE
+
+parent:add(box.widget) --DOC_HIDE

--- a/tests/test-naughty-screen.lua
+++ b/tests/test-naughty-screen.lua
@@ -5,6 +5,7 @@ local steps = {}
 
 local naughty = require("naughty")
 local grect   = require("gears.geometry").rectangle
+local rnotif  = require("ruled.notification")
 
 -- Do not use whatever `rc.lua` has. This avoids having to update the test
 -- every time.
@@ -72,6 +73,7 @@ end
 
 -- Create notifications in each position.
 table.insert(steps, function()
+    rnotif._clear()
     add_many(s1)
 
     return true

--- a/themes/default/theme.lua
+++ b/themes/default/theme.lua
@@ -4,6 +4,7 @@
 
 local theme_assets = require("beautiful.theme_assets")
 local xresources = require("beautiful.xresources")
+local rnotification = require("ruled.notification")
 local dpi = xresources.apply_dpi
 
 local gfs = require("gears.filesystem")
@@ -125,6 +126,14 @@ theme.awesome_icon = theme_assets.awesome_icon(
 -- Define the icon theme for application icons. If not set then the icons
 -- from /usr/share/icons and /usr/share/icons/hicolor will be used.
 theme.icon_theme = nil
+
+-- Set different colors for urgent notifications.
+rnotification.connect_signal('request::rules', function()
+    rnotification.append_rule {
+        rule       = { urgency = 'critical' },
+        properties = { bg = '#ff0000', fg = '#ffffff' }
+    }
+end)
 
 return theme
 

--- a/themes/gtk/theme.lua
+++ b/themes/gtk/theme.lua
@@ -5,6 +5,7 @@
 
 local theme_assets = require("beautiful.theme_assets")
 local dpi = require("beautiful.xresources").apply_dpi
+local rnotification = require("ruled.notification")
 local gfs = require("gears.filesystem")
 local themes_path = gfs.get_themes_dir()
 local gears_shape = require("gears.shape")
@@ -344,6 +345,14 @@ wallpaper_alt_fg = mix(wallpaper_alt_fg, wallpaper_fg, 0.4)
 theme.wallpaper = function(s)
     return theme_assets.wallpaper(wallpaper_bg, wallpaper_fg, wallpaper_alt_fg, s)
 end
+
+-- Set different colors for urgent notifications.
+rnotification.connect_signal('request::rules', function()
+    rnotification.append_rule {
+        rule       = { urgency = 'critical' },
+        properties = { bg = '#ff0000', fg = '#ffffff' }
+    }
+end)
 
 return theme
 

--- a/themes/sky/theme.lua
+++ b/themes/sky/theme.lua
@@ -6,6 +6,7 @@
 
 local theme_assets = require("beautiful.theme_assets")
 local xresources = require("beautiful.xresources")
+local rnotification = require("ruled.notification")
 local dpi = xresources.apply_dpi
 local themes_path = require("gears.filesystem").get_themes_dir()
 
@@ -96,6 +97,15 @@ theme.titlebar_maximized_button_normal_inactive = themes_path .. "default/titleb
 theme.titlebar_maximized_button_focus_inactive = themes_path .. "default/titlebar/maximized_focus_inactive.png"
 theme.titlebar_maximized_button_normal_active = themes_path .. "default/titlebar/maximized_normal_active.png"
 theme.titlebar_maximized_button_focus_active = themes_path .. "default/titlebar/maximized_focus_active.png"
+
+
+-- Set different colors for urgent notifications.
+rnotification.connect_signal('request::rules', function()
+    rnotification.append_rule {
+        rule       = { urgency = 'critical' },
+        properties = { bg = '#ff0000', fg = '#ffffff' }
+    }
+end)
 
 return theme
 

--- a/themes/xresources/theme.lua
+++ b/themes/xresources/theme.lua
@@ -5,6 +5,7 @@
 
 local theme_assets = require("beautiful.theme_assets")
 local xresources = require("beautiful.xresources")
+local rnotification = require("ruled.notification")
 local dpi = xresources.apply_dpi
 local xrdb = xresources.get_current_theme()
 local gfs = require("gears.filesystem")
@@ -128,6 +129,14 @@ end
 theme.wallpaper = function(s)
     return theme_assets.wallpaper(wallpaper_bg, wallpaper_fg, wallpaper_alt_fg, s)
 end
+
+-- Set different colors for urgent notifications.
+rnotification.connect_signal('request::rules', function()
+    rnotification.append_rule {
+        rule       = { urgency = 'critical' },
+        properties = { bg = '#ff0000', fg = '#ffffff' }
+    }
+end)
 
 return theme
 

--- a/themes/zenburn/theme.lua
+++ b/themes/zenburn/theme.lua
@@ -4,6 +4,7 @@
 -------------------------------
 
 local themes_path = require("gears.filesystem").get_themes_dir()
+local rnotification = require("ruled.notification")
 local dpi = require("beautiful.xresources").apply_dpi
 
 -- {{{ Main
@@ -130,6 +131,14 @@ theme.titlebar_maximized_button_focus_inactive  = themes_path .. "zenburn/titleb
 theme.titlebar_maximized_button_normal_inactive = themes_path .. "zenburn/titlebar/maximized_normal_inactive.png"
 -- }}}
 -- }}}
+
+-- Set different colors for urgent notifications.
+rnotification.connect_signal('request::rules', function()
+    rnotification.append_rule {
+        rule       = { urgency = 'critical' },
+        properties = { bg = '#ff0000', fg = '#ffffff' }
+    }
+end)
 
 return theme
 


### PR DESCRIPTION
This is the final "main" PR in the notification rewrite. It replaces the old "preset" concept with a full `awful.rules` like system to control the notification. It can be used to set the color, ignore them, set custom widget templates, etc. The basic usage is:

```lua
   ruled.notification.connect_signal("request::rules", function()
       -- Add a red background for urgent notifications.
       ruled.notification.append_rule {
           rule       = { urgency = "critical" },
           properties = { bg = "#ff0000", fg = "#ffffff", timeout = 0 }
       }

       -- Or green background for normal ones.
       ruled.notification.append_rule {
           rule       = { urgency = "normal" },
           properties = { bg      = "#00ff00", fg = "#000000"}
       }
   end)
```

Please note that this is currently in a new module called "ruled". I prefer this over adding `naughty.rules` since I also plan to expand the rules to tags, screens and the clipboard. `awful.rules` itself would be moved to this new module. If someone has a better name, please come forward.

The content of this PR is less or more final. ~~The tests are lacking and a bit broken~~. The NEWS.md also needs to updated to reflect the entire rewrite effort. I don't plan to merge this in the immediate future. It will co-exist for a while with some other PRs to introduce the other components of the new `ruled` module.