### PR TITLE
Remove unused first parameter in some constructors

### DIFF
--- a/docs/89-NEWS.md
+++ b/docs/89-NEWS.md
@@ -45,6 +45,7 @@ This document was last updated at commit v4.3-197-g9085ed631.
   Lua code using `io.popen`. Usage of `io.popen` is still strongly discouraged.
 * `wibox{ input_passthrough = true }` now works correctly. Previously, the
   property could only be set on already-constructed wiboxes.
+* Remove unused first parameter from multiple widget constructors: `wibox.container.place`,  `wibox.container.radialprogressbar`,  `wibox.layout.stack`,  `wibox.widget.slider`.
 
 ## Behavior changes
 

--- a/lib/wibox/container/place.lua
+++ b/lib/wibox/container/place.lua
@@ -199,8 +199,8 @@ local function new(widget, halign, valign)
     return ret
 end
 
-function place.mt:__call(_, ...)
-    return new(_, ...)
+function place.mt:__call(...)
+    return new(...)
 end
 
 --@DOC_widget_COMMON@

--- a/lib/wibox/container/radialprogressbar.lua
+++ b/lib/wibox/container/radialprogressbar.lua
@@ -277,7 +277,7 @@ local function new(widget)
     return ret
 end
 
-function radialprogressbar.mt:__call(_, ...)
+function radialprogressbar.mt:__call(...)
     return new(...)
 end
 

--- a/lib/wibox/layout/stack.lua
+++ b/lib/wibox/layout/stack.lua
@@ -204,7 +204,7 @@ local function new(...)
     return ret
 end
 
-function stack.mt:__call(_, ...)
+function stack.mt:__call(...)
     return new(...)
 end
 

--- a/lib/wibox/widget/slider.lua
+++ b/lib/wibox/widget/slider.lua
@@ -534,7 +534,7 @@ local function new(args)
     return ret
 end
 
-function slider.mt:__call(_, ...)
+function slider.mt:__call(...)
     return new(...)
 end
 

--- a/spec/wibox/container/place_spec.lua
+++ b/spec/wibox/container/place_spec.lua
@@ -5,10 +5,20 @@
 
 local place = require("wibox.container.place")
 local utils = require("wibox.test_utils")
+local base = require("wibox.widget.base")
 
 describe("wibox.container.place", function()
     it("common interfaces", function()
         utils.test_container(place())
+    end)
+
+    describe("constructor", function()
+        it("applies arguments", function()
+            local inner = base.empty_widget()
+            local widget = place(inner)
+
+            assert.is.equal(widget.widget, inner)
+        end)
     end)
 end)
 

--- a/spec/wibox/container/radialprogressbar_spec.lua
+++ b/spec/wibox/container/radialprogressbar_spec.lua
@@ -5,10 +5,20 @@
 
 local radialprogressbar = require("wibox.container.radialprogressbar")
 local utils = require("wibox.test_utils")
+local base = require("wibox.widget.base")
 
 describe("wibox.container.radialprogressbar", function()
     it("common interfaces", function()
         utils.test_container(radialprogressbar())
+    end)
+
+    describe("constructor", function()
+        it("applies arguments", function()
+            local inner = base.empty_widget()
+            local widget = radialprogressbar(inner)
+
+            assert.is.same(widget:get_children(), { inner })
+        end)
     end)
 end)
 

