### PR TITLE
Tile container

### DIFF
--- a/lib/wibox/container/init.lua
+++ b/lib/wibox/container/init.lua
@@ -17,6 +17,7 @@ return setmetatable({
     radialprogressbar = require("wibox.container.radialprogressbar");
     arcchart = require("wibox.container.arcchart");
     place = require("wibox.container.place");
+    tile = require("wibox.container.tile");
 }, {__call = function(_, args) return base.make_widget_declarative(args) end})
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/wibox/container/place.lua
+++ b/lib/wibox/container/place.lua
@@ -23,13 +23,8 @@ local align_fct = {
 }
 align_fct.top, align_fct.bottom = align_fct.left, align_fct.right
 
--- Layout this layout
-function place:layout(context, width, height)
-
-    if not self._private.widget then
-        return
-    end
-
+-- Shared with some subclasses like the `tiled` and `scaled` modules.
+function place:_layout(context, width, height)
     local w, h = base.fit_widget(self, context, self._private.widget, width, height)
 
     if self._private.content_fill_horizontal then
@@ -44,6 +39,21 @@ function place:layout(context, width, height)
     local halign = self._private.halign or "center"
 
     local x, y = align_fct[halign](w, width), align_fct[valign](h, height)
+
+    -- Sub pixels makes everything blurry. This is now what people expect.
+    x, y = math.floor(x), math.floor(y)
+
+    return x, y, w, h
+end
+
+-- Layout this layout
+function place:layout(context, width, height)
+
+    if not self._private.widget then
+        return
+    end
+
+    local x, y, w, h = self:_layout(context, width, height)
 
     return { base.place_widget_at(self._private.widget, x, y, w, h) }
 end

--- a/lib/wibox/container/place.lua
+++ b/lib/wibox/container/place.lua
@@ -107,6 +107,8 @@ end
 -- * *center* (default)
 -- * *bottom*
 --
+--@DOC_wibox_container_place_valign_EXAMPLE@
+--
 -- @property valign
 -- @tparam[opt="center"] string valign
 -- @propemits true false
@@ -118,6 +120,8 @@ end
 -- * *left*
 -- * *center* (default)
 -- * *right*
+--
+--@DOC_wibox_container_place_halign_EXAMPLE@
 --
 -- @property halign
 -- @tparam[opt="center"] string halign
@@ -169,6 +173,8 @@ end
 
 --- Stretch the contained widget so it takes all the vertical space.
 --
+--@DOC_wibox_container_place_content_fill_vertical_EXAMPLE@
+--
 -- @property content_fill_vertical
 -- @tparam[opt=false] boolean content_fill_vertical
 -- @propemits true false
@@ -180,6 +186,8 @@ function place:set_content_fill_vertical(value)
 end
 
 --- Stretch the contained widget so it takes all the horizontal space.
+--
+--@DOC_wibox_container_place_content_fill_horizontal_EXAMPLE@
 --
 -- @property content_fill_horizontal
 -- @tparam[opt=false] boolean content_fill_horizontal

