### PR TITLE
Extend wibox.widget.imagebox to encompass the required wallpaper API features

### DIFF
--- a/tests/examples/wibox/widget/imagebox/clip_shape.lua
+++ b/tests/examples/wibox/widget/imagebox/clip_shape.lua
@@ -1,0 +1,62 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+local gears = {shape=require("gears.shape")} --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 380, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+local names = {"circle", "squircle", "rounded_rect"} --DOC_HIDE
+
+for _, resize in ipairs {true, false} do
+    local row = wibox.layout { --DOC_HIDE
+        spacing = 5, --DOC_HIDE
+        layout = wibox.layout.fixed.horizontal --DOC_HIDE
+    } --DOC_HIDE
+
+    row:add(wibox.widget { --DOC_HIDE
+        markup = "<b>resize = "..(resize and "true" or "false").."</b>", --DOC_HIDE
+        forced_width = 80, --DOC_HIDE
+        widget = wibox.widget.textbox --DOC_HIDE
+    }) --DOC_HIDE
+
+    for idx, shape in ipairs {gears.shape.circle, gears.shape.squircle, gears.shape.rounded_rect} do
+        local w = wibox.widget {
+            {
+                {
+                    image         = beautiful.awesome_icon,
+                    forced_height = 32,
+                    forced_width  = 32,
+                    clip_shape    = shape,
+                    resize        = resize,
+                    widget        = wibox.widget.imagebox
+                },
+                widget = wibox.container.place
+            },
+            forced_height = 64, --DOC_HIDE
+            forced_width = 64, --DOC_HIDE
+            widget = wibox.container.background
+        }
+
+
+        row:add(wibox.widget {--DOC_HIDE
+            {--DOC_HIDE
+                markup = "<b>`shape` = "..names[idx].."</b>",--DOC_HIDE
+                widget = wibox.widget.textbox,--DOC_HIDE
+            },--DOC_HIDE
+            w,--DOC_HIDE
+            layout = wibox.layout.fixed.vertical,--DOC_HIDE
+        }) --DOC_HIDE
+    end
+
+    l:add(row) --DOC_HIDE
+end
+
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/imagebox/halign.lua
+++ b/tests/examples/wibox/widget/imagebox/halign.lua
@@ -1,0 +1,58 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 360, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+for _, resize in ipairs {true, false} do
+    local row = wibox.layout { --DOC_HIDE
+        spacing = 5, --DOC_HIDE
+        layout = wibox.layout.fixed.horizontal --DOC_HIDE
+    } --DOC_HIDE
+
+    row:add(wibox.widget { --DOC_HIDE
+        markup = "<b>resize = "..(resize and "true" or "false").."</b>", --DOC_HIDE
+        forced_width = 80, --DOC_HIDE
+        widget = wibox.widget.textbox --DOC_HIDE
+    }) --DOC_HIDE
+
+    for _, halign in ipairs {"left", "center", "right"} do
+        local w = wibox.widget {
+            {
+                {
+                    image         = beautiful.awesome_icon,
+                    forced_height = 32,
+                    forced_width  = 32,
+                    halign        = halign,
+                    resize        = resize,
+                    widget        = wibox.widget.imagebox
+                },
+                bg     = beautiful.bg_normal,
+                forced_height = 32, --DOC_HIDE
+                forced_width = 80, --DOC_HIDE
+                widget = wibox.container.background
+            },
+            widget = wibox.container.place
+        }
+
+        row:add(wibox.widget {--DOC_HIDE
+            {--DOC_HIDE
+                markup = "<b>`valign` = "..halign.."</b>",--DOC_HIDE
+                widget = wibox.widget.textbox,--DOC_HIDE
+            },--DOC_HIDE
+            w,--DOC_HIDE
+            layout = wibox.layout.fixed.vertical,--DOC_HIDE
+        }) --DOC_HIDE
+    end
+
+    l:add(row) --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/imagebox/horizontal_fit_policy.lua
+++ b/tests/examples/wibox/widget/imagebox/horizontal_fit_policy.lua
@@ -1,0 +1,81 @@
+--DOC_HIDE_ALL
+--DOC_GEN_IMAGE
+local parent    = ...
+local wibox     = require( "wibox"     )
+local beautiful = require( "beautiful" )
+local lgi = require("lgi")
+local cairo = lgi.cairo
+
+-- A simple Awesome logo
+local function demo()
+    local img = cairo.ImageSurface.create(cairo.Format.ARGB32, 22, 32)
+    local cr = cairo.Context(img)
+
+    -- Awesome default #555555
+    cr:set_source_rgb(0,0,1)
+    cr:paint()
+
+    cr:set_source_rgb(1,0,0)
+
+    cr:rectangle(0, 15, 22, 2)
+    cr:rectangle(10, 0, 2, 32)
+    cr:fill()
+
+    cr:set_source_rgb(0,1,0)
+
+    cr:arc(11, 16, 8, 0, 2*math.pi)
+    cr:fill()
+
+    return img
+end
+
+
+local function cell_centered_widget(widget)
+    return wibox.widget {
+        widget,
+        valign = 'center',
+        halign = 'center',
+        content_fill_vertical = false,
+        content_fill_horizontal = false,
+        widget = wibox.container.place
+    }
+end
+
+local function build_ib(size, policy)
+    return cell_centered_widget(wibox.widget {
+        {
+            horizontal_fit_policy = policy,
+            forced_height = size,
+            forced_width = size,
+            image  = demo(),
+            widget = wibox.widget.imagebox
+        },
+        forced_width  = size + 2,
+        forced_height = size + 2,
+        color         = beautiful.border_color,
+        margins       = 1,
+        widget        = wibox.container.margin
+    })
+end
+
+
+local l = wibox.widget {
+    homogeneous   = false,
+    spacing       = 5,
+    layout        = wibox.layout.grid,
+}
+parent:add(l)
+
+l:add_widget_at(wibox.widget.textbox('horizontal_fit_policy = "auto"'), 1, 1)
+l:add_widget_at(wibox.widget.textbox('horizontal_fit_policy = "none"'), 2, 1)
+l:add_widget_at(wibox.widget.textbox('horizontal_fit_policy = "fit"'), 3, 1)
+l:add_widget_at(wibox.widget.textbox('imagebox size'), 4, 1)
+
+for i,size in ipairs({16, 32, 64}) do
+    l:add_widget_at(build_ib(size, "auto"), 1, i + 1)
+    l:add_widget_at(build_ib(size, "none"), 2, i + 1)
+    l:add_widget_at(build_ib(size, "fit" ), 3, i + 1)
+    l:add_widget_at(cell_centered_widget(wibox.widget.textbox(size..'x'..size)), 4, i + 1)
+end
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/imagebox/max_scaling_factor.lua
+++ b/tests/examples/wibox/widget/imagebox/max_scaling_factor.lua
@@ -15,12 +15,12 @@ local function cell_centered_widget(widget)
     }
 end
 
