### PR TITLE
Fix 3384

### DIFF
--- a/lib/naughty/action.lua
+++ b/lib/naughty/action.lua
@@ -57,7 +57,13 @@ local action = {}
 -- @propemits true false
 
 --- When a notification is invoked.
+--
+-- Note that it is possible to call `:invoke()` without a notification object.
+-- It is possible the `notification` parameter will be nil.
+--
 -- @signal invoked
+-- @tparam naughty.action action The action.
+-- @tparam naughty.notification|nil notification The notification, if known.
 
 function action:get_selected()
     return self._private.selected

--- a/lib/naughty/list/actions.lua
+++ b/lib/naughty/list/actions.lua
@@ -337,7 +337,10 @@ local function new(_, args)
     update_style(wdg)
 
     wdg._private.default_buttons = gtable.join(
-        abutton({ }, 1, function(a) a:invoke(args.notification) end)
+        abutton({ }, 1, function(a)
+            local notif = wdg._private.notification or args.notification
+            a:invoke(notif)
+        end)
     )
 
     return wdg


### PR DESCRIPTION
There is no test for this because it was an UI problem. The `naughty.lists.actions` widget wasn't sending the object. Writing a new test suite with fake clicks just for this is a little overkill, so I only did manual testing with @p-himik reproducer.