### PR TITLE
[RFC] Implement wibox.widget.template for the awful.widget.layoutbox

### DIFF
--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -6,7 +6,7 @@
 -- @author Julien Danjou &lt;julien@danjou.info&gt;
 -- @copyright 2009 Julien Danjou
 -- @widgetmod awful.widget.layoutbox
--- @supermodule wibox.layout.fixed
+-- @supermodule wibox.widget.template
 ---------------------------------------------------------------------------
 
 local setmetatable = setmetatable
@@ -20,28 +20,62 @@ local gdebug = require("gears.debug")
 local gtable = require("gears.table")
 
 local function get_screen(s)
-    return s and capi.screen[s]
+    return s and capi.screen[s] or 1
+end
+
+local default_template = {
+    {
+        {
+            id = "icon_role",
+            widget = wibox.widget.imagebox,
+        },
+        {
+            id = "text_role",
+            widget = wibox.widget.imagebox,
+        },
+        fill_space = true,
+        layout = wibox.layout.fixed.horizontal,
+    },
+    id = "background_role",
+    widget = wibox.container.background,
+}
+
+local function default_update_callback(template_widget, args)
+    screen = get_screen(args.screen)
+    local w = template_widget.widget
+    local name = layout.getname(layout.get(screen))
+
+    template_widget._layoutbox_tooltip:set_text(name or "[no name]")
+
+    local img = surface.load_silently(beautiful["layout_" .. name], false)
+    w:get_children_by_id("icon_role")[1].image = img
+    w:get_children_by_id("text_role")[1].text = img and "" or name
+end
+
+local function build_default_widget()
+    local widget = wibox.widget.template {
+        template = default_template,
+        update_callback = default_update_callback,
+        update_now = true,
+    }
+
+    widget._layoutbox_tooltip = tooltip {
+        objects = { widget },
+        delay_show = 1,
+    }
+
+    return widget
 end
 
 local layoutbox = { mt = {} }
 
 local boxes = nil
 
-local function update(w, screen)
-    screen = get_screen(screen)
-    local name = layout.getname(layout.get(screen))
-    w._layoutbox_tooltip:set_text(name or "[no name]")
-
-    local img = surface.load_silently(beautiful["layout_" .. name], false)
-    w.imagebox.image = img
-    w.textbox.text   = img and "" or name
-end
-
 local function update_from_tag(t)
     local screen = get_screen(t.screen)
     local w = boxes[screen]
     if w then
-        update(w, screen)
+        w:update { screen = screen }
     end
 end
 
@@ -50,6 +84,11 @@ end
 -- @tparam table args The arguments.
 -- @tparam screen args.screen The screen number that the layout will be represented for.
 -- @tparam table args.buttons The `awful.button`s for this layoutbox.
+-- @tparam[opt] table args.widget_template Widget template arguments.
+-- @tparam[opt] widget args.widget_template.template Base widget for the
+--   template.
+-- @tparam[opt] function args.widget_template.update_callback Update function
+--   for the widget template.
 -- @return The layoutbox.
 function layoutbox.new(args)
     args = args or {}
@@ -76,7 +115,7 @@ function layoutbox.new(args)
         capi.tag.connect_signal("property::screen", function()
             for s, w in pairs(boxes) do
                 if s.valid then
-                    update(w, s)
+                    w:update { screen = s }
                 end
             end
         end)
@@ -86,24 +125,13 @@ function layoutbox.new(args)
     -- Do we already have a layoutbox for this screen?
     local w = boxes[screen]
     if not w then
-        w = wibox.widget {
-            {
-                id     = "imagebox",
-                widget = wibox.widget.imagebox
-            },
-            {
-                id     = "textbox",
-                widget = wibox.widget.textbox
-            },
-            layout = wibox.layout.fixed.horizontal
-        }
-
-        w._layoutbox_tooltip = tooltip {objects = {w}, delay_show = 1}
+        w = args.widget_template and wibox.widget.template(args.widget_template)
+            or build_default_widget()
 
         -- Apply the buttons, visible, forced_width and so on
         gtable.crush(w, args)
 
