### PR TITLE
[RFC] Redesign how notification icons are handled.

### DIFF
--- a/lib/gears/object.lua
+++ b/lib/gears/object.lua
@@ -134,7 +134,8 @@ function object:emit_signal(name, ...)
     end
 end
 
-function object._setup_class_signals(t)
+function object._setup_class_signals(t, args)
+    args = args or {}
     local conns = {}
 
     function t.connect_signal(name, func)
@@ -142,6 +143,18 @@ function object._setup_class_signals(t)
         conns[name] = conns[name] or {}
         table.insert(conns[name], func)
     end
+
+    -- A variant of emit_signal which stops once a condition is met.
+    if args.allow_chain_of_responsibility then
+        function t._emit_signal_if(name, condition, ...)
+            assert(name)
+            for _, func in pairs(conns[name] or {}) do
+                if condition(...) then return end
+                func(...)
+            end
+        end
+    end
+
 
     --- Emit a notification signal.
     -- @tparam string name The signal name.

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -561,9 +561,18 @@ naughty.connect_signal("request::screen", naughty.default_screen_handler)
 -- If an icon is found, the handler must set the `icon` property on the `action`
 -- object to a path or a `gears.surface`.
 --
--- @signal request::icon
+-- There is no implementation by default. To use the XDG-icon, the common
+-- implementation will be:
+--
+--    naughty.connect_signal("request::action_icon", function(a, context, hints)
+--         a.icon = menubar.utils.lookup_icon(hints.id)
+--    end)
+--
+-- @signal request::action_icon
 -- @tparam naughty.action action The action.
--- @tparam string icon_name The icon name.
+-- @tparam string context The context.
+-- @tparam table hints
+-- @tparam string args.id The action id. This will often by the (XDG) icon name.
 
 --- Emitted when the screen is not defined or being removed.
 -- @signal request::screen

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -274,7 +274,9 @@ function naughty.suspend()
     properties.suspended = true
 end
 
-local conns = gobject._setup_class_signals(naughty)
+local conns = gobject._setup_class_signals(
+    naughty, {allow_chain_of_responsibility=true}
+)
 
 local function resume()
     properties.suspended = false

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -594,6 +594,7 @@ naughty.connect_signal("request::screen", naughty.default_screen_handler)
 -- * path
 -- * image
 -- * images
+-- * dbus_clear
 --
 -- For example, an implementation which uses the `app_icon` to perform an XDG
 -- icon lookup will look like:
@@ -798,11 +799,21 @@ function naughty.icon_path_handler(self, context, hints)
     )
 end
 
+--- Request handler for clearing the icon when asked by ie, DBus.
+-- @signalhandler naughty.icon_clear_handler
+function naughty.icon_clear_handler(self, context, hints) --luacheck: no unused args
+    if context ~= "dbus_clear" then return end
+
+    self._private.icon = nil
+    self:emit_signal("property::icon")
+end
+
 naughty.connect_signal("property::screen"  , update_index)
 naughty.connect_signal("property::position", update_index)
 
 naughty.connect_signal("request::icon", naughty.client_icon_handler)
 naughty.connect_signal("request::icon", naughty.icon_path_handler  )
+naughty.connect_signal("request::icon", naughty.icon_clear_handler )
 
 --@DOC_signals_COMMON@
 

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -574,6 +574,43 @@ naughty.connect_signal("request::screen", naughty.default_screen_handler)
 -- @tparam table hints
 -- @tparam string args.id The action id. This will often by the (XDG) icon name.
 
+--- Emitted when a notification icon could not be loaded.
+--
+-- When an icon is passed in some "encoded" formats, such as XDG icon names or
+-- network URLs, AwesomeWM will not attempt to load it. If you wish to see the
+-- icon displayed, you must provide an handler. It is highly recommended for
+-- handler to only set `n.icon` when they *found* the icon. That way multiple
+-- handlers can be attached for multiple protocols.
+--
+-- The `context` argument is the origin of the icon to decode. If an handler
+-- only supports one if them, it should check the `context` and return if it
+-- doesn't handle it. The currently valid contexts are:
+--
+-- * app_icon
+-- * clients
+-- * image
+-- * images
+--
+-- For example, an implementation which uses the `app_icon` to perform an XDG
+-- icon lookup will look like:
+--
+--    naughty.connect_signal("request::icon", function(n, context, hints)
+--        if context ~= "app_icon" then return end
+--
+--        local path = menubar.utils.lookup_icon(hints.app_icon) or
+--            menubar.utils.lookup_icon(hints.app_icon:lower())
+--
+--        if path then
+--            n.icon = path
+--        end
+--    end)
+--
+-- @signal request::icon
+-- @tparam notification n The notification.
+-- @tparam string context The source of the icon to look for.
+-- @tparam table hints The hints.
+-- @tparam string hints.app_icon The name of the icon to look for.
+
 --- Emitted when the screen is not defined or being removed.
 -- @signal request::screen
 -- @tparam table notification The `naughty.notification` object. This is

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -326,8 +326,12 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
             -- Update the icon if necessary.
             if app_icon ~= notification._private.app_icon then
                 notification._private.app_icon = app_icon
