### PR TITLE
Signalled error: bad argument #3 to 'timeout_add' (number has no integer representation)

### DIFF
--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -61,6 +61,7 @@ local glib = require("lgi").GLib
 local object = require("gears.object")
 local protected_call = require("gears.protected_call")
 local gdebug = require("gears.debug")
+local gmath = require("gears.math")
 
 --- Timer objects. This type of object is useful when triggering events repeatedly.
 -- The timer will emit the "timeout" signal every N seconds, N being the timeout
@@ -91,7 +92,7 @@ function timer:start()
         gdebug.print_error(traceback("timer already started"))
         return
     end
-    local timeout_ms = math.floor(self.data.timeout * 1000 + 0.5)
+    local timeout_ms = gmath.round(self.data.timeout * 1000)
     self.data.source_id = glib.timeout_add(glib.PRIORITY_DEFAULT, timeout_ms, function()
         protected_call(self.emit_signal, self, "timeout")
         return true

--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -91,7 +91,8 @@ function timer:start()
         gdebug.print_error(traceback("timer already started"))
         return
     end
-    self.data.source_id = glib.timeout_add(glib.PRIORITY_DEFAULT, self.data.timeout * 1000, function()
+    local timeout_ms = math.floor(self.data.timeout * 1000 + 0.5)
+    self.data.source_id = glib.timeout_add(glib.PRIORITY_DEFAULT, timeout_ms, function()
         protected_call(self.emit_signal, self, "timeout")
         return true
     end)

--- a/lib/wibox/hierarchy.lua
+++ b/lib/wibox/hierarchy.lua
@@ -172,6 +172,10 @@ function hierarchy_update(self, context, widget, width, height, region, matrix_t
     -- Are there any children which were removed? Their area needs a redraw.
     for _, child in ipairs(old_children) do
         local x, y, w, h = matrix.transform_rectangle(child._matrix_to_device, child:get_draw_extents())
+        x = math.floor(x)
+        y = math.floor(y)
+        w = math.ceil(w)
+        h = math.ceil(h)
         region:union_rectangle(cairo.RectangleInt{
             x = x, y = y, width = w, height = h
         })


### PR DESCRIPTION
Output of `awesome --version`:

```
awesome v4.3-1314-ge7a21947e-dirty (Too long)
 • Compiled against Lua 5.3.6 (running with Lua 5.3)
 • API level: 4
 • D-Bus support: yes
 • xcb-errors support: yes
 • execinfo support: yes
 • xcb-randr version: 1.6
 • LGI version: 0.9.2
 • Transparency enabled: yes
 • Custom search paths: no
```

Steps to reproduce:
```
$ lua5.3
> require'lgi'.GLib.timeout_add(0, 1/60, function() end)
```

At [awful/permissions/init.lua:471](https://github.com/awesomeWM/awesome/blob/e7a21947e6785f53042338c684b9b96cc9b0f500/lib/awful/permissions/init.lua#L471) the timeout is set to `1/60` which is 0.016̅ - and then at [gears/timer.lua:94](https://github.com/awesomeWM/awesome/blob/e7a21947e6785f53042338c684b9b96cc9b0f500/lib/gears/timer.lua#L94) after multiplication by a 1000 it becomes 16.6̅ - which suddenly started being an issue (I'm guessing after an lgi update) as I get awesome error notification that's in the title.

By adding `math.floor` for the argument in the second place I not only fixed this, but also a couple of other small silent-ish issues I was having - clients sometimes spawning non-maximized on maximized tags on startup, wibar sometimes taking an entire screen on startup requiring to reload awesome a couple of times to fix, probably a couple more, was blaming on potentially outdated things in my `rc.lua` while installing the bleeding-edge-yesterday-commits, finally found time to try to fix them.

The fix was trivial to convert an issue to a PR.