### PR TITLE
Fix composite widgets with top level container

### DIFF
--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -533,32 +533,34 @@ local function drill(ids, content)
         end
     end
 
-    -- Add all widgets.
-    for k = 1, max do
-        -- ipairs cannot be used on sparse tables.
-        local v, id2, e = widgets[k], id, nil
-        if v then
-            -- It is another declarative container, parse it.
-            if (not v.is_widget) and (v.widget or v.layout) then
-                e, id2 = drill(ids, v)
-                widgets[k] = e
-            elseif (not v.is_widget) and is_callable(v) then
-                 widgets[k] = v()
-            end
-            base.check_widget(widgets[k])
+    if widgets and max > 0 then
+        -- Add all widgets.
+        for k = 1, max do
+            -- ipairs cannot be used on sparse tables.
+            local v, id2, e = widgets[k], id, nil
+            if v then
+                -- It is another declarative container, parse it.
+                if (not v.is_widget) and (v.widget or v.layout) then
+                    e, id2 = drill(ids, v)
+                    widgets[k] = e
+                elseif (not v.is_widget) and is_callable(v) then
+                     widgets[k] = v()
+                end
+                base.check_widget(widgets[k])
 
-            -- Place the widget in the access table.
-            if id2 then
-                l  [id2] = e
-                ids[id2] = ids[id2] or {}
-                table.insert(ids[id2], e)
+                -- Place the widget in the access table.
+                if id2 then
+                    l  [id2] = e
+                    ids[id2] = ids[id2] or {}
+                    table.insert(ids[id2], e)
+                end
             end
         end
-    end
-    -- Replace all children (if any) with the new ones.
-    if widgets then
+
+        -- Replace all children (if any) with the new ones.
         l:set_children(widgets)
     end
+
     return l, id
 end
 

--- a/spec/wibox/container/margin_spec.lua
+++ b/spec/wibox/container/margin_spec.lua
@@ -3,12 +3,59 @@
 -- @copyright 2017 Uli Schlachter
 ---------------------------------------------------------------------------
 
+local base = require('wibox.widget.base')
 local margin = require("wibox.container.margin")
+local imagebox = require("wibox.widget.imagebox")
 local utils = require("wibox.test_utils")
 
 describe("wibox.container.margin", function()
     it("common interfaces", function()
         utils.test_container(margin())
+    end)
+
+    describe("composite widgets", function()
+        it("can be wrapped with child", function()
+            local widget_name = "test_widget"
+            local new = function()
+                local ret = base.make_widget_declarative {
+                    {
+                        id = "img",
+                        widget = imagebox,
+                    },
+                    widget = margin,
+                }
+
+                ret.widget_name = widget_name
+
+                return ret
+            end
+
+            local widget = base.make_widget_declarative {
+                widget = new,
+            }
+
+            assert.is.equal(
+                widget_name,
+                widget.widget_name,
+                "Widget name doesn't match"
+            )
+            local children = widget:get_children()
+            assert.is_not.Nil(children, "Widget doesn't have children")
+            assert.is.equal(
+                1,
+                #children,
+                "Widget should have exactly one child"
+            )
+            assert.is.True(
+                children[1].is_widget,
+                "Child widget should be a valid widget"
+            )
+            assert.is.equal(
+                widget.img,
+                children[1],
+                "Child widget should match the id accessor"
+            )
+        end)
     end)
 end)
 


### PR DESCRIPTION
When wrapping container widgets to create reusable composite widgets, `drill` will be called twice on the same widget definition. The first call happens within the wrapping function and applies the children widgets fine. The second call happens when the composite widget is used, but since there are no children widgets defined, the call to `set_children` sets the existing child to `nil` instead.

This change will prevent the second call from overriding the children created by the first call.

Fixes #3213.