### PR TITLE
[RFC/WIP] Implement wibox.widget.template: An abstract widget that handles a preset of concrete widget.

### DIFF
--- a/lib/wibox/widget/init.lua
+++ b/lib/wibox/widget/init.lua
@@ -21,6 +21,7 @@ local widget = {
     slider = require("wibox.widget.slider");
     calendar = require("wibox.widget.calendar");
     separator = require("wibox.widget.separator");
+    template = require("wibox.widget.template");
 }
 
 setmetatable(widget, {

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -1,0 +1,90 @@
+---------------------------------------------------------------------------
+-- An abstract widget that handles a preset of concrete widget.
+--
+-- The `wibox.widget.template` widget is an abstraction layer that contains a
+-- concrete widget definition. The template widget can be used to build widgets
+-- that the user can customize at their will, thanks to the template mechanism.
+--
+-- @author Aire-One
+-- @copyright 2021 Aire-One <aireone@aireone.xyz>
+--
+-- @classmod wibox.widget.template
+-- @supermodule wibox.widget.base
+---------------------------------------------------------------------------
+
+local wbase = require("wibox.widget.base")
+local gtable = require("gears.table")
+local gtimer = require("gears.timer")
+
+local default_update_callback = function()
+    return nil
+end
+
+local default_template_widget = wbase.empty_widget()
+
+local template = {
+    mt = {},
+    queued_updates = {}
+}
+
+function template:_do_update_now(args)
+    self:update_callback(args)
+    template.queued_updates[self] = false
+end
+
+--- Update the widget.
+-- This function will call the `update_callback` function at the end of the
+-- current GLib event loop. Updates are batched by event loop, it means that the
+-- widget can only be update once by event loop. If the `template:update` method
+-- is called multiple times during the same GLib event loop, only the first call
+-- will be run.
+-- All arguments are passed to the queued `update_callback` call.
+-- @treturn boolean Returns `true` if the update_callback have been queued to be
+--   run at the end of the event loop. Returns `false` if there is already an update
+--   in the queue (in this case, this new update request is discared).
+function template:update(args)
+    local update_args = gtable.crush(gtable.clone(self.update_args, false), args or {})
+
+    if not template.queued_updates[self] then
+        gtimer.delayed_call(
+            function()
+                self:_do_update_now(update_args)
+            end
+        )
+        template.queued_updates[self] = true
+
+        return true
+    end
+
+    return false
+end
+
+--- Create a new `wibox.widget.template` instance.
+-- @tparam[opt] table args
+-- @tparam[opt] table|widget|function args.widget_template The template of widget to use.
+-- @tparam[opt] function args.update_callback The callback function to update the widget.
+-- @treturn wibox.widget.template The new instance.
+function template.new(args)
+    args = args or {}
+
+    local widget_template =
+        type(args.widget_template) == "function" and args.widget_template() or args.widget_template or
+        default_template_widget
+
+    local widget = wbase.make_widget_from_value(widget_template)
+
+    widget.update_callback = args.update_callback or default_update_callback
+    widget.update_args = args.update_args or {}
+
+    gtable.crush(widget, template, true)
+
+    return widget
+end
+
+function template.mt:__call(...) --luacheck: ignore unused variable self
+    return template.new(...)
+end
+
+return setmetatable(template, template.mt)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/spec/preload.lua
+++ b/spec/preload.lua
@@ -4,7 +4,10 @@
 require("lgi")
 
 -- Always show deprecated messages
-_G.awesome = {version = "v9999"}
+_G.awesome = {
+    version = "v9999",
+    api_level = 9999,
+}
 
 -- "fix" some intentional beautiful breakage done by .travis.yml
 require("beautiful").init{a_key="a_value"}

--- a/spec/wibox/widget/template_spec.lua
+++ b/spec/wibox/widget/template_spec.lua
@@ -1,0 +1,71 @@
+---------------------------------------------------------------------------
+-- @author Aire-One
+-- @copyright 2021 Aire-One
+---------------------------------------------------------------------------
+
+_G.awesome.connect_signal = function() end
+
+local template = require("wibox.widget.template")
+local gtable = require("gears.table")
+local gtimer = require("gears.timer")
+
+local function is_same_table_struture(state, arguments) -- luacheck: ignore unused argument state
+    return function(value)
+        return table.concat(gtable.keys(arguments[1])) == table.concat(gtable.keys(value))
+    end
+end
+
+assert:register(
+    "matcher",
+    "is_same_table_struture",
+    is_same_table_struture
+)
+
+describe("wibox.widget.template", function()
+    local widget
+
+    before_each(function()
+        widget = template()
+    end)
+
+    describe("widget:update()", function()
+        it("batch calls", function()
+            local spied_update_callback = spy.new(function() end)
+
+            widget.update_callback = spied_update_callback
+
+            -- Multiple calls to update
+            widget:update()
+            widget:update()
+            widget:update()
+
+            -- update_callback shouldn't be called before the end of the event loop
+            assert.spy(spied_update_callback).was.called(0)
+
+            gtimer.run_delayed_calls_now()
+
+            -- updates are batched, so only 1 call should have been performed
+            assert.spy(spied_update_callback).was.called(1)
+        end)
+
+        it("update parameters", function()
+            local spied_update_callback = spy.new(function() end)
+            local args_structure = { foo = "string" }
+            local update_args = { foo = "bar" }
+
+            widget.update_args = args_structure
+            widget.update_callback = spied_update_callback
+
+            widget:update(update_args)
+
+            gtimer.run_delayed_calls_now()
+
+            assert.spy(spied_update_callback).was.called_with(
+                match.is_ref(widget),
+                match.is_same_table_struture(widget.update_args)
+            )
+        end)
+    end)
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Hello :wave: 

I think it'll need more work to be ready, I hope to get feedbacks to improve this new widget.

This PR is (what I think to be) the response we need to provide a standard API that address issues raised by initiatives like #2955 and #3208.

The idea behind this new "template widget" is to standardize how we want/try to implement widget template across the `awful.widget` library (and third-party libraries that want to implement user customizable widget). Thanks to this widget, I hope we can build more extendable widgets that allow end-users to easily implement their own customization.

In the scope of this PR, I only want to implement the `wibox.widget.template` widget and the tools it needs. If you validate this approach, more PRs will come to implement usage of the template widget across widgets from `awful.widget`. 

For the record, here is a naive attempt at implementing the widget template for the layoutbox widget : https://github.com/Aire-One/awesome/tree/feature/widget_template/layoutbox

Short list for todos :

- [ ] Documentation
- [ ] Usage examples
- [ ] Rename `widget_template` parameter (?)
- [ ] Intermediate constructor (to prevent `w = layoutbox { widget_template = wibox.widget.template{...} }`)
- [ ] Save arguments from dismissed update call (?)