### PR TITLE
[RFC,doc] Change author mention

### DIFF
--- a/docs/ldoc.ltp
+++ b/docs/ldoc.ltp
@@ -231,7 +231,18 @@
     <h3>Info:</h3>
     <ul>
 #     for tag, value in module.info:iter() do
-            <li><strong>$(tag)</strong>: $(M(value,module))</li>
+#           if tag == 'Author' then
+                <li>
+                    <strong>Originally authored by</strong>: $(M(value,module))<br />
+                    <small>(Full contributors list available on
+                    <a href="https://github.com/awesomeWM/awesome/graphs/contributors">
+                        our github project)
+                    </a></small>
+
+                </li>
+#           else
+                <li><strong>$(tag)</strong>: $(M(value,module))</li>
+#           end
 #     end
     </ul>
   </div>


### PR DESCRIPTION
This was discussed multiple time in the past. The objective with this PR is to have a place to discuss this change.

Here is a first (very basic) proposal: Change the mention "from Author" to "Originally authored by" and add a link to the GitHub contributors list.

Other implementation can use git-blame to get the real list of contributors for a given file/class. (I have no idea of where/how to do that, tho)

Another proposed solution would be to completely remove the Author field from the info section.

Pick your poison, add more propositions (implement them?), let's discuss all of this! :)