### PR TITLE
Stop timer when stopping keygrabber

### DIFF
--- a/lib/awful/keygrabber.lua
+++ b/lib/awful/keygrabber.lua
@@ -474,11 +474,19 @@ function keygrabber:start()
 end
 
 --- Stop the keygrabber.
+--
+-- Also stops any `timeout`.
+--
 -- @method stop
 -- @emits stopped
 -- @emits property::current_instance
 function keygrabber:stop(_stop_key, _stop_mods) -- (at)function disables ldoc params
     keygrab.stop(self.grabber)
+
+    local timer = self._private.timer
+    if timer and timer.started then
+        timer:stop()
+    end
 
     if self.stop_callback then
         self.stop_callback(

--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -99,11 +99,13 @@ function timer:start()
 end
 
 --- Stop the timer.
+--
+-- Does nothing if the timer isn't running.
+--
 -- @method stop
 -- @emits stop
 function timer:stop()
     if self.data.source_id == nil then
-        gdebug.print_error(traceback("timer not started"))
         return
     end
     glib.source_remove(self.data.source_id)


### PR DESCRIPTION
When stopping a keygrabber with a timeout manually or through the `stop_key`, the timer would continue and call the stop callback again some time later.

The error message in `gears.timer:stop` is removed, since there actually is no harm in just returning immediately. And the timer implementation itself calls `:stop` in certain places without checking for `.started`, which lead to a situation where the internal call to `stop` triggered
the error message.

Alternatively, I could add the `if self.started` check where the timer calls `:stop` on itself, if you prefer to keep the error message (e.g. https://github.com/sclu1034/awesome/blob/master/lib/gears/timer.lua#L188-L190).

**Minimal test `rc.lua`**
```lua
local awful = require("awful")

local keypress = function(_, mod, key, event)
    print(event .. ": " .. key)
end

local grabber = awful.keygrabber{
    stop_event = "press",
    stop_key = "Escape",
    stop_callback = function () print("Escape key pressed, in stop callback ...") end,
    timeout = 5,
    timeout_callback = function () print("timed out") end,
    keypressed_callback = keypress,
    keyreleased_callback = keypress
}

grabber:connect_signal("started", function() print("keygrabber started") end)
grabber:connect_signal("stopped", function () print("keygrabber stopped") end)

awful.keyboard.append_global_keybindings({
    awful.key({ "Mod4" }, "F2",  nil, function()
        print("start")
        grabber:start()
    end),
})
```