### PR TITLE
screen: Correctly detect tiled_clients.

### DIFF
--- a/lib/awful/screen.lua
+++ b/lib/awful/screen.lua
@@ -503,9 +503,8 @@ function screen.object.get_tiled_clients(s, stacked)
     -- Remove floating clients
     for _, c in pairs(clients) do
         if not c.floating
-            and not c.fullscreen
-            and not c.maximized_vertical
-            and not c.maximized_horizontal then
+            and not c.immobilized_horizontal
+            and not c.immobilized_vertical then
             table.insert(tclients, c)
         end
     end


### PR DESCRIPTION
At some point we added an unified `maximized` property to the client class. Originally it was just setting both horizontal and vertical maximization. Later on, this was rewritten to make the state change more atomic and reversible.

Soon after, we added  `immobilized_horizontal` and `immobilized_vertical` to make most `if` simpler. `screen.tiled_clients` was missed in that refactoring.

Fix #3169