### PR TITLE
Fix awful.util.geticonpath search order

### DIFF
--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -250,7 +250,7 @@ function util.geticonpath(iconname, exts, dirs, size)
         for _,e in ipairs(exts) do
             local icon = string.format("%s/%s.%s", d, iconname, e)
             if gfs.file_readable(icon) then
-                return icon
+                return icon:gsub("//+", "/")
             end
         end
     end

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -227,7 +227,7 @@ end
 -- @param iconname The name of the icon to search for.
 -- @param exts Table of image extensions allowed, otherwise { 'png', gif' }
 -- @param dirs Table of dirs to search, otherwise { '/usr/share/pixmaps/' }
--- @tparam[opt] string size The size. If this is specified, subdirectories `x`
+-- @tparam[opt] string size The size. If this is specified, subdirectories `sizexsize`
 --   of the dirs are searched first.
 -- @staticfct awful.util.geticonpath
 function util.geticonpath(iconname, exts, dirs, size)

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -235,20 +235,22 @@ function util.geticonpath(iconname, exts, dirs, size)
     dirs = dirs or { '/usr/share/pixmaps/', '/usr/share/icons/hicolor/' }
     local icontypes = { 'apps', 'actions',  'categories',  'emblems',
         'mimetypes',  'status', 'devices', 'extras', 'places', 'stock' }
-    for _, d in pairs(dirs) do
-        local icon
-        for _, e in pairs(exts) do
-            icon = d .. iconname .. '.' .. e
+    local dirlist = {}
+    if size then
+        for _, d in pairs(dirs) do
+            local path = string.format("%s%ux%u/", d, size, size)
+            table.insert(dirlist,path)
+            for _, t in pairs(icontypes) do
+                table.insert(dirlist, string.format("%s/%s/", path, t))
+            end
+        end
+    end
+    dirlist = gtable.join(dirlist, dirs)
+    for _,d in pairs(dirlist) do
+        for _,e in pairs(exts) do
+            local icon = string.format("%s%s.%s", d, iconname, e)
             if gfs.file_readable(icon) then
                 return icon
-            end
-            if size then
-                for _, t in pairs(icontypes) do
-                    icon = string.format("%s%ux%u/%s/%s.%s", d, size, size, t, iconname, e)
-                    if gfs.file_readable(icon) then
-                        return icon
-                    end
-                end
             end
         end
     end

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -227,7 +227,7 @@ end
 -- @param iconname The name of the icon to search for.
 -- @param exts Table of image extensions allowed, otherwise { 'png', gif' }
 -- @param dirs Table of dirs to search, otherwise { '/usr/share/pixmaps/' }
--- @tparam[opt] string size The size. If this is specified, subdirectories `sizexsize`
+-- @tparam[opt] string size The size. If this is specified, subdirectories `SIZExSIZE` (e.g. `48x48`)
 --   of the dirs are searched first.
 -- @staticfct awful.util.geticonpath
 function util.geticonpath(iconname, exts, dirs, size)

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -238,7 +238,7 @@ function util.geticonpath(iconname, exts, dirs, size)
     local dirlist = {}
     if size then
         for _, d in ipairs(dirs) do
-            local path = string.format("%s%ux%u/", d, size, size)
+            local path = string.format("%s/%ux%u/", d, size, size)
             table.insert(dirlist,path)
             for _, t in ipairs(icontypes) do
                 table.insert(dirlist, string.format("%s/%s/", path, t))
@@ -248,7 +248,7 @@ function util.geticonpath(iconname, exts, dirs, size)
     dirlist = gtable.merge(dirlist, dirs)
     for _,d in ipairs(dirlist) do
         for _,e in ipairs(exts) do
-            local icon = string.format("%s%s.%s", d, iconname, e)
+            local icon = string.format("%s/%s.%s", d, iconname, e)
             if gfs.file_readable(icon) then
                 return icon
             end

--- a/lib/awful/util.lua
+++ b/lib/awful/util.lua
@@ -237,17 +237,17 @@ function util.geticonpath(iconname, exts, dirs, size)
         'mimetypes',  'status', 'devices', 'extras', 'places', 'stock' }
     local dirlist = {}
     if size then
-        for _, d in pairs(dirs) do
+        for _, d in ipairs(dirs) do
             local path = string.format("%s%ux%u/", d, size, size)
             table.insert(dirlist,path)
-            for _, t in pairs(icontypes) do
+            for _, t in ipairs(icontypes) do
                 table.insert(dirlist, string.format("%s/%s/", path, t))
             end
         end
     end
-    dirlist = gtable.join(dirlist, dirs)
-    for _,d in pairs(dirlist) do
-        for _,e in pairs(exts) do
+    dirlist = gtable.merge(dirlist, dirs)
+    for _,d in ipairs(dirlist) do
+        for _,e in ipairs(exts) do
             local icon = string.format("%s%s.%s", d, iconname, e)
             if gfs.file_readable(icon) then
                 return icon


### PR DESCRIPTION
Fixing the `geticonpath` function to match its documentation of searching first for the size directory.

Issue: https://github.com/awesomeWM/awesome/issues/3646

Given the example:
```lua
awful.util.geticonpath('my-icon', { 'svg', 'png' }, { '/dir1', '/dir2' }, '22')
```

Search pattern before (`xxx` represent the hard-coded sub-folders present in the size folders for a theme):
* search for `/dir1/my-icon.svg`
* search for `/dir1/22x22/xxx/my-icon.svg`
* search for `/dir1/my-icon.png`
* search for `/dir1/22x22/xxx/my-icon.png`
* search for `/dir2/my-icon.svg`
* search for `/dir2/22x22/xxx/my-icon.svg`
* search for `/dir2/my-icon.png`
* search for `/dir2/22x22/xxx/my-icon.png

Search pattern now (`xxx` represent the hard-coded sub-folders present in the size folders for a theme):
* search for `/dir1/22x22/my-icon.svg`
* search for `/dir1/22x22/my-icon.png`
* search for `/dir1/22x22/xxx/my-icon.svg`
* search for `/dir1/22x22/xxx/my-icon.png`
* search for `/dir2/22x22/my-icon.svg`
* search for `/dir2/22x22/my-icon.png`
* search for `/dir2/22x22/xxx/my-icon.svg`
* search for `/dir2/22x22/xxx/my-icon.png`
* search for `/dir1/my-icon.svg`
* search for `/dir1/my-icon.png`
* search for `/dir2/my-icon.svg`
* search for `/dir2/my-icon.png`

## What the fix does not add
* Does not fall back to a different size directory.
* Unsure about the return value if no files are found (I am not good enough in lua to know if it would default to return a nil?)
* Does not find icons inside a sub-directory of `dirs/sizexsize` which is not hard-coded into.

## About Unit Test
I looked around a bit, but I need to look more into it (as I said I have never done any), as there is not much of docs or template for them (All unit test have so many different formatting).
So I need to check/learn, what to install, how to use them and how to create the file. As well as where/how to create dummy icons files (lua function vs touch etc...) to check all the scenario for the unit test. (Feel free to redirect me to any good resources you have).

## Documentation
I fixed the doc from `subdirectories x` to `subdirectories sizexsize`. It's possible more improvement can be made to make it clear on what folders it does search and it does not (but I do not know yet except by example).

Maybe stating what is happening if it couldn't find the icon?! So the user can handle the error.