### PR TITLE
Fix the keyboard widget

### DIFF
--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -252,6 +252,9 @@ local function update_layout(self)
     update_status(self)
 end
 
+--- Select the next layout.
+-- @method next_layout
+
 --- Create a keyboard layout widget.
 --
 -- It shows current keyboard layout name in a textbox.

--- a/lib/awful/widget/keyboardlayout.lua
+++ b/lib/awful/widget/keyboardlayout.lua
@@ -260,7 +260,7 @@ end
 -- @return A keyboard layout widget.
 function keyboardlayout.new()
     local widget = textbox()
-    local self = widget_base.make_widget(widget)
+    local self = widget_base.make_widget(widget, nil, {enable_properties=true})
 
     self.widget = widget
 

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -684,8 +684,15 @@ end
 -- @constructorfct wibox.widget.base.make_widget
 function base.make_widget(proxy, widget_name, args)
     args = args or {}
+
+    local prop_default = args.enable_properties ~= false
+
+    if awesome.api_level < 5 then
+        prop_default = args.enable_properties
+    end
+
     local ret = object {
-        enable_properties = args.enable_properties,
+        enable_properties = prop_default,
         class             = args.class,
     }
 

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -765,6 +765,13 @@ function base.make_widget(proxy, widget_name, args)
 
             return rawget(ret, key)
         end
+        mt.__newindex = function(_, key, value)
+            if key == "buttons" then
+                base.widget.set_buttons(ret, value)
+            else
+                rawset(ret, key, value)
+            end
+        end
     end
 
     return setmetatable(ret, mt)

--- a/spec/wibox/test_utils.lua
+++ b/spec/wibox/test_utils.lua
@@ -10,6 +10,8 @@ local say = require("say")
 local assert = require("luassert")
 local no_parent = base.no_parent_I_know_what_I_am_doing
 
+_G.awesome.api_level = 9999
+
 -- {{{ Own widget-based assertions
 local function widget_fit(state, arguments)
     if #arguments ~= 3 then


### PR DESCRIPTION
The reason `buttons` was no longer working is mostly bitrot. That widget, along with the systray and textclock, are among the last remaining v3.5 era widgets which were not modernized at some point or another.