### PR TITLE
Make CMake Lua executable customizable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,14 +412,14 @@ if ("${TEST_MANUAL_SCREENS}" MATCHES "1")
 endif()
 
 add_custom_target(check-integration
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${TESTS_RUN_ENV} ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' LUA_EXECUTABLE='${LUA_EXECUTABLE}' ${TESTS_RUN_ENV} ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
     DEPENDS ${PROJECT_AWE_NAME}
     USES_TERMINAL)
 add_dependencies(check-integration test-gravity)
 add_custom_target(check-themes
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' ${TESTS_RUN_ENV} ./tests/themes/run.sh
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' LUA_EXECUTABLE='${LUA_EXECUTABLE}' ${TESTS_RUN_ENV} ./tests/themes/run.sh
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Testing themes"
     USES_TERMINAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,14 +412,14 @@ if ("${TEST_MANUAL_SCREENS}" MATCHES "1")
 endif()
 
 add_custom_target(check-integration
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' LUA_EXECUTABLE='${LUA_EXECUTABLE}' ${TESTS_RUN_ENV} ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' LUA='${LUA_EXECUTABLE}' ${TESTS_RUN_ENV} ./tests/run.sh \$\${TEST_RUN_ARGS:--W}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Running integration tests"
     DEPENDS ${PROJECT_AWE_NAME}
     USES_TERMINAL)
 add_dependencies(check-integration test-gravity)
 add_custom_target(check-themes
-    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' LUA_EXECUTABLE='${LUA_EXECUTABLE}' ${TESTS_RUN_ENV} ./tests/themes/run.sh
+    ${CMAKE_COMMAND} -E env CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}' LUA='${LUA_EXECUTABLE}' ${TESTS_RUN_ENV} ./tests/themes/run.sh
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Testing themes"
     USES_TERMINAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,7 +427,7 @@ add_custom_target(check-themes
 add_dependencies(check check-themes)
 
 add_custom_target(check-requires
-    lua "${CMAKE_SOURCE_DIR}/build-utils/check_for_invalid_requires.lua"
+    ${LUA_EXECUTABLE} "${CMAKE_SOURCE_DIR}/build-utils/check_for_invalid_requires.lua"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Checking use of require()"
     USES_TERMINAL

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -33,6 +33,7 @@ macro(a_find_program var prg req)
     endif()
 endmacro()
 
+a_find_program(LUA_EXECUTABLE lua TRUE)
 a_find_program(GIT_EXECUTABLE git FALSE)
 # programs needed for man pages
 a_find_program(ASCIIDOCTOR_EXECUTABLE asciidoctor FALSE)
@@ -374,7 +375,7 @@ add_custom_command(TARGET setup_directories
 
 add_custom_command(
         OUTPUT ${BUILD_DIR}/docs/06-appearance.md
-        COMMAND lua ${SOURCE_DIR}/docs/06-appearance.md.lua
+        COMMAND ${LUA_EXECUTABLE} ${SOURCE_DIR}/docs/06-appearance.md.lua
         ${BUILD_DIR}/docs/06-appearance.md
         DEPENDS
             lgi-check-run
@@ -385,7 +386,7 @@ add_custom_command(
 foreach(RULE_TYPE client tag screen notification)
     add_custom_command(
         OUTPUT ${BUILD_DIR}/docs/common/${RULE_TYPE}_rules_index.ldoc
-        COMMAND lua ${SOURCE_DIR}/docs/build_rules_index.lua
+        COMMAND ${LUA_EXECUTABLE} ${SOURCE_DIR}/docs/build_rules_index.lua
             ${BUILD_DIR}/docs/common/${RULE_TYPE}_rules_index.ldoc
             ${RULE_TYPE}
 
@@ -405,7 +406,7 @@ endforeach()
 add_custom_command(
         OUTPUT ${BUILD_DIR}/awesomerc.lua ${BUILD_DIR}/docs/05-awesomerc.md
             ${BUILD_DIR}/script_files/rc.lua
-        COMMAND lua ${SOURCE_DIR}/docs/05-awesomerc.md.lua
+        COMMAND ${LUA_EXECUTABLE} ${SOURCE_DIR}/docs/05-awesomerc.md.lua
         ${BUILD_DIR}/docs/05-awesomerc.md ${SOURCE_DIR}/awesomerc.lua
         ${BUILD_DIR}/awesomerc.lua
         ${BUILD_DIR}/script_files/rc.lua
@@ -414,7 +415,7 @@ add_custom_command(
 
 add_custom_command(
         OUTPUT ${BUILD_DIR}/script_files/theme.lua
-        COMMAND lua ${SOURCE_DIR}/docs/sample_theme.lua ${BUILD_DIR}/script_files/
+        COMMAND ${LUA_EXECUTABLE} ${SOURCE_DIR}/docs/sample_theme.lua ${BUILD_DIR}/script_files/
 )
 
 # Create a target for the auto-generated awesomerc.lua and other files

--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -8,34 +8,42 @@ Awesome is a highly configurable, next generation framework window manager for X
 
 After extracting the dist tarball, run:
 
-    make
+```sh
+make
+```
 
 This will create a build directory, run `cmake` in it and build Awesome.
 
 After building is finished, you can either install via `make install`:
 
-    make install  # you might need root permissions
+```sh
+make install  # you might need root permissions
+```
 
 or by auto-generating a .deb or .rpm package, for easy removal later on:
 
-    make package
+```sh
+make package
 
-    sudo dpkg -i awesome-x.y.z.deb
-    # or
-    sudo rpm -Uvh awesome-x.y.z.rpm
+sudo dpkg -i awesome-x.y.z.deb
+# or
+sudo rpm -Uvh awesome-x.y.z.rpm
+```
 
 NOTE: Awesome uses [`cmake`](https://cmake.org) to build. In case you want to
 pass arguments to `cmake`, please use the `CMAKE_ARGS` environment variable. For
 instance:
 
-    CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=/opt/awesome" make
+```sh
+CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=/opt/awesome" make
+```
 
 
 ### Installing current git master as a package receipts
 
 #### Arch Linux AUR
 
-```
+```sh
 sudo pacman -S --needed base-devel git
 git clone https://aur.archlinux.org/awesome-git.git
 cd awesome-git
@@ -44,7 +52,7 @@ makepkg -fsri
 
 #### Debian-based
 
-```
+```sh
 sudo apt build-dep awesome
 git clone https://github.com/awesomewm/awesome
 cd awesome
@@ -116,12 +124,16 @@ You can directly select Awesome from your display manager. If not, you can
 add the following line to your `.xinitrc` to start Awesome using `startx`
 or to `.xsession` to start Awesome using your display manager:
 
-    exec awesome
+```sh
+exec awesome
+```
 
 In order to connect Awesome to a specific display, make sure that
 the `DISPLAY` environment variable is set correctly, e.g.:
 
-    DISPLAY=foo.bar:1 exec awesome
+```sh
+DISPLAY=foo.bar:1 exec awesome
+```
 
 (This will start Awesome on display `:1` of the host foo.bar.)
 
@@ -145,12 +157,16 @@ problem.
 
 You can call `awesome` with `gdb` like this:
 
-    DISPLAY=:2 gdb awesome
+```sh
+DISPLAY=:2 gdb awesome
+```
 
 Then in `gdb` set any arguments and run it:
 
-    (gdb) set args --replace
-    (gdb) run
+```
+(gdb) set args --replace
+(gdb) run
+```
 
 ## Asking questions
 

--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -6,21 +6,21 @@ Awesome is a highly configurable, next generation framework window manager for X
 
 ## Building and installation
 
-After extracting the dist tarball, run:
+After extracting the dist tarball or cloning the repository, run:
 
 ```sh
 make
+sudo make install
 ```
 
-This will create a build directory, run `cmake` in it and build Awesome.
+This will
 
-After building is finished, you can either install via `make install`:
+1. create a build directory at `./build`,
+2. run `cmake`,
+3. build Awesome and
+4. install it to the default prefix path `/usr/local`.
 
-```sh
-make install  # you might need root permissions
-```
-
-or by auto-generating a .deb or .rpm package, for easy removal later on:
+Alternatively to the above, you can generate a `.deb` or `.rpm` package, for easy installation management:
 
 ```sh
 make package
@@ -30,14 +30,9 @@ sudo dpkg -i awesome-x.y.z.deb
 sudo rpm -Uvh awesome-x.y.z.rpm
 ```
 
-NOTE: Awesome uses [`cmake`](https://cmake.org) to build. In case you want to
-pass arguments to `cmake`, please use the `CMAKE_ARGS` environment variable. For
-instance:
+### Advanced options and testing
 
-```sh
-CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=/opt/awesome" make
-```
-
+A full list of dependencies, more advanced build options, as well as instructions on how to use the test suite can be found [here](https://awesomewm.org/apidoc/10-building-and-testing.md.html).
 
 ### Installing current git master as a package receipts
 
@@ -59,64 +54,6 @@ cd awesome
 make package
 sudo apt install *.deb
 ```
-
-
-### Build dependencies
-
-Awesome has the following dependencies (besides a more-or-less standard POSIX
-environment):
-
-- [CMake >= 3.0.0](https://cmake.org)
-- [Lua >= 5.1.0](https://www.lua.org) or [LuaJIT](http://luajit.org)
-- [LGI >= 0.8.0](https://github.com/pavouk/lgi)
-- [xproto >= 7.0.15](https://www.x.org/archive//individual/proto/)
-- [libxcb >= 1.6](https://xcb.freedesktop.org/) with support for the RandR, XTest, Xinerama, SHAPE and
-  XKB extensions
-- [libxcb-cursor](https://xcb.freedesktop.org/)
-- [libxcb-util >= 0.3.8](https://xcb.freedesktop.org/)
-- [libxcb-keysyms >= 0.3.4](https://xcb.freedesktop.org/)
-- [libxcb-icccm >= 0.3.8](https://xcb.freedesktop.org/)
-- [libxcb-xfixes](https://xcb.freedesktop.org/)
-- [xcb-util-xrm >= 1.0](https://github.com/Airblader/xcb-util-xrm)
-- [libxkbcommon](http://xkbcommon.org/) with X11 support enabled
-- [libstartup-notification >=
-  0.10](https://www.freedesktop.org/wiki/Software/startup-notification/)
-- [cairo](https://www.cairographics.org/) with support for XCB and GObject
-  introspection
-- [Pango](http://www.pango.org/) with support for Cairo and GObject
-  introspection
-- [GLib >= 2.40](https://wiki.gnome.org/Projects/GLib) with support for GObject
-  introspection
-- [GIO](https://developer.gnome.org/gio/stable/) with support for GObject
-  introspection
-- [GdkPixbuf](https://wiki.gnome.org/Projects/GdkPixbuf)
-- libX11 with xcb support
-- [Imagemagick's convert utility](http://www.imagemagick.org/script/index.php)
-- [libxdg-basedir >= 1.0.0](https://github.com/devnev/libxdg-basedir)
-
-Additionally, the following optional dependencies exist:
-
-- [DBus](https://www.freedesktop.org/wiki/Software/dbus/) for DBus integration
-  and the `awesome-client` utility
-- [asciidoctor](https://asciidoctor.org/) for generating man pages
-- [gzip](http://www.gzip.org/) for compressing man pages
-- [ldoc >= 1.4.5](https://stevedonovan.github.io/ldoc/) for generating the
-  documentation
-- [busted](https://olivinelabs.com/busted/) for running unit tests
-- [luacheck](https://github.com/mpeterv/luacheck) for static code analysis
-- [LuaCov](https://keplerproject.github.io/luacov/) for collecting code coverage
-  information
-- libexecinfo on systems where libc does not provide `backtrace_symbols()` to
-  generate slightly better backtraces on crashes
-- `Xephyr` or `Xvfb` for running integration tests
-- [GTK+ >= 3.10](https://www.gtk.org/) for `./themes/gtk/`
-- [xcb-errors](https://gitlab.freedesktop.org/xorg/lib/libxcb-errors) for
-  pretty-printing of X11 errors
-- [libRSVG](https://wiki.gnome.org/action/show/Projects/LibRsvg) for displaying
-  SVG files without scaling artifacts
-- [wmctrl](http://tripie.sweb.cz/utils/wmctrl) for testing WM interactions
-  with external actions
-- [xterm](https://invisible-island.net/xterm/) for various test cases
 
 ## Running Awesome
 

--- a/docs/10-building-and-testing.md
+++ b/docs/10-building-and-testing.md
@@ -138,5 +138,5 @@ Individual test categories can be run as well:
 * `make check-qa`: Run `luacheck` against the Lua library
 * `make check-unit`: Run unit tests with `busted` against the Lua library. You can also run `busted <options> ./spec` if you want to specify options for `busted`.
 * `make check-requires`: Check for invalid `require()` calls.
-* `make check-examples`: Run integration tests within the examples in `./tests/examples'.
+* `make check-examples`: Run integration tests within the examples in `./tests/examples`.
 * `make check-themes`: Test themes.

--- a/docs/10-building-and-testing.md
+++ b/docs/10-building-and-testing.md
@@ -1,0 +1,142 @@
+# Building and Testing
+
+## Dependencies
+
+Awesome has the following dependencies (besides a more-or-less standard POSIX
+environment):
+
+- [CMake >= 3.0.0](https://cmake.org)
+- [Lua >= 5.1.0](https://www.lua.org) or [LuaJIT](http://luajit.org)
+- [LGI >= 0.8.0](https://github.com/pavouk/lgi)
+- [xproto >= 7.0.15](https://www.x.org/archive//individual/proto/)
+- [libxcb >= 1.6](https://xcb.freedesktop.org/) with support for the RandR, XTest, Xinerama, SHAPE and
+  XKB extensions
+- [libxcb-cursor](https://xcb.freedesktop.org/)
+- [libxcb-util >= 0.3.8](https://xcb.freedesktop.org/)
+- [libxcb-keysyms >= 0.3.4](https://xcb.freedesktop.org/)
+- [libxcb-icccm >= 0.3.8](https://xcb.freedesktop.org/)
+- [libxcb-xfixes](https://xcb.freedesktop.org/)
+- [xcb-util-xrm >= 1.0](https://github.com/Airblader/xcb-util-xrm)
+- [libxkbcommon](http://xkbcommon.org/) with X11 support enabled
+- [libstartup-notification >=
+  0.10](https://www.freedesktop.org/wiki/Software/startup-notification/)
+- [cairo](https://www.cairographics.org/) with support for XCB and GObject
+  introspection
+- [Pango](http://www.pango.org/) with support for Cairo and GObject
+  introspection
+- [GLib >= 2.40](https://wiki.gnome.org/Projects/GLib) with support for GObject
+  introspection
+- [GIO](https://developer.gnome.org/gio/stable/) with support for GObject
+  introspection
+- [GdkPixbuf](https://wiki.gnome.org/Projects/GdkPixbuf)
+- libX11 with xcb support
+- [Imagemagick's convert utility](http://www.imagemagick.org/script/index.php)
+- [libxdg-basedir >= 1.0.0](https://github.com/devnev/libxdg-basedir)
+
+Additionally, the following optional dependencies exist:
+
+- [DBus](https://www.freedesktop.org/wiki/Software/dbus/) for DBus integration
+  and the `awesome-client` utility
+- [asciidoctor](https://asciidoctor.org/) for generating man pages
+- [gzip](http://www.gzip.org/) for compressing man pages
+- [ldoc >= 1.4.5](https://stevedonovan.github.io/ldoc/) for generating the
+  documentation
+- [busted](https://olivinelabs.com/busted/) for running unit tests
+- [luacheck](https://github.com/mpeterv/luacheck) for static code analysis
+- [LuaCov](https://keplerproject.github.io/luacov/) for collecting code coverage
+  information
+- libexecinfo on systems where libc does not provide `backtrace_symbols()` to
+  generate slightly better backtraces on crashes
+- `Xephyr` or `Xvfb` for running integration tests
+- [GTK+ >= 3.10](https://www.gtk.org/) for `./themes/gtk/`
+- [xcb-errors](https://gitlab.freedesktop.org/xorg/lib/libxcb-errors) for
+  pretty-printing of X11 errors
+- [libRSVG](https://wiki.gnome.org/action/show/Projects/LibRsvg) for displaying
+  SVG files without scaling artifacts
+- [wmctrl](http://tripie.sweb.cz/utils/wmctrl) for testing WM interactions
+  with external actions
+- [xterm](https://invisible-island.net/xterm/) for various test cases
+
+## Building
+
+With all dependencies installed, run the following commands within the root of the repository to build and install Awesome on your system:
+
+```sh
+make
+sudo make install
+```
+
+### Create packages
+
+To ease installation management, you can pack Awesome into `.deb` or `.rpm` packages. The following command will build the correct package for your system's package manager:
+
+```sh
+make package
+```
+
+To install the package, run one of the following commands:
+
+```sh
+sudo dpkg -i awesome-x.y.z.deb
+# or
+sudo rpm -Uvh awesome-x.y.z.rpm
+```
+
+### Customizing build options
+
+Awesome allows customizing various aspects of the build process through CMake variables. To change these variables, pass the `CMAKE_ARGS` environment variable to `make` with CMake flags as content (see `cmake -h`).
+
+Here is an example:
+
+```sh
+CMAKE_ARGS="-DLUA_EXECUTABLE=/usr/bin/lua5.3" make
+```
+
+**Note:**
+
+CMake arguments only need to be specified on the first run of `make` or after `make distclean`.
+
+#### Skip documentation
+
+The CMake variables `GENERATE_DOC` and `GENERATE_MANPAGES` toggle generation of HTML documentation and man pages respectively. They are enabled by default but can be set to `OFF`.
+
+```sh
+CMAKE_ARGS="-DGENERATE_DOC=OFF -DGENERATE_MANPAGES=OFF" make
+```
+
+#### Change the Lua version
+
+Both the build steps and the final binary require a working Lua interpreter. To change the Lua interpreter that both the build process and Awesome should use, specify an absolute path to a `lua` binary for `LUA_EXECUTABLE` and values that match the binary's version for `LUA_LIBRARY` and `LUA_INCLUDE_DIR`.
+
+Example to build on Arch Linux:
+
+```sh
+CMAKE_ARGS="-DLUA_EXECUTABLE=/usr/bin/lua5.3 -DLUA_LIBRARY=/usr/lib/liblua.so.5.3 -DLUA_INCLUDE_DIR=/usr/include/lua5.3" make
+```
+
+#### Additional options
+
+Additional variables can be found through CMake. Run the following command to print a list of all available variables, including the ones explained above:
+
+```sh
+cmake -B build -L
+```
+
+## Testing
+
+Once Awesome has been built, you can run various test suites to verify functionality for both the binary and the Lua library. Make sure to install applicable dependencies as outlined at the top.
+
+**Full test suite:**
+
+```sh
+make check
+```
+
+Individual test categories can be run as well:
+
+* `make check-integration`: Run integration tests within a Xephyr session.
+* `make check-qa`: Run `luacheck` against the Lua library
+* `make check-unit`: Run unit tests with `busted` against the Lua library. You can also run `busted <options> ./spec` if you want to specify options for `busted`.
+* `make check-requires`: Check for invalid `require()` calls.
+* `make check-examples`: Run integration tests within the examples in `./tests/examples'.
+* `make check-themes`: Test themes.

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -83,6 +83,7 @@ topics={
     '07-my-first-awesome.md',
     '08-client-layout-system.md',
     '09-options.md',
+    '10-building-and-testing.md',
     '16-using-cairo.md',
     '17-porting-tips.md',
     '90-FAQ.md',

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -1,5 +1,10 @@
 local spawn = require("awful.spawn")
 
+local lua_executable = os.getenv("LUA_EXECUTABLE")
+if lua_executable == nil or lua_executable == "" then
+    lua_executable = "lua"
+end
+
 -- This file provide a simple, yet flexible, test client.
 -- It is used to test the `ruled.client`
 
@@ -106,7 +111,7 @@ local pipe
 local function init()
     if initialized then return end
     initialized = true
-    local cmd = { os.getenv("LUA_EXECUTABLE"), "-e", test_client_source }
+    local cmd = { lua_executable, "-e", test_client_source }
     local _, _, stdin, stdout, stderr = awesome.spawn(cmd, false, true, true, true)
     pipe = Gio.UnixOutputStream.new(stdin, true)
     stdout = Gio.UnixInputStream.new(stdout, true)

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -106,7 +106,7 @@ local pipe
 local function init()
     if initialized then return end
     initialized = true
-    local cmd = { "lua", "-e", test_client_source }
+    local cmd = { os.getenv("LUA_EXECUTABLE"), "-e", test_client_source }
     local _, _, stdin, stdout, stderr = awesome.spawn(cmd, false, true, true, true)
     pipe = Gio.UnixOutputStream.new(stdin, true)
     stdout = Gio.UnixInputStream.new(stdout, true)

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -1,6 +1,6 @@
 local spawn = require("awful.spawn")
 
-local lua_executable = os.getenv("LUA_EXECUTABLE")
+local lua_executable = os.getenv("LUA")
 if lua_executable == nil or lua_executable == "" then
     lua_executable = "lua"
 end

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 cmake_minimum_required(VERSION 3.0.0)
 
 # Get and update the LUA_PATH so the scripts can be executed without awesome.
-execute_process(COMMAND lua -e "p = package.path:gsub(';', '\\\\;'); io.stdout:write(p)"
+execute_process(COMMAND ${LUA_EXECUTABLE} -e "p = package.path:gsub(';', '\\\\;'); io.stdout:write(p)"
     OUTPUT_VARIABLE "LUA_PATH_")
 
 # Allow to use the example tests by themselves.
@@ -40,9 +40,9 @@ if (DO_COVERAGE)
     message(${TEST_ERROR})
     message(FATAL_ERROR "Failed to run luacov.runner.")
   endif()
-  set(LUA_COV_RUNNER lua "-erequire('luacov.runner')('${TOP_SOURCE_DIR}/.luacov')")
+  set(LUA_COV_RUNNER ${LUA_EXECUTABLE} "-erequire('luacov.runner')('${TOP_SOURCE_DIR}/.luacov')")
 else()
-  set(LUA_COV_RUNNER lua)
+  set(LUA_COV_RUNNER ${LUA_EXECUTABLE})
 endif()
 
 if (STRICT_TESTS)

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 if (DO_COVERAGE)
   execute_process(
-    COMMAND env "SOURCE_DIRECTORY=${TOP_SOURCE_DIR}" lua -e "require('luacov.runner')('${TOP_SOURCE_DIR}/.luacov')"
+    COMMAND env "SOURCE_DIRECTORY=${TOP_SOURCE_DIR}" ${LUA_EXECUTABLE} -e "require('luacov.runner')('${TOP_SOURCE_DIR}/.luacov')"
     RESULT_VARIABLE TEST_RESULT
     ERROR_VARIABLE  TEST_ERROR
     ERROR_STRIP_TRAILING_WHITESPACE)

--- a/tests/test-selection-getter.lua
+++ b/tests/test-selection-getter.lua
@@ -8,7 +8,7 @@ local lgi = require("lgi")
 local Gio = lgi.Gio
 local GdkPixbuf = lgi.GdkPixbuf
 
-local lua_executable = os.getenv("LUA_EXECUTABLE")
+local lua_executable = os.getenv("LUA")
 if lua_executable == nil or lua_executable == "" then
     lua_executable = "lua"
 end

--- a/tests/test-selection-getter.lua
+++ b/tests/test-selection-getter.lua
@@ -48,7 +48,7 @@ runner.run_steps{
 
     -- Clear the clipboard to get to a known state
     function()
-        spawn.with_line_callback({ "lua", "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
         return true
     end,
@@ -79,7 +79,7 @@ runner.run_steps{
 
         -- Now set the clipboard to some text
         continue = false
-        spawn.with_line_callback({ "lua", "-e", acquire_clipboard_text },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_clipboard_text },
             { stdout = function(line)
                 assert(line == "initialisation done",
                     "Unexpected line: " .. line)
@@ -143,7 +143,7 @@ runner.run_steps{
 
         -- Now set the clipboard to an image
         continue = false
-        spawn.with_line_callback({ "lua", "-e", acquire_clipboard_pixbuf },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_clipboard_pixbuf },
             { stdout = function(line)
                 assert(line == "initialisation done",
                     "Unexpected line: " .. line)

--- a/tests/test-selection-getter.lua
+++ b/tests/test-selection-getter.lua
@@ -8,6 +8,11 @@ local lgi = require("lgi")
 local Gio = lgi.Gio
 local GdkPixbuf = lgi.GdkPixbuf
 
+local lua_executable = os.getenv("LUA_EXECUTABLE")
+if lua_executable == nil or lua_executable == "" then
+    lua_executable = "lua"
+end
+
 local header = [[
 local lgi = require("lgi")
 local Gdk = lgi.Gdk
@@ -48,7 +53,7 @@ runner.run_steps{
 
     -- Clear the clipboard to get to a known state
     function()
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ lua_executable, "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
         return true
     end,
@@ -79,7 +84,7 @@ runner.run_steps{
 
         -- Now set the clipboard to some text
         continue = false
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_clipboard_text },
+        spawn.with_line_callback({ lua_executable, "-e", acquire_clipboard_text },
             { stdout = function(line)
                 assert(line == "initialisation done",
                     "Unexpected line: " .. line)
@@ -143,7 +148,7 @@ runner.run_steps{
 
         -- Now set the clipboard to an image
         continue = false
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_clipboard_pixbuf },
+        spawn.with_line_callback({ lua_executable, "-e", acquire_clipboard_pixbuf },
             { stdout = function(line)
                 assert(line == "initialisation done",
                     "Unexpected line: " .. line)

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -3,6 +3,11 @@
 local runner = require("_runner")
 local spawn = require("awful.spawn")
 
+local lua_executable = os.getenv("LUA_EXECUTABLE")
+if lua_executable == nil or lua_executable == "" then
+    lua_executable = "lua"
+end
+
 -- Assemble data for the large transfer that will be done later
 local large_transfer_piece = "a"
 for _ = 1, 25 do
@@ -86,7 +91,7 @@ runner.run_steps({
             end
         end)
         awesome.sync()
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_targets_and_text },
+        spawn.with_line_callback({ lua_executable, "-e", check_targets_and_text },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -124,7 +129,7 @@ runner.run_steps({
             end
         end)
         awesome.sync()
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_targets_and_text },
+        spawn.with_line_callback({ lua_executable, "-e", check_targets_and_text },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -161,7 +166,7 @@ runner.run_steps({
             end
         end)
         awesome.sync()
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_large_transfer },
+        spawn.with_line_callback({ lua_executable, "-e", check_large_transfer },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -177,7 +182,7 @@ runner.run_steps({
         -- Now test that :release() works
         selection_object:release()
         awesome.sync()
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_empty_selection },
+        spawn.with_line_callback({ lua_executable, "-e", check_empty_selection },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -196,7 +201,7 @@ runner.run_steps({
             "Failed to acquire the clipboard selection")
         selection_object:connect_signal("release", function() selection_released = true end)
         awesome.sync()
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ lua_executable, "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
         return true
     end,

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -3,7 +3,7 @@
 local runner = require("_runner")
 local spawn = require("awful.spawn")
 
-local lua_executable = os.getenv("LUA_EXECUTABLE")
+local lua_executable = os.getenv("LUA")
 if lua_executable == nil or lua_executable == "" then
     lua_executable = "lua"
 end

--- a/tests/test-selection-transfer.lua
+++ b/tests/test-selection-transfer.lua
@@ -86,7 +86,7 @@ runner.run_steps({
             end
         end)
         awesome.sync()
-        spawn.with_line_callback({ "lua", "-e", check_targets_and_text },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_targets_and_text },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -124,7 +124,7 @@ runner.run_steps({
             end
         end)
         awesome.sync()
-        spawn.with_line_callback({ "lua", "-e", check_targets_and_text },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_targets_and_text },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -161,7 +161,7 @@ runner.run_steps({
             end
         end)
         awesome.sync()
-        spawn.with_line_callback({ "lua", "-e", check_large_transfer },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_large_transfer },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -177,7 +177,7 @@ runner.run_steps({
         -- Now test that :release() works
         selection_object:release()
         awesome.sync()
-        spawn.with_line_callback({ "lua", "-e", check_empty_selection },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", check_empty_selection },
             { stdout = function(line)
                 assert(line == "done", "Unexpected line: " .. line)
                 continue = true
@@ -196,7 +196,7 @@ runner.run_steps({
             "Failed to acquire the clipboard selection")
         selection_object:connect_signal("release", function() selection_released = true end)
         awesome.sync()
-        spawn.with_line_callback({ "lua", "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
         return true
     end,

--- a/tests/test-selection-watcher.lua
+++ b/tests/test-selection-watcher.lua
@@ -62,7 +62,7 @@ runner.run_steps{
     -- Clear the clipboard to get to a known state
     function()
         check_state(0, 0)
-        spawn.with_line_callback({ "lua", "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
         return true
     end,
@@ -81,7 +81,7 @@ runner.run_steps{
 
         -- Set the clipboard
         continue = false
-        spawn.with_line_callback({ "lua", "-e", acquire_clipboard },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_clipboard },
             { stdout = function(line)
                 assert(line == "initialisation done",
                     "Unexpected line: " .. line)
@@ -100,7 +100,7 @@ runner.run_steps{
 
         -- Now clear the clipboard again
         continue = false
-        spawn.with_line_callback({ "lua", "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
 
         return true

--- a/tests/test-selection-watcher.lua
+++ b/tests/test-selection-watcher.lua
@@ -3,7 +3,7 @@
 local runner = require("_runner")
 local spawn = require("awful.spawn")
 
-local lua_executable = os.getenv("LUA_EXECUTABLE")
+local lua_executable = os.getenv("LUA")
 if lua_executable == nil or lua_executable == "" then
     lua_executable = "lua"
 end

--- a/tests/test-selection-watcher.lua
+++ b/tests/test-selection-watcher.lua
@@ -3,6 +3,11 @@
 local runner = require("_runner")
 local spawn = require("awful.spawn")
 
+local lua_executable = os.getenv("LUA_EXECUTABLE")
+if lua_executable == nil or lua_executable == "" then
+    lua_executable = "lua"
+end
+
 local header = [[
 local lgi = require("lgi")
 local Gdk = lgi.Gdk
@@ -62,7 +67,7 @@ runner.run_steps{
     -- Clear the clipboard to get to a known state
     function()
         check_state(0, 0)
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ lua_executable, "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
         return true
     end,
@@ -81,7 +86,7 @@ runner.run_steps{
 
         -- Set the clipboard
         continue = false
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_clipboard },
+        spawn.with_line_callback({ lua_executable, "-e", acquire_clipboard },
             { stdout = function(line)
                 assert(line == "initialisation done",
                     "Unexpected line: " .. line)
@@ -100,7 +105,7 @@ runner.run_steps{
 
         -- Now clear the clipboard again
         continue = false
-        spawn.with_line_callback({ os.getenv("LUA_EXECUTABLE"), "-e", acquire_and_clear_clipboard },
+        spawn.with_line_callback({ lua_executable, "-e", acquire_and_clear_clipboard },
             { exit = function() continue = true end })
 
         return true

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -3,7 +3,7 @@
 local runner = require("_runner")
 local spawn = require("awful.spawn")
 
-local lua_executable = os.getenv("LUA_EXECUTABLE")
+local lua_executable = os.getenv("LUA")
 if lua_executable == nil or lua_executable == "" then
     lua_executable = "lua"
 end

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -11,7 +11,7 @@ local exit_yay, exit_snd = nil, nil
 -- * spawn with startup notification is covered by test-spawn-snid.lua
 
 local tiny_client = function(class)
-    return {"lua", "-e", [[
+    return {os.getenv("LUA_EXECUTABLE"), "-e", [[
 local lgi = require 'lgi'
 local Gtk = lgi.require('Gtk')
 local class = ']]..class..[['

--- a/tests/test-spawn.lua
+++ b/tests/test-spawn.lua
@@ -3,6 +3,11 @@
 local runner = require("_runner")
 local spawn = require("awful.spawn")
 
+local lua_executable = os.getenv("LUA_EXECUTABLE")
+if lua_executable == nil or lua_executable == "" then
+    lua_executable = "lua"
+end
+
 local spawns_done = 0
 local async_spawns_done = 0
 local exit_yay, exit_snd = nil, nil
@@ -11,7 +16,7 @@ local exit_yay, exit_snd = nil, nil
 -- * spawn with startup notification is covered by test-spawn-snid.lua
 
 local tiny_client = function(class)
-    return {os.getenv("LUA_EXECUTABLE"), "-e", [[
+    return { lua_executable, "-e", [[
 local lgi = require 'lgi'
 local Gtk = lgi.require('Gtk')
 local class = ']]..class..[['

--- a/tests/test-titlebar.lua
+++ b/tests/test-titlebar.lua
@@ -4,6 +4,11 @@ local rules = require("ruled.client")
 local spawn = require("awful.spawn")
 local gdebug = require("gears.debug")
 
+local lua_executable = os.getenv("LUA_EXECUTABLE")
+if lua_executable == nil or lua_executable == "" then
+    lua_executable = "lua"
+end
+
 local tiny_client_code_template = [[
 pcall(require, 'luarocks.loader')
 local Gtk, class = require('lgi').require('Gtk'), 'client'
@@ -18,8 +23,8 @@ function app:on_activate()
 end
 app:run {''}
 ]]
-local tiny_client = {os.getenv("LUA_EXECUTABLE"), "-e", string.format(tiny_client_code_template, "")}
-local tiny_client_undecorated = {os.getenv("LUA_EXECUTABLE"), "-e",
+local tiny_client = { lua_executable, "-e", string.format(tiny_client_code_template, "") }
+local tiny_client_undecorated = { lua_executable, "-e",
     string.format(tiny_client_code_template, [[
 window.decorated = false
 ]])

--- a/tests/test-titlebar.lua
+++ b/tests/test-titlebar.lua
@@ -18,8 +18,8 @@ function app:on_activate()
 end
 app:run {''}
 ]]
-local tiny_client = {"lua", "-e", string.format(tiny_client_code_template, "")}
-local tiny_client_undecorated = {"lua", "-e",
+local tiny_client = {os.getenv("LUA_EXECUTABLE"), "-e", string.format(tiny_client_code_template, "")}
+local tiny_client_undecorated = {os.getenv("LUA_EXECUTABLE"), "-e",
     string.format(tiny_client_code_template, [[
 window.decorated = false
 ]])

--- a/tests/test-titlebar.lua
+++ b/tests/test-titlebar.lua
@@ -4,7 +4,7 @@ local rules = require("ruled.client")
 local spawn = require("awful.spawn")
 local gdebug = require("gears.debug")
 
-local lua_executable = os.getenv("LUA_EXECUTABLE")
+local lua_executable = os.getenv("LUA")
 if lua_executable == nil or lua_executable == "" then
     lua_executable = "lua"
 end


### PR DESCRIPTION
Some platforms, such as Arch Linux, already moved to Lua 5.4, while
offering Lua 5.3 as a separate executable, such as `/usr/bin/lua5.3`.
To be able to build awesomeWM on these platforms without extensive
shims, this change introduces a new CMake variable `LUA_EXECUTABLE`.

Its default is set by `find_program` to the usual `/usr/bin/lua`,
but allows running CMake like this:

```sh
cmake ../ \
    -DLUA_INCLUDE_DIR=/usr/include/lua5.3 \
    -DLUA_LIBRARY=/usr/lib/liblua.so.5.3 \
    -DLUA_EXECUTABLE=/usr/bin/lua5.3
```