### PR TITLE
[CI] Run `Run examples tests` on every supported Lua Version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -305,7 +305,6 @@ jobs:
         run: cd "${{ github.workspace }}/build" && make check-unit
 
       - name: Run examples tests
-        if: matrix.coverage
         run: cd "${{ github.workspace }}/build" && make check-examples
 
       - name: Run requires tests

--- a/tests/examples/wibox/widget/textbox/font1.lua
+++ b/tests/examples/wibox/widget/textbox/font1.lua
@@ -28,7 +28,16 @@ local ret = wibox.layout.fixed.vertical()
        --DOC_NEWLINE
        -- Use the low level Pango API to validate the font was parsed properly.
        local desc = pango.FontDescription.from_string(w.font)
-       print(w.font, desc:get_size(), desc:get_family(), desc:get_variant(), desc:get_style())
+       print(
+           string.format(
+               "%s %d %s %s %s",
+               w.font,
+               desc:get_size(),
+               desc:get_family(),
+               desc:get_variant(),
+               desc:get_style()
+            )
+       )
 
     --DOC_HIDE_START
 

--- a/tests/examples/wibox/widget/textbox/font1.output.txt
+++ b/tests/examples/wibox/widget/textbox/font1.output.txt
@@ -1,4 +1,4 @@
-sans	0.0	sans	NORMAL	NORMAL
-Roboto, Bold	0.0	Roboto	NORMAL	NORMAL
-DejaVu Sans, Oblique	0.0	DejaVu Sans	NORMAL	OBLIQUE
-Noto Mono, Regular	0.0	Noto Mono	NORMAL	NORMAL
+sans 0 sans NORMAL NORMAL
+Roboto, Bold 0 Roboto NORMAL NORMAL
+DejaVu Sans, Oblique 0 DejaVu Sans NORMAL OBLIQUE
+Noto Mono, Regular 0 Noto Mono NORMAL NORMAL


### PR DESCRIPTION
Hello,

I don't know the exact reason why we disabled this step in the first place.

The idea is to run the examples for every supported Lua version. With some luck, we would have seen the bug from https://github.com/awesomeWM/awesome/issues/3557 before.

This PR includes a fix about the Lua integer representation to force the output of the `tests/examples/wibox/widget/textbox/font1.lua` example to produce non-floating integers, regardless of the Lua version.

~~The remaining failure in Lua5.4 Job is what PR https://github.com/awesomeWM/awesome/pull/3572 fixes.~~ Now it's merged, I have rebase