### PR TITLE
Allow codecove to be green for small PRs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,6 @@ indent_size = 4
 # In a Makefile, the tab is significant and not "just" whitespace
 [Makefile]
 indent_style = tab
+
+[*.yml]
+indent_size = 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 5%
+        threshold: 0.5%


### PR DESCRIPTION
Hello,

We have some PRs that needs to be manually merged because codecov is red. Most of the time, they are simple fixes where codecove yields a reduction of coverage of -0.01%. The last example in date is https://github.com/awesomeWM/awesome/pull/3593 (I guess this PR will also be affected)

With this yml config, we allow a threshold of 5% (arbitrarily selected to allow a little bandwidth for quick fix/patch). 

I have no idea if it'll work. It's all assumption based on https://docs.codecov.com/docs/common-recipe-list and https://docs.codecov.com/docs/commit-status#threshold.