### PR TITLE
Added disable_task_name_focus

### DIFF
--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -167,6 +167,10 @@ local instances
 -- @beautiful beautiful.tasklist_disable_task_name
 -- @tparam[opt=false] boolean tasklist_disable_task_name
 
+--- Disable the tasklist client titles for the focused client.
+-- @beautiful beautiful.tasklist_disable_task_name_focus
+-- @tparam[opt=false] boolean tasklist_disable_task_name_focus
+
 --- Disable the extra tasklist client property notification icons.
 --
 -- See the <a href="#status_icons">Status icons</a> section for more details.
@@ -332,6 +336,7 @@ local function tasklist_label(c, args, tb)
     local bg_image_minimize = args.bg_image_minimize or theme.tasklist_bg_image_minimize or theme.bg_image_minimize
     local tasklist_disable_icon = args.tasklist_disable_icon or theme.tasklist_disable_icon or false
     local disable_task_name = args.disable_task_name or theme.tasklist_disable_task_name or false
+    local disable_task_name_focus = args.disable_task_name_focus or theme.tasklist_disable_task_name_focus or (disable_task_name and args.disable_task_name_focus == nil and theme.tasklist_disable_task_name_focus == nil)
     local font = args.font or theme.tasklist_font or theme.font or ""
     local font_focus = args.font_focus or theme.tasklist_font_focus or theme.font_focus or font or ""
     local font_minimized = args.font_minimized or theme.tasklist_font_minimized or theme.font_minimized or font or ""
@@ -396,9 +401,15 @@ local function tasklist_label(c, args, tb)
 
     if focused then
         bg = bg_focus
-        text = text .. "<span color='"..fg_focus.."'>"..name.."</span>"
         bg_image = bg_image_focus
         font = font_focus
+
+        if not disable_task_name_focus and disable_task_name then
+            name = name .. (gstring.xml_escape(c.name) or gstring.xml_escape("<untitled>"))
+        elseif disable_task_name_focus then
+            name = ""
+        end
+        text = text .. "<span color='"..fg_focus.."'>"..name.."</span>"
 
         if args.shape_focus or theme.tasklist_shape_focus then
             shape = args.shape_focus or theme.tasklist_shape_focus
@@ -535,6 +546,7 @@ end
 -- @tparam[opt='⬌'] string args.style.maximized_horizontal Extra icon when client is maximized_horizontal
 -- @tparam[opt='⬍'] string args.style.maximized_vertical Extra icon when client is maximized_vertical
 -- @tparam[opt=false] boolean args.style.disable_task_name
+-- @tparam[opt=false] boolean args.style.disable_task_name_focus
 -- @tparam[opt=nil] string args.style.font
 -- @tparam[opt=left] string args.style.align *left*, *right* or *center*
 -- @tparam[opt=nil] string args.style.font_focus

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -336,6 +336,7 @@ local function tasklist_label(c, args, tb)
     local bg_image_minimize = args.bg_image_minimize or theme.tasklist_bg_image_minimize or theme.bg_image_minimize
     local tasklist_disable_icon = args.tasklist_disable_icon or theme.tasklist_disable_icon or false
     local disable_task_name = args.disable_task_name or theme.tasklist_disable_task_name or false
+    -- Check if option is set, else refere to the value of disable_task_name as default for backward compatibility
     local disable_task_name_focus = args.disable_task_name_focus or theme.tasklist_disable_task_name_focus or (disable_task_name and args.disable_task_name_focus == nil and theme.tasklist_disable_task_name_focus == nil)
     local font = args.font or theme.tasklist_font or theme.font or ""
     local font_focus = args.font_focus or theme.tasklist_font_focus or theme.font_focus or font or ""

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -169,7 +169,7 @@ local instances
 
 --- Disable the tasklist client titles for the focused client.
 -- @beautiful beautiful.tasklist_disable_task_name_focus
--- @tparam[opt=false] boolean tasklist_disable_task_name_focus
+-- @tparam[opt=value of tasklist_disable_task_name] boolean tasklist_disable_task_name_focus
 
 --- Disable the extra tasklist client property notification icons.
 --
@@ -547,7 +547,7 @@ end
 -- @tparam[opt='⬌'] string args.style.maximized_horizontal Extra icon when client is maximized_horizontal
 -- @tparam[opt='⬍'] string args.style.maximized_vertical Extra icon when client is maximized_vertical
 -- @tparam[opt=false] boolean args.style.disable_task_name
--- @tparam[opt=false] boolean args.style.disable_task_name_focus
+-- @tparam[opt=value of disable_task_name] boolean args.style.disable_task_name_focus
 -- @tparam[opt=nil] string args.style.font
 -- @tparam[opt=left] string args.style.align *left*, *right* or *center*
 -- @tparam[opt=nil] string args.style.font_focus


### PR DESCRIPTION
Added the option to disable the task name of the focus client.
This option can also be used to show the task name of the focused
client, if the task name of the other clients is disabled.

If `theme.tasklist_disable_task_name_focus` or the argument `disable_task_name_focus` are set to false, it will always show the title of the focused client.      
If `theme.tasklist_disable_task_name_focus` or the argument `disable_task_name_focus` are set to true, it will always hide  the title of the focused client.      
If the options isn't set, it will refer to the value given by `theme.tasklist_disable_task_name` or the argument `disable_task_name`, to maintain backwards compatibility.

Note: The assignment of `disable_task_name_focus` is pretty ugly, but i couldn't find a better way with maintaining backwards compatibility and keeping the naming consistent. I would like to hear a better solution and general improvements, if needed before the merge.