### PR TITLE
theme: remove mouse finder remnants

### DIFF
--- a/themes/default/theme.lua
+++ b/themes/default/theme.lua
@@ -38,7 +38,6 @@ theme.border_color_marked = "#91231c"
 -- tasklist_[bg|fg]_[focus|urgent]
 -- titlebar_[bg|fg]_[normal|focus]
 -- tooltip_[font|opacity|fg_color|bg_color|border_width|border_color]
--- mouse_finder_[color|timeout|animate_timeout|radius|factor]
 -- prompt_[fg|bg|fg_cursor|bg_cursor|font]
 -- hotkeys_[bg|fg|border_width|border_color|shape|opacity|modifiers_fg|label_bg|label_fg|group_margin|font|description_font]
 -- Example:

--- a/themes/gtk/theme.lua
+++ b/themes/gtk/theme.lua
@@ -143,7 +143,6 @@ end
 -- tasklist_[bg|fg|shape|shape_border_color|shape_border_width]_[focus|urgent|minimized]
 -- titlebar_[bg|fg]_[normal|focus]
 -- tooltip_[font|opacity|fg_color|bg_color|border_width|border_color]
--- mouse_finder_[color|timeout|animate_timeout|radius|factor]
 
 theme.tasklist_fg_normal = theme.wibar_fg
 theme.tasklist_bg_normal = theme.wibar_bg

--- a/themes/xresources/theme.lua
+++ b/themes/xresources/theme.lua
@@ -42,7 +42,6 @@ theme.border_color_marked = xrdb.color10
 -- tasklist_[bg|fg]_[focus|urgent]
 -- titlebar_[bg|fg]_[normal|focus]
 -- tooltip_[font|opacity|fg_color|bg_color|border_width|border_color]
--- mouse_finder_[color|timeout|animate_timeout|radius|factor]
 -- Example:
 --theme.taglist_bg_focus = "#ff0000"
 

--- a/themes/zenburn/theme.lua
+++ b/themes/zenburn/theme.lua
@@ -59,11 +59,6 @@ theme.titlebar_bg_normal = "#3F3F3F"
 --theme.border_widget    = "#3F3F3F"
 -- }}}
 
--- {{{ Mouse finder
-theme.mouse_finder_color = "#CC9393"
--- mouse_finder_[timeout|animate_timeout|radius|factor]
--- }}}
-
 -- {{{ Menu
 -- Variables set for theming the menu:
 -- menu_[bg|fg]_[normal|focus]


### PR DESCRIPTION
Was searching for `animate` in the code base, was surprised to stumble upon something I've never heard of and was eager to try it, but it appears that this functionality was removed back in 2016 but had some code left behind. :)