-                notification._private.icon = nil
-                notification:emit_signal("property::icon")
+
+                naughty._emit_signal_if(
+                    "request::icon", function()
+                        if notification._private.icon then return true end
+                    end, notification, "dbus_clear", {}
+                )
             end
 
             -- Even if no property changed, restart the timeout.

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -173,7 +173,7 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
                 -- and `naughty` doesn't depend on `menubar`, so delegate the
                 -- icon "somewhere" using a request.
                 if hints["action-icons"] and action_id ~= "" then
-                    naughty.emit_signal("request::icon", a, action_id)
+                    naughty.emit_signal("request::action_icon", a, "dbus", {id = action_id})
                 end
 
                 a:connect_signal("invoked", function()

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -647,6 +647,11 @@ for _, prop in ipairs { "category", "resident" } do
     end
 end
 
+-- Stop the request::icon when one is found.
+local function request_filter(self, _, _)
+    if self._private.icon then return true end
+end
+
 function notification.get_icon(self)
     -- Honor all overrides.
     if self._private.icon then
@@ -689,7 +694,7 @@ function notification.get_icon(self)
     -- understand.
     if err then
         local ctx = self._private.app_icon and "app_icon" or "image"
-        naughty.emit_signal("request::icon", self, ctx, {
+        naughty._emit_signal_if("request::icon", request_filter, self, ctx, {
             app_icon = self._private.app_icon,
             image    = self.image
         })

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -23,6 +23,7 @@ local gfs      = require("gears.filesystem")
 local cst      = require("naughty.constants")
 local naughty  = require("naughty.core")
 local gdebug   = require("gears.debug")
+local pcommon = require("awful.permissions._common")
 
 local notification = {}
 
@@ -648,7 +649,8 @@ for _, prop in ipairs { "category", "resident" } do
 end
 
 -- Stop the request::icon when one is found.
-local function request_filter(self, _, _)
+local function request_filter(self, context, _)
+    if not pcommon.check(self, "notification", "icon", context) then return true end
     if self._private.icon then return true end
 end
 
@@ -1010,6 +1012,22 @@ local function create(args)
 
     return n
 end
+
+--- Grant a permission for a notification.
+--
+-- @method grant
+-- @tparam string permission The permission name (just the name, no `request::`).
+-- @tparam string context The reason why this permission is requested.
+-- @see awful.permissions
+
+--- Deny a permission for a notification
+--
+-- @method deny
+-- @tparam string permission The permission name (just the name, no `request::`).
+-- @tparam string context The reason why this permission is requested.
+-- @see awful.permissions
+
+pcommon.setup_grant(notification, "notification")
 
 -- This allows notification to be updated later.
 local counter = 1

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -648,31 +648,54 @@ for _, prop in ipairs { "category", "resident" } do
 end
 
 function notification.get_icon(self)
+    -- Honor all overrides.
     if self._private.icon then
         return self._private.icon == "" and nil or self._private.icon
-    elseif self.image and self.image ~= "" then
-        return self.image
-    elseif self._private.app_icon and self._private.app_icon ~= "" then
-        return self._private.app_icon
     end
 
+    local ret = nil
+
+    -- First, check if the image is passed as a surface or a path.
+    if self.image and self.image ~= "" then
+        ret = self.image
+    elseif self._private.app_icon and self._private.app_icon ~= "" then
+        ret = self._private.app_icon
+    end
+
+    local s, err = nil, nil
+
+    -- See if this is a valid path.
+    if ret and ret ~= "" then
+        s, err = gsurface.load_silently(ret)
+    end
+
+    if s and not err then
+        return s
+    end
+
+    -- The second fallback are the client(s) icon(s).
     local clients = notification.get_clients(self)
 
-    for _, c in ipairs(clients) do
-        if c.type == "normal" then
-            self._private.icon = gsurface(c.icon)
-            return self._private.icon
+    for _, t in ipairs { "normal", "dialog" } do
+        for _, c in ipairs(clients) do
+            if c.type == t then
+                self._private.icon = gsurface(c.icon) --TODO support other size
+                return self._private.icon
+            end
         end
     end
 
-    for _, c in ipairs(clients) do
-        if c.type == "dialog" then
-            self._private.icon = gsurface(c.icon)
-            return self._private.icon
-        end
+    -- Now, it might be an XDG icon name or something a request handler can
+    -- understand.
+    if err then
+        local ctx = self._private.app_icon and "app_icon" or "image"
+        naughty.emit_signal("request::icon", self, ctx, {
+            app_icon = self._private.app_icon,
+            image    = self.image
+        })
     end
 
-    return nil
+    return self._private.icon == "" and nil or self._private.icon
 end
 
 function notification.get_clients(self)

--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -892,10 +892,9 @@ local icon_requests = {}
 table.insert(steps, function()
     assert(#active == 0)
 
-    naughty.connect_signal("request::icon", function(a, icon_name)
-        icon_requests[icon_name] = a
-
-        a.icon = icon_name == "list-add" and small_icon or big_icon
+    naughty.connect_signal("request::action_icon", function(a, context, hints)
+        icon_requests[hints.id] = a
+        a.icon = hints.id == "list-add" and small_icon or big_icon
     end)
 
     local hints = {

--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -897,6 +897,10 @@ table.insert(steps, function()
         a.icon = hints.id == "list-add" and small_icon or big_icon
     end)
 
+    naughty.connect_signal("request::icon", function(n, context, hints)
+        icon_requests[n] = true
+    end)
+
     local hints = {
         ["action-icons"] = GLib.Variant("b", true),
     }
@@ -911,6 +915,8 @@ table.insert(steps, function()
     if #active ~= 1 then return end
 
     local n = active[1]
+
+    assert(not icon_requests[n])
 
     assert(n._private.freedesktop_hints)
     assert(n._private.freedesktop_hints["action-icons"] == true)
@@ -952,9 +958,10 @@ table.insert(steps, function()
     gdebug.deprecate = function() end
 
     local n = naughty.notification {
-        title   = "foo",
-        message = "bar",
-        timeout = 25000,
+        title    = "foo",
+        message  = "bar",
+        timeout  = 25000,
+        app_icon = "baz"
     }
 
     -- Make sure the suspension don't cause errors
@@ -980,6 +987,7 @@ table.insert(steps, function()
     assert(not naughty.suspended)
 
     -- Replace the text
+    assert(icon_requests[n])
     assert(n.title   == "foo")
     assert(n.message == "bar")
     assert(n.text    == "bar")

--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -968,7 +968,7 @@ table.insert(steps, function()
 
     local n = active[1]
 
-    assert(not icon_requests[n])
+    assert(icon_requests[n])
 
     assert(n._private.freedesktop_hints)
     assert(n._private.freedesktop_hints["action-icons"] == true)


### PR DESCRIPTION
(WARNING: This breaks unreleased APIs)

Following some recent problems with how icons are handled in the new notification API, I redesigned it. It became clear from all the bug reports and recent Reddit thread that the old/current design wont scale. Icons can come in ~15 different format or protocols. My previous rewrite supported 4 and the old API supported 6. In either case, the problem remain: some people wont be happy.

As usual, when something is too complex to hide in the private implementation, I ported it to the `request::` API. With this PR, it becomes possible to plug new handlers to support more notification icons. All existing code has been moved to handlers.

For example, it is now possible to add an handler to support icons passed with an HTTPS URI rather than a local file. It is also possible to use the permission system to control which kind of handler can be used for each notification.

A documented example shows how to enable XDG icon lookup. The legacy API had a very broken implementation of this built-in (`awful.util.geticonpath`), but it failed more than 60% of the time. The example shows how to use the menubar implementation of the XDG icon spec. An even better alternative would be to use GTK own implementation through LGI. I don't plan to enable XDG lookup by default for the next few releases. Our current implementations (we have 3!) are all badly unsalvageable. The day will come when someone brave enough assemble all the pieces into a coherent and fast implementation. If you read this, you can be this Hero, I wont be.

@elenapan @manilarome Please review / comment on the changes. It breaks the API a little bit (`request::icon` was used for notification actions and it was moved to `request::action_icon`). You input is also generally welcome since you use this the most.