### PR TITLE
fix wibox declarative opacity, Fixes #2997

### DIFF
--- a/lib/wibox/init.lua
+++ b/lib/wibox/init.lua
@@ -384,6 +384,10 @@ local function new(args)
         ret.border_color = args.border_color
     end
 
+    if args.opacity then
+        ret.opacity = args.opacity
+    end
+
     if args.input_passthrough then
         ret.input_passthrough = args.input_passthrough
     end


### PR DESCRIPTION
I finally did a git bisect, the commit which introduced this issue is: https://github.com/awesomeWM/awesome/commit/04c757322c079a8b9f13a51d0dc4c37e5a5b7965

The test I'm using:
```lua
local runner = require("_runner")
local wibox = require("wibox")

local wb = wibox {
    opacity = 0.50,
    visible   = true,
    height  = 200,
    width   = 200,
}

local steps = {
    function()
        local rounded = tonumber(string.format("%.3f", wb.opacity))
        assert(rounded == 0.5)
        return true
    end,
}

runner.run_steps(steps)
```
