### PR TITLE
Fix wibox.layout.stack:raise() returning prematurely and inserting the widget at the end instead of the start

### DIFF
--- a/lib/wibox/layout/stack.lua
+++ b/lib/wibox/layout/stack.lua
@@ -170,8 +170,8 @@ end
 
 function stack:set_horizontal_offset(value)
     self._private.h_offset = value
-    self:emit_signal("widget::horizontal_offset")
-    self:emit_signal("property::top_only", value)
+    self:emit_signal("widget::layout_changed")
+    self:emit_signal("property::horizontal_offset", value)
 end
 
 function stack:set_vertical_offset(value)

--- a/lib/wibox/layout/stack.lua
+++ b/lib/wibox/layout/stack.lua
@@ -116,11 +116,11 @@ end
 -- @method raise
 -- @tparam number index the widget index to raise
 function stack:raise(index)
-    if (not index) or self._private.widgets[index] then return end
+    if (not index) or (not self._private.widgets[index]) then return end
 
     local w = self._private.widgets[index]
     table.remove(self._private.widgets, index)
-    table.insert(self._private.widgets, w)
+    table.insert(self._private.widgets, 1, w)
 
     self:emit_signal("widget::layout_changed")
 end

--- a/lib/wibox/layout/stack.lua
+++ b/lib/wibox/layout/stack.lua
@@ -174,10 +174,18 @@ function stack:set_horizontal_offset(value)
     self:emit_signal("property::horizontal_offset", value)
 end
 
+function stack:get_horizontal_offset()
+    return self._private.h_offset
+end
+
 function stack:set_vertical_offset(value)
     self._private.v_offset = value
     self:emit_signal("widget::layout_changed")
     self:emit_signal("property::vertical_offset", value)
+end
+
+function stack:get_vertical_offset()
+    return self._private.v_offset
 end
 
 --- Create a new stack layout.


### PR DESCRIPTION
Fixes #3186.

There seem to be two issues here:

1. The if-statement at the beginning of the function will return prematurely if `self._private.widgets[index]` exists. There seems to be a missing `not` there.
2. The widget is inserted at the end of `self._private.widgets` since no index was specified to `table.insert()`. Index 1 is interpreted as the top of the stack (according to the behaviour that I observed, although the documentation says otherwise). 

For the first, I added the missing `not`. For the second, I pass index `1` to `table.insert()` (`table.insert()` takes an optional index as the second parameter).