### PR TITLE
fix(gears: matcher: default_matcher): handle sidecase of string.match-ing the empty string ('')

### DIFF
--- a/lib/gears/matcher.lua
+++ b/lib/gears/matcher.lua
@@ -80,10 +80,10 @@ local matcher = {}
 
 local function default_matcher(a, b)
     local result = a == b
-    if result then return result end
+    if result then return true end
     if type(a) == "string" and type(b) == "string" then
       result = a:match(b)
-      if result == '' then result = nil end
+      if result == '' then return false end
     end
     return result
 end

--- a/lib/gears/matcher.lua
+++ b/lib/gears/matcher.lua
@@ -79,7 +79,13 @@ local matcher = {}
 -- @see remove_matching_source
 
 local function default_matcher(a, b)
-    return a == b or (type(a) == "string" and a:match(b))
+    local result = a == b
+    if result then return result end
+    if type(a) == "string" and type(b) == "string" then
+      result = a:match(b)
+      if result == '' then result = nil end
+    end
+    return result
 end
 
 local function greater_matcher(a, b)

--- a/spec/gears/matcher_spec.lua
+++ b/spec/gears/matcher_spec.lua
@@ -1,0 +1,46 @@
+---------------------------------------------------------------------------
+-- @author Yauheni Kirylau
+-- @copyright 2020 Yauheni Kirylau
+---------------------------------------------------------------------------
+
+local matcher = require("gears.matcher")
+
+local matcher_instance = matcher()
+local test_obj = {
+    foo='bar',
+    spam='',
+}
+
+describe("gears.matcher", function()
+
+    describe("matching by normal string value", function()
+        local rule = {
+            foo='bar',
+        }
+        assert.is_true(matcher_instance:_match(test_obj, rule))
+    end)
+
+    describe("not matching by normal string value", function()
+        local rule = {
+            foo='nah',
+        }
+        assert.is_false(matcher_instance:_match(test_obj, rule))
+    end)
+
+    describe("matching by empty string value", function()
+        local rule = {
+            spam='',
+        }
+        assert.is_true(matcher_instance:_match(test_obj, rule))
+    end)
+
+    describe("not matching by empty string value", function()
+        local rule = {
+            foo='',
+        }
+        assert.is_false(matcher_instance:_match(test_obj, rule))
+    end)
+
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
without the patch the test would fail:

```
Error → ./spec/gears/matcher_spec.lua @ 37
gears.matcher not matching by empty string value
./spec/gears/matcher_spec.lua:41: Expected objects to be the same.
Passed in:
(boolean) true
Expected:
(boolean) false

stack traceback:
        ./spec/gears/matcher_spec.lua:41: in function <./spec/gears/matcher_spec.lua:37>
```