### PR TITLE
Fix prompt navigation

### DIFF
--- a/lib/awful/prompt.lua
+++ b/lib/awful/prompt.lua
@@ -170,7 +170,7 @@ local function history_check_load(id, max)
 end
 
 local function is_word_char(c)
-    if string.find("[{[(,.:;_-+=@/ ]", c) then
+    if string.find(c, "[{[(,.:;_-+=@/ ]") then
         return false
     else
         return true


### PR DESCRIPTION
1. Open any awful.prompt(mod+r or mod+x)
2. Type ()->
3. Press alt+b two times