### PR TITLE
progressbar: Fix a major regression.

### DIFF
--- a/lib/wibox/widget/progressbar.lua
+++ b/lib/wibox/widget/progressbar.lua
@@ -480,7 +480,7 @@ for _, prop in ipairs(properties) do
         end
     end
     if not progressbar["get_"..prop] then
-        progressbar["set_" .. prop] = function(pbar)
+        progressbar["get_" .. prop] = function(pbar)
             return pbar._private[prop]
         end
     end


### PR DESCRIPTION
The typo was introduced when the signal and accessors were standardized
for to make the documentation less wrong.

Fix #2932