### PR TITLE
Fix runner.sh compatibility with OpenBSD and FreeBSD

### DIFF
--- a/tests/examples/runner.sh
+++ b/tests/examples/runner.sh
@@ -45,7 +45,7 @@ then
 fi
 
 # Check if we got the output we wanted
-if ! cmp --silent "${file_stdout}" "${expected_output}"
+if ! cmp -s "${file_stdout}" "${expected_output}"
 then
     echo "Expected text from ${expected_output}, but got:"
     diff -u "${expected_output}" "${file_stdout}" || true


### PR DESCRIPTION
`runner.sh` compares files silently with the `--silent` switch but unfortunately that switch is not available [on OpenBSD](https://man.openbsd.org/cmp.1) nor [on FreeBSD](https://www.unix.com/man-page/FreeBSD/1/cmp/). This PR fixes that and maintains compatibility [with GNU/Linux](https://linux.die.net/man/1/cmp).