### PR TITLE
Make scroll work in the usual way in default rc.lua

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -135,8 +135,8 @@ screen.connect_signal("request::desktop_decoration", function(s)
         buttons = {
             awful.button({ }, 1, function () awful.layout.inc( 1) end),
             awful.button({ }, 3, function () awful.layout.inc(-1) end),
-            awful.button({ }, 4, function () awful.layout.inc( 1) end),
-            awful.button({ }, 5, function () awful.layout.inc(-1) end),
+            awful.button({ }, 4, function () awful.layout.inc(-1) end),
+            awful.button({ }, 5, function () awful.layout.inc( 1) end),
         }
     }
 
@@ -157,8 +157,8 @@ screen.connect_signal("request::desktop_decoration", function(s)
                                                 client.focus:toggle_tag(t)
                                             end
                                         end),
-            awful.button({ }, 4, function(t) awful.tag.viewnext(t.screen) end),
-            awful.button({ }, 5, function(t) awful.tag.viewprev(t.screen) end),
+            awful.button({ }, 4, function(t) awful.tag.viewprev(t.screen) end),
+            awful.button({ }, 5, function(t) awful.tag.viewnext(t.screen) end),
         }
     }
 
@@ -172,8 +172,8 @@ screen.connect_signal("request::desktop_decoration", function(s)
                 c:activate { context = "tasklist", action = "toggle_minimization" }
             end),
             awful.button({ }, 3, function() awful.menu.client_list { theme = { width = 250 } } end),
-            awful.button({ }, 4, function() awful.client.focus.byidx( 1) end),
-            awful.button({ }, 5, function() awful.client.focus.byidx(-1) end),
+            awful.button({ }, 4, function() awful.client.focus.byidx(-1) end),
+            awful.button({ }, 5, function() awful.client.focus.byidx( 1) end),
         }
     }
 
@@ -207,8 +207,8 @@ end)
 -- @DOC_ROOT_BUTTONS@
 awful.mouse.append_global_mousebindings({
     awful.button({ }, 3, function () mymainmenu:toggle() end),
-    awful.button({ }, 4, awful.tag.viewnext),
-    awful.button({ }, 5, awful.tag.viewprev),
+    awful.button({ }, 4, awful.tag.viewprev),
+    awful.button({ }, 5, awful.tag.viewnext),
 })
 -- }}}
 


### PR DESCRIPTION
When hovering over the layoutbox, taglist, tasklist or root window, scrolling up or down has the effect of moving to the next or previous layout/tag/client.

This is very similar to how tab lists works on many other popular programs.

In those other programs, scrolling _down_ moves to the _next_ tab (i.e. to the right). I'm no UX designer, but it seems quite intuitive, and all of the programs that I could find that reacted to scroll when mousing over the tab list worked in this direction (namely Chromium, Atom and Gimp). Some others that I tried did not react to scroll (Visual studio code, Thunar, Nautilus, Firefox). But I did not find one that worked in the other direction...

...Except awesome, where (with the default rc.lua) scrolling down moves to the previous/left tag/client/layout.

This made this scroll feature very frustrating to me before I decided to change it, and even though it is easy enough to change, I reckon it should be the default.