### PR TITLE
Untangle some easily avoidable circular dependencies

### DIFF
--- a/lib/awful/mouse/client.lua
+++ b/lib/awful/mouse/client.lua
@@ -1,0 +1,143 @@
+--- Client related mouse operations.
+--
+-- @author Emmanuel Lepage Vallee &lt;elv1313@gmail.com&gt;
+-- @copyright 2016 Emmanuel Lepage Vallee
+-- @submodule mouse
+
+local aplace = require("awful.placement")
+local capi = { mouse = mouse, client = client }
+local mresize = require("awful.mouse.resize")
+local gdebug = require("gears.debug")
+
+local module = {}
+
+--- Move a client.
+-- @staticfct awful.mouse.client.move
+-- @param c The client to move, or the focused one if nil.
+-- @param snap The pixel to snap clients.
+-- @param finished_cb Deprecated, do not use
+function module.move(c, snap, finished_cb) --luacheck: no unused args
+    if finished_cb then
+        gdebug.deprecate("The mouse.client.move `finished_cb` argument is no longer"..
+            " used, please use awful.mouse.resize.add_leave_callback(f, 'mouse.move')", {deprecated_in=4})
+    end
+
+    c = c or capi.client.focus
+
+    if not c
+        or c.fullscreen
+        or c.maximized
+        or c.type == "desktop"
+        or c.type == "splash"
+        or c.type == "dock" then
+        return
+    end
+
+    -- Compute the offset
+    local coords = capi.mouse.coords()
+    local geo    = aplace.centered(capi.mouse,{parent=c, pretend=true})
+
+    local offset = {
+        x = geo.x - coords.x,
+        y = geo.y - coords.y,
+    }
+
+    mresize(c, "mouse.move", {
+        placement = aplace.under_mouse,
+        offset    = offset,
+        snap      = snap
+    })
+end
+
+module.dragtotag = { }
+
+--- Move a client to a tag by dragging it onto the left / right side of the screen.
+-- @deprecated awful.mouse.client.dragtotag.border
+-- @param c The client to move
+function module.dragtotag.border(c)
+    gdebug.deprecate("Use awful.mouse.snap.drag_to_tag_enabled = true instead "..
+        "of awful.mouse.client.dragtotag.border(c). It will now be enabled.", {deprecated_in=4})
+
+    -- Enable drag to border
+    require("awful.mouse.snap").drag_to_tag_enabled = true
+
+    return module.move(c)
+end
+
+--- Get a client corner coordinates.
+-- @deprecated awful.mouse.client.corner
+-- @tparam[opt=client.focus] client c The client to get corner from, focused one by default.
+-- @tparam string corner The corner to use: auto, top_left, top_right, bottom_left,
+-- bottom_right, left, right, top bottom. Default is auto, and auto find the
+-- nearest corner.
+-- @treturn string The corner name
+-- @treturn number x The horizontal position
+-- @treturn number y The vertical position
+function module.corner(c, corner)
+    gdebug.deprecate(
+        "Use awful.placement.closest_corner(mouse) or awful.placement[corner](mouse)"..
+        " instead of awful.mouse.client.corner", {deprecated_in=4}
+    )
+
+    c = c or capi.client.focus
+    if not c then return end
+
+    local ngeo = nil
+
+    if (not corner) or corner == "auto" then
+        ngeo, corner = aplace.closest_corner(mouse, {parent = c})
+    elseif corner and aplace[corner] then
+        ngeo = aplace[corner](mouse, {parent = c})
+    end
+
+    return corner, ngeo and ngeo.x or nil, ngeo and ngeo.y or nil
+end
+
+--- Resize a client.
+-- @staticfct awful.mouse.client.resize
+-- @param c The client to resize, or the focused one by default.
+-- @tparam string corner The corner to grab on resize. Auto detected by default.
+-- @tparam[opt={}] table args A set of `awful.placement` arguments
+-- @treturn string The corner (or side) name
+function module.resize(c, corner, args)
+    c = c or capi.client.focus
+
+    if not c then return end
+
+    if c.fullscreen
+        or c.maximized
+        or c.type == "desktop"
+        or c.type == "splash"
+        or c.type == "dock" then
+        return
+    end
+
+    -- Set some default arguments
+    local new_args = setmetatable(
+        {
+            include_sides = (not args) or args.include_sides ~= false
+        },
+        {
+            __index = args or {}
+        }
+    )
+
+    -- Move the mouse to the corner
+    if corner and aplace[corner] then
+        aplace[corner](capi.mouse, {parent=c})
+    else
+        local _
+        _, corner = aplace.closest_corner(capi.mouse, {
+            parent        = c,
+            include_sides = new_args.include_sides ~= false,
+        })
+    end
+
+    new_args.corner = corner
+
+    mresize(c, "mouse.resize", new_args)
+
+    return corner
+end
+
+return module

