### PR TITLE
Fixed showing hotkeys_popup on the focused screen

### DIFF
--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -591,6 +591,7 @@ function widget.new(args)
             placement = place_func,
             minimum_width = wibox_width,
             minimum_height = wibox_height,
+            screen = s,
         }
 
         local widget_obj = {


### PR DESCRIPTION
I faced the following issue: when hotkeys_popup is called, it's shown on the same screen, regardless of the focus. Someone forgot to add x and y arguments when changed hotkeys_popup from wibox to popup.
Fix #3118