### PR TITLE
fix: make markup available

### DIFF
--- a/lib/awful/widget/calendar_popup.lua
+++ b/lib/awful/widget/calendar_popup.lua
@@ -137,11 +137,14 @@ local function parse_cell_options(cell, args)
         -- Get default
         props[prop] = args[prop] or beautiful["calendar_" .. cell .. "_" .. prop] or bl_style[prop] or default
     end
-    props['markup'] = cell == "focus" and
-        (args['markup'] or beautiful["calendar_" .. cell .. "_markup"] or bl_style['markup'] or
-        string.format('<span foreground="%s" background="%s"><b>%s</b></span>',
-            props['fg_color'], props['bg_color'], "%s")
+    if cell == "focus" and props.markup == nil then
+        local fg = props.fg_color and string.format('foreground="%s"', props.fg_color) or ""
+        local bg = props.bg_color and string.format('background="%s"', props.bg_color) or ""
+        props.markup = string.format(
+            '<span %s %s><b>%s</b></span>',
+            fg, bg, "%s"
         )
+    end
     return props
 end
 

--- a/lib/awful/widget/calendar_popup.lua
+++ b/lib/awful/widget/calendar_popup.lua
@@ -46,6 +46,9 @@ local styles = { "year", "month", "yearheader", "monthheader", "header", "weekda
 -- @tparam cell_properties table Table of cell style properties
 
 --- Cell properties.
+--
+-- @DOC_awful_widget_calendar_popup_cell_properties_EXAMPLE@
+--
 -- @field markup Markup function or format string
 -- @field fg_color Text foreground color
 -- @field bg_color Text background color

--- a/tests/examples/awful/widget/calendar_popup/cell_properties.lua
+++ b/tests/examples/awful/widget/calendar_popup/cell_properties.lua
@@ -1,0 +1,42 @@
+--DOC_HIDE_START --DOC_GEN_IMAGE
+local awful = require("awful")
+local wibox = require("wibox")
+
+screen[1]._resize { width = 480, height = 200 }
+
+local wb = awful.wibar { position = "top", }
+
+-- Create the same number of tags as the default config
+awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, screen[1], awful.layout.layouts[1])
+
+-- Only bother with widgets that are visible by default
+local mykeyboardlayout = awful.widget.keyboardlayout()
+local my_text_clock = wibox.widget.textclock()
+local mytaglist = awful.widget.taglist(screen[1], awful.widget.taglist.filter.all, {})
+local mytasklist = awful.widget.tasklist(screen[1], awful.widget.tasklist.filter.currenttags, {})
+--DOC_HIDE_END
+
+local my_header_properties = {
+    markup = function(text) return "<i>" .. text .. "</i>" end,
+}
+local my_options = { style_header = my_header_properties, }
+local month_calendar = awful.widget.calendar_popup.month(my_options)
+month_calendar:attach(my_text_clock, "tr")
+
+--DOC_HIDE_START
+wb:setup {
+    layout = wibox.layout.align.horizontal,
+    {
+        mytaglist,
+        layout = wibox.layout.fixed.horizontal,
+    },
+    mytasklist,
+    {
+        layout = wibox.layout.fixed.horizontal,
+        mykeyboardlayout,
+        my_text_clock,
+    },
+}
+month_calendar:toggle()
+
+--vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80 --DOC_HIDE_END


### PR DESCRIPTION
Note: This text has been translated from [DeepL](https://www.deepl.com/translator).

Currently, the `markup` in `awful.widget.calendar_popup.cell_properties` is not working.

In [this line](https://github.com/awesomeWM/awesome/blob/master/lib/awful/widget/calendar_popup.lua#L140), if `prop` is `'markup'`, reassign to `props[prop]`. Assign `false` to `props['markup']` when `cell` is not `"focus"`. This is unintended behavior, since `markup` is either a Markup function or a format string.

My pull request is a fix to avoid that behavior. I haven't made many changes to account for [this pull request](https://github.com/awesomeWM/awesome/pull/2269).