### PR TITLE
Improve (and fix) the doc.

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -178,10 +178,24 @@ local function wrap_modname(str, item)
         .. str:sub(#item.module.name+2, 9999)
 end
 
+local named_args = {
+    [ "(args)"       ] = true,
+    [ "([args=nil])" ] = true,
+    [ "([args={}])"  ] = true
+}
+
 -- Wrap the arguments for the CSS highlight.
 local function wrap_args(item)
     if not item.args then return "" end
-    return "<span class='function_args'>"..item.args.."</span>"
+
+    -- Display named args with `{}` and ordered args with `()`
+    if named_args[item.args] then
+        return "<span class='function_named_args'><b>{</b>[args]<b>}</b></span>"
+    end
+
+    local new_args = item.args:sub(2, item.args:len()-2)
+
+    return "<span class='function_args'> <b>(</b>"..new_args.."<b>)</b></span>"
 end
 
 

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -99,10 +99,10 @@ kind_names={topic='Documentation', module='Libraries', script='Sample files'}
 sort_modules=true
 
 -- Add more project level (left side index) types.
+new_type("coreclassmod", "Core_components"  , true)
 new_type("widgetmod"   , "Widgets"   , true)
 new_type("containermod", "Widget_containers", true)
 new_type("layoutmod"   , "Widget_layouts"   , true)
-new_type("coreclassmod", "Core_components"  , true)
 new_type("popupmod"    , "Popups_and_bars"  , true)
 new_type("utillib"     , "Utility_libraries", true)
 new_type("themelib"    , "Theme_related_libraries", true)

--- a/docs/ldoc.css
+++ b/docs/ldoc.css
@@ -315,6 +315,25 @@ table.function_list .function_args /*.function_modname*/ {
     text-decoration-color: #bbd3ff;
 }
 
+table.function_list .function_args b {
+    font-weight: 500;
+    color: #95b1ff;
+    text-decoration: underline;
+    text-decoration-color: #bbd3ff;
+}
+
+table.function_list .function_named_args b {
+    color: #b37cff;
+    text-decoration: underline;
+    text-decoration-color: #bbd3ff;
+}
+
+table.function_list .function_named_args {
+    color: #ba97ff;
+    text-decoration: underline;
+    text-decoration-color: #bbd3ff;
+}
+
 dl.function {
     margin-right: 15px;
     margin-left: 15px;

--- a/lib/naughty/list/notifications.lua
+++ b/lib/naughty/list/notifications.lua
@@ -260,7 +260,7 @@ end
 -- @tparam gears.color|string args.style.fg_selected
 -- @tparam gears.surface|string args.style.bgimage_normal
 -- @tparam gears.surface|string args.style.bgimage_selected
--- @tparam[opt] table widget_template A custom widget to be used for each
+-- @tparam[opt] table args.widget_template A custom widget to be used for each
 --  notifications.
 -- @treturn widget The notification list widget.
 -- @constructorfct naughty.list.notifications

--- a/tests/examples/uml/template.lua
+++ b/tests/examples/uml/template.lua
@@ -6,7 +6,7 @@ local wibox = require("wibox")
 local beautiful = require("beautiful")
 
 -- Make the path relative.
-image_path = "../" .. image_path:match("/(images/[^/]+)$")
+local relative_image_path = "../" .. image_path:match("/(images/[^/]+)$")
 
 -- This template generates an HTML table with how other classes are associated
 -- with a given class.
@@ -204,9 +204,10 @@ function module.generate_nav_table(t)
                 assert(entry.class)
                 assert(entry.left.msg and entry.left.card)
                 assert(entry.right.msg and entry.right.card)
-                local path = image_path..counter..".svg"
+                local path = relative_image_path..counter..".svg"
+                local fpath = image_path..counter..".svg"
                 local widget = gen_table_uml(entry, t.class, entry.class, false)
-                wibox.widget.draw_to_svg_file(widget, path, 320, 50)
+                wibox.widget.draw_to_svg_file(widget, fpath, 320, 50)
                 get_table_row(path, entry.class, entry[tab.."_property"])
                 counter = counter + 1
             end


### PR DESCRIPTION
The main change is that the functions, constructors and method using named arguments now use `{[args]}` in the doc instead of `([args])`. This is more in line with the coding style used in `rc.lua`. This will reduce the confusion of what support `{}` and what does not.

The recent push of the UML template didn't quite fully work. This is because `awesome-www` and my setup use different relative path for the build system. The UML HTML used relative paths for the image and the builder used the same relative path to save the file. It works only as long as the build dir path is in the right place. The fix is more generic.

Another little change is to move "Core components" higher than "Widgets" in the index. The core components are more important than the widgets, so they should be easier to spot.

The last fix add a missing `args.` in naughty documentation. This caused `widget_template` to be rendered as an ordered parameter while it is a named parameter.

All in all, those changes are very minor and I will merge this soon-ish.