### PR TITLE
pass tag icon directly to imagebox

### DIFF
--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -49,7 +49,6 @@ local common = require("awful.widget.common")
 local tag = require("awful.tag")
 local beautiful = require("beautiful")
 local fixed = require("wibox.layout.fixed")
-local surface = require("gears.surface")
 local timer = require("gears.timer")
 local gcolor = require("gears.color")
 local gstring = require("gears.string")
@@ -372,7 +371,7 @@ function taglist.taglist_label(t, args)
     end
     if not taglist_disable_icon then
         if t.icon then
-            icon = surface.load(t.icon)
+            icon = t.icon
         end
     end
 


### PR DESCRIPTION
so that svg icons can be rendered with rsvg.

fix #3634 