--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -7,7 +7,7 @@
 ---------------------------------------------------------------------------
 
 -- Grab environment we need
-local layout = require("awful.layout")
+local floating = require("awful.layout.suit.floating")
 local aplace = require("awful.placement")
 local gdebug = require("gears.debug")
 local type = type
@@ -241,7 +241,7 @@ function mouse.resize_handler(c, context, hints)
         local t = c.screen.selected_tag
         local lay = t and t.layout or nil
 
-        if (lay and lay == layout.suit.floating) or c.floating then
+        if (lay and lay == floating) or c.floating then
             c:geometry {
                 x      = hints.x,
                 y      = hints.y,
@@ -262,9 +262,9 @@ mouse.resize.add_enter_callback(function(c, args) --luacheck: no unused args
     if c.floating then return end
 
     local l = c.screen.selected_tag and c.screen.selected_tag.layout or nil
-    if l == layout.suit.floating then return end
+    if l == floating then return end
 
-    if l ~= layout.suit.floating and l.mouse_resize_handler then
+    if l.mouse_resize_handler then
         capi.mousegrabber.stop()
 
         local geo, corner = aplace.closest_corner(capi.mouse, {parent=c})

--- a/lib/awful/mouse/resize.lua
+++ b/lib/awful/mouse/resize.lua
@@ -10,8 +10,9 @@
 ---------------------------------------------------------------------------
 
 local aplace = require("awful.placement")
-local capi = {mousegrabber = mousegrabber}
+local capi = {mousegrabber = mousegrabber, client = client}
 local beautiful = require("beautiful")
+local floating = require("awful.layout.suit.floating")
 
 local module = {}
 
@@ -228,6 +229,28 @@ local function handler(_, client, context, args) --luacheck: no unused_args
         return false
     end, cursor)
 end
+
+function module._resize_handler(c, context, hints)
+    if hints and context and context:find("mouse.*") then
+        -- This handler only handle the floating clients. If the client is tiled,
+        -- then it let the layouts handle it.
+        local t = c.screen.selected_tag
+        local lay = t and t.layout or nil
+
+        if (lay and lay == floating) or c.floating then
+            c:geometry {
+                x      = hints.x,
+                y      = hints.y,
+                width  = hints.width,
+                height = hints.height,
+            }
+        elseif lay and lay.resize_handler then
+            lay.resize_handler(c, context, hints)
+        end
+    end
+end
+
+capi.client.connect_signal("request::geometry", module._resize_handler)
 
 return setmetatable(module, {__call=handler})
 

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -392,31 +392,29 @@ local function geometry_common(obj, args, new_geo, ignore_border_width)
             and obj.coords(new_geo) or obj.coords()
         return {x=coords.x, y=coords.y, width=0, height=0}
     elseif obj.geometry then
-        local geo = obj.geometry
-
-        -- It is either a drawable or something that implement its API
-        if type(geo) == "function" then
-            local dgeo = area_common(
-                obj, fix_new_geometry(new_geo, args), ignore_border_width, args
-            )
-
-            -- Apply the margins
-            if args.margins then
-                local delta = get_decoration(args)
-
-                return {
-                    x      = dgeo.x      - (delta.left or 0),
-                    y      = dgeo.y      - (delta.top  or 0),
-                    width  = dgeo.width  + (delta.left or 0) + (delta.right  or 0),
-                    height = dgeo.height + (delta.top  or 0) + (delta.bottom or 0),
-                }
-            end
-
-            return dgeo
+        if obj.get_bounding_geometry then
+            -- It is a screen, it doesn't support setting new sizes.
+            return obj:get_bounding_geometry(args)
         end
 
-        -- It is a screen, it doesn't support setting new sizes.
-        return obj:get_bounding_geometry(args)
+        -- It is either a drawable or something that implement its API
+        local dgeo = area_common(
+            obj, fix_new_geometry(new_geo, args), ignore_border_width, args
+        )
+
+        -- Apply the margins
+        if args.margins then
+            local delta = get_decoration(args)
+
+            return {
+                x      = dgeo.x      - (delta.left or 0),
+                y      = dgeo.y      - (delta.top  or 0),
+                width  = dgeo.width  + (delta.left or 0) + (delta.right  or 0),
+                height = dgeo.height + (delta.top  or 0) + (delta.bottom or 0),
+            }
+        end
+
+        return dgeo
     else
         assert(false, "Invalid object")
     end
@@ -1462,7 +1460,7 @@ function placement.next_to(d, args)
     args = add_context(args, "next_to")
     d    = d or capi.client.focus
 
-    local osize = type(d.geometry) == "function"  and d:geometry() or nil
+    local osize = type(d.geometry) == "function"  and d:geometry() or d.geometry
     local original_pos, original_anchors = args.preferred_positions, args.preferred_anchors
 
     if type(original_pos) == "string" then

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -89,7 +89,6 @@ local capi =
     mouse = mouse,
     client = client
 }
