### PR TITLE
Mergify doesn't pick up the GitHub Actions success status

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,8 +3,8 @@ pull_request_rules:
     conditions:
       - label!=no-mergify
       - '#approved-reviews-by>=2'
-      - status-success=Build & Test
-      - status-success=Update API docs
+      - check-success=Build & Test
+      - check-success=Update API docs
       - status-success=codecov/patch
     actions:
       merge:


### PR DESCRIPTION
Example with PR https://github.com/awesomeWM/awesome/pull/3225/checks?check_run_id=5167727706