### PR TITLE
Fix some wibar bugs, polish the API a bit and add some doc.

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -179,26 +179,27 @@ screen.connect_signal("request::desktop_decoration", function(s)
 
     -- @DOC_WIBAR@
     -- Create the wibox
-    s.mywibox = awful.wibar({ position = "top", screen = s })
-
-    -- @DOC_SETUP_WIDGETS@
-    -- Add widgets to the wibox
-    s.mywibox.widget = {
-        layout = wibox.layout.align.horizontal,
-        { -- Left widgets
-            layout = wibox.layout.fixed.horizontal,
-            mylauncher,
-            s.mytaglist,
-            s.mypromptbox,
-        },
-        s.mytasklist, -- Middle widget
-        { -- Right widgets
-            layout = wibox.layout.fixed.horizontal,
-            mykeyboardlayout,
-            wibox.widget.systray(),
-            mytextclock,
-            s.mylayoutbox,
-        },
+    s.mywibox = awful.wibar {
+        position = "top",
+        screen   = s,
+        -- @DOC_SETUP_WIDGETS@
+        widget   = {
+            layout = wibox.layout.align.horizontal,
+            { -- Left widgets
+                layout = wibox.layout.fixed.horizontal,
+                mylauncher,
+                s.mytaglist,
+                s.mypromptbox,
+            },
+            s.mytasklist, -- Middle widget
+            { -- Right widgets
+                layout = wibox.layout.fixed.horizontal,
+                mykeyboardlayout,
+                wibox.widget.systray(),
+                mytextclock,
+                s.mylayoutbox,
+            },
+        }
     }
 end)
 -- }}}

--- a/lib/awful/placement.lua
+++ b/lib/awful/placement.lua
@@ -184,6 +184,10 @@ local function compose(...)
             attach(d, ret, args)
         end
 
+        -- Cleanup the override because otherwise it might leak into
+        -- future calls.
+        rawset(args, "override_geometry", nil)
+
         return last_geo, rets
     end, "compose")
 

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -1,11 +1,13 @@
 ---------------------------------------------------------------------------
---- Wibox module for awful.
+--- The main AwesomeWM "bar" module.
+--
 -- This module allows you to easily create wibox and attach them to the edge of
 -- a screen.
 --
 --@DOC_awful_wibar_default_EXAMPLE@
 --
 -- You can even have vertical bars too.
+--
 --@DOC_awful_wibar_left_EXAMPLE@
 --
 -- @author Emmanuel Lepage Vallee &lt;elv1313@gmail.com&gt;
@@ -56,6 +58,9 @@ local align_map = {
 }
 
 --- If the wibar needs to be stretched to fill the screen.
+--
+-- @DOC_awful_wibar_stretch_EXAMPLE@
+--
 -- @property stretch
 -- @tparam boolean stretch
 -- @propbeautiful
