### PR TITLE
Apply presets before registering notification

### DIFF
--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -1029,13 +1029,13 @@ local function create(args)
 
     n.id = n.id or notification._gen_next_id()
 
-    -- Register the notification before requesting a widget
-    n:emit_signal("new", args)
-
     -- The rules are attached to this.
     if naughty._has_preset_handler then
         naughty.emit_signal("request::preset", n, "new", args)
     end
+
+    -- Register the notification before requesting a widget
+    n:emit_signal("new", args)
 
     -- Let all listeners handle the actual visual aspects
     if (not n.ignore) and ((not n.preset) or n.preset.ignore ~= true) and (not get_suspended(n)) then


### PR DESCRIPTION
## Issue
This PR fixes an issue I have encountered when using a notification rule to apply a default position to all notifications.
```lua
ruled.notification.append_rule {
    rule = { },
    properties = {
        position = beautiful.notification_position
    }
}
```
This created a problem because when a notification was created, it was registered with naughty before the notification rules were applied. The notification would then be registered with the default position of `"top_right"` instead of the position specified in the rules. The notification will still be displayed in the right position because the rules are applied before emitting the `"request::display"` signal. The problem comes when clicking on a notification (that isn't in index 1) to destroy it. The assertion in `cleanup()` in core.lua fails because the notification was registered under `"top_right"` but the assertion expects it to be under a different position. In practice this means the `idx` property will be wrong.
## Fix
The simple solution to this is applying the notification presets before registering the notification to ensure all the notification properties have been updated before registering.