### PR TITLE
Update Debian install instructions

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -53,7 +53,7 @@ git clone https://github.com/awesomewm/awesome
 cd awesome
 make package
 cd build
-sudo apt install *.deb
+sudo dpkg -i *.deb
 ```
 
 ## Running Awesome


### PR DESCRIPTION
Because of [this line](https://github.com/awesomeWM/awesome/blob/master/Makefile#L8) in the Makefile, the .deb build goes to the `build` directory instead, so you need to `cd` into it to be able to install. The `apt install` command appears to be looking for the `.deb` in their own repositories instead of local as well any more, so I've changed it to the more successful `dpkg -I` command (See the below screenshot)

<img width="588" alt="image" src="https://user-images.githubusercontent.com/60970073/168101719-5d51f95c-10b5-4d5c-bf0e-f5117dbfb3f1.png">