@@ -72,6 +77,8 @@ local align_map = {
 --  * right
 --  * centered
 --
+--  @DOC_awful_wibar_align_EXAMPLE@
+--
 -- @property align
 -- @tparam string align
 -- @propbeautiful
@@ -83,16 +90,25 @@ local align_map = {
 -- It can either be a table if `top`, `bottom`, `left`, `right` or a
 -- single number.
 --
+-- @DOC_awful_wibar_margins_EXAMPLE@
+--
 -- @property margins
 -- @tparam number|table margins
 -- @propbeautiful
 -- @propemits true false
 
 --- If the wibar needs to be stretched to fill the screen.
+--
 -- @beautiful beautiful.wibar_stretch
 -- @tparam boolean stretch
 
 --- Allow or deny the tiled clients to cover the wibar.
+--
+-- In the example below, we can see that the first screen workarea
+-- shrunk by the height of the wibar while the second screen is
+-- unchanged.
+--
+-- @DOC_screen_wibar_workarea_EXAMPLE@
 --
 -- @property update_workarea
 -- @tparam[opt=true] boolean update_workarea
@@ -101,6 +117,15 @@ local align_map = {
 -- @see screen.workarea
 
 --- If there is both vertical and horizontal wibar, give more space to vertical ones.
+--
+-- By default, if multiple wibars risk overlapping, it will be resolved
+-- by giving more space to the horizontal one:
+--
+-- ![wibar position](../images/AUTOGEN_awful_wibar_position.svg)
+--
+-- If this variable is to to `true`, it will behave like:
+--
+-- @DOC_awful_wibar_position2_EXAMPLE@
 --
 -- @beautiful beautiful.wibar_favor_vertical
 -- @tparam[opt=false] boolean favor_vertical
@@ -262,6 +287,8 @@ end
 -- * right
 -- * top
 -- * bottom
+--
+-- @DOC_awful_wibar_position_EXAMPLE@
 --
 -- @property position
 -- @tparam string position Either "left", right", "top" or "bottom"
@@ -502,6 +529,9 @@ end
 -- @tparam[opt=nil] table args
 -- @tparam string args.position The position.
 -- @tparam string args.stretch If the wibar need to be stretched to fill the screen.
+-- @tparam boolean args.update_workarea Allow or deny the tiled clients to cover the wibar.
+-- @tparam string args.align How to align non-stretched wibars.
+-- @tparam table|number args.margins The wibar margins.
 --@DOC_wibox_constructor_COMMON@
 -- @return The new wibar
 -- @constructorfct awful.wibar

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -100,6 +100,11 @@ local align_map = {
 -- @see client.struts
 -- @see screen.workarea
 
+--- If there is both vertical and horizontal wibar, give more space to vertical ones.
+--
+-- @beautiful beautiful.wibar_favor_vertical
+-- @tparam[opt=false] boolean favor_vertical
+
 --- The wibar border width.
 -- @beautiful beautiful.wibar_border_width
 -- @tparam integer border_width
@@ -193,9 +198,12 @@ local function get_margins(w)
     margins[position] =  margins[position] + get_margin(w, position, true)
 
     -- Avoid overlapping wibars
-    if position == "left" or position == "right" then
+    if (position == "left" or position == "right") and not beautiful.wibar_favor_vertical then
         margins.top    = get_margin(w, "top"   )
         margins.bottom = get_margin(w, "bottom")
+    elseif (position == "top" or position == "bottom") and beautiful.wibar_favor_vertical then
+        margins.left  = get_margin(w, "left" )
+        margins.right = get_margin(w, "right")
     end
 
     return margins

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -92,6 +92,14 @@ local align_map = {
 -- @beautiful beautiful.wibar_stretch
 -- @tparam boolean stretch
 
+--- Allow or deny the tiled clients to cover the wibar.
+--
+-- @property update_workarea
+-- @tparam[opt=true] boolean update_workarea
+-- @propemits true false
+-- @see client.struts
+-- @see screen.workarea
+
 --- The wibar border width.
 -- @beautiful beautiful.wibar_border_width
 -- @tparam integer border_width
@@ -219,7 +227,7 @@ end
 local function attach(wb, position)
     gen_placement(position, wb._private.align, wb._stretch)(wb, {
         attach          = true,
-        update_workarea = true,
+        update_workarea = wb._private.update_workarea,
         margins         = get_margins(wb)
     })
 end
@@ -316,6 +324,19 @@ function awfulwibar.set_stretch(w, value)
     attach(w, w.position)
 
     w:emit_signal("property::stretch", value)
+end
+
+
+function awfulwibar.get_update_workarea(w)
+    return w._private.update_workarea
+end
+
+function awfulwibar.set_update_workarea(w, value)
+    w._private.update_workarea = value
+
+    attach(w, w.position)
+
+    w:emit_signal("property::update_workarea", value)
 end
 
 
@@ -540,6 +561,8 @@ function awfulwibar.new(args)
         bottom = 0
     }
     w._private.meta_margins = meta_margins(w)
+
+    w._private.update_workarea = true
 
     -- `w` needs to be inserted in `wiboxes` before reattach or its own offset
     -- will not be taken into account by the "older" wibars when `reattach` is

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -71,11 +71,11 @@ local align_map = {
 --
 -- Values are:
 --
---  * top
---  * bottom
---  * left
---  * right
---  * centered
+--  * `"top"`
+--  * `"bottom"`
+--  * `"left"`
+--  * `"right"`
+--  * `"centered"`
 --
 --  @DOC_awful_wibar_align_EXAMPLE@
 --
@@ -87,8 +87,8 @@ local align_map = {
 
 --- Margins on each side of the wibar.
 --
--- It can either be a table if `top`, `bottom`, `left`, `right` or a
--- single number.
+-- It can either be a table with `top`, `bottom`, `left` and `right`
+-- properties, or a single number that apply to all fourth sides.
 --
 -- @DOC_awful_wibar_margins_EXAMPLE@
 --
@@ -385,12 +385,12 @@ function awfulwibar.set_margins(w, value)
         }
     end
 
-   value = value or {
+   value = gtable.crush({
         left   = 0,
         right  = 0,
         top    = 0,
         bottom = 0
-    }
+    }, value or {}, true)
 
     w._private.margins = value
 

--- a/lib/awful/wibar.lua
+++ b/lib/awful/wibar.lua
@@ -65,7 +65,7 @@ local align_map = {
 -- @tparam boolean stretch
 -- @propbeautiful
 -- @propemits true false
--- see align
+-- @see align
 
 --- How to align non-stretched wibars.
 --
@@ -88,7 +88,7 @@ local align_map = {
 --- Margins on each side of the wibar.
 --
 -- It can either be a table with `top`, `bottom`, `left` and `right`
--- properties, or a single number that apply to all fourth sides.
+-- properties, or a single number that applies to all four sides.
 --
 -- @DOC_awful_wibar_margins_EXAMPLE@
 --
@@ -110,8 +110,8 @@ local align_map = {
 --
 -- @DOC_screen_wibar_workarea_EXAMPLE@
 --
--- @property update_workarea
--- @tparam[opt=true] boolean update_workarea
+-- @property restrict_workarea
+-- @tparam[opt=true] boolean restrict_workarea
 -- @propemits true false
 -- @see client.struts
 -- @see screen.workarea
@@ -260,7 +260,7 @@ end
 local function attach(wb, position)
     gen_placement(position, wb._private.align, wb._stretch)(wb, {
         attach          = true,
-        update_workarea = wb._private.update_workarea,
+        update_workarea = wb._private.restrict_workarea,
         margins         = get_margins(wb)
     })
 end
@@ -362,16 +362,16 @@ function awfulwibar.set_stretch(w, value)
 end
 
 
-function awfulwibar.get_update_workarea(w)
-    return w._private.update_workarea
+function awfulwibar.get_restrict_workarea(w)
+    return w._private.restrict_workarea
 end
 
-function awfulwibar.set_update_workarea(w, value)
-    w._private.update_workarea = value
+function awfulwibar.set_restrict_workarea(w, value)
+    w._private.restrict_workarea = value
 
     attach(w, w.position)
 
-    w:emit_signal("property::update_workarea", value)
+    w:emit_signal("property::restrict_workarea", value)
 end
 
 
@@ -385,12 +385,14 @@ function awfulwibar.set_margins(w, value)
         }
     end
 
-   value = gtable.crush({
+    local old = gtable.crush({
         left   = 0,
         right  = 0,
         top    = 0,
         bottom = 0
-    }, value or {}, true)
+    }, w._private.margins or {}, true)
+
+   value = gtable.crush(old, value or {}, true)
 
     w._private.margins = value
 
@@ -529,7 +531,7 @@ end
 -- @tparam[opt=nil] table args
 -- @tparam string args.position The position.
 -- @tparam string args.stretch If the wibar need to be stretched to fill the screen.
--- @tparam boolean args.update_workarea Allow or deny the tiled clients to cover the wibar.
+-- @tparam boolean args.restrict_workarea Allow or deny the tiled clients to cover the wibar.
 -- @tparam string args.align How to align non-stretched wibars.
 -- @tparam table|number args.margins The wibar margins.
 --@DOC_wibox_constructor_COMMON@
@@ -600,7 +602,7 @@ function awfulwibar.new(args)
     }
     w._private.meta_margins = meta_margins(w)
 
-    w._private.update_workarea = true
+    w._private.restrict_workarea = true
 
     -- `w` needs to be inserted in `wiboxes` before reattach or its own offset
     -- will not be taken into account by the "older" wibars when `reattach` is

--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -191,7 +191,9 @@ naughty.notifications = { suspended = { }, _expired = {{}} }
 
 naughty._active = {}
 
-screen.connect_for_each_screen(function(s)
+local function init_screen(s)
+    if naughty.notifications[s] then return end
+
     naughty.notifications[s] = {
         top_left = {},
         top_middle = {},
@@ -201,7 +203,9 @@ screen.connect_for_each_screen(function(s)
         bottom_right = {},
         middle = {},
     }
-end)
+end
+
+screen.connect_for_each_screen(init_screen)
 
 capi.screen.connect_signal("removed", function(scr)
     -- Allow the notifications to be moved to another screen.
@@ -645,6 +649,10 @@ local function register(notification, args)
     end
 
     assert(s)
+
+    if not naughty.notifications[s] then
+        init_screen(get_screen(s))
+    end
 
     -- insert the notification to the table
     table.insert(naughty._active, notification)

--- a/tests/examples/awful/wibar/align.lua
+++ b/tests/examples/awful/wibar/align.lua
@@ -1,0 +1,54 @@
+--DOC_GEN_IMAGE
+--DOC_HIDE_START
+local awful     = require("awful")
+local wibox     = require("wibox")
+
+screen._track_workarea = true
+screen[1]._resize {width = 360, height = 60}
+screen._add_screen {x = 0, width = 360, height = 64, y = 72} --DOC_HIDE
+screen._add_screen {x = 0, width = 360, height = 64, y = 144} --DOC_HIDE
+screen._add_screen {x = 372, width = 64, height = 210, y = 0} --DOC_HIDE
+screen._add_screen {x = 444, width = 64, height = 210, y = 0} --DOC_HIDE
+screen._add_screen {x = 516, width = 64, height = 210, y = 0} --DOC_HIDE
+
+--DOC_HIDE_END
+
+for s, align in ipairs { "left", "centered", "right" } do
+    awful.wibar {
+        position = "top",
+        screen   = screen[s],
+        stretch  = false,
+        width    = 196,
+        align    = align,
+        widget   = {
+            text   = align,
+            align  = "center",
+            widget = wibox.widget.textbox
+        },
+    }
+end
+
+--DOC_NEWLINE
+
+for s, align in ipairs { "top", "centered", "bottom" } do
+    awful.wibar {
+        position = "left",
+        screen   = screen[s+3],
+        stretch  = false,
+        height   = 128,
+        align    = align,
+        widget   = {
+            {
+                text   = align,
+                align  = "center",
+                widget = wibox.widget.textbox
+            },
+            direction = "east",
+            widget    = wibox.container.rotate
+        },
+    }
+end
+
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80
+

--- a/tests/examples/awful/wibar/margins.lua
+++ b/tests/examples/awful/wibar/margins.lua
@@ -1,0 +1,99 @@
+--DOC_GEN_IMAGE
+--DOC_HIDE_START
+local awful     = require("awful")
+local wibox     = require("wibox")
+local beautiful = require("beautiful")
+
+screen._track_workarea = true
+screen[1]._resize {width = 480, height = 128}
+screen._add_screen {x = 0, width = 480, height = 128, y = 140}
+
+local t1 = awful.tag.add("1", {
+    screen   = screen[1],
+    selected = true,
+    layout   = awful.layout.suit.tile.right,
+    gap      = 4
+})
+
+local c1 = client.gen_fake {hide_first=true, screen = screen[2]}
+c1:tags{t1}
+
+local t2 = awful.tag.add("1", {
+    screen   = screen[2],
+    selected = true,
+    layout   = awful.layout.suit.tile.right,
+    gap      = 4
+})
+
+local c2 = client.gen_fake {hide_first=true}
+c2:tags{t2}
+
+for _, c in ipairs {c1, c2} do
+    local top_titlebar = awful.titlebar(c, {
+        size      = 20,
+        bg_normal =  beautiful.bg_highligh,
+    })
+    top_titlebar : setup {
+        { -- Left
+            awful.titlebar.widget.iconwidget(c),
+            layout  = wibox.layout.fixed.horizontal
+        },
+        { -- Middle
+            { -- Title
+                align  = "center",
+                widget = awful.titlebar.widget.titlewidget(c)
+            },
+            layout  = wibox.layout.flex.horizontal
+        },
+        { -- Right
+            awful.titlebar.widget.floatingbutton (c),
+            awful.titlebar.widget.maximizedbutton(c),
+            awful.titlebar.widget.stickybutton   (c),
+            awful.titlebar.widget.ontopbutton    (c),
+            awful.titlebar.widget.closebutton    (c),
+            layout = wibox.layout.fixed.horizontal()
+        },
+        layout = wibox.layout.align.horizontal
+    }
+end
+
+--DOC_HIDE_END
+
+awful.wibar {
+    position = "top",
+    screen   = screen[1],
+    stretch  = false,
+    width    = 196,
+    margins  = 24,
+    widget   = {
+        align  = "center",
+        text   = "unform margins",
+        widget = wibox.widget.textbox
+    }
+}
+
+--DOC_NEWLINE
+
+awful.wibar {
+    position = "top",
+    screen   = screen[2],
+    stretch  = false,
+    width    = 196,
+    margins = {
+        top    = 12,
+        bottom = 5
+    },
+    widget   = {
+        align  = "center",
+        text   = "non unform margins",
+        widget = wibox.widget.textbox
+    }
+
+}
+
+awful.layout.arrange(screen[1]) --DOC_HIDE
+awful.layout.arrange(screen[2]) --DOC_HIDE
+c1:_hide_all() --DOC_HIDE
+c2:_hide_all() --DOC_HIDE
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/awful/wibar/position.lua
+++ b/tests/examples/awful/wibar/position.lua
@@ -1,0 +1,36 @@
+--DOC_GEN_IMAGE --DOC_NO_USAGE
+--DOC_HIDE_START
+local awful     = require("awful")
+local wibox     = require("wibox")
+
+screen[1]._resize {width = 480, height = 196}
+--DOC_HIDE_END
+
+   local colors = {
+       top    = "#ffff00",
+       bottom = "#ff00ff",
+       left   = "#00ffff",
+       right  = "#ffcc00"
+   }
+
+   --DOC_NEWLINE
+
+   for _, position in ipairs { "top", "bottom", "left", "right" } do
+       awful.wibar {
+           position = position,
+           bg       = colors[position],
+           widget   = {
+               {
+                   text   = position,
+                   align  = "center",
+                   widget = wibox.widget.textbox
+               },
+               direction = (position == "left" or position == "right") and
+                   "east" or "north",
+               widget    = wibox.container.rotate
+           },
+       }
+   end
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80
+

--- a/tests/examples/awful/wibar/position2.lua
+++ b/tests/examples/awful/wibar/position2.lua
@@ -1,0 +1,38 @@
+--DOC_GEN_IMAGE --DOC_NO_USAGE --DOC_HIDE_ALL
+--DOC_HIDE_START
+local awful     = require("awful")
+local wibox     = require("wibox")
+local beautiful = require("beautiful")
+
+screen[1]._resize {width = 480, height = 196}
+
+    local colors = {
+        top    = "#ffff00",
+        bottom = "#ff00ff",
+        left   = "#00ffff",
+        right  = "#ffcc00"
+    }
+
+--DOC_HIDE_END
+    beautiful.wibar_favor_vertical = true
+    --DOC_NEWLINE
+
+    for _, position in ipairs { "top", "bottom", "left", "right" } do
+        awful.wibar {
+            position = position,
+            bg       = colors[position],
+            widget   = {
+                {
+                    text   = position,
+                    align  = "center",
+                    widget = wibox.widget.textbox
+                },
+                direction = (position == "left" or position == "right") and
+                    "east" or "north",
+                widget    = wibox.container.rotate
+            },
+        }
+    end
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80
+

--- a/tests/examples/awful/wibar/stretch.lua
+++ b/tests/examples/awful/wibar/stretch.lua
@@ -1,0 +1,40 @@
+--DOC_GEN_IMAGE
+--DOC_HIDE_START
+local awful     = require("awful")
+local wibox     = require("wibox")
+
+screen._track_workarea = true
+screen[1]._resize {width = 480, height = 60}
+screen._add_screen {x = 0, width = 480, height = 64, y = 72} --DOC_HIDE
+
+--DOC_HIDE_END
+
+awful.wibar {
+    position = "top",
+    screen   = screen[1],
+    stretch  = true,
+    width    = 196,
+    widget   = {
+        text   = "stretched",
+        align  = "center",
+        widget = wibox.widget.textbox
+    },
+}
+
+--DOC_NEWLINE
+
+awful.wibar {
+    position = "top",
+    screen   = screen[2],
+    stretch  = false,
+    width    = 196,
+    widget   = {
+        text   = "not stretched",
+        align  = "center",
+        widget = wibox.widget.textbox
+    },
+}
+
+
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80
+

--- a/tests/examples/screen/client_snap.lua
+++ b/tests/examples/screen/client_snap.lua
@@ -39,7 +39,7 @@ local clients = {
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
     draw_client_snap      = true, --FIXME

--- a/tests/examples/screen/gap_single_client_false.lua
+++ b/tests/examples/screen/gap_single_client_false.lua
@@ -35,7 +35,7 @@ local clients = {
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
     draw_gaps             = true,

--- a/tests/examples/screen/gap_single_client_true.lua
+++ b/tests/examples/screen/gap_single_client_true.lua
@@ -35,7 +35,7 @@ local clients = {
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
     draw_gaps             = true,

--- a/tests/examples/screen/gaps.lua
+++ b/tests/examples/screen/gaps.lua
@@ -36,7 +36,7 @@ local clients = {
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
     draw_gaps             = true,

--- a/tests/examples/screen/gaps2.lua
+++ b/tests/examples/screen/gaps2.lua
@@ -36,7 +36,7 @@ local clients = {
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
     draw_gaps             = true,

--- a/tests/examples/screen/geometry.lua
+++ b/tests/examples/screen/geometry.lua
@@ -29,8 +29,8 @@ end --DOC_HIDE
     }
 
 return { --DOC_HIDE
-    factor             = 2    , --DOC_HIDE
-    show_boxes         = false, --DOC_HIDE
-    highlight_geometry = true , --DOC_HIDE
-    draw_wibar         = wibar, --DOC_HIDE
+    factor             = 2      , --DOC_HIDE
+    show_boxes         = false  , --DOC_HIDE
+    highlight_geometry = true   , --DOC_HIDE
+    draw_wibars        = {wibar}, --DOC_HIDE
 } --DOC_HIDE

--- a/tests/examples/screen/mfpol.lua
+++ b/tests/examples/screen/mfpol.lua
@@ -45,9 +45,9 @@ for _,c in ipairs(clients) do
 end
 
 return {
-    factor                = 2    ,
+    factor                = 2,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
 }

--- a/tests/examples/screen/mfpol2.lua
+++ b/tests/examples/screen/mfpol2.lua
@@ -47,7 +47,7 @@ end
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
 }

--- a/tests/examples/screen/mwfact.lua
+++ b/tests/examples/screen/mwfact.lua
@@ -48,7 +48,7 @@ end
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
     draw_mwfact           = true,

--- a/tests/examples/screen/mwfact2.lua
+++ b/tests/examples/screen/mwfact2.lua
@@ -51,7 +51,7 @@ end
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
     draw_mwfact           = true,

--- a/tests/examples/screen/padding.lua
+++ b/tests/examples/screen/padding.lua
@@ -32,8 +32,8 @@ end --DOC_HIDE
     } --DOC_HIDE
 
 return { --DOC_HIDE
-    factor                = 2    , --DOC_HIDE
-    show_boxes            = false, --DOC_HIDE
-    highlight_padding_area = true , --DOC_HIDE
-    draw_wibar            = wibar, --DOC_HIDE
+    factor                 = 2      , --DOC_HIDE
+    show_boxes             = false  , --DOC_HIDE
+    highlight_padding_area = true   , --DOC_HIDE
+    draw_wibars            = {wibar}, --DOC_HIDE
 } --DOC_HIDE

--- a/tests/examples/screen/struts.lua
+++ b/tests/examples/screen/struts.lua
@@ -6,7 +6,7 @@ local awful = { --DOC_HIDE
     wibar = require("awful.wibar"), --DOC_HIDE
     tag = require("awful.tag"), --DOC_HIDE
     tag_layout = require("awful.layout.suit.tile") --DOC_HIDE
-}
+} --DOC_HIDE
 
     -- Wibars and docked clients are the main users of the struts.
     local wibar = awful.wibar {

--- a/tests/examples/screen/struts.lua
+++ b/tests/examples/screen/struts.lua
@@ -51,9 +51,9 @@ local clients = { --DOC_HIDE
 } --DOC_HIDE
 
 return { --DOC_HIDE
-    factor                = 2   , --DOC_HIDE
+    factor                = 2, --DOC_HIDE
     show_boxes            = true, --DOC_HIDE
-    draw_wibar            = wibar, --DOC_HIDE
+    draw_wibars           = {wibar}, --DOC_HIDE
     draw_clients          = clients, --DOC_HIDE
     display_screen_info   = false, --DOC_HIDE
     draw_struts           = true, --DOC_HIDE

--- a/tests/examples/screen/template.lua
+++ b/tests/examples/screen/template.lua
@@ -15,6 +15,8 @@ local args = loadfile(file_path)() or 10
 args = args or {}
 args.factor = args.factor or 10
 
+local SCALE_FACTOR = 0.66
+
 local factor, img, cr = 1/args.factor
 
 require("gears.timer").run_delayed_calls_now()
@@ -470,7 +472,7 @@ local function draw_struts(s)
     if left > 0 then
         draw_hruler(
             s,
-            s.geometry.y*0.66,
+            s.geometry.y*SCALE_FACTOR,
             get_text_height(),
             {x = s.geometry.x+tr_x*2, width = left, color = colors.gaps.."66", align = true},
             1
@@ -481,7 +483,7 @@ local function draw_struts(s)
         draw_vruler(
             s,
             get_text_height()*1.5,
-            s.geometry.x*0.66,
+            s.geometry.x*SCALE_FACTOR,
             {y=s.geometry.y+tr_y*(1/factor), height = top, color = colors.gaps.."66", align = true},
             1
         )
@@ -490,7 +492,7 @@ local function draw_struts(s)
     if right > 0 then
         draw_hruler(
             s,
-            s.geometry.y*0.66,
+            s.geometry.y*SCALE_FACTOR,
             get_text_height(),
             {x = s.geometry.x, width = left, color = colors.gaps.."66", align = true},
             1
@@ -501,7 +503,7 @@ local function draw_struts(s)
         draw_vruler(
             s,
             get_text_height()*1.5,
-            s.geometry.x*0.66,
+            s.geometry.x*SCALE_FACTOR,
             {
                 y      = s.geometry.y+tr_y*(1/factor)+s.geometry.height - bottom,
                 height = bottom,
@@ -689,7 +691,7 @@ evaluate_translation(
 local sew, seh = screen._get_extents()
 sew, seh = sew/args.factor + (screen.count()-1)*10+2, seh/args.factor+2
 
-sew, seh = sew + tr_x, seh + 0.66*tr_y
+sew, seh = sew + tr_x, seh + SCALE_FACTOR*tr_y
 
 sew, seh = sew + 5*get_text_height(), seh + 5*get_text_height()
 
@@ -697,7 +699,7 @@ img = cairo.SvgSurface.create(image_path..".svg", sew, seh)
 cr  = cairo.Context(img)
 
 -- Instead of adding origin offset everywhere, translate the viewport.
-cr:translate(tr_x, tr_y * 0.66)
+cr:translate(tr_x, tr_y * SCALE_FACTOR)
 
 -- Draw the various areas.
 for k=1, screen.count() do

--- a/tests/examples/screen/tiled_clients.lua
+++ b/tests/examples/screen/tiled_clients.lua
@@ -47,7 +47,7 @@ end
 return {
     factor                = 2    ,
     show_boxes            = true,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
     draw_clients          = clients,
     display_screen_info   = false,
 }

--- a/tests/examples/screen/tiling_area.lua
+++ b/tests/examples/screen/tiling_area.lua
@@ -27,5 +27,5 @@ return {
     factor                = 2    ,
     show_boxes            = false,
     highlight_tiling_area = true ,
-    draw_wibar            = wibar,
+    draw_wibars           = {wibar},
 }

--- a/tests/examples/screen/wibar_workarea.lua
+++ b/tests/examples/screen/wibar_workarea.lua
@@ -11,19 +11,19 @@ local awful = { --DOC_HIDE
 } --DOC_HIDE
 
 local screen1_wibar = awful.wibar {
-    position        = "top",
-    update_workarea = true,
-    height          = 24,
-    screen          = screen[1],
+    position          = "top",
+    restrict_workarea = true,
+    height            = 24,
+    screen            = screen[1],
 }
 
 --DOC_NEWLINE
 
 local screen2_wibar = awful.wibar {
-    position        = "top",
-    update_workarea = false,
-    height          = 24,
-    screen          = screen[2],
+    position          = "top",
+    restrict_workarea = false,
+    height            = 24,
+    screen            = screen[2],
 }
 
 return { --DOC_HIDE

--- a/tests/examples/screen/wibar_workarea.lua
+++ b/tests/examples/screen/wibar_workarea.lua
@@ -1,0 +1,35 @@
+--DOC_GEN_IMAGE
+
+screen[1]._resize {x = 0, width = 640, height = 480} --DOC_HIDE
+
+screen._add_screen {x = 820, width = 640, height = 480, y = -22} --DOC_HIDE
+
+local awful = { --DOC_HIDE
+    wibar = require("awful.wibar"), --DOC_HIDE
+    tag = require("awful.tag"), --DOC_HIDE
+    tag_layout = require("awful.layout.suit.tile") --DOC_HIDE
+} --DOC_HIDE
+
+local screen1_wibar = awful.wibar {
+    position        = "top",
+    update_workarea = true,
+    height          = 24,
+    screen          = screen[1],
+}
+
+--DOC_NEWLINE
+
+local screen2_wibar = awful.wibar {
+    position        = "top",
+    update_workarea = false,
+    height          = 24,
+    screen          = screen[2],
+}
+
+return { --DOC_HIDE
+    factor                = 2   , --DOC_HIDE
+    show_boxes            = true, --DOC_HIDE
+    draw_wibars           = {screen1_wibar, screen2_wibar}, --DOC_HIDE
+    display_screen_info   = false, --DOC_HIDE
+    draw_struts           = true, --DOC_HIDE
+} --DOC_HIDE

--- a/tests/examples/screen/workarea.lua
+++ b/tests/examples/screen/workarea.lua
@@ -35,8 +35,8 @@ end --DOC_HIDE
     }
 
 return { --DOC_HIDE
-    factor             = 2    , --DOC_HIDE
+    factor             = 2, --DOC_HIDE
     show_boxes         = false, --DOC_HIDE
     highlight_workarea = true , --DOC_HIDE
-    draw_wibar         = wibar, --DOC_HIDE
+    draw_wibars        = {wibar}, --DOC_HIDE
 } --DOC_HIDE

--- a/tests/examples/shims/screen.lua
+++ b/tests/examples/shims/screen.lua
@@ -1,21 +1,35 @@
 local gears_obj = require("gears.object")
 local gears_tab = require("gears.table")
+local grect = require("gears.geometry").rectangle
 
 local screen, meta = awesome._shim_fake_class()
 screen._count, screen._deleted = 0, {}
+
+local function get_drawin_screen(s, d)
+    return grect.area_intersect_area (s.geometry, {
+        x      = d:geometry().x,
+        y      = d:geometry().y,
+        width  = 1,
+        height = 1
+    })
+end
 
 local function compute_workarea(s)
     local struts = {top=0,bottom=0,left=0,right=0}
 
     for _, c in ipairs(drawin.get()) do
-        for k,v in pairs(struts) do
-            struts[k] = v + (c:struts()[k] or 0)
+        if get_drawin_screen(s, c) then
+            for k,v in pairs(struts) do
+                struts[k] = v + (c:struts()[k] or 0)
+            end
         end
     end
 
     for _, c in ipairs(client.get()) do
-        for k,v in pairs(struts) do
-            struts[k] = v + (c:struts()[k] or 0)
+        if c.screen == s then
+            for k,v in pairs(struts) do
+                struts[k] = v + (c:struts()[k] or 0)
+            end
         end
     end
 


### PR DESCRIPTION
While I was working on the wallpaper stuff, I found a really bad bug with the wibar. Turns out setting the height has been broken since 4.0. Once upon a time, @psychon let me merge the `awful.placement` code with pretty much "I don't understand this code, but it seems to work". 5 years later, I must admit I no longer understand it either. So fixing it took a bit longer than I hoped... Anyway, it works now.

While I was messing with the placement code anyway (ie, before I forget how it works again), I unbroke the ability to align a wibar, added a margin property (feature request from reddit) and exposed a couple previously hardcoded knobs.

It is still not perfect because the doc claims it is based on `awful.popup`, and it should be, but it is not. Using the popup as the base would allow auto resized wibar to fit the content. But for now this took 3 weeks already, so lets review/merge the part that works.

![image](https://user-images.githubusercontent.com/340384/124571429-9ec2dd80-ddfc-11eb-95bb-7c05c83f3742.png)
