### PR TITLE
shape: Add a "solid shadow" shape.

### DIFF
--- a/tests/examples/gears/shape/solid_rectangle_shadow.lua
+++ b/tests/examples/gears/shape/solid_rectangle_shadow.lua
@@ -1,0 +1,12 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+local shape,cr,show = ... --DOC_HIDE
+
+shape.solid_rectangle_shadow(cr, 70, 70, 10, 5)
+show(cr) --DOC_HIDE
+
+shape.solid_rectangle_shadow(cr, 70, 70, 5, -10)
+show(cr) --DOC_HIDE
+
+shape.solid_rectangle_shadow(cr, 70, 70, 30, -30)
+show(cr) --DOC_HIDE
+--DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Credit to @actionless for originally using it in some of his themes.

![image](https://user-images.githubusercontent.com/340384/139363065-e9078e4c-929b-44fb-8ad4-b8e7a0474d44.png)

In my case, I originally wrote it for this MS-DOS homage demo https://imgur.com/a/8ikCPl0

I upstream it now because it got some little interest in the chat.