### PR TITLE
legacy: Temporary workaround for #2897.

### DIFF
--- a/lib/gears/object/properties.lua
+++ b/lib/gears/object/properties.lua
@@ -161,9 +161,15 @@ function object._legacy_accessors(obj, name, capi_name, is_object, join_if, set_
     magic_obj["get_"..name] = function(self)
         self = is_object and self or obj
 
+        --FIXME v5 all objects should use _private instead of getproperty.
+        if not self._private then
+            self._private = {}
+        end
+
         self._private[name] = self._private[name] or copy_object(
             obj, {}, name, capi_name, is_object, join_if, set_empty
         )
+
 
         assert(self._private[name])
         return self._private[name]


### PR DESCRIPTION
Temporary workaround until next weekend. I will merge this real soon to prevent more damage when people upgrade. A more complete solution with tests will have to wait until Saturday.

The `:keys()` and `:buttons()` APIs moved from get/set single methods to properties. It works fine if you use the new or old API, but has limitations when mixing them. `awful.rules` calls properties in a loop after checking if it is a function. Thus it triggers the secondary codepath to try to handle the mixed new/old API case.

This codepath was tested with gears.objects based components (ie. widgets). It was not tested with clients and tags, and it didn't work because they use `awful.tag.getproperty` and `awful.client.property.get` instead of `._private` like all newer components. Those old functions are officially deprecated, but used by tons of configs and modules ported from v3.5 and thus still the default way to access Lua properties in our implementation.

This commit adds a `_private` to anything that doesn't have one to at least make the error stop. It will "mostly" work until a more complete solution is added. Reverting the 2 PRs that changed this
would delay getting more feedbacks. The more complete solution is to move `awful.tag.getproperty` and `awful.client.property.get` to be implemented on top of `_private`.