### PR TITLE
Group-Comments: corr in-consequences

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -210,6 +210,7 @@ screen.connect_signal("request::desktop_decoration", function(s)
         }
     }
 end)
+
 -- }}}
 
 -- {{{ Mouse bindings
@@ -516,7 +517,6 @@ ruled.client.connect_signal("request::rules", function()
     --     properties = { screen = 1, tag = "2" }
     -- }
 end)
-
 -- }}}
 
 -- {{{ Titlebars
@@ -558,6 +558,7 @@ client.connect_signal("request::titlebars", function(c)
         layout = wibox.layout.align.horizontal
     }
 end)
+-- }}}
 
 -- {{{ Notifications
 


### PR DESCRIPTION
Some group comments ("-- {{{" and/or "-- }}}") were either not closed or had in-consequences with line-feeds before or after.