### PR TITLE
fixed: Try to handle zero sized widgets again.

### DIFF
--- a/spec/wibox/layout/fixed_spec.lua
+++ b/spec/wibox/layout/fixed_spec.lua
@@ -78,6 +78,7 @@ describe("wibox.layout.fixed", function()
                     assert.widget_layout(layout, { 100, 20 }, {
                         p(first,  0,  0, 100, 10),
                         p(second, 0, 10, 100, 10),
+                        p(third, 0, 20, 100, 0),
                     })
                 end)
             end)
@@ -121,6 +122,7 @@ describe("wibox.layout.fixed", function()
                             p(first,  0, 0, 100, 10),
                             p(spacing_widget,  0, 10, 100, 10),
                             p(second, 0, 20, 100, 15),
+                            p(third, 0, 35, 100, 0),
                         })
                     end)
                 end)


### PR DESCRIPTION
The newly changed code doesn't handle this well:

    local w = wibox.widget {
        {
            --add anything here,
            {
                text = "",
                widget = wibox.widget.textbox,
            },
            {
                id = "mytextbox",
                text = "",
                widget = wibox.widget.textbox,
            },
            {
                text = "",
                widget = wibox.widget.textbox,
            },
            widget = wibox.layout.fixed.horizontal
        },
        widget = wibox.layout.fixed.horizontal,
    }

    awesome.emit_signal("refresh")

    w:get_children_by_id("mytextbox")[1].text = "something"

This will cause the "inner" fixed layout to have the minimum size
it supports. In that case, if the last widget has "no size" because
it supports up to 0x0, then it isn't added to the layout.

This was done "on purpose" because if there is a spacing, then `:fit`
would have returned a size "too small" because the last spacing area
would be (correctly) missing.

But if the zero sized widget isn't added to the layout, then it's size
isn't tracked. So if it emits a layout_changed signal, nothing catches
it.

The "fix" is rather hacky and probably a little incorrect. It rely
on the behavior of `:fit()` to avoid adding the "wrong" widgets to
the layout, which is fragile.

However, I don't have a better idea. @ShayAgros any alternative to this hack?

Fix #3351