### PR TITLE
Fail awesome compilation for Lua5.4 or newer (#3324)

### DIFF
--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -71,6 +71,13 @@ if (NOT LUA_FOUND)
         "You might want to hint it using the LUA_DIR environment variable, "
         "or set the LUA_INCLUDE_DIR / LUA_LIBRARY CMake variables.")
 endif()
+
+set(LUA_FULL_VERSION "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
+if(LUA_FULL_VERSION VERSION_EQUAL 5.4.0 OR LUA_FULL_VERSION VERSION_GREATER 5.4.0 )
+    message(FATAL_ERROR "Awesome doesn't support Lua versions newer than 5.3, please refer to"
+                        "https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
+endif()
+
 # }}}
 
 # {{{ Check if documentation can be build

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -73,8 +73,9 @@ if (NOT LUA_FOUND)
 endif()
 
 set(LUA_FULL_VERSION "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
-if(LUA_FULL_VERSION VERSION_EQUAL 5.4.0 OR LUA_FULL_VERSION VERSION_GREATER 5.4.0 )
-    message(FATAL_ERROR "Awesome doesn't support Lua versions newer than 5.3, please refer to"
+# 5.1 <= LUA_VERSION < 5.4
+if(NOT ((LUA_FULL_VERSION VERSION_EQUAL 5.1.0 OR LUA_FULL_VERSION VERSION_GREATER 5.1.0) AND LUA_FULL_VERSION VERSION_LESS 5.4.0))
+    message(FATAL_ERROR "Awesome only supports Lua versions 5.1-5.3, please refer to"
                         "https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
 endif()
 

--- a/luaa.h
+++ b/luaa.h
@@ -32,7 +32,7 @@
 #include "common/luaclass.h"
 
 #if !(501 <= LUA_VERSION_NUM && LUA_VERSION_NUM < 504)
-print("Awesome only supports Lua versions 5.1-5.3, please refer to, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
+print("Awesome only supports Lua versions 5.1-5.3, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
 #endif
 
 #define luaA_deprecate(L, repl) \

--- a/luaa.h
+++ b/luaa.h
@@ -32,7 +32,7 @@
 #include "common/luaclass.h"
 
 #if !(501 <= LUA_VERSION_NUM && LUA_VERSION_NUM < 504)
-print("Awesome only supports Lua versions 5.1-5.3, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
+#error "Awesome only supports Lua versions 5.1-5.3 and LuaJIT2, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building"
 #endif
 
 #define luaA_deprecate(L, repl) \

--- a/luaa.h
+++ b/luaa.h
@@ -31,8 +31,8 @@
 #include "common/lualib.h"
 #include "common/luaclass.h"
 
-#if LUA_VERSION_NUM > 503
-print("Awesome doesn't support Lua versions newer than 5.3, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
+#if !(501 <= LUA_VERSION_NUM && LUA_VERSION_NUM < 504)
+print("Awesome only supports Lua versions 5.1-5.3, please refer to, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
 #endif
 
 #define luaA_deprecate(L, repl) \

--- a/luaa.h
+++ b/luaa.h
@@ -31,6 +31,10 @@
 #include "common/lualib.h"
 #include "common/luaclass.h"
 
+#if LUA_VERSION_NUM > 503
+print("Awesome doesn't support Lua versions newer than 5.3, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
+#endif
+
 #define luaA_deprecate(L, repl) \
     do { \
         luaA_warn(L, "%s: This function is deprecated and will be removed, see %s", \


### PR DESCRIPTION
Since Awesome doesn't support these versions, preventing the project from
compiling with it saves the users some very frustrating and hard to
debug bugs.

The cmake version check is redundant with the version check in luaa.h.
Nevertheless, adding it allows to fail the project build sooner and
provides better user experience.

Fixes: #3324