### PR TITLE
modeline: Check the first XDG and fallback paths for modelines.

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -645,7 +645,7 @@ main(int argc, char **argv)
 
     /* Parse `rc.lua` to see if it has an AwesomeWM modeline */
     if (!(default_init_flags & INIT_FLAG_FORCE_CMD_ARGS))
-        options_init_config(awesome_argv[0], confpath, &default_init_flags, &searchpath);
+        options_init_config(&xdg, awesome_argv[0], confpath, &default_init_flags, &searchpath);
 
     /* Setup pipe for SIGCHLD processing */
     {

--- a/options.c
+++ b/options.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <getopt.h>
+#include <basedir_fs.h>
 
 #define KEY_VALUE_BUF_MAX 64
 #define READ_BUF_MAX 127
@@ -71,7 +72,7 @@ push_arg(string_array_t *args, char *value, size_t *len)
  * Support both shebang and modeline modes.
  */
 bool
-options_init_config(char *execpath, char *configpath, int *init_flags, string_array_t *paths)
+options_init_config(xdgHandle *xdg, char *execpath, char *configpath, int *init_flags, string_array_t *paths)
 {
     /* The different state the parser can have. */
     enum {
@@ -105,7 +106,27 @@ options_init_config(char *execpath, char *configpath, int *init_flags, string_ar
     string_array_init(&argv);
     string_array_append(&argv, a_strdup(execpath));
 
-    FILE *fp = fopen(configpath, "r");
+    FILE *fp = NULL;
+
+    /* It is too early to know which config works. So we assume
+     * the first one found is the one to use for the modeline. This
+     * may or may not end up being the config that works. However since
+     * knowing if the config works requires to load it, and loading must
+     * be done only after the modeline is parsed, this is the best we can
+     * do
+     */
+    if (!configpath) {
+        const char *xdg_confpath = xdgConfigFind("awesome/rc.lua", xdg);
+
+        /* xdg_confpath is "string1\0string2\0string3\0\0" */
+        if (xdg_confpath && *xdg_confpath)
+            fp = fopen(xdg_confpath, "r");
+        else
+            fp = fopen(AWESOME_DEFAULT_CONF, "r");
+
+        p_delete(&xdg_confpath);
+    } else
+        fp = fopen(configpath, "r");
 
     /* Share the error codepath with parsing errors */
     if (!fp)

--- a/options.h
+++ b/options.h
@@ -35,5 +35,5 @@ typedef enum {
 } awesome_init_config_t;
 
 char *options_detect_shebang(int argc, char **argv);
-bool options_init_config(char *execpath, char *configpath, int *init_flags, string_array_t *paths);
+bool options_init_config(xdgHandle *xdg, char *execpath, char *configpath, int *init_flags, string_array_t *paths);
 char *options_check_args(int argc, char **argv, int *init_flags, string_array_t *paths);


### PR DESCRIPTION
This is not perfect. If the first config is invalid, then it wont use
the correct modeline. However there is no way to know if the config
is valid before attempting to execute it, so it's the best we can do.

Fix #3166