### PR TITLE
Fix awesome-client example

### DIFF
--- a/manpages/awesome-client.1.de.txt
+++ b/manpages/awesome-client.1.de.txt
@@ -28,7 +28,7 @@ Das Modul 'awful.remote' muss geladen sein, um diesen Befehl zu benutzen.
 BEISPIELE
 ---------
 ....
-$ awesome-client 'return 1+1, "Hello, world"\
+$ awesome-client 'return 1+1, "Hello, world"'
    double 2
    string "Hello, world"
 

--- a/manpages/awesome-client.1.de.txt
+++ b/manpages/awesome-client.1.de.txt
@@ -35,11 +35,11 @@ $ awesome-client 'return 1+1, "Hello, world"'
 # Das folgende Beispiel erzeugt keine Ausgabe auf der Kommandozeile,
 # sondern zeigt eine Benachrichtigung an.
 $ awesome-client '
-> naughty = require("naughty")
-> naughty.notify({
-> title="CLI-Benachrichtigung",
-> text="Dies ist eine Benachrichtigung von der Kommandozeile!"})
-> '
+  naughty = require("naughty")
+  naughty.notify({
+  title="CLI-Benachrichtigung",
+  text="Dies ist eine Benachrichtigung von der Kommandozeile!"})
+'
 
 # Starte eine lesen-ausführen-ausgeben-Schleife (REPL).
 # In diesem Modus wird jede Zeile zu awesome geschickt; auf die selbe Art

--- a/manpages/awesome-client.1.es.txt
+++ b/manpages/awesome-client.1.es.txt
@@ -38,11 +38,11 @@ $ awesome-client 'return 1+1, "Hello, world"'
 # The following does not return anything on the command line,
 # but will show a notification.
 $ awesome-client '
-> naughty = require("naughty")
-> naughty.notify({
-> title="CLI Notification",
-> text="This is a notification sent from the command line!"})
-> '
+  naughty = require("naughty")
+  naughty.notify({
+  title="CLI Notification",
+  text="This is a notification sent from the command line!"})
+'
 
 # Entering read-eval-print-loop mode
 # This mode will send every line to awesome, exactly the same as passing

--- a/manpages/awesome-client.1.es.txt
+++ b/manpages/awesome-client.1.es.txt
@@ -31,7 +31,7 @@ funcione.
 EXAMPLES
 -------
 ....
-$ awesome-client 'return 1+1, "Hello, world"\
+$ awesome-client 'return 1+1, "Hello, world"'
    double 2
    string "Hello, world"
 

--- a/manpages/awesome-client.1.fr.txt
+++ b/manpages/awesome-client.1.fr.txt
@@ -35,11 +35,11 @@ $ awesome-client 'return 1+1, "Hello, world"'
 # The following does not return anything on the command line,
 # but will show a notification.
 $ awesome-client '
-> naughty = require("naughty")
-> naughty.notify({
-> title="CLI Notification",
-> text="This is a notification sent from the command line!"})
-> '
+  naughty = require("naughty")
+  naughty.notify({
+  title="CLI Notification",
+  text="This is a notification sent from the command line!"})
+'
 
 # Entering read-eval-print-loop mode
 # This mode will send every line to awesome, exactly the same as passing

--- a/manpages/awesome-client.1.fr.txt
+++ b/manpages/awesome-client.1.fr.txt
@@ -28,7 +28,7 @@ Le module 'awful.remote' doit être chargé pour que cette commande fonctionne.
 EXAMPLES
 -------
 ....
-$ awesome-client 'return 1+1, "Hello, world"\
+$ awesome-client 'return 1+1, "Hello, world"'
    double 2
    string "Hello, world"
 

--- a/manpages/awesome-client.1.it.txt
+++ b/manpages/awesome-client.1.it.txt
@@ -31,7 +31,7 @@ comando.
 EXAMPLES
 -------
 ....
-$ awesome-client 'return 1+1, "Hello, world"\
+$ awesome-client 'return 1+1, "Hello, world"'
    double 2
    string "Hello, world"
 

--- a/manpages/awesome-client.1.it.txt
+++ b/manpages/awesome-client.1.it.txt
@@ -38,11 +38,11 @@ $ awesome-client 'return 1+1, "Hello, world"'
 # The following does not return anything on the command line,
 # but will show a notification.
 $ awesome-client '
-> naughty = require("naughty")
-> naughty.notify({
-> title="CLI Notification",
-> text="This is a notification sent from the command line!"})
-> '
+  naughty = require("naughty")
+  naughty.notify({
+  title="CLI Notification",
+  text="This is a notification sent from the command line!"})
+'
 
 # Entering read-eval-print-loop mode
 # This mode will send every line to awesome, exactly the same as passing

--- a/manpages/awesome-client.1.ru.txt
+++ b/manpages/awesome-client.1.ru.txt
@@ -37,11 +37,11 @@ $ awesome-client 'return 1+1, "Hello, world"'
 # Следующий пример не возвращает ничего в командную строку,
 # но показывает уведомление.
 $ awesome-client '
-> naughty = require("naughty")
-> naughty.notify({
-> title="CLI Notification",
-> text="Это уведомление было отправлено из командной строки!"})
-> '
+  naughty = require("naughty")
+  naughty.notify({
+  title="CLI Notification",
+  text="Это уведомление было отправлено из командной строки!"})
+'
 
 # Интерактивный режим (REPL)
 # В данном режиме каждая строка введенная пользователем

--- a/manpages/awesome-client.1.ru.txt
+++ b/manpages/awesome-client.1.ru.txt
@@ -30,7 +30,7 @@ awesome через D-Bus. Если установлен «rlwrap», то он б
 ПРИМЕРЫ
 -------
 ....
-$ awesome-client 'return 1+1, "Hello, world"\
+$ awesome-client 'return 1+1, "Hello, world"'
    double 2
    string "Hello, world"
 

--- a/manpages/awesome-client.1.txt
+++ b/manpages/awesome-client.1.txt
@@ -36,11 +36,11 @@ $ awesome-client 'return 1+1, "Hello, world"'
 # The following does not return anything on the command line,
 # but will show a notification.
 $ awesome-client '
-> naughty = require("naughty")
-> naughty.notify({
-> title="CLI Notification",
-> text="This is a notification sent from the command line!"})
-> '
+  naughty = require("naughty")
+  naughty.notify({
+  title="CLI Notification",
+  text="This is a notification sent from the command line!"})
+'
 
 # Entering read-eval-print-loop mode
 # This mode will send every line to awesome, exactly the same as passing

--- a/manpages/awesome-client.1.txt
+++ b/manpages/awesome-client.1.txt
@@ -29,7 +29,7 @@ The 'awful.remote' module has to be loaded if you want this command to work.
 EXAMPLES
 -------
 ....
-$ awesome-client 'return 1+1, "Hello, world"\
+$ awesome-client 'return 1+1, "Hello, world"'
    double 2
    string "Hello, world"
 


### PR DESCRIPTION
There should have been a single quote instead of a backslash. Removed the `>`s to make cut and pasting easier.