### PR TITLE
fix: bad argument to apply_size_hints

### DIFF
--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -1137,7 +1137,7 @@ function placement.resize_to_mouse(d, args)
     remove_border(d, args, ngeo)
 
     -- Now, correct the geometry by the given size_hints offset
-    if d.apply_size_hints then
+    if d.apply_size_hints and ngeo.width ~= 0 and ngeo.height ~= 0 then
         local w, h = d:apply_size_hints(
             ngeo.width,
             ngeo.height


### PR DESCRIPTION
While in floating mode user can resize window to a zero width or height size.
If this happens an error occures: bad argument 1 to apply_size_hints (value in [1, 65535] expected, got 0).
After this error window size cannot be changed.