### PR TITLE
Fix an `rc.lua` comment typo.

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -489,7 +489,7 @@ ruled.client.connect_signal("request::rules", function()
     }
 
     -- Set Firefox to always map on the tag named "2" on screen 1.
-    -- ruled.tag.append_rule {
+    -- ruled.client.append_rule {
     --     rule       = { class = "Firefox"     },
     --     properties = { screen = 1, tag = "2" }
     -- }


### PR DESCRIPTION
I don't know how it got there. Either copy/paste or find and replace
mistake.

Thanks to @Aire-One 