### PR TITLE
notifications: Make `:reset_timer()` more intuitive.

### DIFF
--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -503,6 +503,13 @@ function notification:reset_timeout(new_timeout)
     -- timer before the constructor ends.
     if new_timeout and self.timer then
         self.timeout = new_timeout
+    elseif new_timeout and new_timeout ~= self._private.timeout then
+        local previous_timer = self._private.timeout
+        timer.delayed_call(function()
+            if self._private.timeout == previous_timer then
+                self.timeout = new_timeout
+            end
+        end)
     end
 
     if self.timer and not self.timer.started then

--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -1076,7 +1076,14 @@ table.insert(steps, function()
     assert(naughty.get_by_id(42) ~= n)
 
     -- The timeout
+    local real, called = n.reset_timeout, false
+    n.reset_timeout = function(...)
+        called = true
+        return real(...)
+    end
     naughty.reset_timeout(n, 1337)
+    assert(called)
+    assert(n.timer and n.timer.started)
 
     -- Destroy using the old API
     local old_count = #destroyed


### PR DESCRIPTION
Previously it would only work if there already was a timeout to avoid some infinite loops. Now it just delay the new timer to the next loop.

Fix #3147