### PR TITLE
Graph widget overhaul

### DIFF
--- a/lib/wibox/widget/graph.lua
+++ b/lib/wibox/widget/graph.lua
@@ -20,9 +20,12 @@
 local setmetatable = setmetatable
 local ipairs = ipairs
 local math = math
+local math_max = math.max
+local math_min = math.min
 local table = table
-local type = type
 local color = require("gears.color")
+local gdebug = require("gears.debug")
+local gtable = require("gears.table")
 local base = require("wibox.widget.base")
 local beautiful = require("beautiful")
 
@@ -39,8 +42,6 @@ local graph = { mt = {} }
 
 --- Set the graph border color.
 --
--- If the value is nil, no border will be drawn.
---
 --@DOC_wibox_widget_graph_border_color_EXAMPLE@
 --
 -- @property border_color
@@ -50,6 +51,8 @@ local graph = { mt = {} }
 -- @see gears.color
 
 --- Set the graph foreground color.
+--
+-- This color is used, when `group_colors` isn't set.
 --
 --@DOC_wibox_widget_graph_color_EXAMPLE@
 --
@@ -69,38 +72,90 @@ local graph = { mt = {} }
 -- @propemits true false
 -- @see gears.color
 
---- Set the maximum value the graph should handle.
+--- Set the colors for data groups.
+--
+-- Colors in this table are used to paint respective data groups.
+-- When this property is unset (default), the `color` property is used
+-- instead for all data groups.
+-- When this property is set, but there's no color for a data group in it
+-- (i.e. `group_colors`[group] is nil or false), then the respective
+-- data group is disabled, i.e. not drawn.
+--
+-- @DOC_wibox_widget_graph_stacked_group_disable_EXAMPLE@
+--
+-- @property group_colors
+-- @tparam table colors A table with colors for data groups.
+-- @see gears.color
+
+--- The maximum value the graph should handle.
+--
+-- This value corresponds to the top of the graph.
+-- If `scale` is also set, the graph never scales up below this value, but it
+-- automatically scales down to make all data fit.
+-- If `scale` and `max_value` are unset, `max_value` defaults to 1.
 --
 -- @DOC_wibox_widget_graph_max_value_EXAMPLE@
---
--- If "scale" is also set, the graph never scales up below this value, but it
--- automatically scales down to make all data fit.
 --
 -- @property max_value
 -- @tparam number max_value
 -- @propemits true false
 
---- The minimum value.
+--- The minimum value the graph should handle.
+--
+-- This value corresponds to the bottom of the graph.
+-- If `scale` is also set, the graph never scales up above this value, but it
+-- automatically scales down to make all data fit.
+-- If `scale` and `min_value` are unset, `min_value` defaults to 0.
 --
 -- @DOC_wibox_widget_graph_min_value_EXAMPLE@
 --
--- Note that the min_value is not supported when used along with the stack
--- property.
 -- @property min_value
 -- @tparam number min_value
 -- @propemits true false
 
 --- Set the graph to automatically scale its values. Default is false.
 --
---@DOC_wibox_widget_graph_scale1_EXAMPLE@
+-- If this property is set to true, the graph calculates
+-- effective `min_value` and `max_value` based on the displayed data,
+-- so that all data fits on screen. The properties themselves aren't changed,
+-- but the graph is drawn as though `min_value`(`max_value`) were equal to
+-- the minimum(maximum) value among itself and the currently drawn values.
+-- If `min_value`(`max_value`) is unset, then only the drawn values
+-- are considered in this calculation.
+--
+-- @DOC_wibox_widget_graph_scale1_EXAMPLE@
 --
 -- @property scale
 -- @tparam boolean scale
 -- @propemits true false
 
---- Set the width or the individual steps.
+--- Clamp graph bars to keep them inside the widget for out-of-range values.
 --
--- Note that it isn't supported when used along with stacked graphs.
+-- Drawing values outside the [`min_value`, `max_value`] range leads to
+-- bar shapes that exceed physical widget dimensions.
+-- Most of the time this doesn't matter, because bar shapes are rectangles
+-- and bar heights aren't large enough to trigger errors in the drawing system.
+-- However for some shapes and values it does make a difference and leads
+-- to visibly different and/or invalid result.
+--
+-- When this property is set to true (the default), the graph clamps
+-- bars' heights to keep them within the graph.
+--
+-- @DOC_wibox_widget_graph_clamp_bars_EXAMPLE@
+--
+-- @property clamp_bars
+-- @tparam boolean clamp_bars
+-- @propemits true false
+
+--- The value corresponding to the starting point of graph bars. Default is 0.
+--
+-- @DOC_wibox_widget_graph_baseline_value_EXAMPLE@
+--
+-- @property baseline_value
+-- @tparam number baseline_value
+-- @propemits true false
+
+--- Set the width or the individual steps.
 --
 --@DOC_wibox_widget_graph_step_EXAMPLE@
 --
@@ -109,8 +164,6 @@ local graph = { mt = {} }
 -- @propemits true false
 
 --- Set the spacing between the steps.
---
--- Note that it isn't supported when used along with stacked graphs.
 --
 --@DOC_wibox_widget_graph_step_spacing_EXAMPLE@
 --
@@ -129,27 +182,58 @@ local graph = { mt = {} }
 
 --- Set the graph to draw stacks. Default is false.
 --
---@DOC_wibox_widget_graph_stacked_EXAMPLE@
+-- When set to true, bars of each successive data group are drawn on top of
+-- bars of previous groups, instead of the baseline.
+-- This necessitates all data values to be non-negative.
+-- Negative values, if present, will trigger @{nan_color|NaN indication}.
+--
+-- @DOC_wibox_widget_graph_normal_vs_stacked_EXAMPLE@
+--
 -- @property stack
 -- @tparam boolean stack
 -- @propemits true false
 
---- Set the graph stacking colors. Order matters.
+--- Display NaN indication. Default is true.
 --
--- @property stack_colors
--- @tparam table stack_colors A table with stacking colors.
-
---- The graph background color.
+-- When the data contains [NaN](https://en.wikipedia.org/wiki/NaN) values,
+-- and `nan_indication` is set, the corresponding area,
+-- where the value bar should have been drawn, is filled
+-- with the `nan_color` from top to bottom.
+-- The painting is done after all other data is rendered,
+-- to make sure that it won't be overpainted and go unnoticed.
 --
--- @beautiful beautiful.graph_bg
--- @param color
+-- @DOC_wibox_widget_graph_nan_color_EXAMPLE@
+--
+-- @property nan_indication
+-- @tparam boolean nan_indication
+-- @propemits true false
 
---- The graph foreground color.
+--- The color of NaN indication.
+--
+-- The color used when `nan_indication` is set.
+-- Defaults to a yellow-black diagonal stripes pattern.
+--
+-- @DOC_wibox_widget_graph_stacked_nan_EXAMPLE@
+--
+-- @property nan_color
+-- @tparam gears.color nan_color The color of NaN indication.
+-- @propemits true false
+-- @see gears.color
+
+--- The graph foreground color
+-- Used, when the `color` property isn't set.
 --
 -- @beautiful beautiful.graph_fg
 -- @param color
 
+--- The graph background color.
+-- Used, when the `background_color` property isn't set.
+--
+-- @beautiful beautiful.graph_bg
+-- @param color
+
 --- The graph border color.
+-- Used, when the `border_color` property isn't set.
 --
 -- @beautiful beautiful.graph_border_color
 -- @param color
@@ -157,70 +241,255 @@ local graph = { mt = {} }
 local properties = { "width", "height", "border_color", "stack",
                      "stack_colors", "color", "background_color",
                      "max_value", "scale", "min_value", "step_shape",
-                     "step_spacing", "step_width", "border_width" }
+                     "step_spacing", "step_width", "border_width",
+                     "clamp_bars", "baseline_value",
+                     "capacity", "nan_color", "nan_indication",
+                     "group_colors",
+}
 
-function graph.draw(_graph, _, cr, width, height)
-    local max_value = _graph._private.max_value
-    local min_value = _graph._private.min_value or (
-        _graph._private.scale and math.huge or 0)
-    local values = _graph._private.values
+-- This is what the properties are set to on widget construction.
+local prop_defaults = {
+    baseline_value   = 0,
+    clamp_bars       = true,
+    nan_indication   = true,
+    step_width       = 1,
+    step_spacing     = 0,
 
-    local step_shape = _graph._private.step_shape
-    local step_spacing = _graph._private.step_spacing or 0
-    local step_width = _graph._private.step_width or 1
-    local bw = _graph._private.border_width or 1
+-- These aren't very useful to set, and the docs don't distinguish between
+-- "defaults to" (equals to in a fresh instance) and
+-- "falls back to" (is assumed to be equal to, when nil) anyway.
+--  scale          = false,
+--  stack          = false,
+}
 
-    cr:set_line_width(bw)
+-- This is what the properties are assumed to be in the code, when unset/falsy.
+local prop_fallbacks = {
+-- This one might become beautiful-themed in the future, so we can't set it
+-- in the constructor.
+    border_width     = 0,
 
-    -- Draw the background first
-    cr:set_source(color(_graph._private.background_color or beautiful.graph_bg or "#000000aa"))
-    cr:paint()
+-- These are better left unreplaced in code, because they're used only in one
+-- place and the intent is more clear when the numbers are directly visible.
+--  min_value        = 0,
+--  max_value        = 1,
 
-    -- Account for the border width
-    cr:save()
+-- This one is set later. It's not in `prop_defaults`, because I don't
+-- want to make it accessible through the getter, lest the user somehow mutates
+-- the Cairo pattern and breaks NaN indication for all other graphs.
+--  nan_color        = make_fallback_nan_color()
+}
 
-    if _graph._private.border_color then
-        cr:translate(bw, bw)
-        width, height = width - 2*bw, height - 2*bw
+-- All property defaults are also necessarily fallbacks.
+gtable.crush(prop_fallbacks, prop_defaults, true)
+
+-- These fallbacks are themed and can change on the fly.
+setmetatable(prop_fallbacks, {
+    __index = function(_, key)
+        -- TODO: maybe theme graph.nan_color too?
+        if key == "background_color" then
+            return beautiful.graph_bg or "#000000aa"
+        elseif key == "border_color" then
+            return beautiful.graph_border_color or "#ffffff"
+        elseif key == "color" then
+            return beautiful.graph_fg or "#ff0000"
+        end
+    end
+})
+
+-- This function sets up default implementations for property getters/setters,
+-- when none exist yet. It will be called at the end of this class module.
+local function build_properties(prototype, prop_names)
+    for _, prop in ipairs(prop_names) do
+        if not prototype["set_" .. prop] then
+            prototype["set_" .. prop] = function(self, value)
+                if self._private[prop] ~= value then
+                    self._private[prop] = value
+                    self:emit_signal("widget::redraw_needed")
+                    self:emit_signal("property::"..prop, value)
+                end
+                return self
+            end
+        end
+        if not prototype["get_" .. prop] then
+            prototype["get_" .. prop] = function(self)
+                return self._private[prop]
+            end
+        end
+    end
+end
+
+-- Creates a yellow-black danger stripe @{gears.color} for NaN indication.
+local function build_fallback_nan_color()
+    local clr = color.create_pattern_uncached({
+        ["type"] = "linear",
+        from = {0, 0}, to = {4, 4},
+        stops={
+            {0, "#000000"},
+            {0.25, "#000000"}, {0.25, "#ffff00"},
+            {0.50, "#ffff00"}, {0.50, "#000000"},
+            {0.75, "#000000"}, {0.75, "#ffff00"},
+            {1, "#ffff00"},
+        },
+    })
+    clr:set_extend("REPEAT")
+    return clr
+end
+
+-- Set up the nan_color fallback.
+prop_fallbacks.nan_color = build_fallback_nan_color()
+
+--
+-- Module and prototype methods.
+--
+
+local function graph_gather_drawn_values_num_stats(self, new_value)
+    if not (new_value >= 0) then
+        return -- is negative or NaN
     end
 
