### PR TITLE
Fix `awful.titlebar` example property.

### DIFF
--- a/tests/examples/awful/titlebar/default.lua
+++ b/tests/examples/awful/titlebar/default.lua
@@ -15,7 +15,7 @@ place.maximize(c, {honor_padding=true, honor_workarea=true}) --DOC_HIDE
     -- function.
 
     local top_titlebar = awful.titlebar(c, {
-        height    = 20,
+        size      = 20,
         bg_normal = "#ff0000",
     })
 


### PR DESCRIPTION
Back with awesome :)

I tried to rice titlebars and I found this quirk in the doc.

Side effect: the image generated for the example is slightly modified. No one care, but still...