-local client = require("awful.client")
 local layout = require("awful.layout")
 local a_screen = require("awful.screen")
 local grect = require("gears.geometry").rectangle
@@ -938,7 +937,7 @@ function placement.no_overlap(c, args)
     local screen   = get_screen(c.screen or a_screen.getbycoord(geometry.x, geometry.y))
     local cls, curlay
     if client_on_selected_tags(c) then
-        cls = client.visible(screen)
+        cls = screen:get_clients(false)
         curlay = layout.get()
     else
         -- When placing a client on unselected tags, place it as if all tags of

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -89,7 +89,7 @@ local capi =
     mouse = mouse,
     client = client
 }
-local layout = require("awful.layout")
+local floating = require("awful.layout.suit.floating")
 local a_screen = require("awful.screen")
 local grect = require("gears.geometry").rectangle
 local gdebug = require("gears.debug")
@@ -938,7 +938,8 @@ function placement.no_overlap(c, args)
     local cls, curlay
     if client_on_selected_tags(c) then
         cls = screen:get_clients(false)
-        curlay = layout.get()
+        local t = screen.selected_tag
+        curlay = t.layout or floating
     else
         -- When placing a client on unselected tags, place it as if all tags of
         -- that client are selected.
@@ -955,7 +956,7 @@ function placement.no_overlap(c, args)
     for _, cl in pairs(cls) do
         if cl ~= c
            and cl.type ~= "desktop"
-           and (cl.floating or curlay == layout.suit.floating)
+           and (cl.floating or curlay == floating)
            and not (cl.maximized or cl.fullscreen) then
             areas = grect.area_remove(areas, area_common(cl))
         end

--- a/tests/test-resize.lua
+++ b/tests/test-resize.lua
@@ -1,6 +1,7 @@
 local test_client = require("_client")
 local placement = require("awful.placement")
 local amouse = require("awful.mouse")
+local wibox = require("wibox")
 local rounded_rect = require("gears.shape").rounded_rect
 
 local steps = {}
@@ -520,6 +521,51 @@ table.insert(steps, function()
     -- window size 0x0.
     assert(c:geometry().width == geo.width)
     assert(c:geometry().height == geo.height)
+    return true
+end)
+
+-- Test the wibox move.
+table.insert(steps, function()
+    local w = wibox {
+        visible = true,
+        width   = 100,
+        height  = 100,
+        bg      = "#ff00ff"
+    }
+
+    placement.centered(w)
+    placement.centered(mouse)
+
+    root.fake_input("button_press",1)
+    amouse.wibox.move(w)
+    mouse.coords {x = 100, y = 100}
+    root.fake_input("button_release",1)
+
+    return true
+end)
+
+-- Trigger floating client the mouse tiling.
+table.insert(steps, function()
+    -- Disable deprecation.
+    require("gears.debug").deprecate = function() end
+
+    local c = client.get()[1]
+
+    root.fake_input("button_press",1)
+    amouse.client.dragtotag.border(c, 10, function() end)
+    mouse.coords {x = c:geometry().x+10, y= c:geometry().y+10}
+    root.fake_input("button_release",1)
+
+    root.fake_input("button_press",1)
+    amouse.client.corner(c, "top_left")
+    mouse.coords {x = c:geometry().x+100, y= c:geometry().y+100}
+    root.fake_input("button_release",1)
+
+    root.fake_input("button_press",1)
+    amouse.client.corner(c, "auto")
+    mouse.coords {x = c:geometry().x+10, y= c:geometry().y+10}
+    root.fake_input("button_release",1)
+
     return true
 end)
 


### PR DESCRIPTION
These commits were part of the "API standardization part 4" PR, but that's blocked on "it's really boring, annoying, hard-not-to-regress-anything and I don't have time". The following commits are cherry-picked from it and could be merged sooner.

It refactor the code to have less internal dependencies (either on modules or behavior). It was required mostly because changing `c:geometry()` to `c.geometry` and other "legacy accessors" along with adding `append/remove` for "set once" list have some weird side effects.

Anyway, having less internal dependencies is a good thing.