--- a/lib/wibox/container/tile.lua
+++ b/lib/wibox/container/tile.lua
@@ -1,0 +1,211 @@
+---------------------------------------------------------------------------
+-- Replicate the content of the widget over and over.
+--
+-- This contained is intended to be used for wallpapers. It currently doesn't
+-- support mouse input in the replicated tiles.
+--
+--@DOC_wibox_container_defaults_tile_EXAMPLE@
+-- @author Emmanuel Lepage-Vallee
+-- @copyright 2021 Emmanuel Lepage-Vallee
+-- @containermod wibox.container.tile
+-- @supermodule wibox.container.place
+local place = require("wibox.container.place")
+local cairo = require("lgi").cairo
+local widget = require("wibox.widget")
+local gtable = require("gears.table")
+
+local module = {mt = {}}
+
+function module:draw(context, cr, width, height)
+    if not self._private.tiled then return end
+    if not self._private.widget then return end
+
+    local x, y, w, h = self:_layout(context, width, height)
+
+    local vspace, hspace = self.vertical_spacing, self.horizontal_spacing
+    local vcrop, hcrop = self.vertical_crop, self.horizontal_crop
+
+    -- In theory we could avoid a few repaints by tracking the child widget
+    -- redraw independently from the container redraw. However it is nearly a
+    -- 1:1 march, so there's little reasons to do it.
+    if not self._private.surface then
+        self._private.surface = cairo.ImageSurface(cairo.Format.ARGB32, w+hspace, h+vspace)
+        self._private.cr = cairo.Context(self._private.surface)
+        self._private.pattern = cairo.Pattern.create_for_surface(self._private.surface)
+        self._private.pattern.extend = cairo.Extend.REPEAT
+        self._private.cr:translate(math.ceil(hspace), math.ceil(vspace))
+    else
+        self._private.cr:set_operator(cairo.Operator.CLEAR)
+        self._private.cr:set_source_rgba(0,0,0,1)
+        self._private.cr:paint()
+        self._private.cr:set_operator(cairo.Operator.SOURCE)
+    end
+
+    widget.draw_to_cairo_context(self._private.widget, self._private.cr, w, h, context)
+
+    cr:save()
+
+    -- We do our own clip.
+    cr:reset_clip()
+
+    local x0, y0 = 0, 0
+
+    -- Avoid painting incomplete tiles
+    if hcrop and x ~= 0 then
+        x0 = x - math.floor(x/(w+hspace))*(w+hspace)
+    end
+
+    if hcrop then
+        width = x + w + hspace + math.floor((width - (x + w + hspace))/(w+hspace))*(w+hspace)
+    end
+
+    if vcrop and y ~= 0 then
+        y0 = y - math.floor(y/(h+vspace))*(h+vspace)
+    end
+
+    if vcrop then
+        height = (y+h+vspace) + math.floor((height - (y+h+vspace))/(h+vspace))*(h+vspace)
+    end
+
+    -- Create a clip around the "real" widget in case there is some transparency.
+    cr:rectangle(x0, y0, width-x0, y-y0)
+    cr:rectangle(x0, y0, x-hspace-x0, height-y0)
+    cr:rectangle(x+hspace+w, y0, width - (x+w+hspace), height-y0)
+    cr:rectangle(x, y+vspace+h, w+hspace, height - (y+h+vspace))
+    cr:clip()
+
+    -- Make sure the tiles are aligned with the child widget.
+    cr:translate(x - hspace, y - vspace)
+
+
+    -- Use OVER rather than SOURCE to preserve the alpha.
+    cr.operator = cairo.Operator.OVER
+    cr.source = self._private.pattern
+    cr:paint()
+
+    cr:restore()
+end
+
+--- The horizontal spacing between the tiled.
+--
+--@DOC_wibox_container_tile_horizontal_spacing_EXAMPLE@
+--
+-- @property horizontal_spacing
+-- @tparam number horizontal_spacing
+-- @propemits true false
+-- @see vertical_spacing
+
+--- The vertical spacing between the tiled.
+--
+--@DOC_wibox_container_tile_vertical_spacing_EXAMPLE@
+--
+-- @property vertical_spacing
+-- @tparam number vertical_spacing
+-- @propemits true false
+-- @see horizontal_spacing
+
+--- Avoid painting incomplete horizontal tiles.
+--
+--@DOC_wibox_container_tile_horizontal_crop_EXAMPLE@
+--
+-- @property horizontal_crop
+-- @tparam[opt=false] boolean tiled
+-- @see vertical_crop
+
+--- Avoid painting incomplete vertical tiles.
+--
+--@DOC_wibox_container_tile_vertical_crop_EXAMPLE@
+--
+-- @property vertical_crop
+-- @tparam[opt=false] boolean tiled
+-- @see horizontal_crop
+
+--- Enable or disable the tiling.
+--
+-- When set to `false`, this container behaves exactly like
+-- `wibox.container.place`.
+--
+--@DOC_wibox_container_tile_tiled_EXAMPLE@
+--
+-- @property tiled
+-- @tparam[opt=true] boolean tiled
+
+local defaults = {
+    horizontal_spacing = 0,
+    vertical_spacing   = 0,
+    tiled              = true,
+    horizontal_crop    = false,
+    vertical_crop      = false,
+}
+
+for prop in pairs(defaults) do
+
+    module["set_"..prop] = function(self, value)
+        self._private[prop] = value
+        self:emit_signal("widget::redraw_needed", value)
+    end
+
+    module["get_"..prop] = function(self)
+        if self._private[prop] == nil then
+            return defaults[prop]
+        end
+
+        return self._private[prop]
+    end
+end
+
+local function new(_, args)
+    args = args or {}
+    local ret = place(args.widget, args.halign, args.valign)
+    gtable.crush(ret, module, true)
+    ret._private.tiled = true
+
+    local function redraw()
+        ret:emit_signal("widget::redraw_needed")
+    end
+
+    -- Resize the pattern as needed.
+    local function reset()
+        if ret._private.surface then
+            ret._private.surface:finish()
+        end
+
+        ret._private.cr = nil
+        ret._private.surface = nil
+        ret._private.pattern = nil
+    end
+
+    local w = nil
+
+    ret:connect_signal("property::widget", function()
+        reset()
+
+        if w then
+            w:disconnect_signal("widget::redraw_needed", redraw)
+            w:disconnect_signal("widget::layout_changed", reset)
+        end
+
+        w = ret._private.widget
+
+        if w then
+            w:connect_signal("widget::redraw_needed", redraw)
+            w:connect_signal("widget::layout_changed", reset)
+        end
+    end)
+
+    return ret
+end
+
+--- Create a new tile container.
+-- @tparam table args
+-- @tparam wibox.widget widget args.widget The widget to tile.
+-- @tparam string args.halign Either `left`, `right` or `center`.
+-- @tparam string args.valign Either `top`, `bottom` or `center`.
+-- @constructorfct wibox.container.tile
+function module.mt:__call(...)
+    return new(...)
+end
+
+return setmetatable(module, module.mt)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -384,6 +384,9 @@ function base.set_widget_common(self, widget)
     end
 
     self._private.widget = w
