### PR TITLE
Quick fix to support libxkbcommon >= 1.0.

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -77,7 +77,7 @@
 
 #include <xcb/xcb_atom.h>
 #include <xcb/xcb_aux.h>
-#include "xkb_utf32_to_keysym.c"
+#include "xkb_utf32_to_keysym_compat.c"
 
 #include <unistd.h> /* for gethostname() */
 
@@ -489,7 +489,7 @@ luaA_get_key_name(lua_State *L)
         keysym = keysyms[0];
     }
     else if ((ucs = one_utf8_to_utf32(input, length)) > 0) //syntax #2
-        keysym = xkb_utf32_to_keysym(ucs);
+        keysym = xkb_utf32_to_keysym_compat(ucs);
     else //syntax #3
         keysym = xkb_keysym_from_name(input, XKB_KEYSYM_NO_FLAGS);
 

--- a/xkb_utf32_to_keysym_compat.c
+++ b/xkb_utf32_to_keysym_compat.c
@@ -839,7 +839,7 @@ static const struct codepair keysymtab[] = {
     { 0x20ac, 0x20ac }, /*                    EuroSign € EURO SIGN */
 };
 
-static xkb_keysym_t xkb_utf32_to_keysym(uint32_t ucs)
+static xkb_keysym_t xkb_utf32_to_keysym_compat(uint32_t ucs)
 {
     /* first check for Latin-1 characters (1:1 mapping) */
     if ((ucs >= 0x0020 && ucs <= 0x007e) ||


### PR DESCRIPTION
This is a quick fix to move our copy of the code to avoid the name collision.  The next step will be to use the "real" function when a `libxkbcommon` version is found rather than the compat version. This will be another PR

Fix #3168