### PR TITLE
LC_CTYPE replaced with LC_ALL

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -588,7 +588,7 @@ main(int argc, char **argv)
     awesome_argv = argv;
 
     /* Text won't be printed correctly otherwise */
-    setlocale(LC_CTYPE, "");
+    setlocale(LC_ALL, "");
 
     char *confpath = options_detect_shebang(argc, argv);
 


### PR DESCRIPTION
## Changes

- `LC_CTYPE` replaced with `LC_ALL`, in `setlocale`

## Explanation

As the docs explain in [textclock widget](https://awesomewm.org/apidoc/widgets/wibox.widget.textclock.html), GLIB should format the date according to the locale.

In my case, the locale is `LANG = es_NI.UTF-8` and `LANGUAGE = es_ES`. And therefore, date format should be in spanish, but AwesomeWM does not format in that way, it's just english.

In the image below, you can see the actual behavior (wibar above), which uses `setlocale(LC_CTYPE, "")`, and the expected behavior (wibar below), that uses `setlocale(LC_ALL, "")`, with `wibox.widget.textclock("%a %B %Y - %H:%M")`

![Screenshot_2021-11-01-55_675x568](https://user-images.githubusercontent.com/59768785/139718160-d3b024f4-cd55-46ae-8077-e48c1a7bab98.png)