-        update(w, screen)
+        w:update { screen = screen }
         boxes[screen] = w
     end
 

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -96,7 +96,7 @@ local clienticon = require("awful.widget.clienticon")
 local wbackground = require("wibox.container.background")
 
 local function get_screen(s)
-    return s and screen[s]
+    return s and capi.screen[s]
 end
 
 local tasklist = { mt = {} }

--- a/lib/wibox/widget/init.lua
+++ b/lib/wibox/widget/init.lua
@@ -21,6 +21,7 @@ local widget = {
     slider = require("wibox.widget.slider");
     calendar = require("wibox.widget.calendar");
     separator = require("wibox.widget.separator");
+    template = require("wibox.widget.template");
 }
 
 setmetatable(widget, {

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -21,8 +21,22 @@ local template = {
     queued_updates = {},
 }
 
-function template:fit(...)
-    return self._private.widget:fit(...)
+-- Layout this layout
+function template:layout(_, width, height)
+    if not self._private.widget then
+        return
+    end
+
+    return { wbase.place_widget_at(self._private.widget, 0, 0, width, height) }
+end
+
+-- Fit this layout into the given area.
+function template:fit(context, width, height)
+    if not self._private.widget then
+        return 0, 0
+    end
+
+    return wbase.fit_widget(self, context, self._private.widget, width, height)
 end
 
 function template:draw(...)

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -134,15 +134,13 @@ function template:update(args)
 end
 
 --- Change the widget template.
--- @tparam table|widget|function widget_template The new widget to use as a
+-- @tparam table|widget widget_template The new widget to use as a
 --   template.
 -- @method set_template
 -- @emits widget::redraw_needed
 -- @hidden
 function template:set_template(widget_template)
-    local widget = type(widget_template) == "function" and widget_template()
-        or widget_template
-        or wbase.empty_widget()
+    local widget = widget_template or wbase.empty_widget()
 
     local widget_instance = wbase.make_widget_from_value(widget)
 
@@ -204,7 +202,7 @@ end
 
 --- Create a new `wibox.widget.template` instance.
 -- @tparam[opt] table args
--- @tparam[opt] table|widget|function args.template The widget template to use.
+-- @tparam[opt] table|widget args.template The widget template to use.
 -- @tparam[opt] function args.update_callback The callback function to update
 --   the widget.
 -- @tparam[opt] boolean args.update_now Update the widget after its

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -25,9 +25,9 @@ local template = {
 
 function template:_do_update_now()
     if type(self.update_callback) == "function" then
-        self:update_callback(self.update_args)
+        self:update_callback(self._private.update_args)
     end
-    self.update_args = nil
+    self._private.update_args = nil
     template.queued_updates[self] = false
 end
 
@@ -40,7 +40,7 @@ end
 -- All arguments are passed to the queued `update_callback` call.
 function template:update(args)
     if type(args) == "table" then
-        self.update_args = gtable.crush(gtable.clone(self.update_args or {}, false), args)
+        self._private.update_args = gtable.crush(gtable.clone(self._private.update_args or {}, false), args)
     end
 
     if not template.queued_updates[self] then

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -216,9 +216,8 @@ function template.new(args)
     ret:set_update_callback(args.update_callback)
     ret:set_update_now(args.update_now)
 
-    if args.buttons then
-        ret:set_buttons(args.buttons)
-    end
+    -- Apply the received buttons, visible, forced_width and so on
+    gtable.crush(ret, args)
 
     return ret
 end

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -51,7 +51,7 @@ function template:_do_update_now()
     end
 
     self._private.update_args = nil
-    template.queued_updates[self] = false
+    template.queued_updates[self] = nil
 end
 
 --- Update the widget.

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -144,8 +144,14 @@ function template:set_template(widget_template)
         or widget_template
         or wbase.empty_widget()
 
+    local widget_instance = wbase.make_widget_from_value(widget)
+
+    if widget_instance then
+        wbase.check_widget(widget_instance)
+    end
+
     self._private.template = widget
-    self._private.widget = wbase.make_widget_from_value(widget)
+    self._private.widget = widget_instance
 
     -- We need to connect to these signals to actually redraw the template
     -- widget when its child needs to.

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -1,0 +1,90 @@
+---------------------------------------------------------------------------
+-- An abstract widget that handles a preset of concrete widget.
+--
+-- The `wibox.widget.template` widget is an abstraction layer that contains a
+-- concrete widget definition. The template widget can be used to build widgets
+-- that the user can customize at their will, thanks to the template mechanism.
+--
+-- @author Aire-One
+-- @copyright 2021 Aire-One <aireone@aireone.xyz>
+--
+-- @classmod wibox.widget.template
+-- @supermodule wibox.widget.base
+---------------------------------------------------------------------------
+
+local wbase = require("wibox.widget.base")
+local gtable = require("gears.table")
+local gtimer = require("gears.timer")
+
+local default_update_callback = function()
+    return nil
+end
+
+local default_template_widget = wbase.empty_widget()
+
+local template = {
+    mt = {},
+    queued_updates = {}
+}
+
+function template:_do_update_now(args)
+    self:update_callback(args)
+    template.queued_updates[self] = false
+end
+
+--- Update the widget.
+-- This function will call the `update_callback` function at the end of the
+-- current GLib event loop. Updates are batched by event loop, it means that the
+-- widget can only be update once by event loop. If the `template:update` method
+-- is called multiple times during the same GLib event loop, only the first call
+-- will be run.
+-- All arguments are passed to the queued `update_callback` call.
+-- @treturn boolean Returns `true` if the update_callback have been queued to be
+--   run at the end of the event loop. Returns `false` if there is already an update
+--   in the queue (in this case, this new update request is discared).
+function template:update(args)
+    local update_args = gtable.crush(gtable.clone(self.update_args, false), args or {})
+
+    if not template.queued_updates[self] then
+        gtimer.delayed_call(
+            function()
+                self:_do_update_now(update_args)
+            end
+        )
+        template.queued_updates[self] = true
+
+        return true
+    end
+
+    return false
+end
+
+--- Create a new `wibox.widget.template` instance.
+-- @tparam[opt] table args
+-- @tparam[opt] table|widget|function args.widget_template The template of widget to use.
+-- @tparam[opt] function args.update_callback The callback function to update the widget.
+-- @treturn wibox.widget.template The new instance.
+function template.new(args)
+    args = args or {}
+
+    local widget_template =
+        type(args.widget_template) == "function" and args.widget_template() or args.widget_template or
+        default_template_widget
+
+    local widget = wbase.make_widget_from_value(widget_template)
+
+    widget.update_callback = args.update_callback or default_update_callback
+    widget.update_args = args.update_args or {}
+
+    gtable.crush(widget, template, true)
+
+    return widget
+end
+
+function template.mt:__call(...) --luacheck: ignore unused variable self
+    return template.new(...)
+end
+
+return setmetatable(template, template.mt)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -22,6 +22,32 @@
 --
 --@DOC_wibox_widget_template_basic_textbox_declarative_EXAMPLE@
 --
+-- Usage in libraries
+-- ==================
+--
+-- (this part is to be completed according to awful.widget comming PRs to implement the widget_template usage)
+--
+-- This widget was designed to be used as a standard way to offer customization
+-- over concrete widget implementation. We use the `wibox.widget.template` as a
+-- base to implement widgets from the `awful.widget` library. This way, it is
+-- easy for the final user to customize the standard widget offered by awesome!
+--
+-- It is possible to use the template widget as a base for a custom 3rd party
+-- widget module to offer more customization to the final user.
+--
+-- Here is an example of implementation for a custom widget inheriting from
+-- `wibox.widget.template` :
+--
+-- The module definition should include a default widget and a builder function
+-- that can build the widget with either, the user values or the default.
+--
+--@DOC_wibox_widget_template_concrete_implementation_module_EXAMPLE@
+--
+-- On the user side, it only requires to call the builder function to get an
+-- instance of the widget.
+--
+--@DOC_wibox_widget_template_concrete_implementation_user_EXAMPLE@
+--
 -- @author Aire-One
 -- @copyright 2021 Aire-One <aireone@aireone.xyz>
 --

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -16,8 +16,6 @@ local wbase = require("wibox.widget.base")
 local gtable = require("gears.table")
 local gtimer = require("gears.timer")
 
-local default_template_widget = wbase.empty_widget()
-
 local template = {
     mt = {},
     queued_updates = {}
@@ -55,15 +53,16 @@ end
 
 --- Create a new `wibox.widget.template` instance.
 -- @tparam[opt] table args
--- @tparam[opt] table|widget|function args.widget_template The template of widget to use.
+-- @tparam[opt] table|widget|function args.template The widget template to use.
 -- @tparam[opt] function args.update_callback The callback function to update the widget.
 -- @treturn wibox.widget.template The new instance.
 function template.new(args)
     args = args or {}
 
-    local widget_template =
-        type(args.widget_template) == "function" and args.widget_template() or args.widget_template or
-        default_template_widget
+    local widget_template = type(args.template) == "function" and
+        args.template() or
+        args.template or
+        wbase.empty_widget()
 
     local widget = wbase.make_widget_from_value(widget_template)
 

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -5,10 +5,27 @@
 -- concrete widget definition. The template widget can be used to build widgets
 -- that the user can customize at their will, thanks to the template mechanism.
 --
+-- Common usage examples
+-- =====================
+--
+-- A basic implementation of the template widget needs a widget definition and
+-- a callback to manage widget updates.
+--
+-- The `:update()` can be called later to update the widget template. Arguments
+-- can be provided to the `:update()` method, it will be forwarded to the
+-- `update_callback` function.
+--
+--@DOC_wibox_widget_template_basic_textbox_EXAMPLE@
+--
+-- Alternatively, you can declare the `template` widget instance using the
+-- declarative pattern (both variants are strictly equivalent):
+--
+--@DOC_wibox_widget_template_basic_textbox_declarative_EXAMPLE@
+--
 -- @author Aire-One
 -- @copyright 2021 Aire-One <aireone@aireone.xyz>
 --
--- @classmod wibox.widget.template
+-- @widgetmod wibox.widget.template
 -- @supermodule wibox.widget.base
 ---------------------------------------------------------------------------
 

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -38,15 +38,16 @@ end
 -- All arguments are passed to the queued `update_callback` call.
 function template:update(args)
     if type(args) == "table" then
-        self._private.update_args = gtable.crush(gtable.clone(self._private.update_args or {}, false), args)
+        self._private.update_args = gtable.crush(
+            gtable.clone(self._private.update_args or {}, false),
+            args
+        )
     end
 
     if not template.queued_updates[self] then
-        gtimer.delayed_call(
-            function()
-                self:_do_update_now()
-            end
-        )
+        gtimer.delayed_call(function()
+            self:_do_update_now()
+        end)
         template.queued_updates[self] = true
     end
 end

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -16,10 +16,6 @@ local wbase = require("wibox.widget.base")
 local gtable = require("gears.table")
 local gtimer = require("gears.timer")
 
-local default_update_callback = function()
-    return nil
-end
-
 local default_template_widget = wbase.empty_widget()
 
 local template = {
@@ -28,7 +24,9 @@ local template = {
 }
 
 function template:_do_update_now(args)
-    self:update_callback(args)
+    if type(self.update_callback) == 'function' then
+        self:update_callback(args)
+    end
     template.queued_updates[self] = false
 end
 
@@ -73,7 +71,7 @@ function template.new(args)
 
     local widget = wbase.make_widget_from_value(widget_template)
 
-    widget.update_callback = args.update_callback or default_update_callback
+    widget.update_callback = args.update_callback
     widget.update_args = args.update_args or {}
 
     gtable.crush(widget, template, true)

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -41,9 +41,8 @@ end
 --   run at the end of the event loop. Returns `false` if there is already an update
 --   in the queue (in this case, this new update request is discared).
 function template:update(args)
-    local update_args = gtable.crush(gtable.clone(self.update_args, false), args or {})
-
     if not template.queued_updates[self] then
+        local update_args = gtable.crush(gtable.clone(self.update_args, false), args or {})
         gtimer.delayed_call(
             function()
                 self:_do_update_now(update_args)

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -117,6 +117,10 @@ function template.new(args)
     ret:set_update_callback(args.update_callback)
     ret:set_update_now(args.update_now)
 
+    if args.buttons then
+        ret:set_buttons(args.buttons)
+    end
+
     return ret
 end
 

--- a/lib/wibox/widget/template.lua
+++ b/lib/wibox/widget/template.lua
@@ -40,7 +40,9 @@ function template:fit(context, width, height)
 end
 
 function template:draw(...)
-    return self._private.widget:draw(...)
+    if type(self._private.widget.draw) == "function" then
+        return self._private.widget:draw(...)
+    end
 end
 
 function template:_do_update_now()

--- a/spec/preload.lua
+++ b/spec/preload.lua
@@ -4,7 +4,10 @@
 require("lgi")
 
 -- Always show deprecated messages
-_G.awesome = {version = "v9999"}
+_G.awesome = {
+    version = "v9999",
+    api_level = 9999,
+}
 
 -- "fix" some intentional beautiful breakage done by .travis.yml
 require("beautiful").init{a_key="a_value"}

--- a/spec/wibox/widget/template_spec.lua
+++ b/spec/wibox/widget/template_spec.lua
@@ -5,8 +5,8 @@
 
 _G.awesome.connect_signal = function() end
 
-local template = require("wibox.widget.template")
 local gtimer = require("gears.timer")
+local template = require("wibox.widget.template")
 
 describe("wibox.widget.template", function()
     local widget
@@ -15,7 +15,21 @@ describe("wibox.widget.template", function()
         widget = template()
     end)
 
-    describe("widget:update()", function()
+    describe(".new()", function()
+        it("update_now", function()
+            local spied_update_callback = spy.new(function() end)
+
+            template {
+                update_callback = function(...) spied_update_callback(...) end,
+                update_now = true,
+            }
+
+            gtimer.run_delayed_calls_now()
+            assert.spy(spied_update_callback).was.called()
+        end)
+    end)
+
+    describe(":update()", function()
         it("batch calls", function()
             local spied_update_callback = spy.new(function() end)
 
@@ -66,7 +80,6 @@ describe("wibox.widget.template", function()
                 match.is_same { foo = "bar", bar = 10 }
             )
         end)
-
     end)
 end)
 

--- a/spec/wibox/widget/template_spec.lua
+++ b/spec/wibox/widget/template_spec.lua
@@ -1,0 +1,71 @@
+---------------------------------------------------------------------------
+-- @author Aire-One
+-- @copyright 2021 Aire-One
+---------------------------------------------------------------------------
+
+_G.awesome.connect_signal = function() end
+
+local template = require("wibox.widget.template")
+local gtable = require("gears.table")
+local gtimer = require("gears.timer")
+
+local function is_same_table_struture(state, arguments) -- luacheck: ignore unused argument state
+    return function(value)
+        return table.concat(gtable.keys(arguments[1])) == table.concat(gtable.keys(value))
+    end
+end
+
+assert:register(
+    "matcher",
+    "is_same_table_struture",
+    is_same_table_struture
+)
+
+describe("wibox.widget.template", function()
+    local widget
+
+    before_each(function()
+        widget = template()
+    end)
+
+    describe("widget:update()", function()
+        it("batch calls", function()
+            local spied_update_callback = spy.new(function() end)
+
+            widget.update_callback = spied_update_callback
+
+            -- Multiple calls to update
+            widget:update()
+            widget:update()
+            widget:update()
+
+            -- update_callback shouldn't be called before the end of the event loop
+            assert.spy(spied_update_callback).was.called(0)
+
+            gtimer.run_delayed_calls_now()
+
+            -- updates are batched, so only 1 call should have been performed
+            assert.spy(spied_update_callback).was.called(1)
+        end)
+
+        it("update parameters", function()
+            local spied_update_callback = spy.new(function() end)
+            local args_structure = { foo = "string" }
+            local update_args = { foo = "bar" }
+
+            widget.update_args = args_structure
+            widget.update_callback = spied_update_callback
+
+            widget:update(update_args)
+
+            gtimer.run_delayed_calls_now()
+
+            assert.spy(spied_update_callback).was.called_with(
+                match.is_ref(widget),
+                match.is_same_table_struture(widget.update_args)
+            )
+        end)
+    end)
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/spec/wibox/widget/template_spec.lua
+++ b/spec/wibox/widget/template_spec.lua
@@ -50,21 +50,36 @@ describe("wibox.widget.template", function()
 
         it("update parameters", function()
             local spied_update_callback = spy.new(function() end)
-            local args_structure = { foo = "string" }
-            local update_args = { foo = "bar" }
+            local args = { foo = "string" }
 
-            widget.update_args = args_structure
             widget.update_callback = function(...) spied_update_callback(...) end
 
-            widget:update(update_args)
+            widget:update(args)
 
             gtimer.run_delayed_calls_now()
 
             assert.spy(spied_update_callback).was.called_with(
                 match.is_ref(widget),
-                match.is_same_table_struture(widget.update_args)
+                match.is_same(args)
             )
         end)
+
+        it("crush update parameters", function()
+            local spied_update_callback = spy.new(function() end)
+
+            widget.update_callback = function(...) spied_update_callback(...) end
+
+            widget:update { foo = "bar" }
+            widget:update { bar = 10 }
+
+            gtimer.run_delayed_calls_now()
+
+            assert.spy(spied_update_callback).was.called_with(
+                match.is_ref(widget),
+                match.is_same { foo = "bar", bar = 10 }
+            )
+        end)
+
     end)
 end)
 

--- a/spec/wibox/widget/template_spec.lua
+++ b/spec/wibox/widget/template_spec.lua
@@ -32,7 +32,7 @@ describe("wibox.widget.template", function()
         it("batch calls", function()
             local spied_update_callback = spy.new(function() end)
 
-            widget.update_callback = spied_update_callback
+            widget.update_callback = function(...) spied_update_callback(...) end
 
             -- Multiple calls to update
             widget:update()
@@ -54,7 +54,7 @@ describe("wibox.widget.template", function()
             local update_args = { foo = "bar" }
 
             widget.update_args = args_structure
-            widget.update_callback = spied_update_callback
+            widget.update_callback = function(...) spied_update_callback(...) end
 
             widget:update(update_args)
 

--- a/spec/wibox/widget/template_spec.lua
+++ b/spec/wibox/widget/template_spec.lua
@@ -6,20 +6,7 @@
 _G.awesome.connect_signal = function() end
 
 local template = require("wibox.widget.template")
-local gtable = require("gears.table")
 local gtimer = require("gears.timer")
-
-local function is_same_table_struture(state, arguments) -- luacheck: ignore unused argument state
-    return function(value)
-        return table.concat(gtable.keys(arguments[1])) == table.concat(gtable.keys(value))
-    end
-end
-
-assert:register(
-    "matcher",
-    "is_same_table_struture",
-    is_same_table_struture
-)
 
 describe("wibox.widget.template", function()
     local widget

--- a/tests/examples/wibox/widget/template/basic_textbox.lua
+++ b/tests/examples/wibox/widget/template/basic_textbox.lua
@@ -1,0 +1,31 @@
+--DOC_GEN_IMAGE --DOC_NO_USAGE
+
+--DOC_HIDE_START
+local parent = ...
+local wibox = require("wibox")
+--DOC_HIDE_END
+
+    local my_template_widget = wibox.widget.template {
+        template = wibox.widget.textbox,
+        update_callback = function(template_widget, args)
+            local text = args.text or "???"
+            template_widget.widget.text = text
+        end,
+    }
+
+--DOC_NEWLINE
+    -- Later in the code
+
+--DOC_NEWLINE
+    -- With no arguments, the update_callback will fallback to "???"
+    my_template_widget:update()
+
+--DOC_NEWLINE
+    -- With custom arguments, the update_callback will changes the displayed text
+    my_template_widget:update { text = "Cool text to update the template!" }
+
+--DOC_HIDE_START
+
+parent:add(my_template_widget)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/template/basic_textbox_declarative.lua
+++ b/tests/examples/wibox/widget/template/basic_textbox_declarative.lua
@@ -1,0 +1,25 @@
+--DOC_NO_USAGE
+
+--DOC_HIDE_START
+local wibox = require("wibox")
+--DOC_HIDE_END
+
+    local my_template_widget = {
+        id = "mytemplatewidget",
+        template = wibox.widget.textbox,
+        update_callback = function(template_widget, args)
+            local text = args.text or "???"
+            template_widget.widget.text = text
+        end,
+        widget = wibox.widget.template,
+    }
+
+--DOC_HIDE_START
+
+-- Generate the widget to use the update method in the example.
+-- A better approch would have been to use an ID and the `get_children_by_id`
+-- on the parent.
+local widget = wibox.widget(my_template_widget)
+widget:update { text = "Cool text to update the template!" }
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/template/concrete_implementation_module.lua
+++ b/tests/examples/wibox/widget/template/concrete_implementation_module.lua
@@ -1,0 +1,56 @@
+--DOC_NO_USAGE
+
+--DOC_HIDE_START
+local parent = ...
+
+local gears = require("gears")
+local wibox = require("wibox")
+
+local concrete_widget_template_builder
+--DOC_HIDE_END
+
+    -- Build the default widget used as a fallback if user doesn't provide a template
+    local default_widget = {
+        template = wibox.widget.textclock,
+        update_callback = function(widget_template, args)
+            local text = args and args.text or "???"
+            widget_template.widget.text = text
+        end,
+    }
+
+--DOC_NEWLINE
+    function concrete_widget_template_builder(args)
+        args = args or {}
+
+--DOC_NEWLINE
+        -- Build an instance of the template widget with either, the
+        -- user provided parameters or the default
+        local ret =  wibox.widget.template(
+            args.widget_template and args.widget_template or
+            default_widget
+        )
+
+--DOC_NEWLINE
+            -- Patch the methods and fields the widget instance should have
+
+--DOC_NEWLINE
+            -- e.g. Apply the received buttons, visible, forced_width and so on
+            gears.table.crush(ret, args)
+
+--DOC_NEWLINE
+            -- Optionally, call update once with parameters to prepare the widget
+            ret:update {
+                text = "default text",
+            }
+
+--DOC_NEWLINE
+        return ret
+    end
+
+--DOC_HIDE_START
+
+local w = concrete_widget_template_builder()
+parent:add(w)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80
+

--- a/tests/examples/wibox/widget/template/concrete_implementation_user.lua
+++ b/tests/examples/wibox/widget/template/concrete_implementation_user.lua
@@ -1,0 +1,38 @@
+--DOC_NO_USAGE
+
+--DOC_HIDE_START
+local parent = ...
+
+local wibox = require("wibox")
+
+local function concrete_widget_template_builder(args)
+    return wibox.widget.template(args)
+end
+--DOC_HIDE_END
+
+    -- Instanciate the widget with the default template
+    local default_widget = concrete_widget_template_builder()
+
+--DOC_NEWLINE
+    -- Instanciate the widget with a custom template
+    local custom_widget = concrete_widget_template_builder {
+        widget_template = {
+            template = wibox.widget.imagebox,
+            update_callback = function (template, args)
+                if args and args.text == "default text" then
+                    template.widget.image = "/path/to/image.png"
+                else
+                    template.widget.image = "/path/to/another-image.png"
+                end
+            end
+
+        }
+    }
+
+--DOC_HIDE_START
+
+parent:add(default_widget)
+parent:add(custom_widget)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80
+


### PR DESCRIPTION
Hello,

With my other PR (#3421) being ready for review, here is the implementation of the template widget for the `awful.widget.layoutbox`. This branch is based on the other PR, only the last commit (eba12a00f024f9a8fcca15c3f81510005860aca7) is relevant.

With the current implementation, an end-user can use/copypast this code example in the `awesomerc.lua` to customize the layoutbox:

```lua
    s.mylayoutbox = awful.widget.layoutbox {
        screen  = s,
        buttons = {
            awful.button({ }, 1, function () awful.layout.inc( 1) end),
            awful.button({ }, 3, function () awful.layout.inc(-1) end),
            awful.button({ }, 4, function () awful.layout.inc(-1) end),
            awful.button({ }, 5, function () awful.layout.inc( 1) end),
        },
        widget_template = {
            template = wibox.widget.textbox,
            update_callback = function(widget_template, args)
                local layout_name = args and args.screen and awful.layout.getname(awful.layout.get(args.screen)) or "dunno"

                widget_template.widget.text = "custom layoutbox : " .. layout_name
            end,
        },
    }
```

I open this PR in draft mode, waiting for the other one to be merged. After the merge, I'll rebase this branch, and it'll be ready.