+
+    self:emit_signal("property::widget")
+
     self:emit_signal("widget::layout_changed")
 end
 

--- a/lib/wibox/widget/slider.lua
+++ b/lib/wibox/widget/slider.lua
@@ -325,7 +325,7 @@ function slider:draw(_, cr, width, height)
 
     local handle_height, handle_width = height, self._private.handle_width
         or beautiful.slider_handle_width
-        or height/2
+        or math.floor(height/2)
 
     local handle_border_width = self._private.handle_border_width
         or beautiful.slider_handle_border_width
@@ -363,7 +363,7 @@ function slider:draw(_, cr, width, height)
         end
     else
         bar_height = bar_height or beautiful.slider_bar_height or height
-        y_offset   = (height - bar_height)/2
+        y_offset   = math.floor((height - bar_height)/2)
     end
 
 
@@ -380,8 +380,10 @@ function slider:draw(_, cr, width, height)
     bar_shape(cr, width - x_offset - right_margin, bar_height or height)
 
     if bar_active_color and type(bar_color) == "string" and type(bar_active_color) == "string" then
-        local bar_active_width = active_rate * (width - x_offset - right_margin)
+        local bar_active_width = math.floor(
+            active_rate * (width - x_offset - right_margin)
             - (handle_width - handle_border_width/2) * (active_rate - 0.5)
+        )
         cr:set_source(color.create_pattern{
             type        = "linear",
             from        = {0,0},
@@ -453,7 +455,7 @@ function slider:draw(_, cr, width, height)
 
     -- Get the widget size back to it's non-transfored value
     local min, _, interval = get_extremums(self)
-    local rel_value = ((value-min)/interval) * (width-handle_width)
+    local rel_value = math.floor(((value-min)/interval) * (width-handle_width))
 
     cr:translate(x_offset + rel_value, y_offset)
 

--- a/tests/examples/wibox/container/defaults/tile.lua
+++ b/tests/examples/wibox/container/defaults/tile.lua
@@ -1,0 +1,25 @@
+--DOC_HIDE_ALL
+--DOC_GEN_IMAGE
+local wibox     = require("wibox")
+
+return {
+    text   = "Before",
+    align  = "center",
+    valign = "center",
+    widget = wibox.widget.textbox,
+},
+{
+    {
+        {
+            text   = "After",
+            align  = "center",
+            valign = "center",
+            widget = wibox.widget.textbox,
+        },
+        valign = "bottom",
+        halign = "right",
+        widget = wibox.container.tile
+    },
+    margins = 5,
+    layout = wibox.container.margin
+}

--- a/tests/examples/wibox/container/place/content_fill_horizontal.lua
+++ b/tests/examples/wibox/container/place/content_fill_horizontal.lua
@@ -4,9 +4,9 @@ local wibox  = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" )  --DOC_HIDE
 
 local l = wibox.layout { --DOC_HIDE
-    forced_width  = 240, --DOC_HIDE
+    forced_width  = 340, --DOC_HIDE
     spacing       = 5, --DOC_HIDE
-    layout        = wibox.layout.flex.vertical --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
 } --DOC_HIDE
 
 for _, i in ipairs {true, false} do
@@ -18,17 +18,18 @@ for _, i in ipairs {true, false} do
                 forced_width  = 30,
                 widget        = wibox.widget.imagebox
             },
-            forced_height  = 80, --DOC_HIDE
-            vertical_crop  = i,
-            widget         = wibox.container.tile
+            bg     = "#ff0000",
+            widget = wibox.container.background
         },
