### PR TITLE
Border color consistency

### DIFF
--- a/docs/common/client_theme.ldoc
+++ b/docs/common/client_theme.ldoc
@@ -485,7 +485,7 @@
 /**
  * The marked clients border color.
  * Note that only solid colors are supported.
- * @beautiful beautiful.border_marked
+ * @beautiful beautiful.border_color_marked
  * @param color
  */
 

--- a/docs/common/client_theme.ldoc
+++ b/docs/common/client_theme.ldoc
@@ -2,6 +2,15 @@
 
 
 /**
+ * The border color when the client is marked.
+ * It has priority over the rest of beautiful border color properties.
+ * Note that only solid colors are supported.
+ * @beautiful beautiful.border_color_marked
+ * @param color
+ * @see request::border
+ */
+
+/**
  * The fallback border color when the client is floating.
  *
  * @beautiful beautiful.border_color_floating
@@ -14,15 +23,27 @@
  */
 
 /**
- * The fallback border color when the client is mazimized.
+ * The fallback border color when the client is maximized.
  *
- * @beautiful beautiful.border_color_mazimized
+ * @beautiful beautiful.border_color_maximized
  * @param color
  * @see request::border
  * @see beautiful.border_color_maximized_active
  * @see beautiful.border_color_maximized_normal
  * @see beautiful.border_color_maximized_urgent
  * @see beautiful.border_color_maximized_new
+ */
+
+ /**
+ * The fallback border color when the client is fullscreen.
+ *
+ * @beautiful beautiful.border_color_fullscreen
+ * @param color
+ * @see request::border
+ * @see beautiful.border_color_fullscreen_active
+ * @see beautiful.border_color_fullscreen_normal
+ * @see beautiful.border_color_fullscreen_urgent
+ * @see beautiful.border_color_fullscreen_new
  */
 
 /**
@@ -160,7 +181,7 @@
  * @param integer
  * @see request::border
  * @see beautiful.border_width_floating
- * @see beautiful.border_width_mazimized
+ * @see beautiful.border_width_maximized
  * @see beautiful.border_width_floating_active
  * @see beautiful.border_width_floating_normal
  * @see beautiful.border_width_floating_urgent
@@ -184,9 +205,9 @@
  */
 
 /**
- * The fallback border width when the client is mazimized.
+ * The fallback border width when the client is maximized.
  *
- * @beautiful beautiful.border_width_mazimized
+ * @beautiful beautiful.border_width_maximized
  * @param integer
  * @see request::border
  * @see beautiful.border_width_maximized_active
@@ -480,13 +501,6 @@
  * @beautiful beautiful.opacity_fullscreen_new
  * @param[opt=1] number
  * @see request::border
- */
-
-/**
- * The marked clients border color.
- * Note that only solid colors are supported.
- * @beautiful beautiful.border_color_marked
- * @param color
  */
 
 /*

--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -630,12 +630,6 @@ end
 -- @emits unmarker (for legacy reasons, use `property::marked`)
 -- @emits property::marked
 
---- The border color when the client is focused.
---
--- @beautiful beautiful.border_marked
--- @param string
---
-
 function client.object.set_marked(self, value)
     local is_marked = self.marked
 

--- a/lib/awful/permissions/init.lua
+++ b/lib/awful/permissions/init.lua
@@ -637,9 +637,18 @@ function permissions.update_border(c, context)
         -- never have been added to the core. The documentation claims it works,
         -- even if it has been broken for 90% of AwesomeWM releases ever since
         -- it was added.
-        if c.marked and beautiful.border_color_marked then
-            c._border_color = beautiful.border_color_marked
-            return
+        if c.marked then
+            if beautiful.border_color_marked then
+                c._border_color = beautiful.border_color_marked
+                return
+            elseif beautiful.border_marked then
+                gdebug.deprecate(
+                    "Use `beautiful.border_color_marked` instead of `beautiful.border_marked`",
+                    {deprecated_in=5}
+                )
+                c._border_color = beautiful.border_marked
+                return
+            end
         end
 
         local tv = beautiful["border_color"..suffix]

--- a/lib/awful/permissions/init.lua
+++ b/lib/awful/permissions/init.lua
@@ -637,8 +637,8 @@ function permissions.update_border(c, context)
         -- never have been added to the core. The documentation claims it works,
         -- even if it has been broken for 90% of AwesomeWM releases ever since
         -- it was added.
-        if c.marked and beautiful.border_marked then
-            c._border_color = beautiful.border_marked
+        if c.marked and beautiful.border_color_marked then
+            c._border_color = beautiful.border_color_marked
             return
         end
 

--- a/lib/awful/permissions/init.lua
+++ b/lib/awful/permissions/init.lua
@@ -543,6 +543,7 @@ end, "mouse_enter")
 -- (urgent, new, active, normal)
 --
 -- @signalhandler awful.ewmh.update_border
+-- @usebeautiful beautiful.border_color_marked
 -- @usebeautiful beautiful.border_color_active
 -- @usebeautiful beautiful.border_color_normal
 -- @usebeautiful beautiful.border_color_new

--- a/themes/default/theme.lua
+++ b/themes/default/theme.lua
@@ -29,7 +29,7 @@ theme.useless_gap         = dpi(0)
 theme.border_width        = dpi(1)
 theme.border_color_normal = "#000000"
 theme.border_color_active = "#535d6c"
-theme.border_marked       = "#91231c"
+theme.border_color_marked = "#91231c"
 
 -- There are other variable sets
 -- overriding the default one when


### PR DESCRIPTION
Rename `border_marked` to `border_color_marked` like the rest of `border_color`s.
Also fix some issues in the client border color documentation.