### PR TITLE
Fix _NET_CURRENT_DESKTOP ClientMessage handling

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -468,7 +468,7 @@ ewmh_process_client_message(xcb_client_message_event_t *ev)
             lua_State *L = globalconf_get_lua_State();
             luaA_object_push(L, globalconf.tags.tab[idx]);
             lua_pushstring(L, "ewmh");
-            luaA_object_emit_signal(L, -1, "request::select", 1);
+            luaA_object_emit_signal(L, -2, "request::select", 1);
             lua_pop(L, 1);
         }
     }


### PR DESCRIPTION
This was broken in commit c5202a48708585cc33 by adding an extra string
to the Lua stack. Hence, the offset -1 now referred to the string and
not the tag.

Fixes: https://github.com/awesomeWM/awesome/issues/3236
Signed-off-by: Uli Schlachter <psychon@znc.in>