### PR TITLE
Use focus.filter in awful.client.focus.(global_)bydirection

### DIFF
--- a/lib/awful/client/focus.lua
+++ b/lib/awful/client/focus.lua
@@ -174,7 +174,9 @@ function focus.bydirection(dir, c, stacked)
         local cltbl = client.visible(sel.screen, stacked)
         local geomtbl = {}
         for i,cl in ipairs(cltbl) do
-            geomtbl[i] = cl:geometry()
+            if focus.filter(cl) then
+                geomtbl[i] = cl:geometry()
+            end
         end
 
         local target = grect.get_in_direction(dir, geomtbl, sel:geometry())
@@ -211,7 +213,9 @@ function focus.global_bydirection(dir, c, stacked)
             local cltbl = client.visible(screen.focused(), stacked)
             local geomtbl = {}
             for i,cl in ipairs(cltbl) do
-                geomtbl[i] = cl:geometry()
+                if focus.filter(cl) then
+                    geomtbl[i] = cl:geometry()
+                end
             end
             local target = grect.get_in_direction(dir, geomtbl, scr.geometry)
 

--- a/tests/test-focus-bydirection.lua
+++ b/tests/test-focus-bydirection.lua
@@ -1,0 +1,40 @@
+-- Test for https://github.com/awesomeWM/awesome/pull/3225
+
+local runner = require("_runner")
+local awful = require("awful")
+local beautiful = require("beautiful")
+
+-- Ensure clients are placed next to each other
+beautiful.column_count = 3
+awful.screen.focused().selected_tag.layout = awful.layout.suit.tile
+
+
+local steps = {
+    function(count)
+        if count == 1 then
+            awful.spawn("xterm")
+            awful.spawn("xterm")
+            awful.spawn("xterm")
+        else
+            local cleft = client.get()[1]
+            local cright = client.get()[3]
+            client.get()[2].focusable = false
+
+            -- Test with focus.bydirection
+            client.focus = cleft
+            awful.client.focus.bydirection("right")
+            assert(client.focus == cright)
+
+            -- Test with focus.global_bydirection
+            client.focus = cleft
+            awful.client.focus.global_bydirection("right")
+            assert(client.focus == cright)
+
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
`awful.client.focus.bydirection` and `global_bydirection` don't check for clients actually being focusable. This is fixed with this commit by filtering clients using `focus.filter`.