### PR TITLE
Correct the name of get_children's return value

### DIFF
--- a/docs/common/widget.ldoc
+++ b/docs/common/widget.ldoc
@@ -10,14 +10,14 @@
 
 --- Get or set the children elements.
 -- @property children
--- @tparam table The children
+-- @tparam table children The children.
 
 --- Get all direct and indirect children widgets.
 -- This will scan all containers recursively to find widgets
 -- Warning: This method it prone to stack overflow id the widget, or any of its
 -- children, contain (directly or indirectly) itself.
 -- @property all_children
--- @tparam table The children
+-- @tparam table children The children.
 
 --- Set a declarative widget hierarchy description.
 -- See [The declarative layout system](../documentation/03-declarative-layout.md.html)

--- a/lib/wibox/container/place.lua
+++ b/lib/wibox/container/place.lua
@@ -73,7 +73,7 @@ end
 
 --- Get or set the children elements.
 -- @property children
--- @tparam table The children
+-- @tparam table children The children.
 
 function place:get_children()
     return {self._private.widget}

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -140,7 +140,7 @@ end
 --- Get the widget's direct children widgets.
 --
 -- This method should be re-implemented by the relevant widgets.
--- @treturn table The children
+-- @treturn table children The children.
 -- @method get_children
 function base.widget:get_children()
     return {}
@@ -170,7 +170,7 @@ end
 --
 -- *Warning*: This method it prone to stack overflow if the widget, or any of
 -- its children, contains (directly or indirectly) itself.
--- @treturn table The children
+-- @treturn table children The children.
 -- @method get_all_children
 function base.widget:get_all_children()
     local ret = {}


### PR DESCRIPTION
get_children's return value should not be called "The". That was a
mistake because ldoc requires a name for return values and parameters.
If a name isn't provided, it thinks the first word of the description
is the name.