### PR TITLE
only use int random number for math.randomseed (for lua5.4)

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -84,7 +84,7 @@ init_rng(void)
     lua_getfield(L, -1, "randomseed");
 
     /* Push a seed */
-    lua_pushnumber(L, g_random_int() + g_random_double());
+    lua_pushnumber(L, g_random_int());
 
     /* Call math.randomseed */
     lua_call(L, 1, 0);

--- a/awesome.c
+++ b/awesome.c
@@ -84,7 +84,7 @@ init_rng(void)
     lua_getfield(L, -1, "randomseed");
 
     /* Push a seed */
-    lua_pushnumber(L, g_random_int());
+    lua_pushnumber(L, ((unsigned long)g_random_int()<<32)+g_random_int());
 
     /* Call math.randomseed */
     lua_call(L, 1, 0);


### PR DESCRIPTION
This PR pass an int random number instead of double number to `math.randomseed`.

It try to fix #3123.