### PR TITLE
Relocate a client window as if it is undecorated when reparenting it back

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -111,8 +111,9 @@ awesome_atexit(bool restart)
     /* Move clients where we want them to be and keep the stacking order intact */
     foreach(c, globalconf.stack)
     {
+        area_t geometry = client_get_undecorated_geometry(*c);
         xcb_reparent_window(globalconf.connection, (*c)->window, globalconf.screen->root,
-                (*c)->geometry.x, (*c)->geometry.y);
+                geometry.x, geometry.y);
     }
 
     /* Save the client order.  This is useful also for "hard" restarts. */

--- a/objects/client.c
+++ b/objects/client.c
@@ -2163,6 +2163,27 @@ client_add_titlebar_geometry(client_t *c, area_t *geometry)
     geometry->height += c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
 }
 
+area_t
+client_get_undecorated_geometry(client_t *c)
+{
+    area_t geometry = c->geometry;
+    if (!c->fullscreen) {
+        int diff_left = c->titlebar[CLIENT_TITLEBAR_LEFT].size;
+        int diff_right = c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
+        int diff_top = c->titlebar[CLIENT_TITLEBAR_TOP].size;
+        int diff_bottom = c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
+        geometry.width -= diff_left + diff_right;
+        geometry.height -= diff_top + diff_bottom;
+        if (c->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY) {
+            xwindow_translate_for_gravity(c->size_hints.win_gravity,
+                                          -diff_left - c->border_width, -diff_top - c->border_width,
+                                          -diff_right - c->border_width, -diff_bottom - c->border_width,
+                                          &geometry.x, &geometry.y);
+        }
+    }
+    return geometry;
+}
+
 /** Send a synthetic configure event to a window.
  */
 void
@@ -2837,9 +2858,10 @@ client_unmanage(client_t *c, client_unmanage_t reason)
 
     if(reason != CLIENT_UNMANAGE_DESTROYED)
     {
+        area_t geometry = client_get_undecorated_geometry(c);
         xcb_unmap_window(globalconf.connection, c->window);
         xcb_reparent_window(globalconf.connection, c->window, globalconf.screen->root,
-                c->geometry.x, c->geometry.y);
+                geometry.x, geometry.y);
     }
 
     if (c->nofocus_window != XCB_NONE)

--- a/objects/client.h
+++ b/objects/client.h
@@ -256,6 +256,7 @@ void client_emit_scanned(void);
 void client_emit_scanning(void);
 drawable_t *client_get_drawable(client_t *, int, int);
 drawable_t *client_get_drawable_offset(client_t *, int *, int *);
+area_t client_get_undecorated_geometry(client_t *);
 
 /** Put client on top of the stack.
  * \param c The client to raise.


### PR DESCRIPTION
This helps resolve some annoying offsets in floating mode after closing and reopening some trayed applications, for example, Telegram. I'm not sure if this is breaking any protocols (I read some ICCCM but haven't found anything related yet). 