### PR TITLE
[Fix/3371] wibox.widget.base set opacity emit "widget::redraw_needed" 

### DIFF
--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -260,7 +260,7 @@ end
 function base.widget:set_opacity(o)
     if o ~= self._private.opacity then
         self._private.opacity = o
-        self:emit_signal("widget::redraw")
+        self:emit_signal("widget::redraw_needed")
     end
 end
 

--- a/spec/wibox/widget/base_spec.lua
+++ b/spec/wibox/widget/base_spec.lua
@@ -87,6 +87,65 @@ describe("wibox.widget.base", function()
             assert.is_true(called2)
         end)
     end)
+
+    describe("Setters emit signals", function()
+        local widget
+        local signal_called
+        local callback = function () signal_called = true end
+
+        before_each(function()
+            widget = base.make_widget()
+            signal_called = false
+        end)
+
+        it("'set_visible' calls 'widget::layout_changed'", function()
+            widget:connect_signal("widget::layout_changed", callback)
+            widget:set_visible(false)
+            assert.is_true(signal_called)
+        end)
+
+        it("'set_visible' calls 'widget::redraw_needed'", function()
+            widget:connect_signal("widget::redraw_needed", callback)
+            widget:set_visible(false)
+            assert.is_true(signal_called)
+        end)
+
+        it("'set_opacity' calls 'widget::redraw_needed'", function()
+            widget:connect_signal("widget::redraw_needed", callback)
+            widget:set_opacity(0)
+            assert.is_true(signal_called)
+        end)
+
+        it("'set_forced_width' calls 'widget::layout_changed'", function()
+            widget:connect_signal("widget::layout_changed", callback)
+            widget:set_forced_width(0)
+            assert.is_true(signal_called)
+        end)
+
+        it("'set_forced_height' calls 'widget::layout_changed'", function()
+            widget:connect_signal("widget::layout_changed", callback)
+            widget:set_forced_height(0)
+            assert.is_true(signal_called)
+        end)
+
+        it("'set_widget_common' calls 'property::widget'", function()
+            -- Implement `set_widget`
+            rawset(widget, "set_widget", base.set_widget_common)
+
+            widget:connect_signal("property::widget", callback)
+            widget:set_widget(base.make_widget())
+            assert.is_true(signal_called)
+        end)
+
+        it("'set_widget_common' calls 'widget::layout_changed'", function()
+            -- Implement `set_widget`
+            rawset(widget, "set_widget", base.set_widget_common)
+
+            widget:connect_signal("widget::layout_changed", callback)
+            widget:set_widget(base.make_widget())
+            assert.is_true(signal_called)
+        end)
+    end)
 end)
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Hello,

I have also added some unit tests to be sure all setters from `wibox.widget.base` calls their signals.
About that, I had a weird issue where signals are correctly called when the test uses the setter method but wasn't working by setting the property directly (i.e. `:set_visible()` vs `visible = `). Is there a particular reason for gears.object meta-setter not being called in unit tests? (Maybe I should have waited for a GLib event loop to passes...?)

Fix: #3371 