### PR TITLE
Fix firefox example in awful.permissions

### DIFF
--- a/lib/awful/permissions/init.lua
+++ b/lib/awful/permissions/init.lua
@@ -218,7 +218,7 @@ end
 --
 --    awful.permissions.add_activate_filter(function(c)
 --        if c.class == "Firefox" then return false end
---    end, "permissions")
+--    end)
 --
 -- @tparam function f The callback
 -- @tparam[opt] string context The `request::activate` context


### PR DESCRIPTION
Was trying out the example and it didn't work until I removed the context string.