-        bg     = beautiful.bg_normal,
-        widget = wibox.container.background
+        forced_height = 80, --DOC_HIDE
+        forced_width = 120, --DOC_HIDE
+        content_fill_horizontal = i,
+        widget = wibox.container.place
     }
 
     l:add(wibox.widget {--DOC_HIDE
         {--DOC_HIDE
-            markup = "<b>`vertical_crop` = "..(i and "true" or "false").."</b>",--DOC_HIDE
+            markup = "<b>`content_fill_horizontal` = "..(i and "true" or "false").."</b>",--DOC_HIDE
             widget = wibox.widget.textbox,--DOC_HIDE
         },--DOC_HIDE
         w,--DOC_HIDE

--- a/tests/examples/wibox/container/place/content_fill_vertical.lua
+++ b/tests/examples/wibox/container/place/content_fill_vertical.lua
@@ -4,9 +4,9 @@ local wibox  = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" )  --DOC_HIDE
 
 local l = wibox.layout { --DOC_HIDE
-    forced_width  = 240, --DOC_HIDE
+    forced_width  = 340, --DOC_HIDE
     spacing       = 5, --DOC_HIDE
-    layout        = wibox.layout.flex.vertical --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
 } --DOC_HIDE
 
 for _, i in ipairs {true, false} do
@@ -18,17 +18,18 @@ for _, i in ipairs {true, false} do
                 forced_width  = 30,
                 widget        = wibox.widget.imagebox
             },
-            forced_height  = 80, --DOC_HIDE
-            vertical_crop  = i,
-            widget         = wibox.container.tile
+            bg     = "#ff0000",
+            widget = wibox.container.background
         },
