### PR TITLE
Apply rules on dbus notification update

### DIFF
--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -334,6 +334,11 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
                 )
             end
 
+            -- The rules are attached to this.
+            if naughty._has_preset_handler then
+                naughty.emit_signal("request::preset", notification, "update", args)
+            end
+
             -- Even if no property changed, restart the timeout.
             notification:reset_timeout()
         else


### PR DESCRIPTION
I encountered this where the urgency was updated for an existing notification but the background, modified by a rule, wasn't changing.

Signed-off-by: Michael Beaumont <mjboamail@gmail.com>