-    -- Draw a stacked graph
-    if _graph._private.stack then
-
-        if _graph._private.scale then
-            for _, v in ipairs(values) do
-                for _, sv in ipairs(v) do
-                    if sv > max_value then
-                        max_value = sv
-                    end
-                    if min_value > sv then
-                        min_value = sv
-                    end
-                end
-            end
-        end
-
-        for i = 0, width do
-            local rel_i = 0
-            local rel_x = i + 0.5
-
-            if _graph._private.stack_colors then
-                for idx, col in ipairs(_graph._private.stack_colors) do
-                    local stack_values = values[idx]
-                    if stack_values and i < #stack_values then
-                        local value = stack_values[#stack_values - i] + rel_i
-                        cr:move_to(rel_x, height * (1 - (rel_i / max_value)))
-                        cr:line_to(rel_x, height * (1 - (value / max_value)))
-                        cr:set_source(color(col or beautiful.graph_fg or "#ff0000"))
-                        cr:stroke()
-                        rel_i = value
-                    end
-                end
-            end
-        end
+    local last_value = self._private.last_drawn_values_num or 0
+    -- Grow instantly and shrink slow
+    if new_value < last_value then
+        self._private.last_drawn_values_num = last_value - 1
     else
-        if _graph._private.scale then
-            for _, v in ipairs(values) do
+        self._private.last_drawn_values_num = new_value
+    end
+end
+
+--- Determine the color to paint a data group with.
+--
+-- The graph uses this method to choose a color for a given data group.
+-- The default implementation uses a color from the `group_colors` table,
+-- if present, otherwise it falls back to `color`, then
+-- `beautiful.graph_fg` and finally to color red (#ff0000).
+--
+-- @method pick_data_group_color
+-- @tparam number group_idx The index of the data group.
+-- @treturn gears.color The color to paint the data group's values with.
+function graph:pick_data_group_color(group_idx)
+    -- Use an individual group color, if there's one
+    local data_group_colors = self._private.group_colors
+    local clr = data_group_colors and data_group_colors[group_idx]
+    -- Or fall back to some other colors
+    return clr or self._private.color or prop_fallbacks.color
+end
+
+--- Determine if a data group should be rendered.
+--
+-- The graph uses this method to decide whether the given data group
+-- should get its values rendered.
+--
+-- The default implementation says yes to all data groups, unless
+-- `group_colors` property is set, in which case only those groups are
+-- rendered, for which there are colors in the `group_colors` table,
+-- so one can e.g. disable groups by setting their colors to false.
+--
+-- @method should_draw_data_group
+-- @tparam number group_idx The index of the data group.
+-- @treturn boolean true if the group should be rendered, false otherwise.
+-- @local I'm not confident, that this is good API, so I'm making it private.
+local function graph_should_draw_data_group(self, group_idx)
+    -- This default implementation decides, whether a group should be drawn,
+    -- based on presence of colors, for reasons of backward compatibility.
+    local data_group_colors = self._private.group_colors
+    if not data_group_colors then
+        -- The colors table isn't set, all data groups are deemed enabled.
+        return true
+    end
+
+    -- A group is enabled if it has a color, i.e. nil color means "don't draw it"
+    return not not data_group_colors[group_idx]
+end
+
+local function graph_preprocess_values(self, values, drawn_values_num)
+    -- TODO: elevate to function documentation, if we decide to make it public API.
+    --- Preprocesses values before drawing them.
+    -- This function can return up to 2 values: drawn_values and scaling_values
+    -- The former will be used as values to draw in place of the original data.
+    -- The latter will be used as values to scan for min/max value for scaling.
+    -- Either can be nil, which means: use values as is.
+
+    -- This default implementation is only used to implement
+    -- presumming values for stacked graphs.
+    if not self._private.stack then
+        return
+    end
+
+    -- Prepare to draw a stacked graph
+
+    -- summed_values[i] = sum [1,#values] of values[c][i]
+    local summed_values = {}
+    -- drawn_values[c][i] = sum [1,c] of values[c][i]
+    local drawn_values = {}
+
+    local nan = 0/0
+
+    -- Add stacked values up to get values we need to render
+    for group_idx, group_values in ipairs(values) do
+        local drawn_row = {}
+        drawn_values[group_idx] = drawn_row
+
+        if graph_should_draw_data_group(self, group_idx) then
+            for idx, value in ipairs(group_values) do
+                if idx > drawn_values_num then
+                    break
+                end
+
+                -- drawn_values will have NaN values in it due to negatives/NaNs in input.
+                -- we can't simply treat them like zeros during rendering,
+                -- in case step_shape() draws visible shapes for actual zero values too.
+                local acc = summed_values[idx] or 0
+                if value >= 0 then
+                    acc = acc + value
+                    drawn_row[idx] = acc
+                else
+                    drawn_row[idx] = nan
+                end
+                summed_values[idx] = acc
+            end
+        end
+    end
+
+    -- In a stacked graph it's sufficient to examine only the last summed row
+    -- to determine the max_value, since all values are necessarily >= 0
+    -- and the min_value should be always at most 0
+    local scaling_values = { {0}, summed_values }
+
+    return drawn_values, scaling_values
+end
+
+local function graph_map_value_to_widget_coordinates(self, value, min_value, max_value, height)
+    -- Scale the value so that [min_value..max_value] maps to [0..1]
+    value = (value - min_value) / (max_value - min_value)
+
+    -- Check whether value is NaN
+    if value == value then
+        if self._private.clamp_bars then
+            -- Don't allow the bar to exceed widget's dimensions
+            value = math_min(1, math_max(0, value))
+        end
+
+        -- Drawing bars up from the lower edge of the widget
+        return height * (1 - value)
+    end
+    return value --NaN
+end
+
+local function graph_choose_coordinate_system(self, scaling_values, drawn_values_num, height)
+    local scale = self._private.scale
+    local max_value = self._private.max_value or (scale and -math.huge or 1)
+    local min_value = self._private.min_value or (scale and math.huge or 0)
+
+    if scale then
+        for _, group_values in ipairs(scaling_values) do
+            for idx, v in ipairs(group_values) do
+                -- Do not let off-screen values affect autoscaling
+                if idx > drawn_values_num then
+                    break
+                end
+
+                -- We don't use math.min/max here to be sure that
+                -- min/max_value don't accidentally get assigned a NaN
                 if v > max_value then
                     max_value = v
                 end
@@ -229,88 +498,247 @@ function graph.draw(_graph, _, cr, width, height)
                 end
             end
         end
-
-        -- Draw the background on no value
-        if #values ~= 0 then
-            -- Draw reverse
-            for i = 0, #values - 1 do
-                local value = values[#values - i]
-                if value >= 0 then
-                    local x = i*step_width + ((i-1)*step_spacing) + 0.5
-                    value = (value - min_value) / max_value
-                    cr:move_to(x, height * (1 - value))
-
-                    if step_shape then
-                        cr:translate(step_width + (i>1 and step_spacing or 0), height * (1 - value))
-                        step_shape(cr, step_width, height)
-                        cr:translate(0, -(height * (1 - value)))
-                    elseif step_width > 1 then
-                        cr:rectangle(x, height * (1 - value), step_width, height)
-                    else
-                        cr:line_to(x, height)
-                    end
-                end
-            end
-            cr:set_source(color(_graph._private.color or beautiful.graph_fg or "#ff0000"))
-
-            if step_shape or step_width > 1 then
-                cr:fill()
-            else
-                cr:stroke()
-            end
+        if min_value == max_value then
+            -- If all values are equal in an autoscaled graph,
+            -- simply draw them in the middle
+            min_value, max_value = min_value - 1, max_value + 1
         end
-
     end
 
-    -- Undo the cr:translate() for the border and step shapes
-    cr:restore()
+    -- The position of the baseline in value coordinates
+    -- It defaults to the usual zero axis
+    local baseline_value = self._private.baseline_value or prop_fallbacks.baseline_value
+    -- Let's map it into widget coordinates
+    local baseline_y = graph_map_value_to_widget_coordinates(
+        self, baseline_value, min_value, max_value, height
+    )
+
+    return min_value, max_value, baseline_y
+end
+
+local function graph_draw_values(self, cr, _, height, drawn_values_num)
+    local values = self._private.values
+
+    local step_shape = self._private.step_shape
+    local step_spacing = self._private.step_spacing or prop_fallbacks.step_spacing
+    local step_width = self._private.step_width or prop_fallbacks.step_width
+
+    -- Cache methods used in the inner loop for a 3x performance boost
+    local cairo_rectangle = cr.rectangle
+    local cairo_translate = cr.translate
+    local cairo_set_matrix = cr.set_matrix
+    local map_coords = graph_map_value_to_widget_coordinates
+
+    -- Preserve the transform centered at the top-left corner of the graph
+    local pristine_transform = step_shape and cr:get_matrix()
+
+    local drawn_values, scaling_values = graph_preprocess_values(self, values, drawn_values_num)
+    -- If preprocessor returned drawn_values = nil, then simply draw the values we have
+    drawn_values = drawn_values or values
+    -- If preprocessor returned scaling_values = nil, then
+    -- all drawn values need to be examined to determine proper scaling
+    scaling_values = scaling_values or drawn_values
+
+    local min_value, max_value, baseline_y = graph_choose_coordinate_system(
+        self, scaling_values, drawn_values_num, height
+    )
+
+    local nan_x = self._private.nan_indication and {}
+    local prev_y = self._private.stack and {}
+
+    for group_idx, group_values in ipairs(drawn_values) do
+        if graph_should_draw_data_group(self, group_idx) then
+            -- Set the data series' color early, in case the user
+            -- wants to do their own painting inside step_shape()
+            cr:set_source(color(self:pick_data_group_color(group_idx)))
+
+            for i = 1, math_min(#group_values, drawn_values_num) do
+                local value = group_values[i]
+
+                local value_y = map_coords(self, value, min_value, max_value, height)
+                local not_nan = value_y == value_y
+
+                -- The coordinate of the i-th bar's left edge
+                local x = (i-1)*(step_width + step_spacing)
+
+                if not_nan then
+                    local base_y = baseline_y
+                    if prev_y then
+                        -- Draw from where the previous stacked series left off
+                        base_y = prev_y[i] or base_y
+                        -- Save our y for the next stacked series
+                        prev_y[i] = value_y
+                    end
+
+                    if step_shape then
+                        -- Shift to the bar beginning
+                        cairo_translate(cr, x, value_y)
+                        step_shape(cr, step_width, base_y - value_y)
+                        -- Undo the shift
+                        cairo_set_matrix(cr, pristine_transform)
+                    else
+                        cairo_rectangle(cr, x, value_y, step_width, base_y - value_y)
+                    end
+                end
+
+                if not not_nan and nan_x then
+                    -- Keep the coordinate to draw NaN indication later
+                    table.insert(nan_x, x)
+                end
+            end
+
+            -- Paint the data series
+            cr:fill()
+        end
+    end
+
+    if nan_x and #nan_x > 0 then
+        cr:set_source(color(self._private.nan_color or prop_fallbacks.nan_color))
+        for _, x in ipairs(nan_x) do
+            -- Draw full-height rectangle with nan_color to indicate NaN
+            cairo_rectangle(cr, x, 0, step_width, height)
+        end
+        cr:fill()
+    end
+end
+
+function graph:draw(_, cr, width, height)
+    local border_width = self._private.border_width or prop_fallbacks.border_width
+    local drawn_values_num = self:compute_drawn_values_num(width-2*border_width)
+
+    -- Track our usage to help us guess the necessary values array capacity
+    graph_gather_drawn_values_num_stats(self, drawn_values_num)
+
+    -- Draw the background first
+    cr:set_source(color(self._private.background_color or prop_fallbacks.background_color))
+    cr:paint()
+
+    -- Draw the values
+    if drawn_values_num > 0 then
+        cr:save()
+
+        -- Account for the border width
+        if border_width > 0 then
+            cr:translate(border_width, border_width)
+        end
+
+        local values_width = width - 2*border_width
+        local values_height = height - 2*border_width
+
+        graph_draw_values(self, cr, values_width, values_height, drawn_values_num)
+
+        -- Undo the cr:translate() for the border and step shapes
+        cr:restore()
+    end
 
     -- Draw the border last so that it overlaps already drawn values
-    if _graph._private.border_color then
-        -- We decremented these by two above
-        width, height = width + 2*bw, height + 2*bw
-
-        -- Draw the border
-        cr:rectangle(bw/2, bw/2, width - bw, height - bw)
-        cr:set_source(color(_graph._private.border_color or beautiful.graph_border_color or "#ffffff"))
+    if border_width > 0 then
+        cr:set_line_width(border_width)
+        cr:rectangle(border_width/2, border_width/2, width - border_width, height - border_width)
+        cr:set_source(color(self._private.border_color or prop_fallbacks.border_color))
         cr:stroke()
     end
 end
 
-function graph.fit(_graph)
-    return _graph._private.width, _graph._private.height
+function graph:fit(_, width, height)
+    return width, height
 end
 
---- Add a value to the graph
+--- Determine how many values should be drawn for a given widget width.
+--
+-- The graph uses this method to determine the upper bound on the
+-- number of values that will be drawn from each data group. This affects,
+-- among other things, how many values will be considered for autoscaling,
+-- when `scale` is true, and, indirectly, how many values will be kept in
+-- the backing array, when `capacity` is unset.
+--
+-- The default implementation computes the minimum number that is enough
+-- to completely cover the given width with `step_width` + `step_spacing`
+-- intervals. The graph calls this method on every redraw and the width
+-- passed is the width of the value drawing area, i.e the graph borders
+-- are subtracted (2\*`border_width`).
+--
+-- @method compute_drawn_values_num
+-- @tparam number usable_width
+function graph:compute_drawn_values_num(usable_width)
+    if usable_width <= 0 then
+        return 0
+    end
+    local step_width = self._private.step_width or prop_fallbacks.step_width
+    local step_spacing = self._private.step_spacing or prop_fallbacks.step_spacing
+    return math.ceil(usable_width / (step_width + step_spacing))
+end
+
+local function guess_capacity(self)
+    local capacity = self._private.capacity
+    if capacity then
+        -- Ensure it's integer, no matter what the user sets.
+        return math.ceil(capacity)
+    end
+
+    local ldwn = self._private.last_drawn_values_num
+    if not ldwn then
+        -- We haven't been drawn even once yet,
+        -- maybe the user will push a ton of values now.
+        -- Our widget is 8K-display-ready.
+        return 8192
+    end
+
+    -- Calculate an appropriate capacity from drawn values num
+    -- with some wiggle room for widget resizes
+    return math.ceil(ldwn/64 + 1)*64
+end
+
+--- Add a value to the graph.
+--
+-- The graph widget keeps its values grouped in _data groups_. Each data group
+-- is drawn with its own set of bars, starting with the latest value
+-- in the data group at the left edge of the graph.
+--
+-- Simply calling this method with a particular data group index is the only
+-- thing necessary and sufficient for creating a data group.
+-- Any natural integer as a group number is ok, but the user is advised to keep
+-- the group numbers low and consecutive for performance reasons.
+--
+-- There are no constraints on the value parameter, other than it should
+-- be a number.
 --
 -- @method add_value
--- @tparam number value The value to be added to the graph
--- @tparam[opt] number group The stack color group index.
+-- @tparam[opt=NaN] number value The value to be added to a graph's data group.
+-- @tparam[opt=1] integer group The index of the data group.
 function graph:add_value(value, group)
-    value = value or 0
+    value = value or 0/0 -- default to NaN
+    group = group or 1
+
     local values = self._private.values
-    local max_value = self._private.max_value
-    value = math.max(0, value)
-    if not self._private.scale then
-        value = math.min(max_value, value)
-    end
-
-    if self._private.stack and group then
-        if not  self._private.values[group]
-        or type(self._private.values[group]) ~= "table"
-        then
-            self._private.values[group] = {}
+    if not values[group] then
+        -- Ensure that there are no gaps in the values array,
+        -- so that ipairs() can reach all data groups.
+        for i = #values+1, group do
+            values[i] = {}
         end
-        values = self._private.values[group]
+        -- If the above loop hasn't set it, then
+        -- `group` wasn't a non-negative integer.
+        if not values[group] then
+            error("Invalid data group index: " .. tostring(group))
+        end
     end
-    table.insert(values, value)
+    values = values[group]
 
-    local border_width = 0
-    if self._private.border_color then border_width = self._private.border_width*2 end
+    local capacity = guess_capacity(self)
+    -- Map negatives, NaNs and zero to nil
+    capacity = (capacity >= 1) and capacity
 
-    -- Ensure we never have more data than we can draw
-    while #values > self._private.width - border_width do
-        table.remove(values, 1)
+    -- Remove old values over capacity
+    -- Invalid capacity means "remove everything"
+    local i = capacity or 1
+    while values[i] do
+        values[i] = nil
+        i = i + 1
+    end
+
+    if capacity then
+        table.insert(values, 1, value)
     end
 
     self:emit_signal("widget::redraw_needed")
@@ -319,6 +747,8 @@ end
 
 --- Clear the graph.
 --
+-- Removes all values from all data groups.
+--
 -- @method clear
 function graph:clear()
     self._private.values = {}
@@ -326,86 +756,154 @@ function graph:clear()
     return self
 end
 
---- Set the graph height.
+--- Set the graph capacity.
 --
--- @property height
--- @tparam number height The height to set.
+-- Since the typical uses of the graph widget imply that `add_value` will be
+-- called an indefinite number of times, the widget needs a way to know, when
+-- to start discarding old values from the backing array.
+--
+-- When `capacity` is set, it defines the maximum number of values to keep in
+-- each data group.
+--
+-- When `capacity` is unset (default), the number is determined heuristically,
+-- which is sufficient most of the time, unless the widget gets resized
+-- too much too fast.
+--
+-- @property capacity
+-- @tparam[opt=nil] integer|nil capacity The maximum number of values to keep
+-- per data group (`nil` for automatic guess).
 -- @propemits true false
-
-function graph:set_height(height)
-    if height >= 5 then
-        self._private.height = height
-        self:emit_signal("widget::layout_changed")
-        self:emit_signal("property::height", height)
+function graph:set_capacity(capacity)
+    -- Property override to avoid emitting the "redraw_needed" signal,
+    -- because nothing visibly changes until the next add_value() call,
+    -- which emits the signal itself.
+    -- It might have been prudent to truncate the values array here
+    -- and emit the signal, but I don't think anyone really needs that.
+    if self._private.capacity ~= capacity then
+        self._private.capacity = capacity
+        self:emit_signal("property::capacity", capacity)
     end
     return self
+end
+
+--- Set the graph height.
+--
+-- This property is deprecated.  Use a `wibox.container.constraint` widget or
+-- `forced_height`.
+---
+-- @deprecatedproperty height
+-- @tparam number height The height to set.
+-- @renamedin 5.0 forced_height
+-- @propemits true false
+function graph:set_height(height)
+    gdebug.deprecate("Use a `wibox.container.constraint` widget or `forced_height`", {deprecated_in=5})
+    if awesome.api_level <= 5 then
+        if height >= 5 then
+            -- this sends "layout_changed" for us
+            self:set_forced_height(height)
+            -- signal, because we did it before
+            self:emit_signal("property::height", height)
+        end
+        return self
+    end
+end
+
+function graph:get_height()
+    gdebug.deprecate("Use `forced_height`", {deprecated_in=5})
+    return awesome.api_level <= 5 and self._private.forced_height or nil
 end
 
 --- Set the graph width.
 --
--- @property width
--- @param number width The width to set.
+-- This property is deprecated.  Use a `wibox.container.constraint` widget or
+-- `forced_width`.
+---
+-- @deprecatedproperty width
+-- @tparam number width The width to set.
+-- @renamedin 5.0 forced_width
 -- @propemits true false
-
 function graph:set_width(width)
-    if width >= 5 then
-        self._private.width = width
-        self:emit_signal("widget::layout_changed")
-        self:emit_signal("property::width", width)
+    gdebug.deprecate("Use a `wibox.container.constraint` widget or `forced_width`", {deprecated_in=5})
+    if awesome.api_level <= 5 then
+        if width >= 5 then
+            -- this sends "layout_changed" for us
+            self:set_forced_width(width)
+            -- signal, because we did it before
+            self:emit_signal("property::width", width)
+        end
+        return self
     end
-    return self
 end
 
--- Build properties function
-for _, prop in ipairs(properties) do
-    if not graph["set_" .. prop] then
-        graph["set_" .. prop] = function(_graph, value)
-            if _graph._private[prop] ~= value then
-                _graph._private[prop] = value
-                _graph:emit_signal("widget::redraw_needed")
-                _graph:emit_signal("property::"..prop, value)
-            end
-            return _graph
+function graph:get_width()
+    gdebug.deprecate("Use `forced_width`", {deprecated_in=5})
+    return awesome.api_level <= 5 and self._private.forced_width or nil
+end
+
+--- Set the colors for data groups.
+--
+-- This property is deprecated. Use `group_colors` instead.
+---
+-- @deprecatedproperty stack_colors
+-- @renamedin 5.0 group_colors
+-- @tparam table colors A table with colors for data groups.
+-- @see group_colors
+function graph:set_stack_colors(colors)
+    gdebug.deprecate("Use `group_colors`", {deprecated_in=5})
+    if awesome.api_level <= 5 then
+        if self._private.group_colors ~= colors then
+            -- this sends "redraw_needed" for us
+            self:set_group_colors(colors)
+            -- signal, because we did it before
+            self:emit_signal("property::stack_colors", colors)
         end
-    end
-    if not graph["get_" .. prop] then
-        graph["get_" .. prop] = function(_graph)
-            return _graph._private[prop]
-        end
+        return self
     end
 end
+
+function graph:get_stack_colors()
+    gdebug.deprecate("Use `group_colors`", {deprecated_in=5})
+    return awesome.api_level <= 5 and self._private.group_colors or nil
+end
+
 
 --- Create a graph widget.
 --
--- @tparam table args Standard widget() arguments. You should add width and height
--- key to set graph geometry.
+-- @tparam table args Standard widget() arguments.
 -- @treturn wibox.widget.graph A new graph widget.
 -- @constructorfct wibox.widget.graph
 function graph.new(args)
     args = args or {}
 
-    local width = args.width or 100
-    local height = args.height or 20
-
-    if width < 5 or height < 5 then return end
-
     local _graph = base.make_widget(nil, nil, {enable_properties = true})
 
-    _graph._private.width     = width
-    _graph._private.height    = height
-    _graph._private.values    = {}
-    _graph._private.max_value = 1
-
-    -- Set methods
-    _graph.add_value = graph["add_value"]
-    _graph.clear = graph["clear"]
-    _graph.draw = graph.draw
-    _graph.fit = graph.fit
-
-    for _, prop in ipairs(properties) do
-        _graph["set_" .. prop] = graph["set_" .. prop]
-        _graph["get_" .. prop] = graph["get_" .. prop]
+    if args.width or args.height then
+        gdebug.deprecate(
+            "`args.width` and `args.height` are deprecated. "..
+            "Use a `wibox.container.constraint` widget "..
+            "or `forced_width`/`forced_height`",
+            {deprecated_in=5, raw=true}
+        )
     end
+
+    if awesome.api_level <= 5 then
+        local width = args.width or 100
+        local height = args.height or 20
+
+        if width < 5 or height < 5 then return end
+
+        _graph._private.forced_width = width
+        _graph._private.forced_height = height
+    end
+
+    -- Set initial values for properties.
+    gtable.crush(_graph._private, prop_defaults, true)
+    _graph._private.values    = {}
+    -- Copy methods and properties over
+    gtable.crush(_graph, graph, true)
+    -- Except those, which don't belong in the widget instance
+    rawset(_graph, "new", nil)
+    rawset(_graph, "mt", nil)
 
     return _graph
 end
@@ -413,6 +911,9 @@ end
 function graph.mt:__call(...)
     return graph.new(...)
 end
+
+-- Setup default impls for property accessors that haven't been implemented explicitly.
+build_properties(graph, properties)
 
 return setmetatable(graph, graph.mt)
 

--- a/spec/wibox/widget/graph_spec.lua
+++ b/spec/wibox/widget/graph_spec.lua
@@ -1,0 +1,925 @@
+---------------------------------------------------------------------------
+-- @author Alex Belykh
+-- @copyright 2021 Alex Belykh
+---------------------------------------------------------------------------
+
+-- Require test_utils for the assert.widget_fit() helper.
+require("wibox.test_utils")
+-- Set emit_signal so as to not die on deprecation warnings.
+_G.awesome.emit_signal = function() end
+-- Silence debug warnings.
+require("gears.debug").print_warning = function() end
+
+local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
+local color = require("gears.color")
+local graph = require("wibox.widget.graph")
+
+local deprecated_properties = {
+    height = true,
+    width = true,
+    stack_colors = true,
+}
+
+local property_defaults = {
+    baseline_value = 0,
+    clamp_bars = true,
+    nan_indication = true,
+    step_width = 1,
+    step_spacing = 0,
+}
+
+local redrawless_properties = {
+    capacity = true,
+    height = true,
+    width = true,
+    stack_colors = true,
+}
+
+local data = {45.5, -44.5, -7.5, 1.5, 47.5, -38.5, 0.5, 38.0, 47.0, 23.5}
+local data2 = {-26.5, 25.0, -19.0, 38.0, 12.0 -19.0, -35.0, 16.5}
+
+local function push_data(widget, d, group_idx)
+    -- Add in reverse, so that d could be compared with
+    -- the backing value array directly.
+    for i = #d,1,-1 do
+        widget:add_value(d[i], group_idx)
+    end
+end
+
+describe("wibox.widget.graph", function()
+    local widget
+    local redraw_needed, layout_changed
+
+    before_each(function()
+        widget = graph()
+
+        widget:connect_signal("widget::redraw_needed", function()
+            redraw_needed = redraw_needed + 1
+        end)
+        widget:connect_signal("widget::layout_changed", function()
+            layout_changed = layout_changed + 1
+        end)
+        redraw_needed, layout_changed = 0, 0
+    end)
+
+    -- Check the trivial properties of all getters and setters.
+    --
+    -- There shouldn't be a field with a "get_/set_*" name, that isn't one.
+    -- Iteration is over module fields, because fields of the instance can be
+    -- polluted by inheritance and whatnot with something, that doesn't
+    -- hold itself to the standard I'm setting here.
+    for field, _ in pairs(graph) do
+
+        if string.sub(field, 1, 4) == "get_" then
+            -- A field with a getter-like name. Let's ensure that it is one.
+            local prop_name = string.sub(field, 5)
+
+            describe("field " .. field, function()
+                it("has a corresponding set_" .. prop_name .. " counterpart", function()
+                    assert.is_function(widget["set_" .. prop_name])
+                end)
+
+                it("is a property getter", function()
+                    assert.is_function(widget[field])
+                    stub(widget, field, 3456)
+                    -- Access the property through metatable magic
+                    local result_value = widget[prop_name]
+
+                    assert.is.equal(3456, result_value)
+                    assert.stub(widget[field]).was_called_with(widget)
+                end)
+            end)
+
+        elseif string.sub(field, 1, 4) == "set_" then
+            -- A field with a setter-like name. Let's ensure that it is one.
+            local prop_name = string.sub(field, 5)
+
+            describe("field " .. field, function()
+                local property_signal_emitted, property_signal_emitted_with
+
+                before_each(function()
+                    widget:connect_signal("property::" .. prop_name, function(...)
+                        property_signal_emitted = property_signal_emitted + 1
+                        property_signal_emitted_with = {...}
+                    end)
+                    property_signal_emitted, property_signal_emitted_with = 0, nil
+                end)
+
+                it("has a corresponding get_" .. prop_name .. " counterpart", function()
+                    assert.is_function(widget["get_" .. prop_name])
+                end)
+
+                it("is a property setter", function()
+                    assert.is_function(widget[field])
+                    assert.is.equal(0, redraw_needed)
+                    assert.is.equal(0, layout_changed)
+                    assert.is.equal(0, property_signal_emitted)
+
+                    local s = spy.on(widget, field)
+
+                    -- An access through metatable magic
+                    widget[prop_name] = 3456
+
+                    -- should have caused the call of the method
+                    assert.spy(s).was_called_with(match.is_ref(widget), 3456)
+
+                    -- and maybe a property::<prop_name> signal
+                    assert.is.equal(deprecated_properties[prop_name] and 0 or 1, property_signal_emitted)
+                    -- and maybe a redraw
+                    assert.is.equal(redrawless_properties[prop_name] and 0 or 1, redraw_needed)
+                    -- but never a layout change.
+                    assert.is.equal(0, layout_changed)
+
+                    if not deprecated_properties[prop_name] then
+                        -- The property signal contains the new value.
+                        assert.is.equal(widget, property_signal_emitted_with[1])
+                        assert.is.equal(3456, property_signal_emitted_with[2])
+                        -- What is set, can be gotten back through the prop_name field.
+                        assert.is.equal(3456, widget[prop_name])
+                        -- The setter returns the widget itself for call chaining.
+                        assert.spy(s).returned_with(match.is_ref(widget))
+                    end
+
+                    s:clear()
+                    assert.spy(s).was_not.called()
+
+                    -- A repeated setting of the same value
+                    widget[prop_name] = 3456
+                    -- should have caused the call of the method again
+                    assert.spy(s).was_called_with(match.is_ref(widget), 3456)
+                    -- but none of the signals.
+                    assert.is.equal(deprecated_properties[prop_name] and 0 or 1, property_signal_emitted)
+                    assert.is.equal(redrawless_properties[prop_name] and 0 or 1, redraw_needed)
+                    assert.is.equal(0, layout_changed)
+                end)
+
+                it("has a specific default value", function()
+                    assert.is_equal(property_defaults[prop_name], widget[prop_name])
+                end)
+
+                it("is not magical on nil-s", function()
+                    -- When set to nil
+                    widget[prop_name] = nil
+                    -- it should stay nil and not fall back to some "default".
+                    assert.is.equal(nil, widget[prop_name])
+                end)
+            end) -- end describe(field)
+
+        end -- end if
+    end -- end field loop
+
+    -- Now let's check some nontrivial behavior
+
+    describe("values", function()
+        it("are empty in a fresh instance", function()
+            assert.is.same({}, widget._private.values)
+        end)
+
+        describe("method add_value()", function()
+            it("adds values", function()
+                push_data(widget, data)
+                -- Adds into the first datagroup by default.
+                assert.is.same({data}, widget._private.values)
+            end)
+
+            it("defaults to NaN when no/falsy value is supplied", function()
+                local amount = 15
+                for _ = 1, amount do
+                    widget:add_value(false)
+                    widget:add_value()
+                    widget:add_value(false, 3)
+                    widget:add_value(nil, 3)
+                end
+
+                assert.array(widget._private.values).has.no.holes()
+                assert.is.equal(3, #widget._private.values)
+                assert.is.equal(2*amount, #widget._private.values[1])
+                assert.is.equal(0, #widget._private.values[2])
+                assert.is.equal(2*amount, #widget._private.values[3])
+
+                for i = 1, 2*amount do
+                    local tmp = widget._private.values[1][i]
+                    assert.is_not.equal(tmp, tmp)
+                    tmp = widget._private.values[3][i]
+                    assert.is_not.equal(tmp, tmp)
+                end
+            end)
+
+            it("adds values into specific data group", function()
+                push_data(widget, data, 15)
+                assert.is.same(data, widget._private.values[15])
+
+                -- Smaller datagroups are present too, but empty.
+                assert.array(widget._private.values).has.no.holes()
+                assert.is.equal(15, #widget._private.values)
+                for i, data_group in ipairs(widget._private.values) do
+                    assert.array(data_group).has.no.holes()
+                    assert.is.equal(i ~= 15 and 0 or #data, #data_group)
+                end
+
+                -- Adding again to a different group
+                push_data(widget, data2, 30)
+                -- works
+                assert.is.same(data2, widget._private.values[30])
+                -- and doesn't affect the other group.
+                assert.is.same(data, widget._private.values[15])
+
+                -- Smaller-index datagroups are present but empty.
+                assert.array(widget._private.values).has.no.holes()
+                assert.is.equal(30, #widget._private.values)
+                for i, data_group in ipairs(widget._private.values) do
+                    assert.array(data_group).has.no.holes()
+                    if i ~= 15 and i ~= 30 then
+                        assert.is.same({}, data_group)
+                    end
+                end
+            end)
+
+            it("doesn't care about group order", function()
+                for i = math.max(#data,#data2),1,-1 do
+                    if i % 2 == 0 and data[i] then
+                        widget:add_value(data[i], 1)
+                    end
+                    if data2[i] then
+                     widget:add_value(data2[i], 2)
+                    end
+                    if i % 2 == 1 and data[i] then
+                        widget:add_value(data[i], 1)
+                    end
+                end
+
+                assert.is.same({data, data2}, widget._private.values)
+            end)
+
+            it("doesn't work with non-natural datagroups", function()
+                for i = #data,1,-1 do
+                    assert.has.errors(function()
+                        widget:add_value(data[i], 14.5)
+                    end)
+                end
+                for i = #data,1,-1 do
+                    assert.has.errors(function()
+                        widget:add_value(data[i], 0)
+                    end)
+                end
+                for i = #data,1,-1 do
+                    assert.has.errors(function()
+                        widget:add_value(data[i], -4)
+                    end)
+                end
+                for i = #data,1,-1 do
+                    assert.has.errors(function()
+                        widget:add_value(data[i], "index")
+                    end)
+                end
+                for i = #data,1,-1 do
+                    assert.has.errors(function()
+                        widget:add_value(data[i], {1, 2, 3})
+                    end)
+                end
+                for i = #data,1,-1 do
+                    assert.has.errors(function()
+                        widget:add_value(data[i], function() end)
+                    end)
+                end
+
+                -- No values were added after all this,
+                -- but some empty datagroups were. This is a bit suboptimal,
+                -- but is not worth fixing. Adding an assert here
+                -- so that one would be reminded to change it to
+                -- a #values == 0 check, if one fixes it.
+                assert.is.equal(14, #widget._private.values)
+                assert.array(widget._private.values).has.no.holes()
+                for _, data_group in ipairs(widget._private.values) do
+                    assert.is.same({}, data_group)
+                end
+            end)
+
+            it("honors the capacity property", function()
+                local function check_cap(cap, expected_len)
+                    expected_len = expected_len or math.max(0, math.ceil(cap))
+
+                    widget.capacity = cap
+
+                    push_data(widget, data, 1)
+                    push_data(widget, data2, 2)
+
+                    -- Only the last inserted elements are kept.
+                    assert.is.same(
+                        {
+                           {unpack(data, 1, expected_len)},
+                           {unpack(data2, 1, expected_len)}
+                        },
+                        widget._private.values
+                    )
+                end
+
+                for i = 0, math.min(#data, #data2) do
+                    check_cap(i)
+                end
+                -- It handles negatives and NaNs like zeros
+                check_cap(-100, 0)
+                check_cap(-100.5, 0)
+                check_cap(0/0)
+                -- And fractional numbers are rounded up
+                check_cap(2.5, 3)
+
+                -- But setting the capacity property by itself doesn't do anything,
+                -- if add_value() wasn't called.
+                widget.capacity = 1
+                assert.is.equal(3, #widget._private.values[1])
+                assert.is.equal(3, #widget._private.values[2])
+            end)
+
+            it("stores up to 8192 values when no usage stats are available", function()
+                assert.is_nil(widget.capacity)
+                assert.is_nil(widget._private.last_drawn_values_num)
+                for i = 1, 9000 do
+                    widget:add_value(i)
+                    widget:add_value(i, 3)
+                end
+                assert.is.equal(8192, #widget._private.values[1])
+                assert.is.equal(8192, #widget._private.values[3])
+            end)
+
+            it("relies on usage stats, when capacity is unset", function()
+                assert.is_nil(widget.capacity)
+                widget._private.last_drawn_values_num = 100
+
+                for i = 1, 400 do
+                    widget:add_value(i)
+                    widget:add_value(i, 3)
+                end
+
+                -- The smallest multiple of 64 that is >= last_drawn_values_num + 64
+                assert.is.equal(192, #widget._private.values[1])
+                assert.is.equal(192, #widget._private.values[3])
+
+                -- so 192 elements will be kept with this too.
+                widget._private.last_drawn_values_num = 128
+
+                widget:add_value(0)
+                widget:add_value(0, 3)
+
+                assert.is.equal(192, #widget._private.values[1])
+                assert.is.equal(192, #widget._private.values[3])
+
+                -- But this is one is already one too many.
+                widget._private.last_drawn_values_num = 129
+
+                for i = 1, 400 do
+                    widget:add_value(i)
+                    widget:add_value(i, 3)
+                end
+
+                assert.is.equal(256, #widget._private.values[1])
+                assert.is.equal(256, #widget._private.values[3])
+
+                -- Setting it back and calling add_value() once is enough
+                -- to purge overflowing elements,
+                widget._private.last_drawn_values_num = 128
+                widget:add_value(0)
+                assert.is.equal(192, #widget._private.values[1])
+                -- but only in the group, for which add_value() happened to be
+                -- called during the time last_drawn_values_num was small enough,
+                -- even though it's probably not a very fair behavior and could
+                -- lead to weird visual artefacts.
+                assert.is.equal(256, #widget._private.values[3])
+
+                -- Calling add_value for the other group puts it in line too.
+                widget:add_value(0, 3)
+                assert.is.equal(192, #widget._private.values[3])
+            end)
+
+
+        end) -- end describe(add_value)
+
+        describe("method clear()", function()
+            it("clears values", function()
+                local function check_clear(i)
+                    assert.is.same({}, widget._private.values)
+                    push_data(widget, data)
+                    assert.is.same({data}, widget._private.values)
+                    widget:clear()
+                    assert.is.same({}, widget._private.values)
+                    push_data(widget, data2, 3*i)
+                    assert.is.same(data2, widget._private.values[3*i])
+                    widget:clear()
+                    assert.is.same({}, widget._private.values)
+                end
+
+                for i = 1, 3 do
+                    check_clear(i)
+                end
+            end)
+        end) -- end describe(clear)
+
+    end) -- end describe(values)
+
+    describe("method fit()", function()
+        it("requests all available space", function()
+            assert.widget_fit(widget, {120, 80}, {120, 80})
+            assert.widget_fit(widget, {1300, 700}, {1300, 700})
+        end)
+    end)
+
+    describe("drawing-related", function()
+        local dimensions
+        local context
+        local cr
+        before_each(function()
+            dimensions = {120, 80}
+            context = { fake_context = "fake context" }
+            cr = setmetatable({"fake cairo"}, {__index = function() return function() end end})
+            -- assert.widget_fit(widget, dimensions, dimensions)
+        end)
+
+        describe("property step_shape()", function()
+            it("is not called when there are no values", function()
+                widget.step_shape = spy.new()
+
+                widget:draw(context, cr, unpack(dimensions))
+                widget:draw(context, cr, unpack(dimensions))
+
+                -- No values to draw, so no shapes drawn
+                assert.spy(widget.step_shape).was_not_called()
+            end)
+
+            it("is called to draw values", function()
+                widget.step_shape = spy.new()
+
+                -- It is called once for each value.
+                push_data(widget, data)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.spy(widget.step_shape).was_called(#data)
+
+                -- All data is drawn despite the gap between data groups
+                push_data(widget, data2, 3)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.spy(widget.step_shape).was_called(2*#data + #data2)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.spy(widget.step_shape).was_called(3*#data + 2*#data2)
+            end)
+
+            it("receives proper arguments from draw()", function()
+                widget.step_shape = spy.new()
+                push_data(widget, data)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.spy(widget.step_shape).was_called_with(
+                    cr, -- cairo
+                    match.is_number(), -- width
+                    match.is_number() -- height
+                )
+            end)
+
+            it("doesn't receive NaNs from draw()", function()
+                widget.step_shape = spy.new(function(_, width, height)
+                    -- These are never NaNs.
+                    assert.is_equal(width, width)
+                    assert.is_equal(height, height)
+                end)
+
+                -- When there are no NaNs in data, there are no NaNs.
+                push_data(widget, data)
+                push_data(widget, data2, 3)
+                widget:draw(context, cr, unpack(dimensions))
+                -- Write out arguments in full once so that one doesn't
+                -- forget to update this test if arguments get changed.
+                assert.spy(widget.step_shape).was_called_with(
+                    cr, match.is_number(), match.is_number()
+                )
+                widget.step_shape:clear()
+
+                -- No matter where the NaNs are,
+                widget:add_value(0/0, 1)
+                widget:add_value(0/0, 2)
+                widget:add_value(0/0, 3)
+                widget:add_value(0/0, 4)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.spy(widget.step_shape).was_called()
+                widget.step_shape:clear()
+
+                -- even if there's nothing but NaNs, we get them not,
+                widget:clear()
+                for _ = 1, 100 do
+                    widget:add_value(0/0, 1)
+                    widget:add_value(0/0, 2)
+                    widget:add_value(0/0, 3)
+                end
+                widget:draw(context, cr, unpack(dimensions))
+                -- in fact we don't even get called.
+                assert.spy(widget.step_shape).was_not_called()
+                widget.step_shape:clear()
+            end)
+
+            it("'s errors are not silenced by draw()", function()
+                widget.step_shape = spy.new(function() assert(false) end)
+                push_data(widget, data)
+
+                assert.has.errors(function()
+                   widget:draw(context, cr, unpack(dimensions))
+                end)
+                assert.spy(widget.step_shape).was_called(1)
+            end)
+
+            it("is disabled by falsy group_colors", function()
+                -- TODO: if should_draw_data_group() gets decided on,
+                -- this should be rewritten in terms of it and
+                -- should_draw_data_group() should be tested by colors in turn.
+                widget.step_shape = spy.new()
+                widget.group_colors = { "#feedf00d", "#deadbeef", "#0badcafe" }
+                push_data(widget, data, 1)
+                push_data(widget, data, 2)
+                push_data(widget, data2, 3)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.spy(widget.step_shape).was_called(2*#data + #data2)
+                widget.step_shape:clear()
+                widget.group_colors = { nil, false, "#feedf00d" }
+                widget:draw(context, cr, unpack(dimensions))
+                assert.spy(widget.step_shape).was_called(#data2)
+            end)
+        end) -- end describe(step_shape)
+
+        describe("method compute_drawn_values_num()", function()
+            it("'s default implementation computes things correctly", function()
+                local function cdvn(param)
+                    return widget:compute_drawn_values_num(param)
+                end
+
+                -- Negative and zero values don't make it return negatives.
+                -- Default settings, border_width=step_spacing=0, step_width=1.
+                assert.is.equal(0, cdvn(-5))
+                assert.is.equal(0, cdvn(0))
+                assert.is.equal(10, cdvn(10))
+                assert.is.equal(11, cdvn(10.5))
+                -- border_width doesn't affect anything, because
+                -- the function assumes that it was subtracted already.
+                widget.border_width = 2
+                assert.is.equal(0, cdvn(-50.5))
+                assert.is.equal(0, cdvn(0))
+                assert.is.equal(9, cdvn(9))
+                assert.is.equal(10, cdvn(10))
+                assert.is.equal(11, cdvn(10.5))
+                -- All of this is just how you'd expect it to be for
+                -- math.ceil(width/(step_width + step_spacing), which it is.
+                widget.step_width = 2
+                assert.is.equal(0, cdvn(-100))
+                assert.is.equal(0, cdvn(0))
+                assert.is.equal(4, cdvn(8))
+                assert.is.equal(5, cdvn(9))
+                assert.is.equal(5, cdvn(10))
+                assert.is.equal(6, cdvn(11))
+                assert.is.equal(6, cdvn(12))
+                widget.step_spacing = 2
+                assert.is.equal(0, cdvn(-100))
+                assert.is.equal(0, cdvn(0))
+                assert.is.equal(2, cdvn(8))
+                assert.is.equal(3, cdvn(9))
+                assert.is.equal(3, cdvn(10))
+                assert.is.equal(3, cdvn(11))
+                assert.is.equal(3, cdvn(12))
+                assert.is.equal(4, cdvn(13))
+            end)
+
+            it("is called by draw() once", function()
+                local s = spy.on(widget, "compute_drawn_values_num")
+
+                widget:draw(context, cr, unpack(dimensions))
+
+                assert.spy(s).was_called(1)
+                assert.spy(s).was_called_with(match.is_ref(widget), dimensions[1])
+            end)
+
+            it("'s result is stored by draw() in last_drawn_values_num", function()
+                local our_value = 10
+                local function cdvn()
+                    return our_value
+                end
+                widget.compute_drawn_values_num = cdvn
+
+                -- The usage stats variable is uninitialized before first call.
+                assert.is_nil(widget._private.last_drawn_values_num)
+
+                widget:draw(context, cr, unpack(dimensions))
+                -- Now it should be initialized.
+                assert.is.equal(our_value, widget._private.last_drawn_values_num)
+
+                -- Repeated calls with increasing values should set it instantly.
+                our_value = 20
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(our_value, widget._private.last_drawn_values_num)
+                our_value = 35
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(our_value, widget._private.last_drawn_values_num)
+                our_value = 50
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(our_value, widget._private.last_drawn_values_num)
+                -- Same values keep it on the same level too.
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(our_value, widget._private.last_drawn_values_num)
+
+                -- Calls with smaller values should only decrement it by one.
+                our_value = 30
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(49, widget._private.last_drawn_values_num)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(48, widget._private.last_drawn_values_num)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(47, widget._private.last_drawn_values_num)
+
+                -- No matter how small the values are.
+                our_value = 0
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(46, widget._private.last_drawn_values_num)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(45, widget._private.last_drawn_values_num)
+
+                -- Negatives and NaNs are outright ignored.
+                our_value = -100
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(45, widget._private.last_drawn_values_num)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(45, widget._private.last_drawn_values_num)
+                our_value = 0/0
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(45, widget._private.last_drawn_values_num)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(45, widget._private.last_drawn_values_num)
+
+                -- Positive infinity will fry the widget forever though.
+                our_value = math.huge
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(math.huge, widget._private.last_drawn_values_num)
+                our_value = 15
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(math.huge, widget._private.last_drawn_values_num)
+            end)
+
+        end) -- end describe(computed_drawn_values_num)
+
+        describe("colors", function()
+            local magic_color
+            local magic_color_used
+            local current_cr_source
+            before_each(function()
+                cr.set_source = function(_, src)
+                    if src == magic_color then
+                        magic_color_used = magic_color_used + 1
+                    end
+                    current_cr_source = src
+                end
+                magic_color, magic_color_used = color("#deadc0de"), 0
+                current_cr_source = nil
+            end)
+
+            it("aren't used, when unset", function()
+                -- Let's check that our magic color isn't some default color
+                -- in a fresh widget
+                assert.is.equal(0, magic_color_used)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(0, magic_color_used)
+                -- even after pushing data.
+                push_data(widget, data, 4)
+                widget:draw(context, cr, unpack(dimensions))
+                assert.is.equal(0, magic_color_used)
+            end)
+
+            describe("property color", function()
+                -- These tests overlap with pick_data_group_color() tests,
+                -- but are added for completeness.
+
+                it("is used by draw() when set", function()
+                    assert.is.equal(0, magic_color_used)
+                    widget.color = magic_color
+                    -- Not used, if there are no values to draw.
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                    -- Used, if there are, once for each data group.
+                    push_data(widget, data, 4)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(4, magic_color_used)
+                end)
+
+                it("is overridden by group_colors property", function()
+                    assert.is.equal(0, magic_color_used)
+                    widget.color = magic_color
+                    widget.group_colors = { "#feedf00d" }
+                    push_data(widget, data, 1)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                end)
+            end) -- end describe(color)
+
+            describe("property group_colors", function()
+                -- These tests overlap with pick_data_group_color() tests,
+                -- but are added for completeness.
+
+                it("is used by draw() when set", function()
+                    assert.is.equal(0, magic_color_used)
+                    widget.group_colors = { "#feedfood", false, magic_color, magic_color }
+                    -- Not used, if there are no values to draw.
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                    -- Not used, if there are no values in its group.
+                    push_data(widget, data, 1)
+                    push_data(widget, data2, 2)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                     -- Used, if there are, once for each data group.
+                    push_data(widget, data, 3)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(1, magic_color_used)
+                    push_data(widget, data2, 4)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(3, magic_color_used)
+                end)
+            end) -- end describe(group_colors)
+
+            describe("property background_color", function()
+                it("is used by draw() when set", function()
+                    assert.is.equal(0, magic_color_used)
+                    widget.background_color = magic_color
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(1, magic_color_used)
+                end)
+            end) -- end describe(background_color)
+
+            describe("property border_color", function()
+                it("is used by draw() when set", function()
+                    assert.is.equal(0, magic_color_used)
+                    widget.border_color = magic_color
+
+                    -- Not used, when border_width <= 0, so not by default either.
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                    widget.border_width = 0
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                    widget.border_width = -1
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+
+                    -- Anything positive enables the border.
+                    widget.border_width = 0.000001
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(1, magic_color_used)
+                end)
+            end) -- end describe(border_color)
+
+            describe("property nan_color", function()
+                it("is good to go by default", function()
+                    assert.is.truthy(widget.nan_indication)
+                    -- TODO: maybe expose default_nan_color and check that it's used.
+                end)
+
+                it("is used by draw() when set", function()
+                    assert.is.equal(0, magic_color_used)
+                    widget.nan_color = magic_color
+                    push_data(widget, data, 4)
+
+                    -- Not used, when there are no NaNs.
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+
+                    -- Is used once when a NaN is found, no matter how many
+                    -- NaNs and groups there are.
+                    widget:add_value(0/0, 4)
+                    widget:add_value(0/0, 4)
+                    widget:add_value(0/0, 5)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(1, magic_color_used)
+
+                    -- But not when nan_indication is disabled.
+                    widget.nan_indication = false
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(1, magic_color_used)
+                end)
+            end) -- end describe(nan_color)
+
+            describe("method pick_data_group_color()", function()
+                it("is called by draw() for each data group", function()
+                    widget.pick_data_group_color = spy.new()
+                    -- Not used, when there are no data groups.
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.spy(widget.pick_data_group_color).was_not.called()
+                    -- Used once for each data group (even empty ones, as it
+                    -- happens, though that is not really necessary).
+                    -- But I'm testing for it here too, so that possible
+                    -- future behavior change can be detected, and it can
+                    -- be decided, if it's ok to break.
+                    push_data(widget, data, 1)
+                    push_data(widget, data2, 3)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.spy(widget.pick_data_group_color).was_called(3)
+                    assert.spy(widget.pick_data_group_color).was_called_with(match.is_ref(widget), 1)
+                    assert.spy(widget.pick_data_group_color).was_called_with(match.is_ref(widget), 2)
+                    assert.spy(widget.pick_data_group_color).was_called_with(match.is_ref(widget), 3)
+                end)
+
+                it("is used by draw() to pick colors", function()
+                    local s = spy.new(function(_, data_group)
+                        return data_group > 2 and magic_color or "#feedf00d"
+                    end)
+                    widget.pick_data_group_color = s
+
+                    -- Not used, if there are no values to draw.
+                    assert.is.equal(0, magic_color_used)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                    assert.spy(s).was_not_called()
+                    -- Colors it returns are used for respective data groups,
+                    -- once for each data group.
+                    push_data(widget, data, 1)
+                    push_data(widget, data2, 2)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(0, magic_color_used)
+                    assert.spy(s).was_called(2)
+                    push_data(widget, data, 3)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(1, magic_color_used)
+                    assert.spy(s).was_called(5)
+                    push_data(widget, data2, 4)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(3, magic_color_used)
+                    assert.spy(s).was_called(9)
+                    s:clear()
+                end)
+
+                it("'s returned color is set early, so as to be available in the corresponding step_shape()", function()
+                    local current_data_group
+                    widget.pick_data_group_color = function(_, data_group)
+                        current_data_group = data_group
+                        return (data_group % 2 == 1) and magic_color or "#feedf00d"
+                    end
+                    widget.step_shape = function()
+                        if current_data_group % 2 == 1 then
+                            assert.is.equal(magic_color, current_cr_source)
+                        else
+                            assert.is_not.equal(magic_color, current_cr_source)
+                        end
+                    end
+                    assert.is.equal(0, magic_color_used)
+                    assert.is_nil(current_cr_source)
+                    push_data(widget, data, 1)
+                    push_data(widget, data2, 2)
+                    push_data(widget, data2, 3)
+                    push_data(widget, data, 4)
+                    widget:draw(context, cr, unpack(dimensions))
+                    assert.is.equal(2, magic_color_used)
+                end)
+
+                it("returns some valid color even in a fresh widget", function()
+                    local groups = {1, 2, 50, 0, -1}
+                    local colors = {}
+                    for i, group in ipairs(groups) do
+                        colors[i] = widget:pick_data_group_color(group)
+                        assert.is.truthy(colors[i])
+                    end
+                    -- Regardless of data presence.
+                    push_data(widget, data, 2)
+                    local colors2 = {}
+                    for i, group in ipairs(groups) do
+                        colors2[i] = widget:pick_data_group_color(group)
+                        assert.is.truthy(colors2[i])
+                    end
+                    assert.is.same(colors, colors2)
+                    -- And it's actually the same default color in all cases.
+                    for i = 2, #colors do
+                        assert.is.equal(colors[i-1], colors[i])
+                    end
+                    -- And gears.color() doesn't choke on it.
+                    assert.is.truthy(color(colors[1]))
+                    -- Because it's red, tbh.
+                    assert.is.equal("#ff0000", colors[1])
+                end)
+
+                it("uses color and group_colors properties", function()
+                    local groups = {1, 2, 5, 3, 4, 0, 6, -1}
+                    for _, group in ipairs(groups) do
+                        assert.is_not.equal(magic_color, widget:pick_data_group_color(group))
+                    end
+                    widget.color = magic_color
+                    for _, group in ipairs(groups) do
+                        assert.is.equal(magic_color, widget:pick_data_group_color(group))
+                    end
+                    -- But group_colors override color.
+                    local group_colors = { "#feedf00d", "#deadbeef", false, nil, "#0badcafe" }
+                    widget.group_colors = {unpack(group_colors, 1, 5)}
+                    for _, group in ipairs(groups) do
+                        if group_colors[group] then
+                            assert.is.equal(group_colors[group], widget:pick_data_group_color(group))
+                        else
+                            -- But not when the color is falsy in the table group_colors.
+                            assert.is.equal(magic_color, widget:pick_data_group_color(group))
+                        end
+                    end
+                end)
+             end) -- end describe(pick_data_group_color)
+
+        end) -- end describe(colors)
+
+    end) -- end describe(drawing-related)
+
+end) -- end describe(graph)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/defaults/graph.lua
+++ b/tests/examples/wibox/widget/defaults/graph.lua
@@ -13,6 +13,8 @@ local data = { --DOC_HIDE
 local w = --DOC_HIDE
 wibox.widget {
     max_value = 29,
+    forced_width = 100, --DOC_HIDE
+    forced_height = 20, --DOC_HIDE
     widget = wibox.widget.graph
 }
 

--- a/tests/examples/wibox/widget/graph/background_color.lua
+++ b/tests/examples/wibox/widget/graph/background_color.lua
@@ -21,11 +21,11 @@ for _, color in ipairs {"#ff0000", "#00ff00", "#0000ff", "#ff00ff" } do
     local w = --DOC_HIDE
 
     wibox.widget {
-        border_width  = 2, --DOC_HIDE
-        margins          = 5, --DOC_HIDE
-        max_value        = 29,
         background_color = color,
-        widget        = wibox.widget.graph,
+        max_value        = 29, --DOC_HIDE
+        margins          = 5, --DOC_HIDE
+        border_width     = 2, --DOC_HIDE
+        widget           = wibox.widget.graph,
     }
 
     l:add(w) --DOC_HIDE

--- a/tests/examples/wibox/widget/graph/baseline_value.lua
+++ b/tests/examples/wibox/widget/graph/baseline_value.lua
@@ -1,0 +1,91 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+
+local data = { --DOC_HIDE
+    1, 2, 3, 4, 5, 0, -5, -4, -3, -2, -1, --DOC_HIDE
+} --DOC_HIDE
+
+local w_normal = --DOC_HIDE
+wibox.widget {
+    --baseline_value = 0, --default
+    min_value      = -5,
+    max_value      = 5,
+    step_width     = 9, --DOC_HIDE
+    step_spacing   = 1, --DOC_HIDE
+    border_width   = 2, --DOC_HIDE
+    margins        = 5, --DOC_HIDE
+    forced_height  = 104, --DOC_HIDE
+    widget         = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w_plus = --DOC_HIDE
+wibox.widget {
+    baseline_value = 5,
+    min_value      = -5,
+    max_value      = 5,
+    step_width     = 9, --DOC_HIDE
+    step_spacing   = 1, --DOC_HIDE
+    border_width   = 2, --DOC_HIDE
+    margins        = 5, --DOC_HIDE
+    forced_height  = 104, --DOC_HIDE
+    widget         = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w_minus = --DOC_HIDE
+wibox.widget {
+    baseline_value = -2.5,
+    min_value      = -5,
+    max_value      = 5,
+    step_width     = 9, --DOC_HIDE
+    step_spacing   = 1, --DOC_HIDE
+    border_width   = 2, --DOC_HIDE
+    margins        = 5, --DOC_HIDE
+    forced_height  = 104, --DOC_HIDE
+    widget         = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+for _, v in ipairs(data) do --DOC_HIDE
+    w_normal:add_value(v) --DOC_HIDE
+    w_plus:add_value(v) --DOC_HIDE
+    w_minus:add_value(v) --DOC_HIDE
+end --DOC_HIDE
+
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>baseline_value = 0</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_normal,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>baseline_value = 5</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_plus,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>baseline_value = -2.5</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_minus,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 342, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+}) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/border_color.lua
+++ b/tests/examples/wibox/widget/graph/border_color.lua
@@ -21,9 +21,9 @@ for _, color in ipairs {"#ff0000", "#00ff00", "#0000ff", "#ff00ff" } do
     local w = --DOC_HIDE
 
     wibox.widget {
-        max_value     = 29,
-        border_width  = 2, --DOC_HIDE
+        border_width  = 2,
         border_color  = color,
+        max_value     = 29, --DOC_HIDE
         margins       = 5, --DOC_HIDE
         widget        = wibox.widget.graph,
     }

--- a/tests/examples/wibox/widget/graph/border_width.lua
+++ b/tests/examples/wibox/widget/graph/border_width.lua
@@ -22,9 +22,9 @@ for _, width in ipairs { 1, 2, 4, 10 } do
     local w = --DOC_HIDE
 
     wibox.widget {
-        max_value     = 30,
-        border_width  = width, --DOC_HIDE
+        border_width  = width,
         border_color  = beautiful.border_color,
+        max_value     = 30, --DOC_HIDE
         margins       = 5, --DOC_HIDE
         widget        = wibox.widget.graph,
     }

--- a/tests/examples/wibox/widget/graph/clamp_bars.lua
+++ b/tests/examples/wibox/widget/graph/clamp_bars.lua
@@ -1,0 +1,73 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local gears  = { --DOC_HIDE
+    matrix = require("gears.matrix"), --DOC_HIDE
+    shape = require("gears.shape"), --DOC_HIDE
+} --DOC_HIDE
+
+local data = { --DOC_HIDE
+    -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, --DOC_HIDE
+} --DOC_HIDE
+
+local w_unclamped = --DOC_HIDE
+wibox.widget {
+    clamp_bars    = false,
+    step_width    = 9,
+    step_spacing  = 1,
+    step_shape    = gears.shape.arrow,
+    min_value     = -3, --DOC_HIDE
+    max_value     = 3, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    forced_height = 104, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w_clamped = --DOC_HIDE
+wibox.widget {
+    --clamp_bars    = true, --default
+    step_width    = 9,
+    step_spacing  = 1,
+    step_shape    = gears.shape.arrow,
+    min_value     = -3, --DOC_HIDE
+    max_value     = 3, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    forced_height = 104, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+for _, v in ipairs(data) do --DOC_HIDE
+    w_unclamped:add_value(v) --DOC_HIDE
+    w_clamped:add_value(v) --DOC_HIDE
+end --DOC_HIDE
+
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>clamp_bars=false</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_unclamped,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>clamp_bars=true</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_clamped,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 221, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+}) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/code_coverage.lua
+++ b/tests/examples/wibox/widget/graph/code_coverage.lua
@@ -1,0 +1,115 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+
+--DOC_HIDE These are not useful examples, but rather a gathering of fringe cases
+--DOC_HIDE that should provide code coverage to ensure that we're handling them.
+
+local data = { --DOC_HIDE
+    -5, -4, 0/0, -2, -4, 0/0, 4, 2, 3, 0/0, 5, --DOC_HIDE
+} --DOC_HIDE
+
+--DOC_HIDE Tests behavior of autoscaling when graph contains only equal values.
+--DOC_HIDE This widget will also be rendered multiple times with different
+--DOC_HIDE sizes, to test last_drawn_values_num stats gathering.
+local w_autoscale_constant = --DOC_HIDE
+wibox.widget {
+    step_width    = 9,
+    step_spacing  = 1,
+    scale         = true,
+    border_width  = 2, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    forced_height = 44, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+--DOC_HIDE Tests behavior of drawn_values_num calculation, when
+--DOC_HIDE border_width > width/2, i.e. there's no free space for drawing.
+local w_too_fat_border = --DOC_HIDE
+wibox.widget {
+    border_width  = 200,
+    step_width    = 9,
+    step_spacing  = 1,
+    scale         = true, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    forced_height = 44, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+--DOC_HIDE Tests behavior of a widget with set capacity property
+local w_set_capacity = --DOC_HIDE
+wibox.widget {
+    capacity      = 5,
+    step_width    = 9,
+    step_spacing  = 1,
+    scale         = true, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    forced_height = 44, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+for _, v in ipairs(data) do --DOC_HIDE
+    w_autoscale_constant:add_value(3) --DOC_HIDE adding the same value
+    w_too_fat_border:add_value(v) --DOC_HIDE
+    w_set_capacity:add_value(v) --DOC_HIDE
+end --DOC_HIDE
+
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>widget clones</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        {--DOC_HIDE
+            w_autoscale_constant,--DOC_HIDE
+            w_autoscale_constant,--DOC_HIDE
+            forced_height = 22,--DOC_HIDE
+            layout = wibox.layout.flex.horizontal,--DOC_HIDE
+        },--DOC_HIDE
+        {--DOC_HIDE
+            w_autoscale_constant,--DOC_HIDE
+            w_autoscale_constant,--DOC_HIDE
+            w_autoscale_constant,--DOC_HIDE
+            forced_height = 22,--DOC_HIDE
+            layout = wibox.layout.flex.horizontal,--DOC_HIDE
+        },--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>autoscale constant</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_autoscale_constant,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>too fat border</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_too_fat_border,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>set capacity=5</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_set_capacity,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 104, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+}) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/color.lua
+++ b/tests/examples/wibox/widget/graph/color.lua
@@ -21,9 +21,9 @@ for _, color in ipairs {"#ff0000", "#00ff00", "#0000ff", "#ff00ff" } do
     local w = --DOC_HIDE
 
     wibox.widget {
-        max_value = 29,
         color     = color,
         widget    = wibox.widget.graph,
+        max_value = 29, --DOC_HIDE
         border_width  = 2, --DOC_HIDE
         margins       = 5, --DOC_HIDE
     }

--- a/tests/examples/wibox/widget/graph/max_value.lua
+++ b/tests/examples/wibox/widget/graph/max_value.lua
@@ -14,6 +14,7 @@ local data = { --DOC_HIDE
 local w1 = --DOC_HIDE
 wibox.widget {
     max_value = 30,
+    forced_height = 20, --DOC_HIDE
     widget    = wibox.widget.graph,
 }
 
@@ -22,6 +23,7 @@ wibox.widget {
 local w2 = --DOC_HIDE
 wibox.widget {
     max_value = 10,
+    forced_height = 20, --DOC_HIDE
     widget    = wibox.widget.graph,
 }
 

--- a/tests/examples/wibox/widget/graph/min_value.lua
+++ b/tests/examples/wibox/widget/graph/min_value.lua
@@ -14,6 +14,7 @@ local data = { --DOC_HIDE
 local w1 = --DOC_HIDE
 wibox.widget {
     max_value = 30,
+    forced_height = 20, --DOC_HIDE
     widget    = wibox.widget.graph,
 }
 
@@ -23,6 +24,7 @@ local w2 = --DOC_HIDE
 wibox.widget {
     min_value = 10,
     max_value = 30,
+    forced_height = 20, --DOC_HIDE
     widget    = wibox.widget.graph,
 }
 

--- a/tests/examples/wibox/widget/graph/nan_color.lua
+++ b/tests/examples/wibox/widget/graph/nan_color.lua
@@ -1,0 +1,98 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local gears  = {shape = require("gears.shape")} --DOC_HIDE
+
+local data = {
+    -5, -4, 0/0, -2, -1, 0/0, 1, 2, 3, 0/0, 5,
+}
+
+--DOC_NEWLINE
+
+local w_default = --DOC_HIDE
+wibox.widget {
+    -- nan_indication = true, -- default
+    -- default nan_color
+    step_width    = 9,
+    step_spacing  = 1,
+    step_shape    = gears.shape.rectangle, --DOC_HIDE
+    scale         = true, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    forced_height = 44, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w_custom = --DOC_HIDE
+wibox.widget {
+    -- nan_indication = true, -- default
+    nan_color     = "#ff00007f",
+    step_width    = 9,
+    step_spacing  = 1,
+    step_shape    = gears.shape.rectangle, --DOC_HIDE
+    scale         = true, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    forced_height = 44, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w_false = --DOC_HIDE
+wibox.widget {
+    nan_indication = false,
+    step_width     = 9,
+    step_spacing   = 1,
+    step_shape     = gears.shape.rectangle, --DOC_HIDE
+    scale          = true, --DOC_HIDE
+    border_width   = 2, --DOC_HIDE
+    margins        = 5, --DOC_HIDE
+    forced_height  = 44, --DOC_HIDE
+    widget         = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+--DOC_HIDE add data in reverse so that visible order corresponds to array order
+for i = #data,1,-1 do --DOC_HIDE
+    local v = data[i] --DOC_HIDE
+    w_default:add_value(v) --DOC_HIDE
+    w_custom:add_value(v) --DOC_HIDE
+    w_false:add_value(v) --DOC_HIDE
+end --DOC_HIDE
+
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>default nan_color</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_default,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>custom nan_color</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_custom,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>nan_indication=false</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_false,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 342, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+}) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/negative_gallery.lua
+++ b/tests/examples/wibox/widget/graph/negative_gallery.lua
@@ -1,0 +1,152 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local gears  = { --DOC_HIDE
+    matrix = require("gears.matrix"), --DOC_HIDE
+    shape = require("gears.shape"), --DOC_HIDE
+} --DOC_HIDE
+
+local data = { --DOC_HIDE
+    -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, --DOC_HIDE
+} --DOC_HIDE
+
+-- For converting normally "horizontal" shapes into vertical ones
+local function transpose(shape)
+    local swap_coords = gears.matrix.create(0, 1, 1, 0, 0, 0)
+    return function(cr, width, height, ...)
+        gears.shape.transform(shape):multiply(swap_coords) (cr, height, width, ...)
+    end
+end
+
+local shapes = {
+    gears.shape.rectangle,
+-- DOC_HIDE rectangular_tag illustrates the mode differences the best
+    transpose(gears.shape.rectangular_tag),
+    gears.shape.squircle,
+-- DOC_HIDE behaves badly: gears.shape.star,
+-- DOC_HIDE looks without params like rounded_bar: gears.shape.rounded_rect,
+    gears.shape.rounded_bar,
+    gears.shape.arrow,
+    transpose(gears.shape.hexagon),
+    transpose(gears.shape.powerline),
+    gears.shape.isosceles_triangle,
+    gears.shape.cross,
+    gears.shape.octogon,
+-- DOC_HIDE centers itself in the bar: gears.shape.circle,
+    gears.shape.losange,
+}
+
+-- When asked to draw the shape with negative height,
+-- draw its counterpart with positive height and mirror it.
+local function mirror_negative(shape)
+    local mirrored_shape = gears.shape.transform(shape):scale(1, -1)
+    return function(cr, width, height, ...)
+        if height < 0 then
+           mirrored_shape(cr, width, -height, ...)
+        else
+           shape(cr, width, height, ...)
+        end
+    end
+end
+
+-- When asked to draw the shape with negative height,
+-- draw its counterpart with positive height and shift it down.
+local function flip_negative(shape)
+    return function(cr, width, height, ...)
+        if height < 0 then
+           gears.shape.transform(shape):translate(0, height) (cr, width, -height, ...)
+        else
+           shape(cr, width, height, ...)
+        end
+    end
+end
+
+for _, shape in ipairs(shapes) do
+
+    local w_normal = --DOC_HIDE
+    wibox.widget {
+        step_width    = 9,
+        step_spacing  = 1,
+        step_shape    = shape,
+        scale         = true, --DOC_HIDE
+        border_width  = 2, --DOC_HIDE
+        color         = "#00ff00", --DOC_HIDE
+        background_color = "#000000", --DOC_HIDE
+        margins       = 5, --DOC_HIDE
+        forced_height = 104, --DOC_HIDE
+        widget        = wibox.widget.graph,
+    }
+
+    --DOC_NEWLINE
+
+    local w_mirror = --DOC_HIDE
+    wibox.widget {
+        step_width    = 9,
+        step_spacing  = 1,
+        step_shape    = mirror_negative(shape),
+        scale         = true, --DOC_HIDE
+        border_width  = 2, --DOC_HIDE
+        color         = "#00ff00", --DOC_HIDE
+        background_color = "#000000", --DOC_HIDE
+        margins       = 5, --DOC_HIDE
+        forced_height = 104, --DOC_HIDE
+        widget        = wibox.widget.graph,
+    }
+
+    --DOC_NEWLINE
+
+    local w_flip = --DOC_HIDE
+    wibox.widget {
+        step_width    = 9,
+        step_spacing  = 1,
+        step_shape    = flip_negative(shape),
+        scale         = true, --DOC_HIDE
+        border_width  = 2, --DOC_HIDE
+        color         = "#00ff00", --DOC_HIDE
+        background_color = "#000000", --DOC_HIDE
+        margins       = 5, --DOC_HIDE
+        forced_height = 104, --DOC_HIDE
+        widget        = wibox.widget.graph,
+    }
+
+    --DOC_NEWLINE
+
+    for _, v in ipairs(data) do --DOC_HIDE
+        w_normal:add_value(v) --DOC_HIDE
+        w_mirror:add_value(v) --DOC_HIDE
+        w_flip:add_value(v) --DOC_HIDE
+    end --DOC_HIDE
+
+    parent:add(wibox.layout {--DOC_HIDE
+        {--DOC_HIDE
+            {--DOC_HIDE
+                markup = "<b>shape</b>",--DOC_HIDE
+                widget = wibox.widget.textbox,--DOC_HIDE
+            },--DOC_HIDE
+            w_normal,--DOC_HIDE
+            layout = wibox.layout.fixed.vertical,--DOC_HIDE
+        },--DOC_HIDE
+        {--DOC_HIDE
+            {--DOC_HIDE
+                markup = "<b>mirror(shape)</b>",--DOC_HIDE
+                widget = wibox.widget.textbox,--DOC_HIDE
+            },--DOC_HIDE
+            w_mirror,--DOC_HIDE
+            layout = wibox.layout.fixed.vertical,--DOC_HIDE
+        },--DOC_HIDE
+        {--DOC_HIDE
+            {--DOC_HIDE
+                markup = "<b>flip(shape)</b>",--DOC_HIDE
+                widget = wibox.widget.textbox,--DOC_HIDE
+            },--DOC_HIDE
+            w_flip,--DOC_HIDE
+            layout = wibox.layout.fixed.vertical,--DOC_HIDE
+        },--DOC_HIDE
+
+        forced_width  = 342, --DOC_HIDE
+        spacing       = 5, --DOC_HIDE
+        layout        = wibox.layout.flex.horizontal --DOC_HIDE
+    }) --DOC_HIDE
+end
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/negative_sine.lua
+++ b/tests/examples/wibox/widget/graph/negative_sine.lua
@@ -1,0 +1,52 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+
+--DOC_HIDE for i = 0, 59 do print(math.floor(math.sin(i/30*math.pi)*64 + 0.5)) end
+local sine = { --DOC_HIDE
+      0,   7,  13,  20,  26,  32,  38,  43,  48,  52,  55,  58,  61,  63,  64, --DOC_HIDE
+     64,  64,  63,  61,  58,  55,  52,  48,  43,  38,  32,  26,  20,  13,   7, --DOC_HIDE
+      0,  -7, -13, -20, -26, -32, -38, -43, -48, -52, -55, -58, -61, -63, -64, --DOC_HIDE
+    -64, -64, -63, -61, -58, -55, -52, -48, -43, -38, -32, -26, -20, -13,  -7, --DOC_HIDE
+} --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_height = 100, --DOC_HIDE
+    forced_width  = 100, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+local colors = {
+    "#ff0000ff",
+    "#00ff00ff",
+    "#0000ffff"
+}
+
+--DOC_NEWLINE
+
+local w = --DOC_HIDE
+wibox.widget {
+    stack        = false,
+    group_colors = colors,
+    step_width   = 1,
+    step_spacing = 1,
+    scale        = true,
+    border_width = 2, --DOC_HIDE
+    margins      = 5, --DOC_HIDE
+    widget       = wibox.widget.graph,
+}
+
+l:add(w) --DOC_HIDE
+
+for idx = 0, #sine-1 do --DOC_HIDE
+    for group = 1, 3 do --DOC_HIDE
+        --DOC_HIDE 64*math.sin(group*idx/30*math.pi) * (4-group)
+        local v = sine[((idx*group) % #sine)+1] * (4-group) --DOC_HIDE
+        w:add_value(v, group) --DOC_HIDE
+    end --DOC_HIDE
+end --DOC_HIDE
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/normal_vs_stacked.lua
+++ b/tests/examples/wibox/widget/graph/normal_vs_stacked.lua
@@ -1,6 +1,7 @@
 --DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
+local gears  = {shape = require("gears.shape")} --DOC_HIDE
 
 local data = { --DOC_HIDE
     {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
@@ -20,40 +21,77 @@ local data = { --DOC_HIDE
     {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
 } --DOC_HIDE
 
-local l = wibox.layout { --DOC_HIDE
-    forced_height = 100, --DOC_HIDE
-    forced_width  = 100, --DOC_HIDE
-    spacing       = 5, --DOC_HIDE
-    layout        = wibox.layout.flex.vertical --DOC_HIDE
-} --DOC_HIDE
-
 local colors = {
     "#ff0000",
     "#00ff00",
     "#0000ff"
 }
 
+local thin_arrow_shape = function(cr, width, height)
+    gears.shape.arrow(cr, width, height, nil, 1, math.max(0, height-4))
+end
+
 --DOC_NEWLINE
 
-local w = --DOC_HIDE
-
+local w1 = --DOC_HIDE
 wibox.widget {
-    stack         = true,
+    --stack         = false, --default
     group_colors  = colors,
-    max_value     = 29, --DOC_HIDE
+    step_width    = 5,
+    step_spacing  = 1,
+    step_shape    = thin_arrow_shape,
+    max_value     = 66, --DOC_HIDE
     border_width  = 2, --DOC_HIDE
     margins       = 5, --DOC_HIDE
     widget        = wibox.widget.graph,
 }
 
-l:add(w) --DOC_HIDE
+--DOC_NEWLINE
+
+local w2 = --DOC_HIDE
+wibox.widget {
+    stack         = true,
+    group_colors  = colors,
+    step_width    = 5,
+    step_spacing  = 1,
+    step_shape    = thin_arrow_shape,
+    max_value     = 66, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
 
 for _, v in ipairs(data) do --DOC_HIDE
     for group, value in ipairs(v) do --DOC_HIDE
-        w:add_value(value, group) --DOC_HIDE
+        w1:add_value(value, group) --DOC_HIDE
+        w2:add_value(value, group) --DOC_HIDE
     end --DOC_HIDE
 end --DOC_HIDE
 
-parent:add(l) --DOC_HIDE
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>stack = false</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w1,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>stack = true</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w2,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 210, --DOC_HIDE
+    forced_height = 110, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+}) --DOC_HIDE
 
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/scale1.lua
+++ b/tests/examples/wibox/widget/graph/scale1.lua
@@ -14,6 +14,7 @@ local data = { --DOC_HIDE
 local w1 = --DOC_HIDE
 wibox.widget {
     scale  = false,
+    forced_height = 20, --DOC_HIDE
     widget = wibox.widget.graph,
 }
 
@@ -22,6 +23,7 @@ wibox.widget {
 local w2 = --DOC_HIDE
 wibox.widget {
     scale  = true,
+    forced_height = 20, --DOC_HIDE
     widget = wibox.widget.graph,
 }
 

--- a/tests/examples/wibox/widget/graph/scale_stacked.lua
+++ b/tests/examples/wibox/widget/graph/scale_stacked.lua
@@ -20,40 +20,61 @@ local data = { --DOC_HIDE
     {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
 } --DOC_HIDE
 
-local l = wibox.layout { --DOC_HIDE
-    forced_height = 100, --DOC_HIDE
-    forced_width  = 100, --DOC_HIDE
-    spacing       = 5, --DOC_HIDE
-    layout        = wibox.layout.flex.vertical --DOC_HIDE
-} --DOC_HIDE
-
 local colors = {
     "#ff0000",
     "#00ff00",
     "#0000ff"
 }
 
---DOC_NEWLINE
-
-local w = --DOC_HIDE
-
+local w1 = --DOC_HIDE
 wibox.widget {
-    stack         = true,
-    group_colors  = colors,
-    max_value     = 29, --DOC_HIDE
-    border_width  = 2, --DOC_HIDE
-    margins       = 5, --DOC_HIDE
-    widget        = wibox.widget.graph,
+    max_value    = 29, --DOC_HIDE
+    scale        = false,
+    stack        = true,
+    group_colors = colors,
+    forced_height = 65, --DOC_HIDE
+    widget = wibox.widget.graph,
 }
 
-l:add(w) --DOC_HIDE
+--DOC_NEWLINE
+
+local w2 = --DOC_HIDE
+wibox.widget {
+    scale        = true,
+    stack        = true,
+    group_colors = colors,
+    forced_height = 65, --DOC_HIDE
+    widget = wibox.widget.graph,
+}
 
 for _, v in ipairs(data) do --DOC_HIDE
     for group, value in ipairs(v) do --DOC_HIDE
-        w:add_value(value, group) --DOC_HIDE
+        w1:add_value(value, group) --DOC_HIDE
+        w2:add_value(value, group) --DOC_HIDE
     end --DOC_HIDE
 end --DOC_HIDE
 
-parent:add(l) --DOC_HIDE
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>scale = false</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w1,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>scale = true</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w2,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 210, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+}) --DOC_HIDE
 
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/stacked_group_disable.lua
+++ b/tests/examples/wibox/widget/graph/stacked_group_disable.lua
@@ -1,0 +1,129 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local gears  = {shape = require("gears.shape")} --DOC_HIDE
+
+local data = { --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+    {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
+} --DOC_HIDE
+
+local colors_normal = {
+    "#ff0000",
+    "#00ff00", -- the data group is green
+    "#0000ff"
+}
+
+local colors_transparent = {
+    "#ff0000",
+    "#00000000", -- the data group is transparent
+    "#0000ff"
+}
+
+local colors_disabled = {
+    "#ff0000",
+    nil, -- the data group is disabled
+    "#0000ff"
+}
+
+--DOC_NEWLINE
+
+local w1 = --DOC_HIDE
+wibox.widget {
+    stack         = true,
+    group_colors  = colors_normal,
+    max_value     = 66, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    step_width    = 5, --DOC_HIDE
+    step_spacing  = 1, --DOC_HIDE
+    step_shape    = gears.shape.rounded_bar, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w2 = --DOC_HIDE
+wibox.widget {
+    stack         = true,
+    group_colors  = colors_transparent,
+    max_value     = 66, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    step_width    = 5, --DOC_HIDE
+    step_spacing  = 1, --DOC_HIDE
+    step_shape    = gears.shape.rounded_bar, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w3 = --DOC_HIDE
+wibox.widget {
+    stack         = true,
+    group_colors  = colors_disabled,
+    max_value     = 66, --DOC_HIDE
+    border_width  = 2, --DOC_HIDE
+    step_width    = 5, --DOC_HIDE
+    step_spacing  = 1, --DOC_HIDE
+    step_shape    = gears.shape.rounded_bar, --DOC_HIDE
+    margins       = 5, --DOC_HIDE
+    widget        = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+for _, v in ipairs(data) do --DOC_HIDE
+    for group, value in ipairs(v) do --DOC_HIDE
+        w1:add_value(value, group) --DOC_HIDE
+        w2:add_value(value, group) --DOC_HIDE
+        w3:add_value(value, group) --DOC_HIDE
+    end --DOC_HIDE
+end --DOC_HIDE
+
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>Normal</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w1,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>Transparent</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w2,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>Disabled</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w3,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 210, --DOC_HIDE
+    forced_height = 110, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+}) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/stacked_nan.lua
+++ b/tests/examples/wibox/widget/graph/stacked_nan.lua
@@ -1,0 +1,115 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+
+--DOC_HIDE for i = 0, 59 do print(math.floor(math.sin(i/30*math.pi)*64 + 0.5)) end
+local sine = { --DOC_HIDE
+      0,   7,  13,  20,  26,  32,  38,  43,  48,  52,  55,  58,  61,  63,  64, --DOC_HIDE
+     64,  64,  63,  61,  58,  55,  52,  48,  43,  38,  32,  26,  20,  13,   7, --DOC_HIDE
+      0,  -7, -13, -20, -26, -32, -38, -43, -48, -52, -55, -58, -61, -63, -64, --DOC_HIDE
+    -64, -64, -63, -61, -58, -55, -52, -48, -43, -38, -32, -26, -20, -13,  -7, --DOC_HIDE
+} --DOC_HIDE
+
+-- The red and blue data groups are constant,
+-- but the green data group is a sine,
+-- which, when it becomes negative,
+-- triggers NaN indication in a stacked graph.
+
+local colors = {
+    "#ff0000",
+    "#00ff00",
+    "#0000ff"
+}
+
+--DOC_NEWLINE
+
+local w_default = --DOC_HIDE
+wibox.widget {
+    --default nan_color
+    stack        = true,
+    group_colors = colors,
+    step_width   = 1,
+    step_spacing = 1,
+    scale        = true, --DOC_HIDE
+    border_width = 2, --DOC_HIDE
+    margins      = 5, --DOC_HIDE
+    forced_height = 44, --DOC_HIDE
+    widget       = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w_custom = --DOC_HIDE
+wibox.widget {
+    nan_color    = "#ff00ff7f",
+    stack        = true,
+    group_colors = colors,
+    step_width   = 1,
+    step_spacing = 1,
+    scale        = true, --DOC_HIDE
+    border_width = 2, --DOC_HIDE
+    margins      = 5, --DOC_HIDE
+    forced_height = 44, --DOC_HIDE
+    widget       = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+local w_false = --DOC_HIDE
+wibox.widget {
+    nan_indication = false,
+    stack          = true,
+    group_colors   = colors,
+    step_width     = 1,
+    step_spacing   = 1,
+    scale          = true, --DOC_HIDE
+    border_width   = 2, --DOC_HIDE
+    margins        = 5, --DOC_HIDE
+    forced_height  = 44, --DOC_HIDE
+    widget         = wibox.widget.graph,
+}
+
+--DOC_NEWLINE
+
+for _, w in ipairs({w_default, w_custom, w_false}) do --DOC_HIDE
+    for idx = 0, #sine-1 do --DOC_HIDE
+        w:add_value(32, 1) --DOC_HIDE
+        w:add_value(32, 3) --DOC_HIDE
+        --DOC_HIDE 64*math.sin(2*idx/30*math.pi)
+        local v = sine[((2*idx) % #sine)+1] --DOC_HIDE
+        w:add_value(v, 2) --DOC_HIDE
+    end --DOC_HIDE
+end --DOC_HIDE
+
+parent:add(wibox.layout {--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>default nan_color</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_default,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>custom nan_color</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_custom,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+    {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>nan_indication=false</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w_false,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    },--DOC_HIDE
+
+    forced_width  = 342, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+}) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/graph/stacked_step_options.lua
+++ b/tests/examples/wibox/widget/graph/stacked_step_options.lua
@@ -1,6 +1,7 @@
 --DOC_GEN_IMAGE --DOC_HIDE
 local parent = ... --DOC_HIDE
 local wibox  = require("wibox") --DOC_HIDE
+local gears  = {shape = require("gears.shape")} --DOC_HIDE
 
 local data = { --DOC_HIDE
     {3, 5, 6}, {4, 11,15}, {19,29,17},{17,14,0}, {0,3,1}, {0,0,22}, {17,7,1}, {0,0,5}, --DOC_HIDE
@@ -38,10 +39,13 @@ local colors = {
 local w = --DOC_HIDE
 
 wibox.widget {
+    max_value     = 66,
     stack         = true,
-    group_colors  = colors,
-    max_value     = 29, --DOC_HIDE
     border_width  = 2, --DOC_HIDE
+    group_colors  = colors,
+    step_width    = 5,
+    step_spacing  = 1,
+    step_shape    = gears.shape.rounded_bar,
     margins       = 5, --DOC_HIDE
     widget        = wibox.widget.graph,
 }

--- a/tests/examples/wibox/widget/graph/step_spacing.lua
+++ b/tests/examples/wibox/widget/graph/step_spacing.lua
@@ -22,10 +22,10 @@ for _, spacing in ipairs {0, 2, 4, 10} do
     local w = --DOC_HIDE
 
     wibox.widget {
-        border_width  = 2, --DOC_HIDE
-        margins          = 5, --DOC_HIDE
-        max_value    = 29,
         step_spacing = spacing,
+        max_value    = 29, --DOC_HIDE
+        border_width = 2, --DOC_HIDE
+        margins      = 5, --DOC_HIDE
         widget       = wibox.widget.graph,
     }
 

--- a/tests/examples/wibox/widget/graph/subpixel.lua
+++ b/tests/examples/wibox/widget/graph/subpixel.lua
@@ -1,0 +1,45 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+
+local data = { --DOC_HIDE
+    3, 5, 6,4, 11,15,19,29,17,17,14,0,0,3,1,0,0, 22, 17,7, 1,0,0,5, --DOC_HIDE
+} --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_height = 100, --DOC_HIDE
+    forced_width  = 100, --DOC_HIDE
+    spacing       = 0, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+for _, small_step in ipairs {1, 1/2, 1/3} do
+    _ = small_step --DOC_HIDE silence luacheck unused var warning
+end --DOC_HIDE actually use truncated numbers, hopefully helps with reproducibility
+
+for _, small_step in ipairs {1, 0.5, 21845/65536} do --DOC_HIDE
+    local w = --DOC_HIDE
+    wibox.widget {
+        -- width = 1000,
+        max_value    = 29,
+        step_width   = small_step,
+        step_spacing = 0,
+        color        = "#ff0000",
+        background_color = "#000000",
+        border_width = 2, --DOC_HIDE
+        margins      = 0, --DOC_HIDE
+        widget       = wibox.widget.graph,
+    }
+
+    l:add(w) --DOC_HIDE
+
+    for _ = 1, 16 do --DOC_HIDE repeat the data enough times to fill the graphs
+        for _, v in ipairs(data) do --DOC_HIDE
+            w:add_value(v) --DOC_HIDE
+        end --DOC_HIDE
+    end --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
I've noticed a bug in the graph widget, which prompted me to delve into the code and discover a huge number of other bugs and missing features, and I got a bit carried away. The fact that few seemed to take note of the problems (e.g. #3289) makes me suspect, that nobody really cares or uses the kind of functionality that I'm fixing here. So I want to know if there's even an interest in merging this and get some feedback on it, before I do more stuff. 

I've tried to organize commits in the order of increasing intrusiveness and visibly changed behavior (e.g. the border_color fix), and with the exception of a pair of commits, every commit is a complete fix, i.e. one can truncate this pull series almost at any point and the widget will perform as expected (but better), so you can take as much as you want (but I'll be sad if it's not gonna be the entirety of it).

So what does this fix? Here are some commit highlights.
###  Fix the "border_width affects graph bar width" bug
A really visually horrible bug. It's a wonder that nobody noticed. Setting `border_width` property > 1 made the bars increasingly large while still overlapping each other. Before and after the fix:
![AUTOGEN_wibox_widget_graph_border_width buggy svg](https://user-images.githubusercontent.com/2304990/115058546-96e75180-9f0f-11eb-90ac-54a00d14a5a8.png) ![AUTOGEN_wibox_widget_graph_border_width fixed svg](https://user-images.githubusercontent.com/2304990/115058989-170db700-9f10-11eb-85b4-86364f70cf94.png)

All the following "before" pictures will have this bug already fixed, otherwise it would have been sometimes hard to see, what is it that I'm fixing there.
### Fix wrong horizontal offset calculations in widget.graph
Increasing `step_spacing` property caused the graph to shift left as a whole, making the leftmost bars vanish offscreen. Before and after the fix:
![2_AUTOGEN_wibox_widget_graph_step_spacing2 svg buggy](https://user-images.githubusercontent.com/2304990/115073832-129ec980-9f23-11eb-8193-63d95719a265.png) ![2_AUTOGEN_wibox_widget_graph_step_spacing2 svg fixed](https://user-images.githubusercontent.com/2304990/115073850-192d4100-9f23-11eb-9203-8dae2f68a522.png)

But! That was the case only for `step_shape = nil`. But drawing with shapes had its own problem: the whole graph was shifted right for `step_width` pixels and the first bar touched the second bar despite `step_spacing`. 
In the following pics the first graph is `step_shape = nil`, and the rest are `rectangle`, `rounded_bar` and `arrow` respectively. Before and after the fix:
![2_AUTOGEN_wibox_widget_graph_step_shape2 svg buggy](https://user-images.githubusercontent.com/2304990/115074579-1848df00-9f24-11eb-882b-d825d36e33b4.png) ![2_AUTOGEN_wibox_widget_graph_step_shape2 svg fixed](https://user-images.githubusercontent.com/2304990/115074584-18e17580-9f24-11eb-9de3-8617aca6f557.png)
 
### Fix graph bar scaling when `min_value` is not 0
The code used a wrong formula which led to underscaling of values, so that even a value == `max_value` wasn't drawn to full widget height. Before and after the fix:
![3_AUTOGEN_wibox_widget_graph_min_value svg buggy](https://user-images.githubusercontent.com/2304990/115075354-25b29900-9f25-11eb-96ce-9f8e09b52633.png) ![3_AUTOGEN_wibox_widget_graph_min_value svg fixed](https://user-images.githubusercontent.com/2304990/115075358-264b2f80-9f25-11eb-9a53-a78ef92f2616.png)

### Fix unsharp edges when drawing graph bars with rectangles
You may have noticed in "Fix wrong horizontal offset calculations in widget.graph", that the `step_shape = nil` case is drawn somehow blurry compared to the `step_shape = rectangle` case, even though it is logically the same. Well yes, there was a wrong `+0.5` offset, which should've been applied only for the special case of drawing 1px-wide bars with lines. Before and after the fix:
![4_AUTOGEN_wibox_widget_graph_step_spacing2 svg buggy](https://user-images.githubusercontent.com/2304990/115076189-63fc8800-9f26-11eb-8bb5-0d77c2ac8d1b.png) ![4_AUTOGEN_wibox_widget_graph_step_spacing2 svg fixed](https://user-images.githubusercontent.com/2304990/115076193-64951e80-9f26-11eb-8a33-321b84599ee4.png)

### Draw shaped graph bars only up to the baseline
Prior to this commit, every step_shape bar was, for some reason, drawn with height = full widget's height, regardless of the value it represents. So for the most bars their lower end was far outside the box and therefore clipped off. So e.g. one couldn't see the lower round edges of rounded rectangles. This commit fixes that by appropriately varying the height that is passed into `step_shape()`, so that lower edges of the bars always exactly touch the lower edge of the graph. Before and after the fix:
![5_AUTOGEN_wibox_widget_graph_step_shape3 svg buggy](https://user-images.githubusercontent.com/2304990/115077526-66f87800-9f28-11eb-9635-314cfdf4fe5d.png) ![5_AUTOGEN_wibox_widget_graph_step_shape3 svg fixed](https://user-images.githubusercontent.com/2304990/115077523-65c74b00-9f28-11eb-9044-4dfce8d7b72a.png)

### Unify stacked and non-stacked graph rendering
Stacked graphs hadn't supported everything the nonstacked do, like `step_width`, `step_spacing` and custom `step_shape`-s. Now they do. Before and after the fix:
![6_AUTOGEN_wibox_widget_graph_stacked svg buggy](https://user-images.githubusercontent.com/2304990/115078930-96a87f80-9f2a-11eb-98dd-4b4102a8e99a.png) ![6_AUTOGEN_wibox_widget_graph_stacked2 svg fixed](https://user-images.githubusercontent.com/2304990/115078933-97d9ac80-9f2a-11eb-84ab-fbc14eb8ba5c.png)

### Implement multiple data series drawing for non-stacked graph
The widget can already hold and draw multiple data groups, so it makes little sense to limit drawing only to one group when `graph.stack = false`. Here's what one can do now:
![7_AUTOGEN_wibox_widget_graph_stacked_not3 svg](https://user-images.githubusercontent.com/2304990/115085325-8dbcab80-9f34-11eb-8e0b-82bcfd65ad19.png) ![7_AUTOGEN_wibox_widget_graph_stacked_not svg](https://user-images.githubusercontent.com/2304990/115085328-8e554200-9f34-11eb-9e36-14d6c35fd82c.png) ![7_AUTOGEN_wibox_widget_graph_stacked_not2 svg](https://user-images.githubusercontent.com/2304990/115085326-8dbcab80-9f34-11eb-974e-5423b095a157.png)

With one tiny change, which is not a part of this pull request yet, the user will be able to easily paint things with e.g. lines connecting the dots by only supplying an appropriate `step_shape`:
![7_AUTOGEN_wibox_widget_graph_stacked_not4 svg](https://user-images.githubusercontent.com/2304990/115085322-8c8b7e80-9f34-11eb-914c-dfc2ecac4023.png)
I guess this guy would've liked to have it: #2899

### Fix border_color/border_width bugs in graph widget
These are numerous, so I suggest to read the respective commit message. I'll only note here, that this is one of the commits that may visibly change the behavior for existing users' configs, because now the widget border is drawn with a fallback color, where it previously didn't, if `border_color` wasn't set. One of such users is awesome's documentation itself, where an explicitly set `border_width = 2` in some examples was ignored, because `border_color` was forgotten. Before and after this commit:
![8_AUTOGEN_wibox_widget_graph_color svg buggy](https://user-images.githubusercontent.com/2304990/115087397-4506f180-9f38-11eb-9207-9f03482ea261.png) ![8_AUTOGEN_wibox_widget_graph_color svg fixed](https://user-images.githubusercontent.com/2304990/115087398-459f8800-9f38-11eb-8f44-852760ece900.png)

### Negative values support
`Add baseline_y and baseline_value properties to graph widget` and `Implement the simplest negative shape handling in graph widget` are some relevant commits. This allows to do e.g. the following now:
![9_AUTOGEN_wibox_widget_graph_stacked_not_negative svg](https://user-images.githubusercontent.com/2304990/115088998-919ffc00-9f3b-11eb-8e25-3bcf7250800a.png) ![9_AUTOGEN_wibox_widget_graph_negative_shape svg](https://user-images.githubusercontent.com/2304990/115088997-91076580-9f3b-11eb-8ecb-946a4400d22f.png)

You might have noted a specific customization challenge that this poses, e.g. how the user should go about it if they want to draw arrows for negative values pointing downwards. I have some ideas, which are waiting to be implemented (or not, if you don't want it).

### More careful value storage handling 
`Add capacity property to graph widget` and `Track graph draw() usage to guess necessary array capacity` are some relevant commits. Prior to them widget relied on its `width` property to guess how many values it should keep, and it has dutifully returned the value in the `fit()` callback, but widgets are not guaranteed to get the dimensions they want. 
Even some examples in awesome's documentation fell prey to this problem. Here's a before and after:
![10_AUTOGEN_wibox_widget_defaults_graph svg buggy](https://user-images.githubusercontent.com/2304990/115090333-c6fa1900-9f3e-11eb-8c96-966d359f3aa7.png) ![10_AUTOGEN_wibox_widget_defaults_graph svg fixed](https://user-images.githubusercontent.com/2304990/115090334-c792af80-9f3e-11eb-8a10-8df156a8b61c.png)

And here is, incidentally, the line that causes the difference: https://github.com/awesomeWM/awesome/blob/fda950d186efdc43a64c4300a27a5e19a55c2bd7/tests/examples/wibox/template.lua#L24

Moreover a widget could be drawn in several places with different widths simultaneously, and for a graph this means a different number of visible values, and of course the invisible values shouldn't affect e.g. the auto-scaling. This is all properly handled now. I'm not sure if the graph widget even needs the width and height properties now.

### And more
I'm running out of time to describe some smaller things like proper `NaN` handling, autoscaling fix for stacked graphs, and performance improvements (despite all those new features and fixes, the graph rendering is now 4 times faster with just one simple trick). And some things to be done, don't worry if they don't make sense to you:

- [x] group_start()
- [x] group_finish()
- [ ] ~~negative stack graphs~~ Too fringe a functionality. It was brought to my attention that stack graphs were already too much to include in one component, let's not make it worse.
- [x] ~~customizable negative shapes~~ Instead of building it in, I've added examples of how the user can do that.
- [x] maybe deprecate set_width
- [x] maybe deprecate weird width/height >= 5 checks
- [ ] ~~baseline shape~~ Could get in the way of future improvements. Better give user a callback to draw whatever grid they wish and to map the coordinate system however they want, but I'm not ready for that now.
- [x] ~~nan shape~~ Can be implemented by user with `step_hook()` if needed. `nan_color` should suffice.
- [x] add_value() default to NaN
- [x] docs