-        bg     = beautiful.bg_normal,
-        widget = wibox.container.background
+        forced_height = 80, --DOC_HIDE
+        forced_width = 120, --DOC_HIDE
+        content_fill_vertical = i,
+        widget = wibox.container.place
     }
 
     l:add(wibox.widget {--DOC_HIDE
         {--DOC_HIDE
-            markup = "<b>`vertical_crop` = "..(i and "true" or "false").."</b>",--DOC_HIDE
+            markup = "<b>`content_fill_vertical` = "..(i and "true" or "false").."</b>",--DOC_HIDE
             widget = wibox.widget.textbox,--DOC_HIDE
         },--DOC_HIDE
         w,--DOC_HIDE

--- a/tests/examples/wibox/container/place/halign.lua
+++ b/tests/examples/wibox/container/place/halign.lua
@@ -4,12 +4,12 @@ local wibox  = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" )  --DOC_HIDE
 
 local l = wibox.layout { --DOC_HIDE
-    forced_width  = 240, --DOC_HIDE
+    forced_width  = 340, --DOC_HIDE
     spacing       = 5, --DOC_HIDE
-    layout        = wibox.layout.flex.vertical --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
 } --DOC_HIDE
 
-for _, i in ipairs {true, false} do
+for _, i in ipairs {"left", "center", "right"} do
     local w = wibox.widget {
         {
             {
@@ -18,17 +18,18 @@ for _, i in ipairs {true, false} do
                 forced_width  = 30,
                 widget        = wibox.widget.imagebox
             },
-            forced_height  = 80, --DOC_HIDE
-            vertical_crop  = i,
-            widget         = wibox.container.tile
+            halign = i,
+            widget = wibox.container.place
         },
         bg     = beautiful.bg_normal,
+        forced_height = 80, --DOC_HIDE
+        forced_width = 120, --DOC_HIDE
         widget = wibox.container.background
     }
 
     l:add(wibox.widget {--DOC_HIDE
         {--DOC_HIDE
-            markup = "<b>`vertical_crop` = "..(i and "true" or "false").."</b>",--DOC_HIDE
+            markup = "<b>`halign` = "..i.."</b>",--DOC_HIDE
             widget = wibox.widget.textbox,--DOC_HIDE
         },--DOC_HIDE
         w,--DOC_HIDE

--- a/tests/examples/wibox/container/place/valign.lua
+++ b/tests/examples/wibox/container/place/valign.lua
@@ -4,12 +4,12 @@ local wibox  = require("wibox") --DOC_HIDE
 local beautiful = require( "beautiful" )  --DOC_HIDE
 
 local l = wibox.layout { --DOC_HIDE
-    forced_width  = 240, --DOC_HIDE
+    forced_width  = 340, --DOC_HIDE
     spacing       = 5, --DOC_HIDE
-    layout        = wibox.layout.flex.vertical --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
 } --DOC_HIDE
 
-for _, i in ipairs {true, false} do
+for _, i in ipairs {"top", "center", "bottom"} do
     local w = wibox.widget {
         {
             {
@@ -18,17 +18,18 @@ for _, i in ipairs {true, false} do
                 forced_width  = 30,
                 widget        = wibox.widget.imagebox
             },
-            forced_height  = 80, --DOC_HIDE
-            vertical_crop  = i,
-            widget         = wibox.container.tile
+            valign = i,
+            widget = wibox.container.place
         },
         bg     = beautiful.bg_normal,
+        forced_height = 80, --DOC_HIDE
+        forced_width = 120, --DOC_HIDE
         widget = wibox.container.background
     }
 
     l:add(wibox.widget {--DOC_HIDE
         {--DOC_HIDE
-            markup = "<b>`vertical_crop` = "..(i and "true" or "false").."</b>",--DOC_HIDE
+            markup = "<b>`valign` = "..i.."</b>",--DOC_HIDE
             widget = wibox.widget.textbox,--DOC_HIDE
         },--DOC_HIDE
         w,--DOC_HIDE

--- a/tests/examples/wibox/container/tile/horizontal_crop.lua
+++ b/tests/examples/wibox/container/tile/horizontal_crop.lua
@@ -22,7 +22,7 @@ for _, i in ipairs {true, false} do
             horizontal_crop = i,
             widget          = wibox.container.tile
         },
-        bg     = "#ff0000",
+        bg     = beautiful.bg_normal,
         widget = wibox.container.background
     }
 

--- a/tests/examples/wibox/container/tile/horizontal_crop.lua
+++ b/tests/examples/wibox/container/tile/horizontal_crop.lua
@@ -1,0 +1,42 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 240, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+for _, i in ipairs {true, false} do
+    local w = wibox.widget {
+        {
+            {
+                image         = beautiful.awesome_icon,
+                forced_height = 30,
+                forced_width  = 30,
+                widget        = wibox.widget.imagebox
+            },
+            forced_height   = 80, --DOC_HIDE
+            horizontal_crop = i,
+            widget          = wibox.container.tile
+        },
+        bg     = "#ff0000",
+        widget = wibox.container.background
+    }
+
+
+    l:add(wibox.widget {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>`horizontal_crop` = "..(i and "true" or "false").."</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    }) --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/container/tile/horizontal_spacing.lua
+++ b/tests/examples/wibox/container/tile/horizontal_spacing.lua
@@ -1,0 +1,38 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 240, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+for _, i in ipairs {0, 2, 5, 10} do
+    local w = wibox.widget {
+        {
+            image         = beautiful.awesome_icon,
+            forced_height = 30,
+            forced_width  = 30,
+            widget        = wibox.widget.imagebox
+        },
+        valign             = "top",
+        halign             = "left",
+        horizontal_spacing = i,
+        widget             = wibox.container.tile
+    }
+
+    l:add(wibox.widget {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>`horizontal_spacing` = "..i.."</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    }) --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/container/tile/tiled.lua
+++ b/tests/examples/wibox/container/tile/tiled.lua
@@ -1,0 +1,36 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 240, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+for _, i in ipairs {true, false} do
+    local w = wibox.widget {
+        {
+            image         = beautiful.awesome_icon,
+            forced_height = 30,
+            forced_width  = 30,
+            widget        = wibox.widget.imagebox
+        },
+        tiled  = i,
+        widget = wibox.container.tile
+    }
+
+    l:add(wibox.widget {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>`tiled` = "..(i and "true" or "false").."</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    }) --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/container/tile/vertical_crop.lua
+++ b/tests/examples/wibox/container/tile/vertical_crop.lua
@@ -1,0 +1,41 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 240, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+for _, i in ipairs {true, false} do
+    local w = wibox.widget {
+        {
+            {
+                image         = beautiful.awesome_icon,
+                forced_height = 30,
+                forced_width  = 30,
+                widget        = wibox.widget.imagebox
+            },
+            forced_height  = 80, --DOC_HIDE
+            vertical_crop  = i,
+            widget         = wibox.container.tile
+        },
+        bg     = "#ff0000",
+        widget = wibox.container.background
+    }
+
+    l:add(wibox.widget {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>`vertical_crop` = "..(i and "true" or "false").."</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    }) --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/container/tile/vertical_spacing.lua
+++ b/tests/examples/wibox/container/tile/vertical_spacing.lua
@@ -1,0 +1,41 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 640, --DOC_HIDE
+    forced_height = 120, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.horizontal --DOC_HIDE
+} --DOC_HIDE
+
+for _, i in ipairs {0, 2, 5, 10} do
+    local w = wibox.widget {
+        {
+            image         = beautiful.awesome_icon,
+            forced_height = 30,
+            forced_width  = 30,
+            widget        = wibox.widget.imagebox
+        },
+        forced_width       = 20, --DOC_HIDE
+        forced_height      = 100, --DOC_HIDE
+        valign             = "top",
+        halign             = "left",
+        vertical_spacing   = i,
+        widget             = wibox.container.tile
+    }
+
+    l:add(wibox.widget {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>`vertical_spacing` = "..i.."</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        w,--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    }) --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Long time ago, I told @actionless I would add a new `awful.wallpaper` module to be able to use `svg` and normal widgets to create a wallpaper. It's kind of blocking 4.4 "because I told people I would do it". There was 2 blocker PRs, one to improve `wibox.widget.imagebox` to add "stretch" properties. The other was a `tile` widget to make tiled wallpaper. I finally finished this one.

@actionless Since you are the only person I know who use tiled (Pokemon!) wallpapers. Do you mind doing a review on this? Thanks.

![image](https://user-images.githubusercontent.com/340384/115207824-cb464380-a0b0-11eb-8fc9-59b23ba97291.png)
