### PR TITLE
Always use the latest time on focus changes

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -1881,7 +1881,7 @@ client_focus_refresh(void)
      * new client gets the input focus.
      */
     xcb_set_input_focus(globalconf.connection, XCB_INPUT_FOCUS_PARENT,
-                        win, globalconf.timestamp);
+                        win, XCB_CURRENT_TIME);
 
     /* Do this last, because client_unban() might set it to true */
     globalconf.focus.need_update = false;


### PR DESCRIPTION
This is more to initiate the conversation than a final fix.

Telegram on awesome has a [very annoying issue](https://github.com/telegramdesktop/tdesktop/issues/1041) caused by focus.

Dead keys cannot be correctly used to reply to messages without switching focus out and in again to telegram. This is caused because when telegram opens the "reply to" popup and changes focus to it, that call updates the latest timestamp for a focusin in X, but awesome still has an older timestamp.

When awesome tries to focus the main telegram window again after the popup is closed, it sends an event with that prior timestamp and X ignores it.

The only solution I could think of was making X use the latest internal time, but I am not sure if that's ideal here.

# Questions

- Is there a better way of keeping track of the latest focusin timestamp?
- Why does awesome keep track of it at all?
- Could/should we use the computer clock for the time instead?