### PR TITLE
Documentation `screen` - Improvement on generated images.

### DIFF
--- a/tests/examples/screen/geometry.lua
+++ b/tests/examples/screen/geometry.lua
@@ -23,7 +23,7 @@ end --DOC_HIDE
     --DOC_NEWLINE
 
     -- This will shift the workarea by 24px at the top.
-    awful.wibar {
+    local wibar = awful.wibar {
         position = "top",
         height   = 24,
     }
@@ -32,4 +32,5 @@ return { --DOC_HIDE
     factor             = 2    , --DOC_HIDE
     show_boxes         = false, --DOC_HIDE
     highlight_geometry = true , --DOC_HIDE
+    draw_wibar         = wibar, --DOC_HIDE
 } --DOC_HIDE

--- a/tests/examples/screen/padding.lua
+++ b/tests/examples/screen/padding.lua
@@ -26,7 +26,7 @@ end --DOC_HIDE
         bottom = 20,
     }
 
-    awful.wibar { --DOC_HIDE
+    local wibar = awful.wibar { --DOC_HIDE
         position = "top", --DOC_HIDE
         height   = 24, --DOC_HIDE
     } --DOC_HIDE
@@ -35,4 +35,5 @@ return { --DOC_HIDE
     factor                = 2    , --DOC_HIDE
     show_boxes            = false, --DOC_HIDE
     highlight_padding_area = true , --DOC_HIDE
+    draw_wibar            = wibar, --DOC_HIDE
 } --DOC_HIDE

--- a/tests/examples/screen/template.lua
+++ b/tests/examples/screen/template.lua
@@ -293,14 +293,14 @@ end
 for _=1, screen.count() do
     local s = screen[1]
 
-    -- The outer geometry.
-    compute_ruler(s, s.geometry, "geometry")
+    -- The padding.
+    compute_ruler(s, s.tiling_area, "tiling_area")
 
     -- The workarea.
     compute_ruler(s, s.workarea, "workarea")
 
-    -- The padding.
-    compute_ruler(s, s.tiling_area, "tiling_area")
+    -- The outer geometry.
+    compute_ruler(s, s.geometry, "geometry")
 end
 
 -- Get the final size of the image.

--- a/tests/examples/screen/tiling_area.lua
+++ b/tests/examples/screen/tiling_area.lua
@@ -18,7 +18,7 @@ screen[1].padding = {
     bottom = 20,
 }
 
-awful.wibar {
+local wibar = awful.wibar {
     position = "top",
     height   = 24,
 }
@@ -27,4 +27,5 @@ return {
     factor                = 2    ,
     show_boxes            = false,
     highlight_tiling_area = true ,
+    draw_wibar            = wibar,
 }

--- a/tests/examples/screen/workarea.lua
+++ b/tests/examples/screen/workarea.lua
@@ -29,7 +29,7 @@ end --DOC_HIDE
     --DOC_NEWLINE
 
     -- This will shift the workarea by 24px at the top.
-    awful.wibar {
+    local wibar = awful.wibar {
         position = "top",
         height   = 24,
     }
@@ -38,4 +38,5 @@ return { --DOC_HIDE
     factor             = 2    , --DOC_HIDE
     show_boxes         = false, --DOC_HIDE
     highlight_workarea = true , --DOC_HIDE
+    draw_wibar         = wibar, --DOC_HIDE
 } --DOC_HIDE


### PR DESCRIPTION
This PR follows my issue #2919.

# Changes from the draft I wrote for the issue

I changed the wibar drawing to make it a solid surface instead of using the stripe pattern and force pushed to my branch.

Here is a preview:

![generated-wibar](https://user-images.githubusercontent.com/6602958/69431203-8b522400-0d37-11ea-8e39-472185a916c7.png)

# Original message from the issue:

> I were looking at the documentation to find what I can do to make it more easy to read and I found these two "issues" on the generated images for the screen API which are fairly easy to fix.
>
> I'd like your feedback :)
>
> ping @Elv13 :)
>
> # Rulers order
>
> ![old-rulers-order](https://user-images.githubusercontent.com/6602958/68998096-181b5e80-08ae-11ea-90dd-a3b9d8d2d085.png)
>
> It just don't seems natural the `geometry` rulers is in the middle. The bubble sort algorithm order rulers correctly but when they have the same size. If rulers have the same size, they keep the order they were inserted into the rulers list. So rulers insertion order impact the result of the bubble sort algorithm.
> 
> By inverting the order, we can make the `geometry` ruler be always the most outer one. The generated image looks more natural.
> 
> ![rulers-order](https://user-images.githubusercontent.com/6602958/68998383-c8d72d00-08b1-11ea-9490-452e0679e992.png)
> 
> # Wibar
> 
> Generated screen images always have a little margin at the top of the `workarea` rect. This space is caused by the wibar which is at the top of the screen in the default `aweseomerc.lua` and in the code to generate images:
> 
> ```lua
> -- This will shift the workarea by 24px at the top.
> awful.wibar {
>     position = "top",
>     height   = 24,
> }
> ```
> 
> It's not a big deal once you know it. However, I think there should be an indication of this mechanism. I added a `draw_wibar` parameter to the template generator to draw it in the generated image:

> ![show-wibar](https://user-images.githubusercontent.com/6602958/68998249-64679e00-08b0-11ea-89cf-56b84df286cf.png)
> 
> I think this still need additional work to be drawn differently than area with the stripe pattern, tho..