### PR TITLE
test-selection-transfer: use new runner "wait_per_step" option

### DIFF
--- a/tests/_runner.lua
+++ b/tests/_runner.lua
@@ -91,14 +91,15 @@ end
 -- success/failure, but can also return nothing if it needs to be called again
 -- later.
 function runner.run_steps(steps, options)
+    options = gtable.crush({
+        kill_clients=true,
+        wait_per_step=2,  -- how long to wait per step in seconds.
+    }, options or {})
     -- Setup timer/timeout to limit waiting for signal and quitting awesome.
     local t = timer({timeout=0})
-    local wait=20
+    local wait=options.wait_per_step / 0.1
     local step=1
     local step_count=0
-    options = options or {
-        kill_clients=true,
-    }
     runner.run_direct()
 
     if options.kill_clients then
@@ -128,7 +129,7 @@ function runner.run_steps(steps, options)
                 -- Next step.
                 step = step+1
                 step_count = 0
-                wait = 20
+                wait = options.wait_per_step / 0.1
                 t.timeout = 0
                 t:again()
             else

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -57,13 +57,7 @@ local selection_object
 local selection_released
 local continue
 
-local function wait_a_bit(count)
-    if continue or count == 5 then
-        return true
-    end
-end
-
-runner.run_steps{
+runner.run_steps({
     function()
         -- Get the selection
         local s = assert(selection.acquire{ selection = "CLIPBOARD" },
@@ -175,14 +169,6 @@ runner.run_steps{
         return true
     end,
 
-    -- The large data transfer above transfers 3 * 2^25 bytes of data. That's
-    -- 96 MiB and takes a while.
-    wait_a_bit,
-    wait_a_bit,
-    wait_a_bit,
-    wait_a_bit,
-    wait_a_bit,
-
     function()
         -- Wait for the previous test to succeed
         if not continue then return end
@@ -222,6 +208,10 @@ runner.run_steps{
         assert(selection_released)
         return true
     end,
-}
+}, {
+    -- Use a larger step timeout for the large data transfer, which
+    -- transfers 3 * 2^25 bytes of data (96 MiB), and takes a while.
+    wait_per_step = 10,
+})
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -101,10 +101,8 @@ runner.run_steps{
     end,
 
     function()
-        -- Wait for the test to succeed
-        if not continue then
-            return
-        end
+        -- Wait for the previous test to succeed
+        if not continue then return end
         continue = false
 
         -- Now test piece-wise selection transfers
@@ -141,10 +139,8 @@ runner.run_steps{
     end,
 
     function()
-        -- Wait for the test to succeed
-        if not continue then
-            return
-        end
+        -- Wait for the previous test to succeed
+        if not continue then return end
         continue = false
 
         -- Now test a huge transfer
@@ -188,10 +184,8 @@ runner.run_steps{
     wait_a_bit,
 
     function()
-        -- Wait for the test to succeed
-        if not continue then
-            return
-        end
+        -- Wait for the previous test to succeed
+        if not continue then return end
         continue = false
 
         -- Now test that :release() works
@@ -207,10 +201,8 @@ runner.run_steps{
     end,
 
     function()
-        -- Wait for the test to succeed
-        if not continue then
-            return
-        end
+        -- Wait for the previous test to succeed
+        if not continue then return end
         continue = false
 
         -- Test for "release" signal when we lose selection
@@ -225,9 +217,7 @@ runner.run_steps{
 
     function()
         -- Wait for the previous test to succeed
-        if not continue then
-            return
-        end
+        if not continue then return end
         continue = false
         assert(selection_released)
         return true


### PR DESCRIPTION
Noticed this via flaky coverage for the check after the "wait_a_bit"
block.

Ref: https://codecov.io/gh/awesomeWM/awesome/pull/2872/changes#L193