### PR TITLE
naughty: Improve backward compatibility to protecting the constants.

### DIFF
--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -1256,4 +1256,15 @@ table.insert(steps, function()
     return true
 end)
 
+-- Make sure it isn't possible to remove default variables (#3145).
+table.insert(steps, function()
+    naughty.config.defaults = {fake_variable = 24}
+    naughty.config.text = 1337
+    assert(naughty.config.defaults.fake_variable == 24)
+    assert(naughty.config.defaults.timeout == 5)
+    assert(naughty.config.text == 1337)
+
+     return true
+end)
+
 require("_runner").run_steps(steps)


### PR DESCRIPTION
If the user copy/pasted `naughty.config.*` into their config rather than set values 1 by 1, we could no longer add new values since they would get removed. To prevent more users being affected by this, we now silently ignore the new table while still setting all the values.

It's not perfect. If the user do

```
local tab = {}
naughty.config.defaults = tab

tab.foo = bar
```

Then that currently did something and it wont work anymore. However if they do

```
naughty.config.defaults = {
    foo = bar
}
```

Then that will help.

Given that the alternative is a fully broken notification subsystem when upgrading (from any version to any version really, this isn't related to my work for 4.4), this is an improvement. 

Fix #3145