### PR TITLE
Added support for custom text for layouts in layoutbox

### DIFF
--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -32,8 +32,9 @@ local function update(w, screen)
     w._layoutbox_tooltip:set_text(name or "[no name]")
 
     local img = surface.load_silently(beautiful["layout_" .. name], false)
+    local text = beautiful["layout_" .. name .. "_text"]
     w.imagebox.image = img
-    w.textbox.text   = img and "" or name
+    w.textbox.text   = img and "" or text or name
 end
 
 local function update_from_tag(t)


### PR DESCRIPTION
If theme variable beautiful.layout_LAYOUTTEXT_text is set for a layout instead of the default name showing it will show the custom text set in the variable.
Precedents is still to the layout image meaning custom text will only be shown if there is no img already set. With no image or custom text set it will still use the layout name.

Use Case: you don't want to use images and would rather use a font like nerdfonts for your icons.

I couldn't find the documentation source for https://awesomewm.org/doc/api/libraries/awful.layout.html so I haven't updated the documentation to show the new theme variables. If anyone could tell me where its located so I could add them it would be greatly appreciated.

If you want anything changed just ask. 
