### PR TITLE
textbox: print traceback on error

### DIFF
--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -188,7 +188,7 @@ end
 function textbox:set_markup(text)
     local success, message = self:set_markup_silently(text)
     if not success then
-        gdebug.print_error(message)
+        gdebug.print_error(debug.traceback("Error parsing markup: "..message.."\nFailed with string: '"..text.."'"))
     end
 end
 


### PR DESCRIPTION
Right now if a textbox fails to parse the markup will print a pretty hard to debug message: `E: awesome: Error on line 28: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;` in the log.

This makes it print the traceback and the error.