### PR TITLE
Less flacky tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,7 +253,7 @@ jobs:
           grep -q 'May not access' lib/beautiful/init.lua
 
       - name: Build
-        run: cd "${{ github.workspace }}/build" && make
+        run: cd "${{ github.workspace }}/build" && make -j3
 
       # Executable needs to be run once to provide coverage results
       - name: Install and run

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,11 @@ add_custom_target(check DEPENDS check-integration)
 add_executable(test-gravity tests/test-gravity.c)
 target_link_libraries(test-gravity
     ${AWESOME_COMMON_REQUIRED_LDFLAGS} ${AWESOME_REQUIRED_LDFLAGS})
+
+add_executable(test-systray tests/test-systray.c)
+target_link_libraries(test-systray
+    ${AWESOME_COMMON_REQUIRED_LDFLAGS} ${AWESOME_REQUIRED_LDFLAGS})
+
 if(DO_COVERAGE)
     set(TESTS_RUN_ENV DO_COVERAGE=1)
 endif()

--- a/lib/naughty/container/background.lua
+++ b/lib/naughty/container/background.lua
@@ -46,22 +46,24 @@ end
 -- @propemits true false
 
 function background:set_notification(notif)
-    if self._private.notification == notif then return end
+    local old = self._private.notification[1]
 
