### PR TITLE
doc: Add a sequence of events template

### DIFF
--- a/build-utils/lgi-check.c
+++ b/build-utils/lgi-check.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 
 const char commands[] =
+"pcall(require, 'luarocks.loader')\n"
 "print(string.format('Building for %s.', jit and jit.version or _VERSION))\n"
 "local lgi_version = require('lgi.version')\n"
 "print(string.format('Found lgi %s.', lgi_version))\n"

--- a/docs/_parser.lua
+++ b/docs/_parser.lua
@@ -1,3 +1,5 @@
+pcall(require, "luarocks.loader")
+
 local gio = require("lgi").Gio
 local gobject = require("lgi").GObject
 local glib = require("lgi").GLib

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -180,6 +180,7 @@ end
 
 local named_args = {
     [ "(args)"       ] = true,
+    [ "([args])"     ] = true,
     [ "([args=nil])" ] = true,
     [ "([args={}])"  ] = true
 }
@@ -193,7 +194,7 @@ local function wrap_args(item)
         return "<span class='function_named_args'><b>{</b>[args]<b>}</b></span>"
     end
 
-    local new_args = item.args:sub(2, item.args:len()-2)
+    local new_args = item.args:sub(2, item.args:len()-1)
 
     return "<span class='function_args'> <b>(</b>"..new_args.."<b>)</b></span>"
 end

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -312,7 +312,7 @@ end
 --
 -- @staticfct awful.tag.new
 -- @tparam table names The tag name, in a table
--- @tparam screen|nil screen The tag screen, or 1 if not set.
+-- @tparam[opt=1] screen|number screen The tag screen (defaults to screen 1).
 -- @tparam table layout The layout or layout table to set for this tags by default.
 -- @treturn table A table with all created tags.
 function tag.new(names, screen, layout)
@@ -918,7 +918,7 @@ end
 --
 --        if (not c2) or c2 == c then return end
 --
