### PR TITLE
Docs: Fixed wrong code example in 03-declarative-layout

### DIFF
--- a/docs/03-declarative-layout.md
+++ b/docs/03-declarative-layout.md
@@ -260,7 +260,7 @@ Code:
         my_textbox1, -- Left
         nil,         -- Nothing in the middle
         my_textbox2, -- Right
-        layout = wibox.layout.fixed.horizontal,
+        layout = wibox.layout.align.horizontal,
     }
 
 


### PR DESCRIPTION
In **Use a wibox.layout.align layout**, the usage of the `wibox.layout.fixed.horizontal` layout in the code example contradicts the point of the section. :smile: