### PR TITLE
Improve textclock property docs

### DIFF
--- a/lib/wibox/widget/textclock.lua
+++ b/lib/wibox/widget/textclock.lua
@@ -44,6 +44,8 @@ function textclock:get_format()
 end
 
 --- Set the clock's timezone
+-- e.g. "Z" for UTC, "±hh:mm" or "Europe/Amsterdam". See
+-- [GTimeZone](https://developer.gnome.org/glib/stable/glib-GTimeZone.html#g-time-zone-new).
 -- @property timezone
 -- @tparam string timezone
 
@@ -59,7 +61,7 @@ end
 
 --- Set the clock's refresh rate
 -- @property refresh
--- @tparam number How often the clock is updated, in seconds
+-- @tparam number refresh How often the clock is updated, in seconds
 
 function textclock:set_refresh(refresh)
     self._private.refresh = refresh or self._private.refresh
@@ -84,11 +86,9 @@ end
 
 --- Create a textclock widget. It draws the time it is in a textbox.
 --
--- @tparam[opt=" %a %b %d, %H:%M "] string format The time format.
+-- @tparam[opt=" %a %b %d&comma; %H:%M "] string format The time [format](#format).
 -- @tparam[opt=60] number refresh How often to update the time (in seconds).
--- @tparam[opt=local timezone] string timezone The timezone to use,
---   e.g. "Z" for UTC, "±hh:mm" or "Europe/Amsterdam". See
---   https://developer.gnome.org/glib/stable/glib-GTimeZone.html#g-time-zone-new.
+-- @tparam[opt=local timezone] string timezone The [timezone](#timezone) to use.
 -- @treturn table A textbox widget.
 -- @constructorfct wibox.widget.textclock
 local function new(format, refresh, tzid)


### PR DESCRIPTION
* Add format docs to the constructor.
* Add timezone docs to the property.
* Give the argument to set_refresh a name other than "How".
  In the ldoc string, the name of the parameter is not optional. If you don't specify a name, but you do add a description, the name will be the first word in your description.
* Fix bug in constructor argument `format` rendering.
  Before the default value for `format` was rendered in the HTML as `" %a %b %d`. It got cut off at the comma. Now it is formatted correctly as `" %a %b %d, %H:%M "`. I had to html-encode the comma to work around this. This might be a bug in ldoc, but I haven't been able to track it down yet.

This is a followup from #2902.