### PR TITLE
Don't force defaults in menubar

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -121,7 +121,7 @@ menubar.left_label = "◀◀"
 local list_interspace = theme.xresources.apply_dpi(4) * 3
 
 --- Allows user to specify custom parameters for prompt.run function
--- (like colors).
+-- (like colors). These will override default parameters.
 -- @see awful.prompt
 menubar.prompt_args = {}
 

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -121,7 +121,7 @@ menubar.left_label = "◀◀"
 local list_interspace = theme.xresources.apply_dpi(4) * 3
 
 --- Allows user to specify custom parameters for prompt.run function
--- (like colors). These will override default parameters.
+-- (like colors). This will merge with the default parameters, overriding affected values.
 -- @see awful.prompt
 menubar.prompt_args = {}
 

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -486,9 +486,7 @@ function menubar.show(scr)
     current_category = nil
     menulist_update(scr)
 
-    local prompt_args = menubar.prompt_args or {}
-
-    awful.prompt.run(setmetatable({
+    local default_prompt_args = {
         prompt              = "Run: ",
         textbox             = instance.prompt.widget,
         completion_callback = awful.completion.shell,
@@ -499,7 +497,10 @@ function menubar.show(scr)
             menulist_update(scr)
         end,
         keypressed_callback = prompt_keypressed_callback
-    }, {__index=prompt_args}))
+    }
+
+    awful.prompt.run(setmetatable(menubar.prompt_args, {__index=default_prompt_args}))
+
 
     instance.wibox.visible = true
 end


### PR DESCRIPTION
Currently, all members of `menubar.prompt_args` will be ignored if there is a default for them.

I suggest instead using all prompt_args and falling back to defaults if the required argument is not set by the user.