### PR TITLE
[Documentation] `screen` module - Improvement on generated image: client part.

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -483,6 +483,8 @@ end
 -- * maximized clients
 -- * floating clients
 --
+-- @DOC_screen_tiled_clients_EXAMPLE@
+--
 -- @property tiled_clients
 -- @param table The clients list, ordered from top to bottom.
 

--- a/tests/examples/screen/tiled_clients.lua
+++ b/tests/examples/screen/tiled_clients.lua
@@ -1,0 +1,53 @@
+--DOC_GEN_IMAGE --DOC_NO_USAGE --DOC_HIDE_ALL
+
+screen[1]._resize {x = 0, width = 640, height = 480}
+
+
+local awful = {
+    wibar = require("awful.wibar"),
+    tag = require("awful.tag"),
+    tag_layout = require("awful.layout.suit.tile")
+}
+
+function awful.spawn(_, args)
+    local c = client.gen_fake{}
+    c:tags({args.tag})
+    assert(#c:tags() == 1)
+    assert(c:tags()[1] == args.tag)
+end
+
+screen[1].padding = {
+    left   = 40,
+    right  = 40,
+    top    = 20,
+    bottom = 20,
+}
+
+local wibar = awful.wibar {
+    position = "top",
+    height   = 24,
+}
+
+awful.tag.add("1", {
+    screen   = screen[1],
+    selected = true,
+    layout   = awful.tag_layout.right,
+    gap      = 5
+})
+
+local clients = {
+    ['client #1'] = client.gen_fake{},
+    ['client #2'] = client.gen_fake{},
+    ['client #3'] = client.gen_fake{}
+}
+for _,c in ipairs(clients) do
+    c:tags{"1"}
+end
+
+return {
+    factor                = 2    ,
+    show_boxes            = true,
+    draw_wibar            = wibar,
+    draw_clients          = clients,
+    display_screen_info   = false,
+}


### PR DESCRIPTION
This PR is the continuation of my previous PR #2922. 

The goal of this PR is to bring support for clients into the screen template image generator used by the screen API documentation.

I'd like to have feedback from @Elv13 to see if I correctly understood what we should do on this one.
The code is a little dirty now and requires a rework of my commit before being merged anyway.

Here is a previous of the generated image for the `screen.tiled_clients` property:
![tiled_clients](https://user-images.githubusercontent.com/6602958/69649351-35e68180-106d-11ea-8931-fe48dd55ce32.png)
