### PR TITLE
[doc] fix(ldoc.ltp): extra-header tag arrangement

### DIFF
--- a/docs/ldoc.ltp
+++ b/docs/ldoc.ltp
@@ -193,8 +193,8 @@
 #     end -- for
     </ul>
 #   end -- if usage
-<div class="extra-header">
-# if module.tags.supermodule or module.tags.knownusage then
+    <div class="extra-header">
+# if module.tags.supermodule then
   <div class="extra-header__section">
     <h3>Class Hierarchy</h3>
     <div class="inheritance">
@@ -216,15 +216,16 @@
         </li>
 #   end
     </ul>
-# end -- module.tags.supermodule
+# end -- function draw_hierary_recursifly
 # draw_hierary_recursifly(#hierarchy)
     </div>
-# end
+  </div>
+# end -- module.tags.supermodule
 
 #   if module.tags.include then
         $(M(ldoc.include_file(module.tags.include)))
 #   end
-  </div>
+
 #   if module.info then
   <div class="extra-header__section">
     <h3>Info:</h3>
@@ -235,25 +236,19 @@
     </ul>
   </div>
 #   end -- if module.info
+
 #   if module.see then
   <div class="extra-header__section">
 #     local li,il = use_li(module.see)
+#     local list_or_p =(#module.see > 1) and 'ul' or 'p'
     <h3>See also:</h3>
-#     if #module.see > 1 then
-    <ul>
-#     else
-    <p>
-#     end
+    <$(list_or_p)>
 #     for see in iter(module.see) do
          $(li)<a href="$(ldoc.href(see))">$(see.label)</a>$(il)
 #    end -- for
-#     if #module.see > 1 then
-    </ul>
-#     else
-    </p>
-#     end
+    </$(list_or_p)>
   </div>
-#   end -- if see
+#   end -- if module.see
 </div>
 
 


### PR DESCRIPTION
This fix the tag arrangement issue @Elv13 spotted following the merge of #3288.

As a side note, there is a block line 225-227 (after applying this patch):

```lua
#   if module.tags.include then
        $(M(ldoc.include_file(module.tags.include)))
#   end
```

I don't know what it is used for, I can't find an instance of `@include` in our codebase, and it seems this if statement is always evaluated to `false` (I tried to force the print of `module.tags.include`, and it was always empty).

@blueyed, git blame says you added these lines (6792415cef33e2a251a11cedf3a24430a03d7fc6), what are this supposed to be used for? Should we move this block to a `extra-header__section` block?