### PR TITLE
tests: do not export build_dir

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -57,7 +57,6 @@ if [ -z "$build_dir" ]; then
         build_dir="$source_dir"
     fi
 fi
-export build_dir
 
 # Get test files: test*, or the ones provided as args (relative to tests/).
 if [ $# != 0 ]; then

--- a/tests/test-gravity.lua
+++ b/tests/test-gravity.lua
@@ -17,7 +17,7 @@ local function check_done()
 end
 
 local err = spawn.with_line_callback(
-    { os.getenv("build_dir") ..  "/test-gravity" },
+    { "./test-gravity" },
     {
         exit = function(what, code)
             assert(what == "exit", what)


### PR DESCRIPTION
If really necessary this should be an uppercased var, but it is only
used with test-gravity.lua, where we can just rely on `$PWD` being the
build dir.