### PR TITLE
naughty: Check if notification.box exists before destroy

### DIFF
--- a/lib/naughty.lua.in
+++ b/lib/naughty.lua.in
@@ -207,7 +207,7 @@ end
 -- @param notification Notification object to be destroyed
 -- @return True if the popup was successfully destroyed, nil otherwise
 function destroy(notification)
-    if notification and notification.box.screen then
+    if notification and notification.box and notification.box.screen then
         if suspended then
             for k, v in pairs(notifications.suspended) do
                 if v.box == notification.box then


### PR DESCRIPTION
If the notification object is set to `{}` the destroy function will trigger an error

Signed-off-by: Aurélien LAJOIE <aurelien.lajoie@manomano.com>