### PR TITLE
tests/run.sh: output "awesome --version"

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -79,8 +79,8 @@ export TEST_PAUSE_ON_ERRORS  # Used in tests/_runner.lua.
 XEPHYR=Xephyr
 XVFB=Xvfb
 AWESOME=$build_dir/awesome
-if ! [ -x "$AWESOME" ]; then
-    echo "$AWESOME is not executable." >&2
+if ! $AWESOME --version; then
+    echo "$AWESOME cannot be run." >&2
     exit 1
 fi
 AWESOME_CLIENT="$source_dir/utils/awesome-client"


### PR DESCRIPTION
Might be good to have a short version of it (single line), but extra
lines are indented, so this seems to be OK.

This helps / shows when the built version is not up-to-date (e.g. after
git-bisect), and serves as a basic check that it can be run in the first
place.