-local function build_ib(size, resize)
+local function build_ib(size, factor)
     return cell_centered_widget(wibox.widget {
         {
-            resize = resize,
             forced_height = size,
             forced_width = size,
+            max_scaling_factor = factor,
             image  = beautiful.awesome_icon,
             widget = wibox.widget.imagebox
         },
@@ -40,13 +40,13 @@ local l = wibox.widget {
 }
 parent:add(l)
 
-l:add_widget_at(cell_centered_widget(wibox.widget.textbox('resize = true')), 1, 1)
-l:add_widget_at(cell_centered_widget(wibox.widget.textbox('resize = false')), 2, 1)
+l:add_widget_at(cell_centered_widget(wibox.widget.textbox('max_scaling_factor = nil')), 1, 1)
+l:add_widget_at(cell_centered_widget(wibox.widget.textbox('max_scaling_factor = 2')), 2, 1)
 l:add_widget_at(cell_centered_widget(wibox.widget.textbox('imagebox size')), 3, 1)
 
 for i,size in ipairs({16, 32, 64}) do
-    l:add_widget_at(build_ib(size, true), 1, i + 1)
-    l:add_widget_at(build_ib(size, false), 2, i + 1)
+    l:add_widget_at(build_ib(size, nil), 1, i + 1)
+    l:add_widget_at(build_ib(size, 2), 2, i + 1)
     l:add_widget_at(cell_centered_widget(wibox.widget.textbox(size..'x'..size)), 3, i + 1)
 end
 

--- a/tests/examples/wibox/widget/imagebox/scaling_quality.lua
+++ b/tests/examples/wibox/widget/imagebox/scaling_quality.lua
@@ -1,0 +1,77 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local lgi = require("lgi")--DOC_HIDE
+local cairo = lgi.cairo --DOC_HIDE
+
+--DOC_HIDE A simple Awesome logo
+local function demo()--DOC_HIDE
+    local img = cairo.ImageSurface.create(cairo.Format.ARGB32, 32, 22)--DOC_HIDE
+    local cr = cairo.Context(img)--DOC_HIDE
+    cr:set_antialias(cairo.Antialias.NONE) --DOC_HIDE
+
+    -- Awesome default #555555--DOC_HIDE
+    cr:set_source_rgb(0,0,1)--DOC_HIDE
+    cr:paint() --DOC_HIDE
+
+    cr:set_source_rgb(1,0,0)--DOC_HIDE
+
+    cr:rectangle(0, 10, 32, 2)--DOC_HIDE
+    cr:rectangle(15, 0, 2, 22)--DOC_HIDE
+    cr:fill()--DOC_HIDE
+
+    cr:set_source_rgb(0,1,0)--DOC_HIDE
+
+    cr:arc(16, 11, 8, 0, 2*math.pi)--DOC_HIDE
+    cr:fill()--DOC_HIDE
+
+    return img--DOC_HIDE
+end--DOC_HIDE
+
+local img = demo () --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    -- forced_width  = 720, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+ for _, quality in ipairs {"fast", "good", "best", "nearest", "bilinear"} do
+    local w = wibox.widget {
+        {
+            {
+                image           = img,
+                forced_height   = 64,
+                forced_width    = 96,
+                scaling_quality = quality,
+                widget          = wibox.widget.imagebox
+            },
+            widget = wibox.container.place
+        },
+        -- forced_height = 96, --DOC_HIDE
+        -- forced_width = 96, --DOC_HIDE
+        widget = wibox.container.background
+    }
+
+    --DOC_HIDE SVG doesn't support those mode, so rasterize everything.
+    local raster = wibox.widget.draw_to_image_surface(w, 96, 64) --DOC_HIDE
+
+    l:add(wibox.widget {--DOC_HIDE
+        {--DOC_HIDE
+            markup = "<b>`scaling_quality` = "..quality.."</b>",--DOC_HIDE
+            widget = wibox.widget.textbox,--DOC_HIDE
+        },--DOC_HIDE
+        { --DOC_HIDE
+            image = raster, --DOC_HIDE
+            forced_height   = 64, --DOC_HIDE
+            forced_width    = 96, --DOC_HIDE
+            widget = wibox.widget.imagebox --DOC_HIDE
+        },--DOC_HIDE
+        layout = wibox.layout.fixed.vertical,--DOC_HIDE
+    }) --DOC_HIDE
+ end
+
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/imagebox/valign.lua
+++ b/tests/examples/wibox/widget/imagebox/valign.lua
@@ -1,0 +1,58 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local parent = ... --DOC_HIDE
+local wibox  = require("wibox") --DOC_HIDE
+local beautiful = require( "beautiful" )  --DOC_HIDE
+
+local l = wibox.layout { --DOC_HIDE
+    forced_width  = 340, --DOC_HIDE
+    spacing       = 5, --DOC_HIDE
+    layout        = wibox.layout.flex.vertical --DOC_HIDE
+} --DOC_HIDE
+
+for _, resize in ipairs {true, false} do
+    local row = wibox.layout { --DOC_HIDE
+        spacing = 5, --DOC_HIDE
+        layout = wibox.layout.fixed.horizontal --DOC_HIDE
+    } --DOC_HIDE
+
+    row:add(wibox.widget { --DOC_HIDE
+        markup = "<b>resize = "..(resize and "true" or "false").."</b>", --DOC_HIDE
+        forced_width = 80, --DOC_HIDE
+        widget = wibox.widget.textbox --DOC_HIDE
+    }) --DOC_HIDE
+
+    for _, valign in ipairs {"top", "center", "bottom"} do
+        local w = wibox.widget {
+            {
+                {
+                    image         = beautiful.awesome_icon,
+                    forced_height = 32,
+                    forced_width  = 32,
+                    valign        = valign,
+                    resize        = resize,
+                    widget        = wibox.widget.imagebox
+                },
+                bg     = beautiful.bg_normal,
+                forced_height = 80, --DOC_HIDE
+                forced_width = 32, --DOC_HIDE
+                widget = wibox.container.background
+            },
+            widget = wibox.container.place
+        }
+
+        row:add(wibox.widget {--DOC_HIDE
+            {--DOC_HIDE
+                markup = "<b>`valign` = "..valign.."</b>",--DOC_HIDE
+                widget = wibox.widget.textbox,--DOC_HIDE
+            },--DOC_HIDE
+            w,--DOC_HIDE
+            layout = wibox.layout.fixed.vertical,--DOC_HIDE
+        }) --DOC_HIDE
+    end
+
+    l:add(row) --DOC_HIDE
+end
+
+parent:add(l) --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/imagebox/vertical_fit_policy.lua
+++ b/tests/examples/wibox/widget/imagebox/vertical_fit_policy.lua
@@ -1,0 +1,81 @@
+--DOC_HIDE_ALL
+--DOC_GEN_IMAGE
+local parent    = ...
+local wibox     = require( "wibox"     )
+local beautiful = require( "beautiful" )
+local lgi = require("lgi")
+local cairo = lgi.cairo
+
+-- A simple Awesome logo
+local function demo()
+    local img = cairo.ImageSurface.create(cairo.Format.ARGB32, 32, 22)
+    local cr = cairo.Context(img)
+
+    -- Awesome default #555555
+    cr:set_source_rgb(0,0,1)
+    cr:paint()
+
+    cr:set_source_rgb(1,0,0)
+
+    cr:rectangle(0, 10, 32, 2)
+    cr:rectangle(15, 0, 2, 22)
+    cr:fill()
+
+    cr:set_source_rgb(0,1,0)
+
+    cr:arc(16, 11, 8, 0, 2*math.pi)
+    cr:fill()
+
+    return img
+end
+
+
+local function cell_centered_widget(widget)
+    return wibox.widget {
+        widget,
+        valign = 'center',
+        halign = 'center',
+        content_fill_vertical = false,
+        content_fill_horizontal = false,
+        widget = wibox.container.place
+    }
+end
+
+local function build_ib(size, policy)
+    return cell_centered_widget(wibox.widget {
+        {
+            vertical_fit_policy = policy,
+            forced_height = size,
+            forced_width = size,
+            image  = demo(),
+            widget = wibox.widget.imagebox
+        },
+        forced_width  = size + 2,
+        forced_height = size + 2,
+        color         = beautiful.border_color,
+        margins       = 1,
+        widget        = wibox.container.margin
+    })
+end
+
+
+local l = wibox.widget {
+    homogeneous   = false,
+    spacing       = 5,
+    layout        = wibox.layout.grid,
+}
+parent:add(l)
+
+l:add_widget_at(wibox.widget.textbox('vertical_fit_policy = "auto"'), 1, 1)
+l:add_widget_at(wibox.widget.textbox('versical_fit_policy = "none"'), 2, 1)
+l:add_widget_at(wibox.widget.textbox('vertical_fit_policy = "fit"'), 3, 1)
+l:add_widget_at(wibox.widget.textbox('imagebox size'), 4, 1)
+
+for i,size in ipairs({16, 32, 64}) do
+    l:add_widget_at(build_ib(size, "auto"), 1, i + 1)
+    l:add_widget_at(build_ib(size, "none"), 2, i + 1)
+    l:add_widget_at(build_ib(size, "fit" ), 3, i + 1)
+    l:add_widget_at(cell_centered_widget(wibox.widget.textbox(size..'x'..size)), 4, i + 1)
+end
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
This is another groundwork PR in the road toward using normal widgets to set the wallpaper. The goal of the larger endeavor is to remove some limitation of our current wallpaper API, such as the lack of SVG, without duplicating too much code.

@psychon The `scaling_quality` doesn't seem to work, any idea why? See the image. There is just no difference, while, at the very least the `nearest` one should be very visible. I did exactly what the API says to do (https://www.cairographics.org/manual/cairo-cairo-pattern-t.html#cairo-pattern-set-filter), so I am confused as to why it doesn't work. Any idea?

![image](https://user-images.githubusercontent.com/340384/116044067-541b2d00-a625-11eb-98db-fafeba76edd4.png)
