### PR TITLE
imagebox:set_widget(): Handle userdata again

### DIFF
--- a/lib/wibox/widget/imagebox.lua
+++ b/lib/wibox/widget/imagebox.lua
@@ -133,6 +133,13 @@ end
 function imagebox:set_image(image)
     local setup_succeed
 
+    if type(image) == "userdata" then
+        -- This function is not documented to handle userdata objects, but
+        -- historically it did, and it did by just assuming they refer to a
+        -- cairo surface.
+        image = surface.load(image)
+    end
+
     if type(image) == "string" then
         -- try to load rsvg handle from file
         setup_succeed = load_and_apply(self, image, load_rsvg_handle, set_handle)


### PR DESCRIPTION
This function is not documented to handle userdata, but historically it
would just pass all arguments to gears.surface.load(), which interpreted
userdata as cairo surfaces. After 3295e9f33d330678384c84031, userdata
objects are restricted.

Accept userdata objects again by explicitly passing them to
gears.surface.load().

Fixes: https://github.com/awesomeWM/awesome/issues/2903
Signed-off-by: Uli Schlachter <psychon@znc.in>