### PR TITLE
Emit property::screen in tag:delete()

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -402,7 +402,7 @@ function tag.object.delete(self, fallback_tag, force)
     end
 
     -- delete the tag
-    self._private.awful_tag_properties.screen = nil
+    tag.setproperty(self, "screen", nil)
     self.activated = false
 
     -- Update all indexes


### PR DESCRIPTION
Before this commit, the code directly modified the table where the tag's
properties were saved. This commit changes the code to call
awful.tag.setproperty() instead. This function ensures that
property::screen is now also emitted.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

This is my patch from https://github.com/awesomeWM/awesome/pull/2916#issuecomment-551129210 / for #2914. I still think this should be merged.