### PR TITLE
Refocus focused window for focus in events on the root window.

### DIFF
--- a/event.c
+++ b/event.c
@@ -696,6 +696,11 @@ event_handle_enternotify(xcb_enter_notify_event_t *ev)
 static void
 event_handle_focusin(xcb_focus_in_event_t *ev)
 {
+    if (ev->event == globalconf.screen->root) {
+        /* Received focus in for root window, refocusing the focused window */
+        globalconf.focus.need_update = true;
+    }
+
     if (ev->mode == XCB_NOTIFY_MODE_GRAB
             || ev->mode == XCB_NOTIFY_MODE_UNGRAB)
         /* Ignore focus changes due to keyboard grabs */


### PR DESCRIPTION
This deals with (admittedly somewhat misbehaving) clients which
use XSetInputFocus to take focus, but then don't properly restore
focus. This has been observed with TK apps, but also, e.g., Steam.

Ported from https://github.com/i3/i3/commit/a06e66982bc921d05b68b75f8e12323c284233d0 by @psychon 

Fixes https://github.com/awesomeWM/awesome/issues/3379