### PR TITLE
Disable colors in luacheck to make the CI output more readable.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -49,4 +49,7 @@ globals = {
 -- Enable cache (uses .luacheckcache relative to this rc file).
 cache = true
 
+-- Do not enable colors to make the Travis CI output more readable.
+color = false
+
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
(made in GitHub UI, untested)

The Travis "raw log" is hard to read with all the ANSI escape sequences.