### PR TITLE
tasklist: Display the same label regardless of window state

### DIFF
--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -376,12 +376,8 @@ local function tasklist_label(c, args, tb)
     end
 
     if not disable_task_name then
-        if c.minimized then
-            name = name .. (gstring.xml_escape(c.icon_name) or gstring.xml_escape(c.name) or
-                            gstring.xml_escape("<untitled>"))
-        else
-            name = name .. (gstring.xml_escape(c.name) or gstring.xml_escape("<untitled>"))
-        end
+        name = name .. (gstring.xml_escape(c.name) or gstring.xml_escape(c.icon_name) or
+                        gstring.xml_escape("<untitled>"))
     end
 
     local focused = c.active


### PR DESCRIPTION
So far tasklist labels displayed WM_ICON_NAME for minimzed windows
and WM_NAME for windows in a different state. This commit changes
that to prefer WM_NAME in general and fall back to WM_ICON_NAME only
if WM_NAME is not set.

Reasons:
a) Coherency across all window states.
b) Users can easily modify the r/w c.name, but not the r/o c.icon_name.
   Thus they can modify c.name to change tasklist labels, the tasklist
   menu, titlebars, ... All at once.

Closes #3476