### PR TITLE
Add keygroups, abbreviate cheatsheet, add ways to select a layout directly

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -372,6 +372,33 @@ awful.keyboard.append_global_keybindings({
                 end
             end
         end,
+    },
+    awful.key {
+        modifiers   = { modkey },
+        keygroup    = "numpad",
+        description = "select layout directly",
+        group       = "layout",
+        on_press    = function (index)
+            local everylayout = {
+                KP_End      = awful.layout.suit.corner.sw,
+                KP_Down     = awful.layout.suit.tile.top,
+                KP_Next     = awful.layout.suit.corner.se,
+                KP_Left     = awful.layout.suit.tile,
+                KP_Begin    = awful.layout.suit.magnifier,
+                KP_Right    = awful.layout.suit.tile.left,
+                KP_Home     = awful.layout.suit.corner.nw,
+                KP_Up       = awful.layout.suit.tile.bottom,
+                KP_Prior    = awful.layout.suit.corner.ne,
+                KP_Insert   = awful.layout.suit.floating,
+                KP_Delete   = awful.layout.suit.max,
+                KP_Divide   = awful.layout.suit.fair,
+                KP_Multiply = awful.layout.suit.spiral,
+                KP_Subtract = awful.layout.suit.fair.horizontal,
+                KP_Add      = awful.layout.suit.spiral.dwindle,
+                KP_Enter    = awful.layout.suit.max.fullscreen
+            }
+            awful.layout.set(everylayout[index])
+        end,
     }
 })
 

