### PR TITLE
Fix setters/getters for grid layout direction properties

### DIFF
--- a/lib/wibox/layout/grid.lua
+++ b/lib/wibox/layout/grid.lua
@@ -692,7 +692,7 @@ end
 -- getting the common property returns the directional property
 -- defined by the `orientation` property
 for _, prop in ipairs(dir_properties) do
-    for _,dir in ipairs{"horizontal_, vertical_"} do
+    for _,dir in ipairs{"horizontal", "vertical"} do
         local dir_prop = dir .. "_" .. prop
         grid["set_"..dir_prop] = function(self, value)
             if self._private[dir_prop] ~= value then


### PR DESCRIPTION
Wow. This code was so weirdly broken, I have no words.

Fixes: https://github.com/awesomeWM/awesome/issues/3198
Signed-off-by: Uli Schlachter <psychon@znc.in>

----

Side node: I do not understand the grid layout. I have to set a property called `expand` just so that I get a grid instead of just its first entry in super-size...?

----

For future me (this is the code from #3198 made to work at the end of the default config):
```lua
local icon = wibox.widget {
  image = beautiful.awesome_icon,
  expand = true,
  widget = wibox.widget.imagebox
}

local grid = wibox.widget {
  icon,
  icon,
  icon,
  icon,
  forced_num_cols = 3,
  spacing       = 5,
  horizontal_expand = true,
  homogeneous = true,
  layout = wibox.layout.grid
}

local wi = wibox.widget {
  grid,
  bg = beautiful.groups_bg,
  shape = function(cr, width, height)
    gears.shape.partially_rounded_rect(cr, width, height, false, false, false, false, beautiful.groups_radius)
  end,
  widget = wibox.container.background
}
local w = wibox{ x = 30, y = 30, width = 300, height = 300, visible = true, widget = wi }
```