### PR TITLE
Fix missing `self` parameter from signals.

### DIFF
--- a/docs/common/widget.ldoc
+++ b/docs/common/widget.ldoc
@@ -88,6 +88,7 @@
 
 --- When a mouse button is pressed over the widget.
 -- @signal button::press
+-- @tparam table self The current object instance itself.
 -- @tparam number lx The horizontal position relative to the (0,0) position in
 -- the widget.
 -- @tparam number ly The vertical position relative to the (0,0) position in the
@@ -118,6 +119,7 @@
 
 --- When a mouse button is released over the widget.
 -- @signal button::release
+-- @tparam table self The current object instance itself.
 -- @tparam number lx The horizontal position relative to the (0,0) position in
 -- the widget.
 -- @tparam number ly The vertical position relative to the (0,0) position in the
@@ -148,6 +150,7 @@
 
 --- When the mouse enter a widget.
 -- @signal mouse::enter
+-- @tparam table self The current object instance itself.
 -- @tparam table find_widgets_result The entry from the result of
 -- @{wibox.drawable:find_widgets} for the position that the mouse hit.
 -- @tparam wibox.drawable find_widgets_result.drawable The drawable containing
@@ -172,6 +175,7 @@
 
 --- When the mouse leave a widget.
 -- @signal mouse::leave
+-- @tparam table self The current object instance itself.
 -- @tparam table find_widgets_result The entry from the result of
 -- @{wibox.drawable:find_widgets} for the position that the mouse hit.
 -- @tparam wibox.drawable find_widgets_result.drawable The drawable containing


### PR DESCRIPTION
The `wibox.widget` common documentation from `docs/common/widget.ldoc` was missing the first `self` parameter on mouse signals.

For the backstory:

I tried to implement the `button::press` signal on a widget I'm working on but the `button` parameter wasn't giving me right values... I found out mouse event (every event actually) give `self` as first parameter.

I quickly tested with: 

```lua
my_widget:connect_signal('button::press', function (self) print('press', self == my_widget) end)
my_widget:connect_signal('button::release', function (self) print('release', self == my_widget) end)
my_widget:connect_signal('mouse::enter', function (self) print('enter', self == my_widget) end)
my_widget:connect_signal('mouse::leave', function (self) print('leave', self == my_widget) end)
```
```
enter   true
leave   true
enter   true
press   true
release true
leave   true
```