### PR TITLE
Fix missing `self` parameter in `awful.keygrabber` documentation usage examples.

### DIFF
--- a/lib/awful/keygrabber.lua
+++ b/lib/awful/keygrabber.lua
@@ -615,13 +615,13 @@ end
 -- @tparam table mod The current modifiers (like "Control" or "Shift").
 -- @tparam string key The key name.
 -- @tparam string event The event ("press" or "release").
--- @usage local function my_keypressed_cb(mod, key, command)
+-- @usage local function my_keypressed_cb(self, mod, key, command)
 --    -- do something
 -- end
 
 --- The callback function to call with mod table, key and command as arguments
 -- when a key was released.
--- @usage local function my_keyreleased_cb(mod, key, command)
+-- @usage local function my_keyreleased_cb(self, mod, key, command)
 --    -- do something
 -- end
 -- @callback keyreleased_callback


### PR DESCRIPTION
Fix usage example in `awful.keygrabber`. Callback usage examples misses the `self` argument.

Source: https://www.reddit.com/r/awesomewm/comments/eumpbp/help_awfulkeygrabber/