### PR TITLE
Menubar match empty

### DIFF
--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -90,6 +90,10 @@ menubar.cache_entries = true
 -- @tfield[opt=true] boolean show_categories
 menubar.show_categories = true
 
+--- When false will hide results if the current query is empty
+-- @tfield[opt=true] boolean match_empty
+menubar.match_empty = true
+
 --- Specifies the geometry of the menubar. This is a table with the keys
 -- x, y, width and height. Missing values are replaced via the screen's
 -- geometry. However, missing height is replaced by the font size.
@@ -310,7 +314,7 @@ local function menulist_update(scr)
     end
 
     -- Add the applications according to their name and cmdline
-    for _, v in ipairs(menubar.menu_entries) do
+    local add_entry = function(v)
         v.focused = false
         if not current_category or v.category == current_category then
 
@@ -341,6 +345,14 @@ local function menulist_update(scr)
             end
         end
     end
+
+    -- Add entries if required
+    if query ~= "" or menubar.match_empty then
+        for _, v in ipairs(menubar.menu_entries) do
+            add_entry(v)
+        end
+    end
+
 
     local function compare_counts(a, b)
         if a.prio == b.prio then

--- a/lib/menubar/init.lua
+++ b/lib/menubar/init.lua
@@ -314,34 +314,34 @@ local function menulist_update(scr)
     end
 
     -- Add the applications according to their name and cmdline
-    local add_entry = function(v)
-        v.focused = false
-        if not current_category or v.category == current_category then
+    local add_entry = function(entry)
+        entry.focused = false
+        if not current_category or entry.category == current_category then
 
             -- check if the query matches either the name or the commandline
             -- of some entry
-            if string.match(v.name, pattern)
-                or string.match(v.cmdline, pattern) then
+            if string.match(entry.name, pattern)
+                or string.match(entry.cmdline, pattern) then
 
-                v.weight = 0
-                v.prio = PRIO_NONE
+                entry.weight = 0
+                entry.prio = PRIO_NONE
 
                 -- get use count from count_table if present
                 -- and use it as weight
-                if string.len(pattern) > 0 and count_table[v.name] ~= nil then
-                    v.weight = tonumber(count_table[v.name])
+                if string.len(pattern) > 0 and count_table[entry.name] ~= nil then
+                    entry.weight = tonumber(count_table[entry.name])
                 end
 
                 -- check for prefix match
-                if string.match(v.name, "^" .. pattern)
-                    or string.match(v.cmdline, "^" .. pattern) then
+                if string.match(entry.name, "^" .. pattern)
+                    or string.match(entry.cmdline, "^" .. pattern) then
                     -- increase default priority
-                    v.prio = PRIO_NONE + 1
+                    entry.prio = PRIO_NONE + 1
                 else
-                    v.prio = PRIO_NONE
+                    entry.prio = PRIO_NONE
                 end
 
-                table.insert (command_list, v)
+                table.insert (command_list, entry)
             end
         end
     end

--- a/tests/test-menubar.lua
+++ b/tests/test-menubar.lua
@@ -37,22 +37,33 @@ do
     end
 end
 
+local show_menubar_and_hide = function(count)
+    -- Just show the menubar and hide it.
+    -- TODO: Write a proper test. But for the mean time this is better than
+    -- nothing (and tells us when errors are thrown).
+
+    if count == 1 then
+        menubar.show()
+    end
+
+    -- Test that the async population of the menubar is done
+    if menubar_refreshed then
+        menubar.hide()
+        awesome.sync()
+        return true
+    end
+end
+
 runner.run_steps {
     function(count)
-        -- Just show the menubar and hide it.
-        -- TODO: Write a proper test. But for the mean time this is better than
-        -- nothing (and tells us when errors are thrown).
+        -- Show and hide with defaults
+        return show_menubar_and_hide(count)
+    end,
 
-        if count == 1 then
-            menubar.show()
-        end
-
-        -- Test that the async population of the menubar is done
-        if menubar_refreshed then
-            menubar.hide()
-            awesome.sync()
-            return true
-        end
+    function(count)
+        -- Show and hide with match_empty set to false
+        menubar.match_empty = false
+        return show_menubar_and_hide(count)
     end,
 
     function()


### PR DESCRIPTION
For minimalist setups, it looks good when the you can only see the suggestions when you start needing them i.e. when you enter something. This allows the user to set the property `menubar.match_empty = false` if the menubar should be completely empty before anything is typed.