### PR TITLE
Fix awful.mouse.move/awful.mouse.resize

### DIFF
--- a/lib/awful/mouse/init.lua
+++ b/lib/awful/mouse/init.lua
@@ -177,7 +177,8 @@ end
 
 --- Move the wibox under the cursor.
 -- @staticfct awful.mouse.wibox.move
---@tparam wibox w The wibox to move, or none to use that under the pointer
+-- @tparam wibox w The wibox to move, or none to use that under the pointer
+-- @request wibox geometry mouse.move granted Requests to move the wibox.
 function mouse.wibox.move(w)
     w = w or mouse.current_wibox
     if not w then return end

--- a/lib/awful/mouse/resize.lua
+++ b/lib/awful/mouse/resize.lua
@@ -103,6 +103,7 @@ end
 -- @tparam client client A client.
 -- @tparam[default=mouse.resize] string context The resizing context.
 -- @tparam[opt={}] table args A set of `awful.placement` arguments.
+-- @request wibox geometry mouse.resize granted Requests to resize the wibox.
 local function handler(_, client, context, args) --luacheck: no unused_args
     args = args or {}
     context = context or "mouse.resize"

--- a/lib/awful/permissions/init.lua
+++ b/lib/awful/permissions/init.lua
@@ -18,6 +18,7 @@ local beautiful = require("beautiful")
 local alayout = require("awful.layout")
 local atag = require("awful.tag")
 local gdebug = require("gears.debug")
+local wibox = require("wibox")
 local pcommon = require("awful.permissions._common")
 
 local permissions = {
@@ -395,6 +396,20 @@ function permissions.geometry(c, context, hints)
     end
 end
 
+--- Move and resize the wiboxes.
+--
+-- This is the default geometry request handler.
+--
+-- @signalhandler awful.permissions.wibox_geometry
+-- @tparam wibox w The wibox.
+-- @tparam string context The context
+-- @tparam[opt={}] table hints The hints to pass to the handler
+function permissions.wibox_geometry(w, context, hints)
+    if not pcommon.check(w, "wibox", "geometry", context) then return end
+
+    w:geometry(hints)
+end
+
 --- Merge the 2 requests sent by clients wanting to be maximized.
 --
 -- The X clients set 2 flags (atoms) when they want to be maximized. This caused
@@ -711,6 +726,8 @@ client.connect_signal("untagged"               , check_focus_delayed)
 client.connect_signal("property::hidden"       , check_focus_delayed)
 client.connect_signal("property::minimized"    , check_focus_delayed)
 client.connect_signal("property::sticky"       , check_focus_delayed)
+
+wibox.connect_signal("request::geometry"       , permissions.wibox_geometry)
 
 tag.connect_signal("property::selected", function (t)
     timer.delayed_call(check_focus_tag, t)

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -399,6 +399,32 @@ end
 -- @param wibox
 -- @method draw
 
+--- Connect a global signal on the wibox class.
+--
+-- Functions connected to this signal source will be executed when any
+-- wibox object emits the signal.
+--
+-- It is also used for some generic wibox signals such as
+-- `request::geometry`.
+--
+-- @tparam string name The name of the signal
+-- @tparam function func The function to attach
+-- @staticfct wibox.connect_signal
+-- @usage wibox.connect_signal("added", function(notif)
+--    -- do something
+-- end)
+
+--- Emit a wibox signal.
+-- @tparam string name The signal name.
+-- @param ... The signal callback arguments
+-- @staticfct wibox.emit_signal
+
+--- Disconnect a signal from a source.
+-- @tparam string name The name of the signal
+-- @tparam function func The attached function
+-- @staticfct wibox.disconnect_signal
+-- @treturn boolean If the disconnection was successful
+
 function wibox.mt:__call(...)
     return new(...)
 end

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -310,8 +310,9 @@ local function new(args)
         ret._drawable:_inform_visible(w.visible)
     end)
 
+    --TODO v5 deprecate this and use `wibox.object`.
     for k, v in pairs(wibox) do
-        if type(v) == "function" then
+        if (not rawget(ret, k)) and type(v) == "function" then
             ret[k] = v
         end
     end

--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -388,6 +388,9 @@ local function new(args)
         ret.input_passthrough = args.input_passthrough
     end
 
+    -- Make sure all signals bubble up
+    ret:_connect_everything(wibox.emit_signal)
+
     return ret
 end
 
@@ -408,6 +411,8 @@ object.properties(capi.drawin, {
 })
 
 capi.drawin.object = wibox.object
+
+object._setup_class_signals(wibox)
 
 return setmetatable(wibox, wibox.mt)
 

--- a/spec/awful/permissions_spec.lua
+++ b/spec/awful/permissions_spec.lua
@@ -14,6 +14,13 @@ describe("awful.permissions.client_geometry_requests", function()
     _G.tag = {
         connect_signal = function() end,
     }
+    _G.awesome = {
+        connect_signal = function() end,
+    }
+    _G.drawin = {
+        set_index_miss_handler    = function() end,
+        set_newindex_miss_handler = function() end
+    }
 
     local permissions = require("awful.permissions")
 


### PR DESCRIPTION
These methods have been broken for a while. There is tests actually calling them, but it doesn't check that they actually worked. There was recent change to this code and I assumed I regressed something, but no, it was just already broken.

Fix #2971 