--- a/lib/awful/hotkeys_popup/keys/firefox.lua
+++ b/lib/awful/hotkeys_popup/keys/firefox.lua
@@ -19,7 +19,7 @@ local firefox_keys = {
     ["Firefox: tabs"] = {{
         modifiers = { "Mod1" },
         keys = {
-            ["1..9"] = "go to tab"
+            ["1…9"] = "go to tab"
         }
     }, {
         modifiers = { "Ctrl" },

--- a/lib/awful/hotkeys_popup/keys/tmux.lua
+++ b/lib/awful/hotkeys_popup/keys/tmux.lua
@@ -53,7 +53,7 @@ local tmux_keys = {
             --['&']     = "close current window",
             p         = "previous window",
             n         = "next window",
-            ['0...9'] = "select window by number"
+            ['0…9'] = "select window by number"
         }
     }},
 
@@ -65,7 +65,7 @@ local tmux_keys = {
             ['"']       = "split pane horizontally",
             ['{']       = "move the current pane left",
             ['}']       = "move the current pane right",
-            ['q 0...9'] = "select pane by number",
+            ['q 0…9'] = "select pane by number",
             o           = "toggle between panes",
             z           = "toggle pane zoom",
             ['space']   = "toggle between layouts",

--- a/lib/awful/key.lua
+++ b/lib/awful/key.lua
@@ -32,6 +32,11 @@ local gobject = require("gears.object")
 --   and its derivative. This is usually the number 1-9 followed by 0.
 -- * **arrows**: The Left/Right/Top/Bottom keys usually located right of the
 --   spacebar.
+-- * **numpad**: Often to the right side of the keyboard, sometimes part of
+--   the alphabet keys and can only be accessed holding the Fn key.
+--   Includes every key but Num Lock.
+-- * **fkeys**: The function keys in the top row of the keyboard, spanning
+--   from F1 to F12.
 --
 -- @property keygroup
 
@@ -299,19 +304,43 @@ local function new_common(mod, _keys, press, release, data)
 end
 
 local keygroups = {
+    -- Left: the keycode in a format which regular awful.key understands.
+    -- Right: the argument of the function ran upon executing the key binding.
     numrow = {},
     arrows = {
         {"Left"  , "Left"  },
         {"Right" , "Right" },
-        {"Top"   , "Top"   },
-        {"Bottom", "Bottom"},
-    }
+        {"Up"    , "Up"    },
+        {"Down"  , "Down"  },
+    },
+    numpad = {
+        {"KP_End"     , "KP_End"     },
+        {"KP_Down"    , "KP_Down"    },
+        {"KP_Next"    , "KP_Next"    },
+        {"KP_Left"    , "KP_Left"    },
+        {"KP_Begin"   , "KP_Begin"   },
+        {"KP_Right"   , "KP_Right"   },
+        {"KP_Home"    , "KP_Home"    },
+        {"KP_Up"      , "KP_Up"      },
+        {"KP_Prior"   , "KP_Prior"   },
+        {"KP_Insert"  , "KP_Insert"  },
+        {"KP_Delete"  , "KP_Delete"  },
+        {"KP_Divide"  , "KP_Divide"  },
+        {"KP_Multiply", "KP_Multiply"},
+        {"KP_Subtract", "KP_Subtract"},
+        {"KP_Add"     , "KP_Add"     },
+        {"KP_Enter"   , "KP_Enter"   },
+    },
+    fkeys = {}
 }
 
 -- Technically, this isn't very popular, but we have been doing this for 12
 -- years and nobody complained too loudly.
 for i = 1, 10 do
     table.insert(keygroups.numrow, {"#" .. i + 9, i == 10 and 0 or i})
+end
+for i = 1, 12 do
+    table.insert(keygroups.fkeys, {"F" .. i, "F" .. i})
 end
 
 -- Allow key objects to provide more than 1 key.

--- a/lib/awful/key.lua
+++ b/lib/awful/key.lua
@@ -303,7 +303,7 @@ local function new_common(mod, _keys, press, release, data)
     return setmetatable(ret, obj_mt)
 end
 
-local keygroups = {
+key.keygroups = {
     -- Left: the keycode in a format which regular awful.key understands.
     -- Right: the argument of the function ran upon executing the key binding.
     numrow = {},
@@ -337,10 +337,10 @@ local keygroups = {
 -- Technically, this isn't very popular, but we have been doing this for 12
 -- years and nobody complained too loudly.
 for i = 1, 10 do
-    table.insert(keygroups.numrow, {"#" .. i + 9, i == 10 and 0 or i})
+    table.insert(key.keygroups.numrow, {"#" .. i + 9, i == 10 and 0 or i})
 end
 for i = 1, 12 do
-    table.insert(keygroups.fkeys, {"F" .. i, "F" .. i})
+    table.insert(key.keygroups.fkeys, {"F" .. i, "F" .. i})
 end
 
 -- Allow key objects to provide more than 1 key.
@@ -355,8 +355,8 @@ local function get_keys(args)
         "Please provide either the `key` or `keygroup` property, not both"
     )
 
-    assert(keygroups[args.keygroup], "Please provide a valid keygroup")
-    return keygroups[args.keygroup]
+    assert(key.keygroups[args.keygroup], "Please provide a valid keygroup")
+    return key.keygroups[args.keygroup]
 end
 
 function key.new(args, _key, press, release, data)


### PR DESCRIPTION
The first commit is just a quick fix to avoid critical errors every time I'm testing `master`. It doesn't seem to break anything.

The second commit revolves around adding a new method to change layouts: besides pressing Super+Space and cycling through the layouts in the main list, one can choose directly a layout by pressing Super and a key in the numeric keypad.

There's a mnemonic method for most keys:

- 1, 7, 9 and 3 lay out the master zone on the corresponding corner (so they set the layout to `corner.sw`, `corner.nw`, `corner.ne` and `corner.se`, respectively).
- 8, 4, 2, 6 lay out the master zone on the corresponding side (so they choose `tile.bottom`, `tile`, `tile.right` and `tile.top`.
- 5 is `magnifier`, with the master zone on the middle.
- 0 is "zero gravity", i.e. `floating`.
- Return is `max.fullscreen` because it's one of the most promiment keys
- The decimal dot besides `max.fullscreen` is `max`.

The third commit adds a method to abbreviate long rows of keys with the same shortcut (F1/F2/F3/F4/F5/F6/F7 would contract to F1…F7) and adds some more aliases for keys. There's still a problem in that keycodes `#10` to `#21` will be printed as `1234567890'=` despite the current keyboard layout (like in Spain, where `#21` maps to `¡`). A function like xev's XLookupString would be needed to print the actual character.

I tested this code manually, but I expect to rewrite some code to improve some minor things. I'd appreciate any suggestion.
