### PR TITLE
Allow `getopt_long` call to manage the `-m` option (short of `--screen`)

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -621,7 +621,7 @@ main(int argc, char **argv)
     setlocale(LC_CTYPE, "");
 
     /* check args */
-    while((opt = getopt_long(argc, argv, "vhkc:ar",
+    while((opt = getopt_long(argc, argv, "vhkc:arm:",
                              long_options, NULL)) != -1)
         switch(opt)
         {


### PR DESCRIPTION
This one was forget by @Elv13 in the #2790 PR.

It's my bad, it was on a line I couldn't add suggestion/comment on (because it is too far from what was modified) so it wasn't included in the final "Apply suggestions from code review " commit.

[Original message](https://github.com/awesomeWM/awesome/pull/2790#discussion_r328601814):

> The `getopt_long` function is missing the `-m` option.
> 
> ```c
> // line 624
> while((opt = getopt_long(argc, argv, "vhkc:arm:", // <= Note the additional "m:"
>                          long_options, NULL)) != -1)
> ```
> 
> While the `--screen` option works, without this, `-m` option is not recognized, so running `awesome -m on` goes to the default case `exit_help` with the message: "unrecognized option: --m".