### PR TITLE
naughty.widget: xml_escape message and title text

### DIFF
--- a/lib/naughty/widget/message.lua
+++ b/lib/naughty/widget/message.lua
@@ -16,12 +16,13 @@
 ----------------------------------------------------------------------------
 local textbox = require("wibox.widget.textbox")
 local gtable  = require("gears.table")
+local gstring = require("gears.string")
 local beautiful = require("beautiful")
 
 local message = {}
 
 local function markup(notif, wdg)
-    local ret = notif.message or ""
+    local ret = gstring.xml_escape(notif.message) or ""
     local fg = notif.fg or beautiful.notification_fg
 
     wdg:set_font(notif.font or beautiful.notification_font)

--- a/lib/naughty/widget/title.lua
+++ b/lib/naughty/widget/title.lua
@@ -16,12 +16,13 @@
 ----------------------------------------------------------------------------
 local textbox = require("wibox.widget.textbox")
 local gtable  = require("gears.table")
+local gstring = require("gears.string")
 local beautiful = require("beautiful")
 
 local title = {}
 
 local function markup(notif, wdg)
-    local ret = "<b>"..(notif.title or "").."</b>"
+    local ret = "<b>"..(gstring.xml_escape(notif.title) or "").."</b>"
     local fg = notif.fg or beautiful.notification_fg
 
     wdg:set_font(notif.font or beautiful.notification_font)


### PR DESCRIPTION
fixes empty notifications when special characters like '&' are used