### PR TITLE
add additional match for firefox in awful.hotkeys_popup/keys/firefox.lua

### DIFF
--- a/lib/awful/hotkeys_popup/keys/firefox.lua
+++ b/lib/awful/hotkeys_popup/keys/firefox.lua
@@ -7,7 +7,7 @@
 ---------------------------------------------------------------------------
 
 local hotkeys_popup = require("awful.hotkeys_popup.widget")
-local fire_rule = { class = { "Firefox" } }
+local fire_rule = { class = { "Firefox", "firefox" } }
 for group_name, group_data in pairs({
     ["Firefox: tabs"] = { color = "#009F00", rule_any = fire_rule }
 }) do


### PR DESCRIPTION
Wasn't getting firefox keys in `hotkeys_popup` despite loading with 

`require("awful.hotkeys_popup.keys")`


`xprop -name "Firefox" `:
```
_NET_STARTUP_ID(UTF8_STRING) = "rofi/|usr|lib|firefox|firefox/104909-0-Athena_TIME9024174"
WM_CLASS(STRING) = "firefox", "Firefox"
WM_COMMAND(STRING) = { "firefox" }
WM_CLIENT_LEADER(WINDOW): window id # 0x2000001
_NET_WM_PID(CARDINAL) = 104933
WM_LOCALE_NAME(STRING) = "en_US.UTF-8"
WM_CLIENT_MACHINE(STRING) = "Athena"
WM_NORMAL_HINTS(WM_SIZE_HINTS):
		program specified size: 10 by 10
WM_PROTOCOLS(ATOM): protocols  WM_DELETE_WINDOW, WM_TAKE_FOCUS, _NET_WM_PING
WM_ICON_NAME(STRING) = "firefox"
_NET_WM_ICON_NAME(UTF8_STRING) = "firefox"
WM_NAME(STRING) = "Firefox"
_NET_WM_NAME(UTF8_STRING) = "Firefox"
```

I added another match in the rules for the keybinding and then it started working again.