### PR TITLE
Correction of error message in awful.keygrabber.run_with_keybindings

### DIFF
--- a/lib/awful/keygrabber.lua
+++ b/lib/awful/keygrabber.lua
@@ -714,12 +714,13 @@ function keygrab.run_with_keybindings(args)
             else
                 gdebug.print_warning(
                     "The hook's 3rd parameter has to be a function. " ..
-                        gdebug.dump(v or {})
+                        gdebug.dump_return(v or {})
                 )
             end
         else
             gdebug.print_warning(
-                "The keybindings should be awful.key objects".. gdebug.dump(v or {})
+                "The keybindings should be awful.key objects" ..
+                        gdebug.dump_return(v or {})
             )
         end
     end


### PR DESCRIPTION
Two calls to gdebug.print_warning() in run_with_keybindings use an
argument that concatenates a fixed string with the result returned by a
call to gdebug.dump(). gdebug.dump() is the debug library function for
immediate printing. It has no return value. This causes the correct
message in print_warning to not be printed, and also causes a
naughty.notify box to appear warning of an attempt to concatenate to an
empty variable.

The call to gdebug.print_warning should have an argument made by
concatenating to gdebug.dump_return(). Incidentally, this is in fact the
function used internally by gdebug.print().

Signed off by: Brian Sobulefsky <brian.sobulefsky@protonmail.com>