### PR TITLE
Cleanup tag history on screen removal

### DIFF
--- a/lib/awful/tag.lua
+++ b/lib/awful/tag.lua
@@ -1676,6 +1676,7 @@ capi.screen.connect_signal("removed", function(s)
             t.data.awful_tag_properties.screen = nil
         end
     end
+    data.history[s] = nil
 end)
 
 function tag.mt:__call(...)

--- a/tests/test-leaks.lua
+++ b/tests/test-leaks.lua
@@ -81,6 +81,16 @@ collectable(awful.widget.tasklist{screen=1, filter=awful.widget.tasklist.filter.
 prepare_for_collect = run_delayed_calls
 collectable(create_wibox())
 
+-- Test that screens can be collected
+local function create_and_remove_screen()
+    local s = screen.fake_add(-10, -10, 10, 10)
+    awful.tag.viewnext(s)
+    s:fake_remove()
+    return s
+end
+prepare_for_collect = run_delayed_calls
+collectable(create_and_remove_screen())
+
 runner.run_steps({ function() return true end })
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The tag history kept a strong reference to a screen even after that
screen was removed. This prevented the garbage collector from cleaning
up.

Fix this by getting rid of the tag history on screen removal.

Related-to: https://github.com/awesomeWM/awesome/issues/2983#issuecomment-584249568
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

Seems like no one created this PR for me yet, so I have to do it myself.