### PR TITLE
add default wibox layout + minor change

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -29,7 +29,7 @@ require("awful.hotkeys_popup.keys")
 naughty.connect_signal("request::display_error", function(message, startup)
     naughty.notification {
         urgency = "critical",
-        title   = "Oops, an error happened"..(startup and " during startup!" or "!"),
+        title   = "Oops, an error occurred"..(startup and " during startup!" or "!"),
         message = message
     }
 end)

--- a/lib/wibox/widget/base.lua
+++ b/lib/wibox/widget/base.lua
@@ -11,6 +11,7 @@ local matrix = require("gears.matrix")
 local gdebug = require("gears.debug")
 local protected_call = require("gears.protected_call")
 local gtable = require("gears.table")
+local wibox = require("wibox")
 local setmetatable = setmetatable
 local pairs = pairs
 local type = type
@@ -700,7 +701,7 @@ local function drill(ids, content)
     if not content then return end
 
     -- Alias `widget` to `layout` as they are handled the same way.
-    content.layout = content.layout or content.widget
+    content.layout = content.layout or content.widget or wibox.layout.fixed.horizontal
 
     -- Make sure the layout is not indexed on a function.
     local layout = type(content.layout) == "function" and  content.layout() or content.layout

--- a/luaa.c
+++ b/luaa.c
@@ -1240,7 +1240,7 @@ luaA_loadrc(const char *confpath)
     const char *err = lua_tostring(L, -1);
     luaA_startup_error(err);
     fprintf(stderr, "%s\n", err);
-    /* An error happened, so reset this. */
+    /* An error occurred, so reset this. */
     conffile = NULL;
     /* Pop luaA_dofunction_on_error() and the error message */
     lua_pop(L, 2);


### PR DESCRIPTION
when no layout is specified no error will popup but instead it will use
the default `wibox.layout.fixed.horizontal`

and a minor change:
error happened -> error occurred (2x)