--- a/spec/wibox/layout/stack_spec.lua
+++ b/spec/wibox/layout/stack_spec.lua
@@ -1,0 +1,143 @@
+---------------------------------------------------------------------------
+-- @author Lucas Schwiderski
+-- @copyright 2021 Lucas Schwiderski
+---------------------------------------------------------------------------
+
+local stack = require("wibox.layout.stack")
+local base = require("wibox.widget.base")
+local utils = require("wibox.test_utils")
+local p = require("wibox.widget.base").place_widget_at
+
+describe("wibox.layout.fixed", function()
+    local layout
+    before_each(function()
+        layout = stack()
+    end)
+
+    it("empty layout fit", function()
+        assert.widget_fit(layout, { 10, 10 }, { 0, 0 })
+    end)
+
+    it("empty layout layout", function()
+        assert.widget_layout(layout, { 0, 0 }, {})
+    end)
+
+    it("empty add", function()
+        assert.has_error(function()
+            layout:add()
+        end)
+    end)
+
+    describe("with widgets", function()
+        local first, second, third
+
+        before_each(function()
+            first = utils.widget_stub(10, 10)
+            second = utils.widget_stub(15, 15)
+            third = utils.widget_stub(10, 10)
+
+            layout:add(first, second, third)
+        end)
+
+        describe("with enough space", function()
+            it("fit", function()
+                assert.widget_fit(layout, { 100, 100 }, { 15, 15 })
+            end)
+
+            it("layout", function()
+                assert.widget_layout(layout, { 100, 100 }, {
+                    p(first,  0, 0, 100, 100),
+                    p(second, 0, 0, 100, 100),
+                    p(third,  0, 0, 100, 100),
+                })
+            end)
+        end)
+
+        describe("without enough height", function()
+            it("fit", function()
+                assert.widget_fit(layout, { 5, 100 }, { 5, 15 })
+            end)
+
+            it("layout", function()
+                assert.widget_layout(layout, { 5, 100 }, {
+                    p(first,  0, 0, 5, 100),
+                    p(second, 0, 0, 5, 100),
+                    p(third,  0, 0, 5, 100),
+                })
+            end)
+        end)
+
+        describe("without enough width", function()
+            it("fit", function()
+                assert.widget_fit(layout, { 100, 5 }, { 15, 5 })
+            end)
+
+            it("layout", function()
+                assert.widget_layout(layout, { 100, 5 }, {
+                    p(first,  0, 0, 100, 5),
+                    p(second, 0, 0, 100, 5),
+                    p(third,  0, 0, 100, 5),
+                })
+            end)
+        end)
+    end)
+
+    describe("emitting signals", function()
+        local layout_changed
+        before_each(function()
+            layout:connect_signal("widget::layout_changed", function()
+                layout_changed = layout_changed + 1
+            end)
+            layout_changed = 0
+        end)
+
+        it("add", function()
+            local w1, w2 = base.empty_widget(), base.empty_widget()
+            assert.is.equal(layout_changed, 0)
+            layout:add(w1)
+            assert.is.equal(layout_changed, 1)
+            layout:add(w2)
+            assert.is.equal(layout_changed, 2)
+            layout:add(w2)
+            assert.is.equal(layout_changed, 3)
+        end)
+
+        it("set_spacing", function()
+            assert.is.equal(layout_changed, 0)
+            layout:set_spacing(0)
+            assert.is.equal(layout_changed, 0)
+            layout:set_spacing(5)
+            assert.is.equal(layout_changed, 1)
+            layout:set_spacing(2)
+            assert.is.equal(layout_changed, 2)
+            layout:set_spacing(2)
+            assert.is.equal(layout_changed, 2)
+        end)
+
+        it("reset", function()
+            assert.is.equal(layout_changed, 0)
+            layout:add(base.make_widget())
+            assert.is.equal(layout_changed, 1)
+            layout:reset()
+            assert.is.equal(layout_changed, 2)
+        end)
+    end)
+
+    it("set_children", function()
+        local w1, w2 = base.empty_widget(), base.empty_widget()
+
+        assert.is.same({}, layout:get_children())
+
+        layout:add(w1)
+        assert.is.same({ w1 }, layout:get_children())
+
+        layout:add(w2)
+        assert.is.same({ w1, w2 }, layout:get_children())
+
+        layout:reset()
+        assert.is.same({}, layout:get_children())
+    end)
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80
+

--- a/spec/wibox/widget/slider_spec.lua
+++ b/spec/wibox/widget/slider_spec.lua
@@ -14,7 +14,7 @@ describe("wibox.widget.slider", function()
 
     describe("constructor", function()
         it("applies arguments", function()
-            local widget = slider({ value = 10 })
+            widget = slider({ value = 10 })
 
             assert.is.equal(widget.value, 10)
         end)

--- a/spec/wibox/widget/slider_spec.lua
+++ b/spec/wibox/widget/slider_spec.lua
@@ -12,6 +12,14 @@ describe("wibox.widget.slider", function()
         widget = slider()
     end)
 
+    describe("constructor", function()
+        it("applies arguments", function()
+            local widget = slider({ value = 10 })
+
+            assert.is.equal(widget.value, 10)
+        end)
+    end)
+
     describe("signal property::value", function()
         local property_value = nil
         before_each(function()


### PR DESCRIPTION
Fixes #3214.

Likely a breaking change, even if only a few people were to use these constructors directly.