### PR TITLE
Docs: Fix code example for cairo usage.

### DIFF
--- a/docs/16-using-cairo.md
+++ b/docs/16-using-cairo.md
@@ -147,7 +147,7 @@ some examples. Here is the most simple example you can get:
     local cr  = cairo.Context(img)
 
     -- Set a red source
-    cr:set_source(1, 0, 0)
+    cr:set_source_rgb(1, 0, 0)
     -- Alternative:
     cr:set_source(gears.color("#ff0000"))
 


### PR DESCRIPTION
I was playing around with cairo, when I noticed that the code example in the docs for cairo surfaces didn't work. `cr:set_source(1, 0, 0)` should actually be `cr:set_source_rgb(1, 0, 0)`.