-    if self._private.notification then
-        self._private.notification:disconnect_signal("property::bg",
+    if old == notif then return end
+
+    if old then
+        old:disconnect_signal("property::bg",
             self._private.background_changed_callback)
-        self._private.notification:disconnect_signal("property::border_width",
+        old:disconnect_signal("property::border_width",
             self._private.background_changed_callback)
-        self._private.notification:disconnect_signal("property::border_color",
+        old:disconnect_signal("property::border_color",
             self._private.background_changed_callback)
-        self._private.notification:disconnect_signal("property::shape",
+        old:disconnect_signal("property::shape",
             self._private.background_changed_callback)
     end
 
     update_background(notif, self)
 
-    self._private.notification = notif
+    self._private.notification = setmetatable({notif}, {__mode="v"})
 
     notif:connect_signal("property::bg"          , self._private.background_changed_callback)
     notif:connect_signal("property::border_width", self._private.background_changed_callback)
@@ -82,12 +84,13 @@ local function new(args)
     args = args or {}
 
     local bg = wbg()
+    bg._private.notification = {}
     bg:set_border_strategy("inner")
 
     gtable.crush(bg, background, true)
 
     function bg._private.background_changed_callback()
-        update_background(bg._private.notification, bg)
+        update_background(bg._private.notification[1], bg)
     end
 
     if args.notification then

--- a/lib/naughty/list/actions.lua
+++ b/lib/naughty/list/actions.lua
@@ -168,14 +168,16 @@ local function wb_label(action, self)
 end
 
 local function update(self)
-    if not self._private.layout or not self._private.notification then return end
+    local n = self._private.notification[1]
+
+    if not self._private.layout or not n then return end
 
     awcommon.list_update(
         self._private.layout,
         self._private.default_buttons,
         function(o) return wb_label(o, self) end,
         self._private.data,
-        self._private.notification.actions,
+        n.actions,
         {
             widget_template = self._private.widget_template
         }
@@ -229,7 +231,7 @@ local actionlist = {}
 
 
 function actionlist:set_notification(notif)
-    self._private.notification = notif
+    self._private.notification = setmetatable({notif}, {__mode="v"})
 
     if not self._private.layout then
         self._private.layout = wibox.layout.fixed.horizontal()
@@ -329,8 +331,9 @@ local function new(_, args)
     gtable.crush(wdg, actionlist, true)
 
     wdg._private.data = {}
+    wdg._private.notification = {}
 
-    gtable.crush(wdg, args)
+    gtable.crush(wdg, args, false)
 
     wdg._private.style = wdg._private.style or {}
 
@@ -338,7 +341,7 @@ local function new(_, args)
 
     wdg._private.default_buttons = gtable.join(
         abutton({ }, 1, function(a)
-            local notif = wdg._private.notification or args.notification
+            local notif = wdg._private.notification[1]
             a:invoke(notif)
         end)
     )

--- a/lib/naughty/widget/_default.lua
+++ b/lib/naughty/widget/_default.lua
@@ -22,7 +22,7 @@ local function notif_size()
     constraint:set_width(beautiful.notification_max_width or dpi(500))
 
     rawset(constraint, "set_notification", function(_, notif)
-        constraint._private.notification = notif
+        constraint._private.notification = setmetatable({notif}, {__mode = "v"})
         local s = false
 
         if notif.width and notif.width ~= beautiful.notification_max_width then
@@ -35,6 +35,10 @@ local function notif_size()
         end
 
         constraint.strategy = s and "exact" or "max"
+    end)
+
+    rawset(constraint, "get_notification", function()
+        return constraint._private.notification[1]
     end)
 
     return constraint

--- a/lib/naughty/widget/icon.lua
+++ b/lib/naughty/widget/icon.lua
@@ -83,10 +83,12 @@ end
 -- @propemits true false
 
 function icon:set_notification(notif)
-    if self._private.notification == notif then return end
+    local old = (self._private.notification or {})[1]
 
-    if self._private.notification then
-        self._private.notification:disconnect_signal("destroyed",
+    if old == notif then return end
+
+    if old then
+        old:disconnect_signal("destroyed",
             self._private.icon_changed_callback)
     end
 
@@ -96,7 +98,7 @@ function icon:set_notification(notif)
         self:set_image(icn)
     end
 
-    self._private.notification = notif
+    self._private.notification = setmetatable({notif}, {__mode="v"})
 
     notif:connect_signal("property::icon", self._private.icon_changed_callback)
     self:emit_signal("property::notification", notif)
@@ -154,10 +156,14 @@ local function new(args)
     local tb = imagebox()
 
     gtable.crush(tb, icon, true)
+    tb._private.notification = {}
 
     function tb._private.icon_changed_callback()
+        local n = tb._private.notification[1]
 
-        local icn = gsurface.load_silently(tb._private.notification.icon)
+        if not n then return end
+
+        local icn = gsurface.load_silently(n.icon)
 
         if icn then
             tb:set_image(icn)

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -14,7 +14,7 @@ pcall(require, 'luarocks.loader')
 local lgi  = require 'lgi'
 local GLib = lgi.require('GLib')
 local Gdk  = lgi.require('Gdk')
-local Gtk  = lgi.require('Gtk')
+local Gtk  = lgi.require('Gtk', '3.0')
 local Gio  = lgi.require('Gio')
 Gtk.init()
 

--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -10,10 +10,11 @@ end
 
 local test_client_source = [[
 pcall(require, 'luarocks.loader')
-local lgi = require 'lgi'
-local Gdk = lgi.require('Gdk')
-local Gtk = lgi.require('Gtk')
-local Gio = lgi.require('Gio')
+local lgi  = require 'lgi'
+local GLib = lgi.require('GLib')
+local Gdk  = lgi.require('Gdk')
+local Gtk  = lgi.require('Gtk')
+local Gio  = lgi.require('Gio')
 Gtk.init()
 
 local function open_window(class, title, options)
@@ -40,6 +41,8 @@ local function open_window(class, title, options)
     end
     if options.maximize_before then
         window:maximize()
+    elseif options.unminimize_after then
+        window:iconify()
     end
     window:set_wmclass(class, class)
     window:show_all()
@@ -47,6 +50,14 @@ local function open_window(class, title, options)
         window:maximize()
     elseif options.unmaximize_after then
         window:unmaximize()
+    elseif options.minimize_after then
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, function()
+            window:iconify()
+        end)
+    elseif options.unminimize_after then
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, function()
+            window:deiconify()
+        end)
     end
     if options.resize_after_width and options.resize_after_height then
        window:resize(
@@ -152,6 +163,13 @@ return function(class, title, sn_rules, callback, resize_increment, args)
     if args.unmaximize_after then
         options = options .. "unmaximize_after,"
     end
+    if args.unminimize_after then
+        options = options .. "unminimize_after,"
+    end
+    if args.minimize_after then
+        options = options .. "minimize_after,"
+    end
+
     if args.size then
         options = table.concat {
             options,

--- a/tests/test-client-shape.lua
+++ b/tests/test-client-shape.lua
@@ -11,6 +11,18 @@ runner.run_steps{
             assert(type(a) == "number", a)
         end
         if #client.get() == 1 then
+            local c = client.get()[1]
+
+            local geo = c:geometry()
+
+            -- Resize it to test shape change events.
+            c:geometry {
+                x      = geo.x,
+                y      = geo.y,
+                width  = geo.width * 2,
+                height = geo.height * 2,
+            }
+
             return true
         end
     end,
@@ -28,7 +40,14 @@ runner.run_steps{
         assert(not surface.load_silently(c.shape_clip, false))
 
         return true
+    end,
+
+    function()
+        client.get()[1]:kill()
+        return true
     end
+
+
 }
 
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-input-binding.lua
+++ b/tests/test-input-binding.lua
@@ -243,8 +243,20 @@ for _, type_name in ipairs { "key", "button" } do
         end)
 
         -- Cleanup (otherwise there is a race with the root.buttons tests)
-        table.insert(steps, function()
-            if #mouse.screen.clients ~= 0 then return end
+        table.insert(steps, function(count)
+            if #mouse.screen.clients ~= 0 then
+                if count > 5 then
+                    -- It's stuck, kill it.
+                    test_client.terminate()
+                else
+                    for _, c in pairs(client.get()) do
+                        c:kill()
+                    end
+                end
+
+
+                return
+            end
 
             return true
         end)
@@ -371,6 +383,8 @@ table.insert(steps, function()
 
     return true
 end)
+
+table.insert(steps, test_client.terminate)
 
 runner.run_steps(steps)
 

--- a/tests/test-maximize.lua
+++ b/tests/test-maximize.lua
@@ -371,8 +371,38 @@ gears.table.merge(steps, {
 
         if not c or counter ~= 2 then return end
 
+        c:kill()
+
+        client.disconnect_signal("request::geometry", geometry_handler)
+
+        test_client(nil,nil,nil,nil,nil,{minimize_after=true})
+
         return true
-    end
+    end,
+    function()
+        -- Test minimization.
+        if #client.get() ~= 1 or not client.get()[1].minimized then return end
+
+        assert(client.get()[1].minimized)
+        client.get()[1]:kill()
+
+        return true
+    end,
+    function()
+        if #client.get() > 0 then return end
+
+        test_client(nil,nil,nil,nil,nil,{unminimize_after=true})
+
+        return true
+    end,
+    function()
+        if #client.get() ~= 1 or client.get()[1].minimized then return end
+
+        assert(not client.get()[1].minimized)
+        client.get()[1]:kill()
+
+        return true
+    end,
 })
 
 runner.run_steps(steps)

--- a/tests/test-systray.c
+++ b/tests/test-systray.c
@@ -1,0 +1,118 @@
+/*
+ * A simple client icon that "does nothing".
+ *
+ * Copyright © 2021 Uli Schlachter <psychon@znc.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xcb/xcb.h>
+#include <xcb/xcb_atom.h>
+#include <xcb/xcb_aux.h>
+
+#include "common/atoms.h"
+#include "common/util.h"
+
+// Include all the C code we might need directly into this file - I am lazy
+#include "common/atoms.c"
+#include "common/util.c"
+
+#define SYSTEM_TRAY_REQUEST_DOCK 0
+
+static xcb_atom_t systray_atom(xcb_connection_t *conn, int screen) {
+    char *atom_name;
+    xcb_intern_atom_reply_t *reply;
+    xcb_atom_t atom;
+
+    atom_name = xcb_atom_name_by_screen("_NET_SYSTEM_TRAY", screen);
+    if(!atom_name)
+        fatal("Error getting systray atom name\n");
+
+    reply = xcb_intern_atom_reply(conn, xcb_intern_atom(conn, 0, strlen(atom_name), atom_name), NULL);
+    free(atom_name);
+    if (!reply)
+        fatal("Error interning systray icon\n");
+
+    atom = reply->atom;
+    free(reply);
+    return atom;
+}
+
+static xcb_window_t find_systray(xcb_connection_t *conn, xcb_atom_t net_system_tray) {
+    xcb_get_selection_owner_reply_t* reply = xcb_get_selection_owner_reply(conn, xcb_get_selection_owner(conn, net_system_tray), NULL);
+    if (!reply)
+        fatal("Failed to request selection owner\n");
+    xcb_window_t owner = reply->owner;
+    if (owner == XCB_NONE)
+        fatal("No systray running\n");
+    free(reply);
+    return owner;
+}
+
+static uint32_t get_color(xcb_connection_t *conn, xcb_screen_t *screen, uint16_t red, uint16_t green, uint16_t blue) {
+    xcb_alloc_color_reply_t *reply = xcb_alloc_color_reply(conn, xcb_alloc_color(conn, screen->default_colormap, red, green, blue), NULL);
+    if (!reply)
+        fatal("Error allocating color");
+    uint32_t pixel = reply->pixel;
+    free(reply);
+    return pixel;
+}
+
+int main() {
+    int default_screen;
+    xcb_connection_t* conn = xcb_connect(NULL, &default_screen);
+    if (xcb_connection_has_error(conn)) {
+        fatal("Could not connect to X11 server: %d\n", xcb_connection_has_error(conn));
+    }
+    atoms_init(conn);
+    xcb_screen_t* screen = xcb_aux_get_screen(conn, default_screen);
+
+    // Create a window for the systray icon
+    xcb_window_t window = xcb_generate_id(conn);
+    xcb_create_window(conn, screen->root_depth, window, screen->root, 0, 0, 10, 10, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT,
+            screen->root_visual, XCB_CW_BACK_PIXEL, (uint32_t[]) { get_color(conn, screen, 0xffff, 0x9999, 0x0000) });
+    xcb_change_property(conn, XCB_PROP_MODE_REPLACE, window, _XEMBED_INFO, _XEMBED_INFO, 32, 2, (uint32_t[]) { 0, 1 });
+
+    // Make our window a systray icon
+    xcb_window_t systray_owner = find_systray(conn, systray_atom(conn, default_screen));
+    xcb_client_message_event_t ev;
+
+    p_clear(&ev, 1);
+    ev.response_type = XCB_CLIENT_MESSAGE;
+    ev.window = systray_owner;
+    ev.format = 32;
+    ev.data.data32[0] = XCB_CURRENT_TIME;
+    ev.data.data32[1] = SYSTEM_TRAY_REQUEST_DOCK;
+    ev.data.data32[2] = window;
+    ev.data.data32[3] = 0;
+    ev.data.data32[4] = 0;
+    ev.type = _NET_SYSTEM_TRAY_OPCODE;
+    xcb_send_event(conn, false, systray_owner, XCB_EVENT_MASK_NO_EVENT, (char *) &ev);
+
+    xcb_flush(conn);
+    xcb_generic_event_t *event;
+    while ((event = xcb_wait_for_event(conn)) != NULL) {
+        free(event);
+    }
+
+    xcb_disconnect(conn);
+    return 0;
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-systray.lua
+++ b/tests/test-systray.lua
@@ -1,0 +1,90 @@
+local spawn = require("awful.spawn")
+local wibox = require("wibox")
+local beautiful = require("beautiful")
+
+local steps, pid1, pid2, draw_w, st = {}
+
+table.insert(steps, function()
+    screen[1].mywibox:remove()
+
+    local widget = wibox.widget.base.make_widget()
+
+    function widget:fit(_, w, h)
+        return w, h
+    end
+
+    function widget:draw(_, _, width)
+        draw_w = width
+    end
+
+    local wb = wibox {
+        x       = 0,
+        y       = 0,
+        width   = 100,
+        height  = 20,
+        visible = true
+    }
+
+    st = wibox.widget.systray()
+
+    wb.widget = {
+        st,
+        widget,
+        layout = wibox.layout.fixed.horizontal
+    }
+
+    pid1 = spawn("./test-systray")
+
+    return true
+end)
+
+table.insert(steps, function()
+    if draw_w ~= 80 then return end
+
+    pid2 = spawn("./test-systray")
+
+    return true
+end)
+
+table.insert(steps, function()
+    if draw_w ~= 60 then return end
+
+    st.reverse = true
+    st.horizontal = false
+
+    return true
+end)
+
+table.insert(steps, function()
+    st.horizontal = true
+
+    beautiful.systray_icon_spacing = 10
+
+    return true
+end)
+
+
+table.insert(steps, function()
+    if draw_w ~= 50 then return end
+
+    st.base_size = 5
+    return true
+end)
+
+
+table.insert(steps, function()
+    if draw_w ~= 80 then return end
+
+    awesome.kill(pid1, 9)
+    awesome.kill(pid2, 9)
+
+    return true
+end)
+
+
+table.insert(steps, function()
+    if draw_w ~= 100 then return end
+    return true
+end)
+
+require("_runner").run_steps(steps)

--- a/tests/test-wallpaper.lua
+++ b/tests/test-wallpaper.lua
@@ -270,7 +270,6 @@ end)
 table.insert(steps, function(count)
     if count == 1 then return end
 
-    print(paint_width, paint_height, screen[1].geometry.width, screen[1].geometry.height)
     assert(paint_width == screen[1].geometry.width)
     assert(paint_height == screen[1].geometry.height)
 


### PR DESCRIPTION
There are various flacky coverage sections in `events.c`, `xproperty.c` and `spawn.c`. This PR adds some explicit tests to make 4 flacky paths coverage stable.

Much more will be needed, like reparenting tests and startup notification tests. But lets do this over many PRs.

(this is to make Mergify more useful)