### PR TITLE
Remove Vicious as async counterexample

### DIFF
--- a/docs/90-FAQ.md
+++ b/docs/90-FAQ.md
@@ -36,8 +36,7 @@ Do **not** use such functions and prefer `awful.spawn.easy_async`,
 fast enough and won't impact the main event loop iteration time, you are wrong.
 *Every* calls to `io.open` are impacted by the system `iowait` queue and can
 spend hundreds of milliseconds blocked *before* being executed. Note that
-some common widget or probe libraries such as
-[Vicious](https://github.com/Mic92/vicious) do not follow this
+some common widget or probe libraries do not follow this
 advice currently and are known to cause input lag on some systems (but not all).
 
 In both case, a warning like:


### PR DESCRIPTION
Vicious has stopped using io.popen since October 2019.