### PR TITLE
wibox.container.margin: Allow nonnegative dimensions

### DIFF
--- a/lib/wibox/container/margin.lua
+++ b/lib/wibox/container/margin.lua
@@ -48,7 +48,7 @@ function margin:layout(_, width, height)
         local resulting_width = width - x - w
         local resulting_height = height - y - h
 
-        if resulting_width > 0 and resulting_height > 0 then
+        if resulting_width >= 0 and resulting_height >= 0 then
             return { base.place_widget_at(self._private.widget, x, y, resulting_width, resulting_height) }
         end
     end


### PR DESCRIPTION
See #2951.
Commit f025409 avoided negative dimensions but 
also stopped allowing width and height to be zero.

For widgets like awful.widget.watch it is reasonable 
to allow dimensions to be zero because in many cases when 
the margin container is being calculated the watch widget is 
still computing and therefore has width and height zero.