### PR TITLE
06 appearance.md duplicates fix (fixes #3328)

### DIFF
--- a/docs/_parser.lua
+++ b/docs/_parser.lua
@@ -165,17 +165,22 @@ local function parse_files(paths, property_name, matcher, name_matcher)
                         )
                     else
                         local insert_name = name:gsub("_", "_")
+                        local link = get_link(file, var, var:match(exp3):gsub("_", "\\_"))
+                        local desc = buffer:gmatch("[-*/ \n]+([^\n.]*)")() or ""
+                        local mod = path_to_module(file)
+
                         if names[insert_name] == nil then
                             count = count + 1
                             table.insert(ret, count, {
                                 file = file,
                                 name = insert_name,
-                                link = get_link(file, var, var:match(exp3):gsub("_", "\\_")),
-                                desc = buffer:gmatch("[-*/ \n]+([^\n.]*)")() or "",
-                                mod  = path_to_module(file)
+                                link = link,
+                                desc = desc,
+                                mod  = mod
                             })
                             names[insert_name] = count
                         else
+                            link = link .. "(" .. mod .. ")"
                             if type(ret[names[insert_name]].link) ~= "table" then
                                 ret[names[insert_name]].file = {
                                     ret[names[insert_name]].file,
@@ -183,25 +188,21 @@ local function parse_files(paths, property_name, matcher, name_matcher)
                                 }
                                 ret[names[insert_name]].link = {
                                     ret[names[insert_name]].link .. " (" .. ret[names[insert_name]].mod .. ")",
-                                    get_link(file, var, var:match(exp3):gsub("_", "\\_")) .. " (" .. path_to_module(file) .. ")",
-
+                                    link
                                 }
                                 ret[names[insert_name]].desc = {
                                     ret[names[insert_name]].desc,
-                                    buffer:gmatch("[-*/ \n]+([^\n.]*)")() or ""
+                                    desc
                                 }
                                 ret[names[insert_name]].mod = {
                                     ret[names[insert_name]].mod,
-                                    path_to_module(file)
+                                    mod
                                 }
                             else
                                 table.insert(ret[names[insert_name]].file, file)
-                                table.insert(ret[names[insert_name]].link,
-                                    get_link(file, var, var:match(exp3):gsub("_", "\\_")) .. " (" .. path_to_module(file) .. ")")
-                                table.insert(ret[names[insert_name]].desc,
-                                    buffer:gmatch("[-*/ \n]+([^\n.]*)")() or "")
-                                table.insert(ret[names[insert_name]].mod,
-                                    path_to_module(file))
+                                table.insert(ret[names[insert_name]].link, link)
+                                table.insert(ret[names[insert_name]].desc, desc)
+                                table.insert(ret[names[insert_name]].mod, mod)
                             end
                         end
                     end

--- a/docs/_parser.lua
+++ b/docs/_parser.lua
@@ -121,6 +121,7 @@ local function parse_files(paths, property_name, matcher, name_matcher)
     local exp2 = matcher or "[-*]*[ ]*".. property_name ..".(.+)"
     local exp3 = name_matcher or "[. ](.+)"
 
+    local names = {} -- Used to check for duplicates
     local ret = {}
 
     table.sort(paths)
@@ -162,13 +163,17 @@ local function parse_files(paths, property_name, matcher, name_matcher)
                             "seems to be misformatted. Use `beautiful.namespace_name`"
                         )
                     else
-                        table.insert(ret, {
-                            file = file,
-                            name = name:gsub("_", "_"),
-                            link = get_link(file, var, var:match(exp3):gsub("_", "\\_")),
-                            desc = buffer:gmatch("[-*/ \n]+([^\n.]*)")() or "",
-                            mod  = path_to_module(file),
-                        })
+                        local insert_name = name:gsub("_", "_")
+                        if names[insert_name] == nil then
+                            table.insert(ret, {
+                                file = file,
+                                name = insert_name,
+                                link = get_link(file, var, var:match(exp3):gsub("_", "\\_")),
+                                desc = buffer:gmatch("[-*/ \n]+([^\n.]*)")() or "",
+                                mod  = path_to_module(file)
+                            })
+                            names[insert_name] = 1
+                        end
                     end
 
                     buffer = ""

--- a/docs/_parser.lua
+++ b/docs/_parser.lua
@@ -227,17 +227,11 @@ local function create_table(entries, columns, prefix)
 
         for _, column in ipairs(columns) do
             if type(entry[column]) == "table" then
-                line = line .. "<td>"
-                local firstline = true
+                line = line .. "<td><ul>"
                 for _,v in pairs(entry[column]) do
-                    if not firstline then
-                        line = line .. "<br>"
-                    else
-                        firstline = false
-                    end
-                    line = line .. v
+                    line = line .. "<li>" .. v .. "</li>"
                 end
-                line = line .. "</td>"
+                line = line .. "</ul></td>"
             else
                 line = line.."<td>"..entry[column].."</td>"
             end


### PR DESCRIPTION
The table entries that were duplicated are now above each other, in the same cell; all the links are still accessible. Formatting could be better.

There are no longer duplicates in the sample file.
