### PR TITLE
Fix missing naughty.dbus.config.mapping defaults

### DIFF
--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -55,7 +55,7 @@ local urgency = {
 -- @tfield table 2 normal urgency
 -- @tfield table 3 critical urgency
 -- @table config.mapping
-dbus.config.mapping = cst.mapping
+dbus.config.mapping = cst.config.mapping
 
 local function sendActionInvoked(notificationId, action)
     if bus_connection then


### PR DESCRIPTION
An error during refactoring was introduced making `naughty.dbus.config.mapping` equal `nil`, instead of a table of urgency defaults, etc.

https://github.com/awesomeWM/awesome/commit/c36d35756f6814f9db70d9848eddd3e9b14bdd1e#diff-3c68347c1193f6509de2691077b9602eR58

`cst.mapping` doesn't exist, the correct location is `cst.config.mapping`.