---        local t = aw_tag.add("Aero", {
+--        local t = awful.tag.add("Aero", {
 --            screen              = c.screen,
 --            volatile            = true,
 --            layout              = awful.layout.suit.tile,

--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -143,6 +143,8 @@ end
 
 --- The tag index.
 --
+-- @DOC_sequences_tag_index_EXAMPLE@
+--
 -- The index is the position as shown in the `awful.widget.taglist`.
 --
 -- **Signal:**
@@ -219,6 +221,9 @@ function tag.move(new_index, target_tag)
 end
 
 --- Swap 2 tags.
+--
+-- @DOC_sequences_tag_swap_EXAMPLE@
+--
 -- @method swap
 -- @param tag2 The second tag
 -- @see client.swap
@@ -296,11 +301,20 @@ function tag.add(name, props)
 end
 
 --- Create a set of tags and attach it to a screen.
+--
+-- This is what's performed by the default config:
+--
+-- @DOC_sequences_tag_default_config_EXAMPLE@
+--
+-- It is also possible to set multiple layouts:
+--
+-- @DOC_sequences_tag_new_with_layouts_EXAMPLE@
+--
 -- @staticfct awful.tag.new
--- @param names The tag name, in a table
--- @param screen The tag screen, or 1 if not set.
--- @param layout The layout or layout table to set for this tags by default.
--- @return A table with all created tags.
+-- @tparam table names The tag name, in a table
+-- @tparam screen|nil screen The tag screen, or 1 if not set.
+-- @tparam table layout The layout or layout table to set for this tags by default.
+-- @treturn table A table with all created tags.
 function tag.new(names, screen, layout)
     screen = get_screen(screen or 1)
     -- True if `layout` should be used as the layout of each created tag
@@ -338,7 +352,7 @@ end
 --
 -- To delete the current tag:
 --
---    mouse.screen.selected_tag:delete()
+-- @DOC_sequences_tag_delete_EXAMPLE@
 --
 -- @method delete
 -- @see awful.tag.add
@@ -893,16 +907,33 @@ end
 --- Define if the tag must be deleted when the last client is untagged.
 --
 -- This is useful to create "throw-away" tags for operation like 50/50
--- side-by-side views.
+-- (Windows "Aero Snap) side-by-side views. This keybinding code for this is:
 --
---    local t = awful.tag.add("Temporary", {
---         screen   = client.focus.screen,
---         volatile = true,
---         clients  = {
---             client.focus,
---             awful.client.focus.history.get(client.focus.screen, 1)
---         }
---    }
+--    local function aero_tag()
+--        local c = client.focus
+--
+--        if not c then return end
+--
+--        local c2 = awful.client.focus.history.list[2]
+--
+--        if (not c2) or c2 == c then return end
+--
+--        local t = aw_tag.add("Aero", {
+--            screen              = c.screen,
+--            volatile            = true,
+--            layout              = awful.layout.suit.tile,
+--            master_width_factor = 0.5
+--        })
+--
+--        t:clients({c, c2})
+--
+--        t:view_only()
+--    end
+--
+-- @DOC_sequences_tag_volatile_EXAMPLE@
+--
+-- As you can see, the "Volatile" tag has been automatically discarded while
+-- the "Non-volatile" tag is still there (but with zero clients).
 --
 -- **Signal:**
 --
@@ -910,6 +941,7 @@ end
 --
 -- @property volatile
 -- @param boolean
+-- @see delete
 
 -- Volatile accessors are implicit
 
@@ -1316,6 +1348,9 @@ function tag.incncol(add, t, sensible)
 end
 
 --- View no tag.
+--
+-- @DOC_sequences_tag_viewnone_EXAMPLE@
+--
 -- @staticfct awful.tag.viewnone
 -- @tparam[opt] int|screen screen The screen.
 function tag.viewnone(screen)
@@ -1326,13 +1361,19 @@ function tag.viewnone(screen)
     end
 end
 
---- View a tag by its taglist index.
+--- Select a tag relative to the currently selected one.
+--
+-- Note that this doesn't work well with multiple selection.
+--
+-- @DOC_sequences_tag_viewidx_EXAMPLE@
 --
 -- This is equivalent to `screen.tags[i]:view_only()`
 -- @staticfct awful.tag.viewidx
 -- @see screen.tags
--- @param i The **relative** index to see.
--- @param[opt] screen The screen.
+-- @tparam number i The **relative** index to see.
+-- @tparam[opt] screen screen The screen.
+-- @see awful.tag.viewnext
+-- @see awful.tag.viewprev
 function tag.viewidx(i, screen)
     screen = get_screen(screen or ascreen.focused())
     local tags = screen.tags
@@ -1363,21 +1404,39 @@ function tag.getidx(query_tag)
     return tag.object.get_index(query_tag or ascreen.focused().selected_tag)
 end
 
---- View next tag. This is the same as tag.viewidx(1).
+
+--- View next tag. This is the same as `tag.viewidx(1)`.
+--
+-- Note that this doesn't work well with multiple selection.
+--
+-- @DOC_sequences_tag_viewnext_EXAMPLE@
+--
 -- @staticfct awful.tag.viewnext
--- @param screen The screen.
+-- @tparam screen screen The screen.
+-- @see awful.tag.viewidx
+-- @see awful.tag.viewprev
 function tag.viewnext(screen)
     return tag.viewidx(1, screen)
 end
 
---- View previous tag. This is the same a tag.viewidx(-1).
+--- View previous tag. This is the same a `tag.viewidx(-1)`.
+--
+-- Note that this doesn't work well with multiple selection.
+--
+-- @DOC_sequences_tag_viewprev_EXAMPLE@
+--
 -- @staticfct awful.tag.viewprev
--- @param screen The screen.
+-- @tparam screen screen The screen.
+-- @see awful.tag.viewidx
+-- @see awful.tag.viewnext
 function tag.viewprev(screen)
     return tag.viewidx(-1, screen)
 end
 
 --- View only a tag.
+--
+-- @DOC_sequences_tag_view_only_EXAMPLE@
+--
 -- @method view_only
 -- @see selected
 function tag.object.view_only(self)
@@ -1398,7 +1457,7 @@ end
 --- View only a tag.
 -- @deprecated awful.tag.viewonly
 -- @see tag.view_only
--- @param t The tag object.
+-- @tparam tag t The tag object.
 function tag.viewonly(t)
     gdebug.deprecate("Use t:view_only() instead of awful.tag.viewonly", {deprecated_in=4})
 
@@ -1412,8 +1471,8 @@ end
 -- more of the tags are already selected, set `maximum` to zero.
 --
 -- @staticfct awful.tag.viewmore
--- @param tags A table with tags to view only.
--- @param[opt] screen The screen of the tags.
+-- @tparam table tags A table with tags to view only.
+-- @tparam[opt] screen screen The screen of the tags.
 -- @tparam[opt=#tags] number maximum The maximum number of tags to select.
 function tag.viewmore(tags, screen, maximum)
     maximum = maximum or #tags

--- a/objects/client.c
+++ b/objects/client.c
@@ -595,6 +595,8 @@
 /**
  * The client is fullscreen or not.
  *
+ * @DOC_sequences_client_fullscreen_EXAMPLE@
+ *
  * **Signal:**
  *
  *  * *property::fullscreen*
@@ -605,6 +607,8 @@
 
 /**
  * The client is maximized (horizontally and vertically) or not.
+ *
+ * @DOC_sequences_client_maximized_EXAMPLE@
  *
  * **Signal:**
  *
@@ -617,6 +621,8 @@
 /**
  * The client is maximized horizontally or not.
  *
+ * @DOC_sequences_client_maximized_horizontal_EXAMPLE@
+ *
  * **Signal:**
  *
  *  * *property::maximized\_horizontal*
@@ -627,6 +633,8 @@
 
 /**
  * The client is maximized vertically or not.
+ *
+ * @DOC_sequences_client_maximized_vertical_EXAMPLE@
  *
  * **Signal:**
  *

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1726,6 +1726,9 @@ luaA_screen_fake_add(lua_State *L)
 }
 
 /** Remove a screen.
+ *
+ * @DOC_sequences_screen_fake_remove_EXAMPLE@
+ *
  * @method fake_remove
  */
 static int
@@ -1753,7 +1756,13 @@ luaA_screen_fake_remove(lua_State *L)
     return 0;
 }
 
-/** Fake-resize a screen
+/** Resize a screen.
+ *
+ * Calling this will resize the screen even if it no longer matches the viewport
+ * size.
+ *
+ * @DOC_sequences_screen_fake_resize_EXAMPLE@
+ *
  * @tparam integer x The new X-coordinate for screen.
  * @tparam integer y The new Y-coordinate for screen.
  * @tparam integer width The new width for screen.
@@ -1789,6 +1798,9 @@ luaA_screen_fake_resize(lua_State *L)
 }
 
 /** Swap a screen with another one in global screen list.
+ *
+ * @DOC_sequences_screen_swap_EXAMPLE@
+ *
  * @client s A screen to swap with.
  * @method swap
  */

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -19,7 +19,7 @@
  *
  */
 
-/** awesome tag API
+ /** awesome tag API.
  *
  * What is a tag?
  * ==============

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -21,12 +21,21 @@
 
 /** awesome tag API
  *
- * Furthermore to the classes described here, one can also use signals as
- * described in @{signals}.
+ * What is a tag?
+ * ==============
+ *
+ * In AwesomeWM, a `tag` is a group of clients. It can either be used as labels
+ * or as more classical workspaces depending on how they are configured.
  *
  * ![Client geometry](../images/tag_props.svg)
  *
- * **Creating tags**:
+ *  * A **tag** can be attached to **multiple clients**
+ *  * A **client** can be attached to **multiple tags**
+ *  * A **tag** can only be in 1 screen *any given time*, but can be moved
+ *  * All **clients** attached to a tag **must be in the same screen as the tag**
+ *
+ * Creating tags
+ * =============
  *
  * The default config initializes tags like this:
  *
@@ -58,7 +67,8 @@
  * Note: the example above sets "First tag" to be selected explicitly,
  * because otherwise you will find yourself without any selected tag.
  *
- * **Accessing tags**:
+ * Accessing tags
+ * ==============
  *
  * To access the "current tags", use
  *
@@ -95,7 +105,8 @@
  *
  *    local t = awful.tag.find_by_name(awful.screen.focused(), "name")
  *
- * **Common shortcuts**:
+ * Common keybindings code
+ * =======================
  *
  * Here is a few useful shortcuts not part of the default `rc.lua`. Add these
  * functions above `-- {{{ Key bindings`:
@@ -209,6 +220,8 @@
 /**
  * Tag name.
  *
+ * @DOC_sequences_tag_name_EXAMPLE@
+ *
  * **Signal:**
  *
  *  * *property::name*
@@ -219,6 +232,8 @@
 
 /**
  * True if the tag is selected to be viewed.
+ *
+ * @DOC_sequences_tag_selected_EXAMPLE@
  *
  * **Signal:**
  *

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -4,6 +4,7 @@ local spawn = require("awful.spawn")
 -- It is used to test the `awful.rules`
 
 local test_client_source = [[
+pcall(require, 'luarocks.loader')
 local lgi = require 'lgi'
 local Gdk = lgi.require('Gdk')
 local Gtk = lgi.require('Gtk')

--- a/tests/examples/sequences/client/fullscreen.lua
+++ b/tests/examples/sequences/client/fullscreen.lua
@@ -1,0 +1,47 @@
+ --DOC_GEN_IMAGE --DOC_NO_USAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout")} --DOC_HIDE
+awful.placement = require("awful.placement") --DOC_HIDE
+require("awful.ewmh") --DOC_HIDE
+screen[1]:fake_resize(0, 0, 1024/2, 768/2) --DOC_HIDE
+screen.fake_add(1034/2, 0, 1024/2, 768/2).outputs = {["eVGA1"] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(2074/2, 0, 1024/2, 768/2).outputs = {["DVI1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(3104/2, 0, 1024/2, 768/2).outputs = {["VGA1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[1], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[2], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[3], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[4], awful.layout.suit.corner.nw) --DOC_HIDE
+
+local function spawn(name, s) --DOC_HIDE
+    s = screen[s] --DOC_HIDE
+    local c = client.gen_fake{ --DOC_HIDE
+        class = name, name = name, x = s.geometry.x, y=s.geometry.x, --DOC_HIDE
+        width = 640/2, height = 480/2, screen = s, floating = true --DOC_HIDE
+    } --DOC_HIDE
+    awful.placement.centered(c) --DOC_HIDE
+end --DOC_HIDE
+
+module.add_event("Spawn some applications", function() --DOC_HIDE
+    spawn("maximize",1) --DOC_HIDE
+    spawn("vertical",2) --DOC_HIDE
+    spawn("horizontal",3) --DOC_HIDE
+    spawn("fullscreen",4) --DOC_HIDE
+    screen[4].clients[1].color = "#ff777733" --DOC_HIDE
+    screen[4].clients[1].border_color = "#ff4444AA" --DOC_HIDE
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Maximize 1 client per screen (differently", function() --DOC_HIDE
+    screen[1].clients[1].maximized            = true
+    screen[2].clients[1].maximized_vertical   = true
+    screen[3].clients[1].maximized_horizontal = true
+    screen[4].clients[1].fullscreen           = true
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute { display_screen = true , display_clients     = true, --DOC_HIDE
+                 display_label  = false, display_client_name = true, --DOC_HIDE
+                 display_mouse  = false, --DOC_HIDE
+} --DOC_HIDE

--- a/tests/examples/sequences/client/maximized.lua
+++ b/tests/examples/sequences/client/maximized.lua
@@ -1,0 +1,47 @@
+ --DOC_GEN_IMAGE --DOC_NO_USAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout")} --DOC_HIDE
+awful.placement = require("awful.placement") --DOC_HIDE
+require("awful.ewmh") --DOC_HIDE
+screen[1]:fake_resize(0, 0, 1024/2, 768/2) --DOC_HIDE
+screen.fake_add(1034/2, 0, 1024/2, 768/2).outputs = {["eVGA1"] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(2074/2, 0, 1024/2, 768/2).outputs = {["DVI1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(3104/2, 0, 1024/2, 768/2).outputs = {["VGA1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[1], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[2], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[3], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[4], awful.layout.suit.corner.nw) --DOC_HIDE
+
+local function spawn(name, s) --DOC_HIDE
+    s = screen[s] --DOC_HIDE
+    local c = client.gen_fake{ --DOC_HIDE
+        class = name, name = name, x = s.geometry.x, y=s.geometry.x, --DOC_HIDE
+        width = 640/2, height = 480/2, screen = s, floating = true --DOC_HIDE
+    } --DOC_HIDE
+    awful.placement.centered(c) --DOC_HIDE
+end --DOC_HIDE
+
+module.add_event("Spawn some applications", function() --DOC_HIDE
+    spawn("maximize",1) --DOC_HIDE
+    spawn("vertical",2) --DOC_HIDE
+    spawn("horizontal",3) --DOC_HIDE
+    spawn("fullscreen",4) --DOC_HIDE
+    screen[1].clients[1].color = "#ff777733" --DOC_HIDE
+    screen[1].clients[1].border_color = "#ff4444AA" --DOC_HIDE
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Maximize 1 client per screen (differently", function() --DOC_HIDE
+    screen[1].clients[1].maximized            = true
+    screen[2].clients[1].maximized_vertical   = true
+    screen[3].clients[1].maximized_horizontal = true
+    screen[4].clients[1].fullscreen           = true
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute { display_screen = true , display_clients     = true, --DOC_HIDE
+                 display_label  = false, display_client_name = true, --DOC_HIDE
+                 display_mouse  = false, --DOC_HIDE
+} --DOC_HIDE

--- a/tests/examples/sequences/client/maximized_horizontal.lua
+++ b/tests/examples/sequences/client/maximized_horizontal.lua
@@ -1,0 +1,47 @@
+ --DOC_GEN_IMAGE --DOC_NO_USAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout")} --DOC_HIDE
+awful.placement = require("awful.placement") --DOC_HIDE
+require("awful.ewmh") --DOC_HIDE
+screen[1]:fake_resize(0, 0, 1024/2, 768/2) --DOC_HIDE
+screen.fake_add(1034/2, 0, 1024/2, 768/2).outputs = {["eVGA1"] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(2074/2, 0, 1024/2, 768/2).outputs = {["DVI1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(3104/2, 0, 1024/2, 768/2).outputs = {["VGA1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[1], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[2], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[3], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[4], awful.layout.suit.corner.nw) --DOC_HIDE
+
+local function spawn(name, s) --DOC_HIDE
+    s = screen[s] --DOC_HIDE
+    local c = client.gen_fake{ --DOC_HIDE
+        class = name, name = name, x = s.geometry.x, y=s.geometry.x, --DOC_HIDE
+        width = 640/2, height = 480/2, screen = s, floating = true --DOC_HIDE
+    } --DOC_HIDE
+    awful.placement.centered(c) --DOC_HIDE
+end --DOC_HIDE
+
+module.add_event("Spawn some applications", function() --DOC_HIDE
+    spawn("maximize",1) --DOC_HIDE
+    spawn("vertical",2) --DOC_HIDE
+    spawn("horizontal",3) --DOC_HIDE
+    spawn("fullscreen",4) --DOC_HIDE
+    screen[2].clients[1].color = "#ff777733" --DOC_HIDE
+    screen[2].clients[1].border_color = "#ff4444AA" --DOC_HIDE
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Maximize 1 client per screen (differently", function() --DOC_HIDE
+    screen[1].clients[1].maximized            = true
+    screen[2].clients[1].maximized_vertical   = true
+    screen[3].clients[1].maximized_horizontal = true
+    screen[4].clients[1].fullscreen           = true
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute { display_screen = true , display_clients     = true, --DOC_HIDE
+                 display_label  = false, display_client_name = true, --DOC_HIDE
+                 display_mouse  = false, --DOC_HIDE
+} --DOC_HIDE

--- a/tests/examples/sequences/client/maximized_vertical.lua
+++ b/tests/examples/sequences/client/maximized_vertical.lua
@@ -1,0 +1,47 @@
+ --DOC_GEN_IMAGE --DOC_NO_USAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout")} --DOC_HIDE
+awful.placement = require("awful.placement") --DOC_HIDE
+require("awful.ewmh") --DOC_HIDE
+screen[1]:fake_resize(0, 0, 1024/2, 768/2) --DOC_HIDE
+screen.fake_add(1034/2, 0, 1024/2, 768/2).outputs = {["eVGA1"] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(2074/2, 0, 1024/2, 768/2).outputs = {["DVI1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+screen.fake_add(3104/2, 0, 1024/2, 768/2).outputs = {["VGA1" ] = {mm_height=60/2, mm_width=80/2 }} --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[1], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[2], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[3], awful.layout.suit.corner.nw) --DOC_HIDE
+awful.tag({ "1", "2", "3" }, screen[4], awful.layout.suit.corner.nw) --DOC_HIDE
+
+local function spawn(name, s) --DOC_HIDE
+    s = screen[s] --DOC_HIDE
+    local c = client.gen_fake{ --DOC_HIDE
+        class = name, name = name, x = s.geometry.x, y=s.geometry.x, --DOC_HIDE
+        width = 640/2, height = 480/2, screen = s, floating = true --DOC_HIDE
+    } --DOC_HIDE
+    awful.placement.centered(c) --DOC_HIDE
+end --DOC_HIDE
+
+module.add_event("Spawn some applications", function() --DOC_HIDE
+    spawn("maximize",1) --DOC_HIDE
+    spawn("vertical",2) --DOC_HIDE
+    spawn("horizontal",3) --DOC_HIDE
+    spawn("fullscreen",4) --DOC_HIDE
+    screen[3].clients[1].color = "#ff777733" --DOC_HIDE
+    screen[3].clients[1].border_color = "#ff4444AA" --DOC_HIDE
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Maximize 1 client per screen (differently", function() --DOC_HIDE
+    screen[1].clients[1].maximized            = true
+    screen[2].clients[1].maximized_vertical   = true
+    screen[3].clients[1].maximized_horizontal = true
+    screen[4].clients[1].fullscreen           = true
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute { display_screen = true , display_clients     = true, --DOC_HIDE
+                 display_label  = false, display_client_name = true, --DOC_HIDE
+                 display_mouse  = false, --DOC_HIDE
+} --DOC_HIDE

--- a/tests/examples/sequences/screen/fake_remove.lua
+++ b/tests/examples/sequences/screen/fake_remove.lua
@@ -1,0 +1,23 @@
+ --DOC_GEN_IMAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+screen[1]:fake_resize(0, 0, 800, 600) --DOC_HIDE
+screen.fake_add(800,0,800,600) --DOC_HIDE
+screen.fake_add(800*2,0,800,600) --DOC_HIDE
+assert(screen.count()==3) --DOC_HIDE
+assert(screen[1].geometry.width == 800) --DOC_HIDE
+assert(screen[1].geometry.height == 600) --DOC_HIDE
+assert(screen[3].geometry.x == 800*2)--DOC_HIDE
+local rw, rh = root.size() --DOC_HIDE
+assert(rw == 3*800) --DOC_HIDE
+assert(rh == 600) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Calling :fake_remove()", function() --DOC_HIDE
+    require("gears.timer").run_delayed_calls_now() --DOC_HIDE
+    screen[2]:fake_remove()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute {display_screen=true} --DOC_HIDE

--- a/tests/examples/sequences/screen/fake_resize.lua
+++ b/tests/examples/sequences/screen/fake_resize.lua
@@ -1,0 +1,15 @@
+ --DOC_GEN_IMAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+screen[1]:fake_resize(0, 0, 1280, 720) --DOC_HIDE
+assert(screen[1].geometry.width == 1280) --DOC_HIDE
+assert(screen[1].geometry.height == 720) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Calling :fake_resize()", function() --DOC_HIDE
+    screen[1]:fake_resize(100, 0, 1024, 768)
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute {display_screen=true, show_code_pointer=false} --DOC_HIDE

--- a/tests/examples/sequences/screen/swap.lua
+++ b/tests/examples/sequences/screen/swap.lua
@@ -1,0 +1,17 @@
+ --DOC_GEN_IMAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+screen[1]:fake_resize(0, 0, 1280, 720) --DOC_HIDE
+screen.fake_add(1280,0,1280,720) --DOC_HIDE
+assert(screen.count()==2) --DOC_HIDE
+assert(screen[1].geometry.width == 1280) --DOC_HIDE
+assert(screen[1].geometry.height == 720) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Calling :swap()", function() --DOC_HIDE
+    screen[2]:swap(screen[1])
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute {display_screen=true, show_code_pointer=false} --DOC_HIDE

--- a/tests/examples/sequences/tag/default_config.lua
+++ b/tests/examples/sequences/tag/default_config.lua
@@ -1,0 +1,19 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, screen[1], awful.layout.layouts[1])
+
+    assert(#screen[1].tags == 9) --DOC_HIDE
+    for _, t in ipairs(screen[1].tags) do --DOC_HIDE
+        assert(t.layout) --DOC_HIDE
+    end --DOC_HIDE
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/delete.lua
+++ b/tests/examples/sequences/tag/delete.lua
@@ -1,0 +1,27 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+
+    screen[1].tags[2]:view_only()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Deleting the selected tag", function() --DOC_HIDE
+    -- Delete the selected tag.
+    mouse.screen.selected_tag:delete()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/index.lua
+++ b/tests/examples/sequences/tag/index.lua
@@ -1,0 +1,32 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Send the first tag to index 3", function() --DOC_HIDE
+    -- Send the first tag to index 3.
+    screen[1].tags[1].index = 3
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+--DOC_NEWLINE
+
+module.add_event("Send the fourth tag to index 1", function() --DOC_HIDE
+    -- Send the first tag to index 3.
+    screen[1].tags[4].index = 1
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/name.lua
+++ b/tests/examples/sequences/tag/name.lua
@@ -1,0 +1,27 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+    screen[1].tags[2]:view_only()
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Change the name to New*tag*name", function() --DOC_HIDE
+    -- Change the name to New*tag*name.
+    screen[1].tags[2].name = "New*tag*name"
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/new_with_layouts.lua
+++ b/tests/examples/sequences/tag/new_with_layouts.lua
@@ -1,0 +1,54 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), --DOC_HIDE
+    layout = require("awful.layout"), --DOC_HIDE
+} --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+function awful.spawn(_, args) --DOC_HIDE
+    local c = client.gen_fake{} --DOC_HIDE
+    c:tags({args.tag}) --DOC_HIDE
+    assert(#c:tags() == 1) --DOC_HIDE
+    assert(c:tags()[1] == args.tag) --DOC_HIDE
+end --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    local some_layouts = {
+        awful.layout.suit.fair,
+        awful.layout.suit.spiral,
+        awful.layout.suit.spiral.dwindle,
+        awful.layout.suit.magnifier,
+        awful.layout.suit.corner.nw,
+        awful.layout.suit.max.fullscreen,
+    }
+
+    --DOC_NEWLINE
+
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four", "five" }, screen[1], some_layouts)
+
+    assert(#screen[1].tags == 5) --DOC_HIDE
+    for k, t in ipairs(screen[1].tags) do --DOC_HIDE
+        assert(t.layout and t.layout == some_layouts[k]) --DOC_HIDE
+        assert(#t:clients() == 0) --DOC_HIDE
+    end --DOC_HIDE
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Add some clients", function() --DOC_HIDE
+    -- Add some clients
+    for _, t in ipairs(screen[1].tags) do
+        for _ = 1, 5 do
+            awful.spawn("xterm", {tag = t})
+        end
+        assert(#t:clients() == 5) --DOC_HIDE
+    end
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute {show_empty = true} --DOC_HIDE

--- a/tests/examples/sequences/tag/new_with_layouts.lua
+++ b/tests/examples/sequences/tag/new_with_layouts.lua
@@ -20,7 +20,6 @@ module.add_event("Calling awful.tag.new", function() --DOC_HIDE
         awful.layout.suit.spiral.dwindle,
         awful.layout.suit.magnifier,
         awful.layout.suit.corner.nw,
-        awful.layout.suit.max.fullscreen,
     }
 
     --DOC_NEWLINE

--- a/tests/examples/sequences/tag/selected.lua
+++ b/tests/examples/sequences/tag/selected.lua
@@ -1,0 +1,26 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE --DOC_ASTERISK
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Change the selection", function() --DOC_HIDE
+    -- Change the selection.
+    screen[1].tags[1].selected = not screen[1].tags[1].selected
+    screen[1].tags[2].selected = true
+    screen[1].tags[3].selected = true
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/swap.lua
+++ b/tests/examples/sequences/tag/swap.lua
@@ -1,0 +1,27 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+    screen[1].tags[2]:view_only()
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Swap tag 2 with tag 4", function() --DOC_HIDE
+    -- Swap tag 2 with tag 4.
+    screen[1].tags[2]:swap(screen[1].tags[4])
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/view_only.lua
+++ b/tests/examples/sequences/tag/view_only.lua
@@ -1,0 +1,34 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Manually select some tags", function() --DOC_HIDE
+    -- Manually select some tags (tag 1 was auto selected).
+    screen[1].tags[3].selected = true
+    screen[1].tags[4].selected = true
+end)--DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Call :view_only()", function() --DOC_HIDE
+    -- Call :view_only() on the second tag.
+    screen[1].tags[2]:view_only()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/viewidx.lua
+++ b/tests/examples/sequences/tag/viewidx.lua
@@ -1,0 +1,36 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+    screen[1].tags[2]:view_only()
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Select the tag relative to idx 2", function() --DOC_HIDE
+    -- Select the tag relative to idx 2.
+    awful.tag.viewidx(2)
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Select the tag relative to idx -2", function() --DOC_HIDE
+    -- Select the tag relative to idx -2.
+    awful.tag.viewidx(-2)
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/viewnext.lua
+++ b/tests/examples/sequences/tag/viewnext.lua
@@ -1,0 +1,36 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+    screen[1].tags[3]:view_only()
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Select the next tag", function() --DOC_HIDE
+    -- Select the next tag.
+    awful.tag.viewnext()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Select the next tag (again)", function() --DOC_HIDE
+    -- Select the next tag (again).
+    awful.tag.viewnext()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/viewnone.lua
+++ b/tests/examples/sequences/tag/viewnone.lua
@@ -1,0 +1,34 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.add_event("Manually select some tags", function() --DOC_HIDE
+    -- Manually select some tags (tag 1 was auto selected).
+    screen[1].tags[3].selected = true
+    screen[1].tags[4].selected = true
+end)--DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Deselect all tags", function() --DOC_HIDE
+    -- Deselect all tags.
+    awful.tag.viewnone()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute{show_code_pointer = true} --DOC_HIDE

--- a/tests/examples/sequences/tag/viewprev.lua
+++ b/tests/examples/sequences/tag/viewprev.lua
@@ -1,0 +1,36 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+module.add_event("Calling awful.tag.new", function() --DOC_HIDE
+    assert(awful.layout.layouts[1]) --DOC_HIDE
+    -- Calling awful.tag.new
+    awful.tag({ "one", "two", "three", "four" }, screen[1])
+
+    --DOC_NEWLINE
+    screen[1].tags[2]:view_only()
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Select the previous tag", function() --DOC_HIDE
+    -- Select the previous tag.
+    awful.tag.viewprev()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Select the previous tag (again)", function() --DOC_HIDE
+    -- Select the previous tag (again).
+    awful.tag.viewprev()
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute() --DOC_HIDE

--- a/tests/examples/sequences/tag/volatile.lua
+++ b/tests/examples/sequences/tag/volatile.lua
@@ -1,0 +1,59 @@
+ --DOC_GEN_IMAGE --DOC --DOC_NO_USAGE
+local module = ... --DOC_HIDE
+local awful = {tag = require("awful.tag"), layout = require("awful.layout") } --DOC_HIDE
+screen[1]._resize {x = 0, width = 128, height = 96} --DOC_HIDE
+
+
+function awful.spawn(_, args) --DOC_HIDE
+    local c = client.gen_fake{} --DOC_HIDE
+    c:tags({args.tag}) --DOC_HIDE
+    assert(#c:tags() == 1) --DOC_HIDE
+    assert(c:tags()[1] == args.tag) --DOC_HIDE
+end --DOC_HIDE
+
+module.add_event("Create a non-volatile and a volatile tag", function() --DOC_HIDE
+    -- Create a non-volatile and a volatile tag.
+    awful.tag.add("Non-Volatile", {
+        screen   = screen[1],
+        layout   = awful.layout.suit.corner.nw,
+        volatile = false,
+    })
+
+--DOC_NEWLINE
+
+    awful.tag.add("Volatile", {
+        screen   = screen[1],
+        layout   = awful.layout.suit.corner.nw,
+        volatile = true,
+    })
+
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Add some clients", function() --DOC_HIDE
+    -- Add some clients.
+    for _, t in ipairs(screen[1].tags) do
+        for _ = 1, 5 do
+            awful.spawn("xterm", {tag = t})
+        end
+        assert(#t:clients() == 5) --DOC_HIDE
+    end
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+--DOC_NEWLINE
+
+module.add_event("Kill all clients", function() --DOC_HIDE
+    -- Kill all clients.
+    while #client.get() ~= 0 do
+        client.get()[1]:kill()
+    end
+end) --DOC_HIDE
+
+module.display_tags() --DOC_HIDE
+
+module.execute {show_empty = true} --DOC_HIDE

--- a/tests/examples/sequences/template.lua
+++ b/tests/examples/sequences/template.lua
@@ -1,0 +1,789 @@
+
+-- This template provides a timeline like display for tag changes.
+-- Basically a taglist with some pretty dots on the side. Note that the way it
+-- copy tags is fragile and probably not really supportable.
+
+local file_path, image_path = ...
+require("_common_template")(...)
+local capi = {client = client, screen = screen}
+local Pango = require("lgi").Pango
+local PangoCairo = require("lgi").PangoCairo
+require("awful.screen")
+require("awful.tag")
+local floating_l = require("awful.layout.suit.floating")
+local taglist = require("awful.widget.taglist")
+local gtable = require("gears.table")
+local shape = require("gears.shape")
+local color = require("gears.color")
+local wibox = require("wibox")
+local beautiful = require("beautiful")
+
+local bar_size, radius = 18, 2
+local screen_scale_factor = 5
+
+local history = {}
+
+local module = {}
+
+-- Draw a mouse cursor at [x,y]
+local function draw_mouse(cr, x, y)
+    cr:set_source_rgb(1, 0, 0)
+    cr:move_to(x, y)
+    cr:rel_line_to( 0, 10)
+    cr:rel_line_to( 3, -2)
+    cr:rel_line_to( 3,  4)
+    cr:rel_line_to( 2,  0)
+    cr:rel_line_to(-3, -4)
+    cr:rel_line_to( 4,  0)
+    cr:close_path()
+    cr:fill()
+end
+
+-- Instead of returning the maximum size, return the preferred one.
+local function fixed_fit2(self, context, orig_width, orig_height)
+    local width, height = orig_width, orig_height
+    local used_in_dir, used_max = 0, 0
+
+    for _, v in pairs(self._private.widgets) do
+        local w, h = wibox.widget.base.fit_widget(self, context, v, width, height)
+
+        -- Catch bugs before they crash Chrome (Firefox handles this better)
+        assert(w < 5000)
+        assert(h < 5000)
+
+        local in_dir, max
+        if self._private.dir == "y" then
+            max, in_dir = w, h
+            height = height - in_dir
+        else
+            in_dir, max = w, h
+            width = width - in_dir
+        end
+        if max > used_max then
+            used_max = max
+        end
+        used_in_dir = used_in_dir + in_dir
+    end
+
+    local spacing = self._private.spacing * (#self._private.widgets-1)
+
+    -- Catch bugs before they crash Chrome (Firefox handles this better)
+    assert(used_max    < 9000)
+    assert(used_in_dir < 9000)
+
+    if self._private.dir == "y" then
+        return used_max, used_in_dir + spacing
+    end
+    return used_in_dir + spacing, used_max
+end
+
+-- Imported from the Collision module.
+local function draw_lines()
+    local ret = wibox.widget.base.make_widget()
+
+    function ret:fit()
+        local pager_w = math.max(root.size()/screen_scale_factor, 60)
+
+        --FIXME support multiple screens.
+        local w = (#screen[1].tags * pager_w)
+            + ((#screen[1].tags - 1)*5)
+
+        return w, self.widget_pos and #self.widget_pos*6 or 30
+    end
+
+    function ret:draw(_, cr, _, h)
+        if (not self.widget_pos) or (not self.pager_pos) then return end
+
+        cr:set_line_width(1)
+        cr:set_source_rgba(0,0,0,0.3)
+
+        local count = #self.widget_pos
+
+        for k, t in ipairs(self.widget_pos) do
+            local point1 = {x = t.widget_x, y = 0, width = t.widget_width, height = 1}
+            local point2 = {x = t.pager_x, y = 0, width = t.pager_width, height = h}
+            assert(point1.x and point1.width)
+            assert(point2.x and point2.width)
+
+            local dx = (point1.x == 0 and radius or 0) + (point1.width and point1.width/2 or 0)
+
+            cr:move_to(bar_size+dx+point1.x, point1.y+2*radius)
+            cr:line_to(bar_size+dx+point1.x, point2.y+(count-k)*((h-2*radius)/count)+2*radius)
+            cr:line_to(point2.x+point2.width/2, point2.y+(count-k)*((h-2*radius)/count)+2*radius)
+            cr:line_to(point2.x+point2.width/2, point2.y+point2.height)
+            cr:stroke()
+
+            cr:arc(bar_size+dx+point1.x, point1.y+2*radius, radius, 0, 2*math.pi)
+            cr:fill()
+
+            cr:arc(point2.x+point2.width/2, point2.y+point2.height-radius, radius, 0, 2*math.pi)
+            cr:fill()
+        end
+    end
+
+    return ret
+end
+
+local function gen_vertical_line(args)
+    args = args or {}
+
+    local w = wibox.widget.base.make_widget()
+
+    function w:draw(_, cr, w2, h)
+        cr:set_source_rgba(0,0,0,0.5)
+
+        if args.begin then
+            cr:rectangle(w2/2-0.5, h/2, 1, h/2)
+        elseif args.finish then
+            cr:rectangle(w2/2-0.5, 0, 1, h/2)
+        else
+            cr:rectangle(w2/2-0.5, 0, 1, h)
+        end
+
+        cr:fill()
+
+        if args.dot then
+            cr:arc(w2/2, args.center and h/2 or w2/2 ,bar_size/4, 0, 2*math.pi)
+            cr:set_source_rgb(1,1,1)
+            cr:fill_preserve()
+            cr:set_source_rgba(0,0,0,0.5)
+            cr:stroke()
+        end
+    end
+
+    function w:fit()
+        return bar_size, bar_size
+    end
+
+    return w
+end
+
+local function gen_taglist_layout_proxy(tags, w2, name)
+    local l = wibox.layout.fixed.horizontal()
+    l.fit = fixed_fit2
+
+    local layout = l.layout
+
+    l.layout = function(self,context, width, height)
+        local ret = layout(self,context, width, height)
+
+        for k, v in ipairs(ret) do
+            tags[k][name.."_x"    ] = v._matrix.x0
+            tags[k][name.."_width"] = v._width
+        end
+
+        if w2 then
+            w2[name.."_pos"] = tags
+
+            if not w2[name.."_configured"] then
+                rawset(w2, name.."_configured", true)
+                w2:emit_signal("widget::redraw_needed")
+                w2:emit_signal("widget::layout_changed")
+            end
+        end
+
+        return ret
+    end
+
+    return l
+end
+
+local function gen_fake_taglist_wibar(tags, w2)
+    local layout = gen_taglist_layout_proxy(tags, w2, "widget")
+    local w = wibox.widget {
+        {
+            {
+                forced_height = bar_size,
+                forced_width  = bar_size,
+                image         = beautiful.awesome_icon,
+                widget        = wibox.widget.imagebox,
+            },
+            taglist {
+                forced_height = 14,
+                forced_width  = 300,
+                layout        = layout,
+                screen        = screen[1],
+                filter        = taglist.filter.all,
+                source        = function() return tags end,
+            },
+            fit = fixed_fit2,
+            layout = wibox.layout.fixed.horizontal,
+        },
+        bg     = beautiful.bg_normal,
+        widget = wibox.container.background
+    }
+
+    -- Make sure it nevers goes unbounded by accident.
+    local w3, h3 = w:fit({dpi=96}, 9999, 9999)
+    assert(w3 < 5000 and h3 < 5000)
+
+    return w
+end
+
+local function gen_cls(c,results)
+    local ret = setmetatable({},{__index = function(_, i)
+            local ret2 = c[i]
+            if type(ret2) == "function" then
+                if i == "geometry" then
+                    return function(_, val)
+                        if val then
+                            c:geometry(gtable.crush(c:geometry(), val))
+                            -- Make a copy as the original will be changed
+                            results[c] = gtable.clone(c:geometry())
+                        end
+                        return c:geometry()
+                    end
+                else
+                    return function(_,...) return ret2(c,...) end
+                end
+            end
+            return ret2
+        end})
+    return ret
+end
+
+local function fake_arrange(tag)
+    local cls,results,flt = {},setmetatable({},{__mode="k"}),{}
+    local _, l = tag.screen, tag.layout
+    local focus, focus_wrap = capi.client.focus, nil
+    for _ ,c in ipairs (tag:clients()) do
+        -- Handle floating client separately
+        if not c.minimized then
+            local floating = c.floating
+            if (not floating) and (l ~=  floating_l) then
+                cls[#cls+1] = gen_cls(c,results)
+                if c == focus then
+                    focus_wrap = cls[#cls]
+                end
+            else
+                flt[#flt+1] = gtable.clone(c:geometry())
+                flt[#flt].c = c
+            end
+        end
+    end
+
+    -- The magnifier layout require a focussed client
+    -- there wont be any as that layout is not selected
+    -- take one at random or (TODO) use stack data
+    if not focus_wrap then
+        focus_wrap = cls[1]
+    end
+
+    local param = {
+        tag              = tag,
+        screen           = 1,
+        clients          = cls,
+        focus            = focus_wrap,
+        geometries       = setmetatable({}, {__mode = "k"}),
+        workarea         = tag.screen.workarea,
+        useless_gap      = tag.gaps or 4,
+        apply_size_hints = false,
+    }
+
+    l.arrange(param)
+
+    local ret = {}
+
+    for _, geo_src in ipairs {param.geometries, flt } do
+        for c, geo in pairs(geo_src) do
+            geo.c = geo.c or c
+            table.insert(ret, geo)
+        end
+    end
+
+    return ret
+end
+
+local function gen_fake_clients(tag, args)
+    local pager = wibox.widget.base.make_widget()
+
+    function pager:fit()
+        return 60, 48
+    end
+
+    if not tag then return end
+
+    local sgeo = tag.screen.geometry
+
+    local show_name = args.display_client_name or args.display_label
+
+    function pager:draw(_, cr, w, h)
+        if not tag.client_geo then return end
+
+        for _, geom in ipairs(tag.client_geo) do
+            local x      = (geom.x*w)/sgeo.width
+            local y      = (geom.y*h)/sgeo.height
+            local width  = (geom.width*w)/sgeo.width
+            local height = (geom.height*h)/sgeo.height
+            cr:set_source(color(geom.c.color or beautiful.bg_normal))
+            cr:rectangle(x,y,width,height)
+            cr:fill_preserve()
+            cr:set_source(color(geom.c.border_color or beautiful.border_color))
+            cr:stroke()
+
+            if show_name and type(geom.c) == "table" and geom.c.name then
+                cr:set_source_rgb(0, 0, 0)
+                cr:move_to(x + 2, y + height - 2)
+                cr:show_text(geom.c.name)
+            end
+        end
+
+        -- Draw the screen outline.
+        cr:set_source(color("#00000044"))
+        cr:set_line_width(1.5)
+        cr:set_dash({10,4},1)
+        cr:rectangle(0, 0, w, h)
+        cr:stroke()
+    end
+
+    return pager
+end
+
+local function gen_fake_pager_widget(tags, w2, args)
+    local layout = gen_taglist_layout_proxy(tags, w2, "pager")
+    layout.spacing = 10
+
+    for _, t in ipairs(tags) do
+        layout:add(wibox.widget {
+            gen_fake_clients(t, args),
+            widget        = wibox.container.background
+        })
+    end
+
+    return layout
+end
+
+local function wrap_timeline(w, dot)
+    return wibox.widget {
+            gen_vertical_line { dot = dot or false},
+            {
+                w,
+                top     = dot and 5 or 0,
+                bottom  = dot and 5 or 0,
+                left    = 0,
+                widget  = wibox.container.margin
+            },
+            fit    = fixed_fit2,
+            layout = wibox.layout.fixed.horizontal
+        }
+end
+
+local function gen_label(text)
+    return wibox.widget {
+            gen_vertical_line {
+                dot    = true,
+                begin  = text == "Begin",
+                finish = text == "End",
+                center = true,
+            },
+        {
+            {
+                {
+                    {
+                        markup       = "<span size='smaller'><b>"..text.."</b> </span>",
+                        forced_width = 50,
+                        widget       = wibox.widget.textbox
+                    },
+                    top    = 2,
+                    bottom = 2,
+                    right  = 5,
+                    left   = 10,
+                    widget = wibox.container.margin
+                },
+                shape        = shape.rectangular_tag,
+                border_width = 2,
+                border_color = beautiful.border_color,
+                bg           = beautiful.bg_normal,
+                widget       = wibox.container.background
+            },
+            top    = 10,
+            bottom = 10,
+            widget = wibox.container.margin
+        },
+        fit    = fixed_fit2,
+        layout = wibox.layout.fixed.horizontal
+    }
+end
+
+local function draw_info(s, cr, factor)
+    cr:set_source_rgba(0, 0, 0, 0.4)
+
+    local pctx    = PangoCairo.font_map_get_default():create_context()
+    local playout = Pango.Layout.new(pctx)
+    local pdesc   = Pango.FontDescription()
+    pdesc:set_absolute_size(11 * Pango.SCALE)
+    playout:set_font_description(pdesc)
+
+    local rows = {
+        "primary", "index", "geometry", "dpi", "dpi range", "outputs:"
+    }
+
+    local dpi_range = s.minimum_dpi and s.preferred_dpi and s.maximum_dpi
+        and (s.minimum_dpi.."-"..s.preferred_dpi.."-"..s.maximum_dpi)
+        or s.dpi.."-"..s.dpi
+
+    local values = {
+        s.primary and "true" or "false",
+        s.index,
+        s.x..":"..s.y.." "..s.width.."x"..s.height,
+        s.dpi,
+        dpi_range,
+        "",
+    }
+
+    for n, o in pairs(s.outputs) do
+        table.insert(rows, "  "..n)
+        table.insert(values,
+            math.ceil(o.mm_width).."mm x "..math.ceil(o.mm_height).."mm"
+        )
+    end
+
+    local col1_width, col2_width, height = 0, 0, 0
+
+    -- Get the extents of the longest label.
+    for k, label in ipairs(rows) do
+        local attr, parsed = Pango.parse_markup(label..":", -1, 0)
+        playout.attributes, playout.text = attr, parsed
+        local _, logical = playout:get_pixel_extents()
+        col1_width = math.max(col1_width, logical.width+10)
+
+        attr, parsed = Pango.parse_markup(values[k], -1, 0)
+        playout.attributes, playout.text = attr, parsed
+        _, logical = playout:get_pixel_extents()
+        col2_width = math.max(col2_width, logical.width+10)
+
+        height = math.max(height, logical.height)
+    end
+
+    local dx = (s.width*factor - col1_width - col2_width - 5)/2
+    local dy = (s.height*factor - #values*height)/2 - height
+
+    -- Draw everything.
+    for k, label in ipairs(rows) do
+        local attr, parsed = Pango.parse_markup(label..":", -1, 0)
+        playout.attributes, playout.text = attr, parsed
+        playout:get_pixel_extents()
+        cr:move_to(dx, dy)
+        cr:show_layout(playout)
+
+        attr, parsed = Pango.parse_markup(values[k], -1, 0)
+        playout.attributes, playout.text = attr, parsed
+        local _, logical = playout:get_pixel_extents()
+        cr:move_to( dx+col1_width+5, dy)
+        cr:show_layout(playout)
+
+        dy = dy + 5 + logical.height
+    end
+end
+
+local function gen_ruler(h_or_v, factor, margins)
+    local ret = wibox.widget.base.make_widget()
+
+    function ret:fit()
+        local w, h
+        local rw, rh = root.size()
+        rw, rh = rw*factor, rh*factor
+
+        if h_or_v == "vertical" then
+            w = 1
+            h = rh + margins.top/2 + margins.bottom/2
+        else
+            w = rw + margins.left/2 + margins.right/2
+            h = 1
+        end
+
+        return w, h
+    end
+
+    function ret:draw(_, cr, w, h)
+        cr:set_source(color("#77000033"))
+        cr:set_line_width(2)
+        cr:set_dash({1,1},1)
+        cr:move_to(0, 0)
+        cr:line_to(w == 1 and 0 or w, h == 1 and 0 or h)
+        cr:stroke()
+    end
+
+    return ret
+end
+
+-- When multiple tags are present, only show the selected tag(s) for each screen.
+local function gen_screens(l, screens, args)
+    local margins = {left=50, right=50, top=30, bottom=30}
+
+    local ret = wibox.layout.manual()
+
+    local sreen_copies = {}
+
+    -- Keep a copy because it can change.
+    local rw, rh = root.size()
+
+    -- Find the current origin.
+    local x0, y0 = math.huge, math.huge
+
+    for s in screen do
+        x0, y0 = math.min(x0, s.geometry.x), math.min(y0, s.geometry.y)
+        local scr_cpy = gtable.clone(s.geometry, false)
+        scr_cpy.outputs = gtable.clone(s.outputs, false)
+        scr_cpy.primary = screen.primary == s
+
+        for _, prop in ipairs {
+          "dpi", "index", "maximum_dpi", "minimum_dpi", "preferred_dpi" } do
+            scr_cpy[prop] = s[prop]
+        end
+
+        table.insert(sreen_copies, scr_cpy)
+    end
+
+    function ret:fit()
+        local w = margins.left+(x0+rw)/screen_scale_factor + 5 + margins.right
+        local h = margins.top +(y0+rh)/screen_scale_factor + 5 + margins.bottom
+        return w, h
+    end
+
+    -- Add the rulers.
+    for _, s in ipairs(sreen_copies) do
+        ret:add_at(
+            gen_ruler("vertical"  , 1/screen_scale_factor, margins),
+            {x=margins.left+s.x/screen_scale_factor, y =margins.top/2}
+        )
+        ret:add_at(
+            gen_ruler("vertical"  , 1/screen_scale_factor, margins),
+            {x=margins.left+s.x/screen_scale_factor+s.width/screen_scale_factor, y =margins.top/2}
+        )
+        ret:add_at(
+            gen_ruler("horizontal", 1/screen_scale_factor, margins),
+            {y=margins.top+s.y/screen_scale_factor, x =margins.left/2}
+        )
+        ret:add_at(
+            gen_ruler("horizontal", 1/screen_scale_factor, margins),
+            {y=margins.top+s.y/screen_scale_factor+s.height/screen_scale_factor, x =margins.left/2}
+        )
+    end
+
+    -- Print an outline for the screens
+    for k, s in ipairs(sreen_copies) do
+        s.widget = wibox.widget.base.make_widget()
+
+        local wb = gen_fake_taglist_wibar(screens[k].tags)
+        wb.forced_width = s.width/screen_scale_factor
+
+        -- The clients have an absolute geometry, transform to relative.
+        if screens[k].tags[1] then
+            for _, geo in ipairs(screens[k].tags[1].client_geo) do
+                geo.x = geo.x - s.x
+                geo.y = geo.y - s.y
+            end
+        end
+
+        local clients_w = gen_fake_clients(screens[k].tags[1], args)
+
+        local content = wibox.widget {
+            wb,
+            clients_w,
+            nil,
+            layout       = wibox.layout.align.vertical,
+            forced_width = s.width/screen_scale_factor,
+        }
+
+        function s.widget:fit()
+            return s.width/screen_scale_factor, s.height/screen_scale_factor
+        end
+
+        function s.widget:draw(_, cr, w, h)
+            cr:set_source(color("#00000044"))
+            cr:set_line_width(1.5)
+            cr:set_dash({10,4},1)
+            cr:rectangle(1,1,w-2,h-2)
+            cr:stroke()
+
+            if args.display_label ~= false then
+                draw_info(s, cr, 1/screen_scale_factor)
+            end
+        end
+
+        function s.widget:after_draw_children(_, cr)
+            if args.display_mouse and mouse.screen.index == s.index then
+                local rel_x = mouse.coords().x - s.x
+                local rel_y = mouse.coords().y - s.y
+                draw_mouse(cr, rel_x/screen_scale_factor+5, rel_y/screen_scale_factor+5)
+            end
+        end
+
+        function s.widget:layout(_, width, height)
+            return { wibox.widget.base.place_widget_at(
+                content, 0, 0, width, height
+            ) }
+        end
+
+        ret:add_at(s.widget, {x=margins.left+s.x/screen_scale_factor, y=margins.top+s.y/screen_scale_factor})
+    end
+
+    l:add(wrap_timeline(wibox.widget {
+        markup  = "<i>Current tags:</i>",
+        opacity = 0.5,
+        widget  = wibox.widget.textbox
+    }, true))
+    l:add(wrap_timeline(ret,false))
+end
+
+-- When a single screen is present, show all tags.
+local function gen_noscreen(l, tags, args)
+    local w2 = draw_lines()
+    l:add(wrap_timeline(wibox.widget {
+        markup  = "<i>Current screens:</i>",
+        opacity = 0.5,
+        widget  = wibox.widget.textbox
+    }, true))
+
+    local wrapped_wibar = wibox.widget {
+        gen_fake_taglist_wibar(tags, w2),
+        fill_space = false,
+        fit = fixed_fit2,
+        layout = wibox.layout.fixed.horizontal
+    }
+
+    l:add(wrap_timeline(wrapped_wibar, false))
+
+    if #capi.client.get() > 0 or args.show_empty then
+        local w3, h3 = w2:fit({dpi=96}, 9999, 9999)
+        assert(w3 < 5000 and h3 < 5000)
+
+        l:add(wrap_timeline(w2, false))
+        l:add(wrap_timeline(gen_fake_pager_widget(tags, w2, args), false))
+    end
+end
+
+local function gen_timeline(args)
+    local l = wibox.layout.fixed.vertical()
+    l.fit = fixed_fit2
+
+    l:add(gen_label("Begin"))
+
+    for _, event in ipairs(history) do
+        local ret = event.callback()
+        if event.event == "event" then
+            l:add(wrap_timeline(wibox.widget {
+                markup = "<u><b>"..event.description.."</b></u>",
+                widget = wibox.widget.textbox
+            }, true))
+        elseif event.event == "tags" and #ret == 1 and not args.display_screen then
+            gen_noscreen(l, ret[1].tags, args)
+        elseif event.event == "tags" and (#ret > 1 or args.display_screen) then
+            gen_screens(l, ret, args)
+        end
+    end
+
+    -- Spacing.
+    l:add(wrap_timeline( wibox.widget {
+        draw   = function() end,
+        fit    = function() return 1, 10 end,
+        widget = wibox.widget.base.make_widget()
+    }))
+
+    l:add(gen_label("End"))
+
+    return l
+end
+
+local function wrap_with_arrows(widget)
+    local w = widget:fit({dpi=96}, 9999,9999)
+
+    local arrows = wibox.widget.base.make_widget()
+
+    function arrows:fit()
+        return w, 10
+    end
+
+    function arrows:draw(_, cr, w2, h)
+
+        cr:set_line_width(1)
+        cr:set_source_rgba(1, 0, 0, 0.3)
+
+        w2 = math.min(640, w2)
+
+        local x = (w2 % 24) / 2
+
+        while x + 15 < w2 do
+            cr:move_to(x+2  , 0  )
+            cr:line_to(x+10 , h-1)
+            cr:line_to(x+20 , 0  )
+            cr:stroke()
+            x = x + 24
+        end
+    end
+
+    assert(w < 5000)
+
+    return wibox.widget {
+        widget,
+        {
+            draw   = function() end,
+            fit    = function() return 1, 10 end,
+            widget = wibox.widget.base.make_widget()
+        },
+        {
+            markup      = "<span color='#ff000055'>Code for this sequence</span>",
+            align       = "center",
+            foced_width = w,
+            widget      = wibox.widget.textbox,
+        },
+        arrows,
+        forced_width = w,
+        fit          = fixed_fit2,
+        layout       = wibox.layout.fixed.vertical
+    }
+end
+
+function module.display_tags()
+    local function do_it()
+        local ret = {}
+        for s in screen do
+            local st = {}
+            for _, t in ipairs(s.tags) do
+                -- Copy just enough for the taglist to work.
+                table.insert(st, {
+                    name                = t.name,
+                    selected            = t.selected,
+                    icon                = t.icon,
+                    screen              = t.screen,
+                    data                = t.data,
+                    clients             = t.clients,
+                    layout              = t.layout,
+                    master_width_factor = t.master_width_factor,
+                    client_geo          = fake_arrange(t),
+                })
+                assert(#st[#st].client_geo == #t:clients())
+            end
+            table.insert(ret, {tags=st})
+        end
+        return ret
+    end
+
+    table.insert(history, {event="tags", callback = do_it})
+end
+
+function module.add_event(description, callback)
+    assert(description and callback)
+    table.insert(history, {
+        event       = "event",
+        description = description,
+        callback    = callback
+    })
+end
+
+function module.execute(args)
+    local widget = gen_timeline(args or {})
+    require("gears.timer").run_delayed_calls_now()
+    require("gears.timer").run_delayed_calls_now()
+    require("gears.timer").run_delayed_calls_now()
+
+    if (not args) or args.show_code_pointer ~= false then
+        widget = wrap_with_arrows(widget)
+    end
+
+    local w, h = widget:fit({dpi=96}, 9999,9999)
+    wibox.widget.draw_to_svg_file(widget, image_path..".svg", w, h)
+end
+
+loadfile(file_path)(module)

--- a/tests/examples/sequences/template.lua
+++ b/tests/examples/sequences/template.lua
@@ -358,7 +358,7 @@ local function wrap_timeline(w, dot)
             gen_vertical_line { dot = dot or false},
             {
                 w,
-                top     = dot and 5 or 0,
+                top     = 0,
                 bottom  = dot and 5 or 0,
                 left    = 0,
                 widget  = wibox.container.margin

--- a/tests/examples/sequences/template.lua
+++ b/tests/examples/sequences/template.lua
@@ -368,6 +368,14 @@ local function wrap_timeline(w, dot)
         }
 end
 
+local function gen_vertical_space(spacing)
+    return wibox.widget {
+        draw   = function() end,
+        fit    = function() return 1, spacing end,
+        widget = wibox.widget.base.make_widget()
+    }
+end
+
 local function gen_label(text)
     return wibox.widget {
             gen_vertical_line {
@@ -663,6 +671,7 @@ local function gen_timeline(args)
     for _, event in ipairs(history) do
         local ret = event.callback()
         if event.event == "event" then
+            l:add(wrap_timeline(gen_vertical_space(5)))
             l:add(wrap_timeline(wibox.widget {
                 markup = "<u><b>"..event.description.."</b></u>",
                 widget = wibox.widget.textbox
@@ -675,11 +684,7 @@ local function gen_timeline(args)
     end
 
     -- Spacing.
-    l:add(wrap_timeline( wibox.widget {
-        draw   = function() end,
-        fit    = function() return 1, 10 end,
-        widget = wibox.widget.base.make_widget()
-    }))
+    l:add(wrap_timeline(gen_vertical_space(10)))
 
     l:add(gen_label("End"))
 

--- a/tests/examples/shims/_common_template.lua
+++ b/tests/examples/shims/_common_template.lua
@@ -1,3 +1,5 @@
+pcall(require, "luarocks.loader")
+
 -- luacheck: globals string
 function string.wlen(self)
     return #self

--- a/tests/test-titlebar.lua
+++ b/tests/test-titlebar.lua
@@ -4,6 +4,7 @@ local rules = require("awful.rules")
 local spawn = require("awful.spawn")
 
 local tiny_client_code_template = [[
+pcall(require, 'luarocks.loader')
 local Gtk, class = require('lgi').require('Gtk'), 'client'
 Gtk.init()
 window = Gtk.Window {default_width=100, default_height=100, title='title'}


### PR DESCRIPTION
This template allows to display a sequence of events for the clients, tags and screens. Currently, it is hard to display images where the state of an object is more complex than "here how it was before" and "here how it is now". With this template, it is possible to have a timeline of events from the initial states to the final states.
    
Now, as the line count shows, this isn't small. It is in fact an enormous template. Worst still, this commit is the first *half* of  it. The second half adds the ability to `print()`, display inline code and support mouse and keyboard events. The code also isn't world class. Maintaining this template might be non-trivial in the long run. I am fully aware of those issues. On the other hand, there is ~100 places where this will be used once the entire "new rule library" project is completed. This will bring the ~1.2k line of code to ~12 lines per consumer. From that point of view,  it makes a lot more sense to merge this given how useful it is at explaining changes within the "core objects".
    
It is also important to keep in mind that there is currently very little or no documentation (beside the mandatory one-liner summary) for these concepts. Those are the most important aspects of AwesomeWM API and they are the least documented. This is just wrong.

Here's one example of this template. There is more complex ones in the future rules pull requests:

![image](https://user-images.githubusercontent.com/340384/65852178-5c18cb00-e323-11e9-972a-e62175380bd9.png)

For those who watch my `experimental` branch doc, I had this for a while. I waited until the Lua managed screen PR got merged before submitting this. It has little impact of actual users. This is all about the doc.