### PR TITLE
Textbox upgrades

### DIFF
--- a/awesomerc.lua
+++ b/awesomerc.lua
@@ -541,7 +541,7 @@ client.connect_signal("request::titlebars", function(c)
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             buttons = buttons,

--- a/docs/03-declarative-layout.md
+++ b/docs/03-declarative-layout.md
@@ -277,7 +277,7 @@ Code:
             {
                 {
                     markup = "<b>Hello World!</b>",
-                    align  = "center",
+                    halign = "center",
                     widget = wibox.widget.textbox
                 },
                 bg     = "#ff0000",

--- a/docs/89-NEWS.md
+++ b/docs/89-NEWS.md
@@ -45,7 +45,12 @@ This document was last updated at commit v4.3-197-g9085ed631.
   Lua code using `io.popen`. Usage of `io.popen` is still strongly discouraged.
 * `wibox{ input_passthrough = true }` now works correctly. Previously, the
   property could only be set on already-constructed wiboxes.
-* Remove unused first parameter from multiple widget constructors: `wibox.container.place`,  `wibox.container.radialprogressbar`,  `wibox.layout.stack`,  `wibox.widget.slider`.
+* Remove unused first parameter from multiple widget constructors:
+ `wibox.container.place`, * `wibox.container.radialprogressbar`,
+ `wibox.layout.stack`,
+ `wibox.widget.slider`.
+* Renamed some properties like `wibox.widget.textbox.align` to
+ `wibox.widget.textbox.halign` for consistency reasons.
 
 ## Behavior changes
 
@@ -80,6 +85,9 @@ This document was last updated at commit v4.3-197-g9085ed631.
    it's main layout. Use the `base_layout` property to access the layout.
    This allows to replace the layout at runtime. The previous behavior
    was undocumented.
+ * Pango 1.44 is now the oldest recommended Pango version. Older versions are
+   still supported, but will lack the ability to use some textbox properties,
+   mainly `wibox.widget.textbox.line_spacing_factor`.
 
 <a name="v43"></a>
 # Awesome window manager framework version 4.3 changes

--- a/lib/awful/widget/layoutlist.lua
+++ b/lib/awful/widget/layoutlist.lua
@@ -79,7 +79,7 @@ local function wb_label(item, _, textbox)
     end
 
     if textbox and item.style.align or beautiful.layoutlist_align then
-        textbox:set_align(item.style.align or beautiful.layoutlist_align)
+        textbox:set_halign(item.style.align or beautiful.layoutlist_align)
     end
 
     local text = ""

--- a/lib/awful/widget/tasklist.lua
+++ b/lib/awful/widget/tasklist.lua
@@ -464,7 +464,7 @@ local function tasklist_label(c, args, tb)
     local minimized = args.minimized or theme.tasklist_minimized or '<b>_</b>'
 
     if tb then
-        tb:set_align(align)
+        tb:set_halign(align)
     end
 
     if not theme.tasklist_plain_task_name then

--- a/lib/wibox/widget/calendar.lua
+++ b/lib/wibox/widget/calendar.lua
@@ -155,7 +155,7 @@ local properties = { "date"        , "font"         , "spacing" , "week_numbers"
 local function make_cell(text, font, center)
     local w = textbox()
     w:set_markup(text)
-    w:set_align(center and "center" or "right")
+    w:set_halign(center and "center" or "right")
     w:set_valign("center")
     w:set_font(font)
     return w

--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -405,6 +405,82 @@ function textbox:get_font()
     return self._private.font
 end
 
+--- Set the distance between the lines.
+--
+--@DOC_wibox_widget_textbox_line_spacing_EXAMPLE@
+--
+-- Please note that the Pango version (one of AwesomeWM dependency) must be at
+-- least 1.44 for this to work.
+--
+-- @property line_spacing_factor
+-- @tparam[opt=nil] number|nil line_spacing_factor
+-- @propertyunit Distance between lines as a ratio of the line height. `1.0` means
+--  no spacing. Less than `1.0` will squash the lines and more than `1.0` will move
+--  them further apart.
+-- @propertytype nil Automatic (most probably `1.0`).
+-- @negativeallowed false
+-- @propemits true false
+
+function textbox:set_line_spacing_factor(spacing)
+    if not pcall(function() return self._private.layout.set_line_spacing ~= nil end) then
+        gdebug.print_error(debug.traceback(
+            "Error your version of Pango is too old to support line_spacing"
+        ))
+    end
+
+    spacing = spacing or 0
+    self._private.layout:set_line_spacing(spacing)
+    self:emit_signal("widget::redraw_needed")
+    self:emit_signal("widget::layout_changed")
+    self:emit_signal("property::line_spacing", spacing)
+end
+
+function textbox:get_line_spacing_factor()
+    return self._private.layout:get_line_spacing()
+end
+
+--- Justify the text when there is more space.
+--
+--@DOC_wibox_widget_textbox_justify_EXAMPLE@
+--
+-- @property justify
+-- @tparam[opt=false] boolean justify
+-- @propemits true false
+
+function textbox:set_justify(justify)
+    self._private.layout:set_justify(justify)
+    self:emit_signal("widget::redraw_needed")
+    self:emit_signal("widget::layout_changed")
+    self:emit_signal("property::justify", justify)
+end
+
+function textbox:get_justify()
+    return self._private.layout:get_justify()
+end
+
+--- How to indent text with multiple lines.
+--
+-- Note that this does nothing if `align == "center"`.
+--
+--@DOC_wibox_widget_textbox_indent_EXAMPLE@
+--
+-- @property indent
+-- @tparam[opt=0.0] number indent
+-- @propertyunit points
+-- @negativeallowed true
+-- @propemits true false
+
+function textbox:set_indent(indent)
+    self._private.layout:set_indent(Pango.units_from_double(indent))
+    self:emit_signal("widget::redraw_needed")
+    self:emit_signal("widget::layout_changed")
+    self:emit_signal("property::indent", indent)
+end
+
+function textbox:get_indent()
+    return self._private.layout:get_indent()
+end
+
 --- Create a new textbox.
 --
 -- @tparam[opt=""] string text The textbox content

--- a/lib/wibox/widget/textbox.lua
+++ b/lib/wibox/widget/textbox.lua
@@ -324,14 +324,22 @@ end
 --
 --@DOC_wibox_widget_textbox_align1_EXAMPLE@
 --
--- @property align
--- @tparam[opt="left"] string align
+-- @property halign
+-- @tparam[opt="left"] string halign
 -- @propertyvalue "left"
 -- @propertyvalue "center"
 -- @propertyvalue "right"
 -- @propemits true false
 
-function textbox:set_align(mode)
+--- The horizontal text alignment.
+--
+-- Renamed to `halign` for consistency with other APIs.
+--
+-- @deprecatedproperty align
+-- @tparam[opt="left"] string align
+-- @propemits true false
+
+function textbox:set_halign(mode)
     local allowed = { left = "LEFT", center = "CENTER", right = "RIGHT" }
     if allowed[mode] then
         if self._private.layout:get_alignment() == allowed[mode] then
@@ -341,7 +349,16 @@ function textbox:set_align(mode)
         self:emit_signal("widget::redraw_needed")
         self:emit_signal("widget::layout_changed")
         self:emit_signal("property::align", mode)
+        self:emit_signal("property::halign", mode)
     end
+end
+
+function textbox:set_align(mode)
+    gdebug.deprecate(
+        "Use `textbox.halign` instead of `textbox.align`",
+        {deprecated_in=5, raw=true}
+    )
+    self:set_halign(mode)
 end
 
 --- Set a textbox font.
@@ -500,7 +517,7 @@ local function new(text, ignore_markup)
     ret:set_ellipsize("end")
     ret:set_wrap("word_char")
     ret:set_valign("center")
-    ret:set_align("left")
+    ret:set_halign("left")
 
     if text then
         if ignore_markup then

--- a/spec/wibox/widget/textbox_spec.lua
+++ b/spec/wibox/widget/textbox_spec.lua
@@ -98,15 +98,15 @@ describe("wibox.widget.textbox", function()
             assert.is.equal(1, layout_changed)
         end)
 
-        it("set_align", function()
+        it("set_halign", function()
             assert.is.equal(0, redraw_needed)
             assert.is.equal(0, layout_changed)
 
-            widget:set_align("left")
+            widget:set_halign("left")
             assert.is.equal(0, redraw_needed)
             assert.is.equal(0, layout_changed)
 
-            widget:set_align("right")
+            widget:set_halign("right")
             assert.is.equal(1, redraw_needed)
             assert.is.equal(1, layout_changed)
         end)

--- a/tests/_multi_screen.lua
+++ b/tests/_multi_screen.lua
@@ -395,7 +395,7 @@ local function show_screens()
                     "+",s.geometry.x,",",s.geometry.y
                 },
                 valign = "center",
-                align  = "center",
+                halign = "center",
                 widget = wibox.widget.textbox,
             },
             bg                 = colors[i],

--- a/tests/examples/awful/client/border_color.lua
+++ b/tests/examples/awful/client/border_color.lua
@@ -29,7 +29,7 @@ client.connect_signal("request::titlebars", function(c)--DOC_HIDE
         },--DOC_HIDE
         { -- Middle--DOC_HIDE
             { -- Title--DOC_HIDE
-                align  = "center",--DOC_HIDE
+                halign = "center",--DOC_HIDE
                 widget = awful.titlebar.widget.titlewidget(c)--DOC_HIDE
             },--DOC_HIDE
             layout  = wibox.layout.flex.horizontal--DOC_HIDE

--- a/tests/examples/awful/client/border_width.lua
+++ b/tests/examples/awful/client/border_width.lua
@@ -29,7 +29,7 @@ client.connect_signal("request::titlebars", function(c)
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             layout  = wibox.layout.flex.horizontal

--- a/tests/examples/awful/client/opacity1.lua
+++ b/tests/examples/awful/client/opacity1.lua
@@ -29,7 +29,7 @@ client.connect_signal("request::titlebars", function(c)
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             layout  = wibox.layout.flex.horizontal

--- a/tests/examples/awful/client/shape1.lua
+++ b/tests/examples/awful/client/shape1.lua
@@ -33,7 +33,7 @@ client.connect_signal("request::titlebars", function(c)
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             layout  = wibox.layout.flex.horizontal

--- a/tests/examples/awful/client/skip_tasklist1.lua
+++ b/tests/examples/awful/client/skip_tasklist1.lua
@@ -29,7 +29,7 @@ client.connect_signal("request::titlebars", function(c)
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             layout  = wibox.layout.flex.horizontal

--- a/tests/examples/awful/client/urgent1.lua
+++ b/tests/examples/awful/client/urgent1.lua
@@ -29,7 +29,7 @@ client.connect_signal("request::titlebars", function(c)
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             layout  = wibox.layout.flex.horizontal

--- a/tests/examples/awful/notification/notificationlist/bottombar.lua
+++ b/tests/examples/awful/notification/notificationlist/bottombar.lua
@@ -79,7 +79,7 @@ beautiful.notification_action_label_only = true --DOC_HIDE
         {
             {
                 text   = "Dismiss all",
-                align  = "center",
+                halign = "center",
                 valign = "center",
                 widget = wibox.widget.textbox
             },

--- a/tests/examples/awful/popup/defaultconfig.lua
+++ b/tests/examples/awful/popup/defaultconfig.lua
@@ -52,7 +52,7 @@ local function create_info(text, x, y, width, height)
         {
             {
                 text = text,
-                align = "center",
+                halign = "center",
                 ellipsize = "none",
                 wrap = "word",
                 widget = wibox.widget.textbox

--- a/tests/examples/awful/popup/wiboxtypes.lua
+++ b/tests/examples/awful/popup/wiboxtypes.lua
@@ -210,7 +210,7 @@ local function create_info(text, x, y, width, height)
         {
             {
                 text = text,
-                align = "center",
+                halign = "center",
                 ellipsize = "none",
                 wrap = "word",
                 widget = wibox.widget.textbox

--- a/tests/examples/awful/template.lua
+++ b/tests/examples/awful/template.lua
@@ -160,7 +160,7 @@ local function client_widget(c, col, label)
             l,
             {
                 text   = label or "",
-                align  = "center",
+                halign = "center",
                 valign = "center",
                 widget = wibox.widget.textbox
             },

--- a/tests/examples/awful/titlebar/constructor.lua
+++ b/tests/examples/awful/titlebar/constructor.lua
@@ -21,7 +21,7 @@ local function setup(bar)
     bar:setup {
         awful.titlebar.widget.iconwidget(c),
         {
-            align  = "center",
+            halign = "center",
             widget = awful.titlebar.widget.titlewidget(c)
         },
         {

--- a/tests/examples/awful/titlebar/default.lua
+++ b/tests/examples/awful/titlebar/default.lua
@@ -50,7 +50,7 @@ place.maximize(c, {honor_padding=true, honor_workarea=true})
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             buttons = buttons,

--- a/tests/examples/awful/titlebar/defaulttitlebar.lua
+++ b/tests/examples/awful/titlebar/defaulttitlebar.lua
@@ -52,7 +52,7 @@ local function create_info(text, x, y, width, height)
         {
             {
                 text = text,
-                align = "center",
+                halign = "center",
                 ellipsize = "none",
                 wrap = "word",
                 widget = wibox.widget.textbox
@@ -93,7 +93,7 @@ local function create_section(x1, y, x2, text)
 
     canvas:add_at(wibox.widget {
         text = text,
-        align = "center",
+        halign = "center",
         ellipsize = "none",
         wrap = "word",
         forced_width = x2-x1,

--- a/tests/examples/awful/wallpaper/add_screen1.lua
+++ b/tests/examples/awful/wallpaper/add_screen1.lua
@@ -36,9 +36,9 @@ require("_default_look")
                     widget = wibox.widget.base.make_widget()
                 },
                 {
-                    text = "Center",
+                    text   = "Center",
                     valign = "center",
-                    align  = "center",
+                    halign = "center",
                     widget = wibox.widget.textbox,
                 },
                 widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/add_screen2.lua
+++ b/tests/examples/awful/wallpaper/add_screen2.lua
@@ -36,9 +36,9 @@ require("_default_look")
                     widget = wibox.widget.base.make_widget()
                 },
                 {
-                    text = "Center",
+                    text   = "Center",
                     valign = "center",
-                    align  = "center",
+                    halign = "center",
                     widget = wibox.widget.textbox,
                 },
                 widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/add_screen3.lua
+++ b/tests/examples/awful/wallpaper/add_screen3.lua
@@ -37,9 +37,9 @@ require("_default_look")
                     widget = wibox.widget.base.make_widget()
                 },
                 {
-                    text = "Center",
+                    text   = "Center",
                     valign = "center",
-                    align  = "center",
+                    halign = "center",
                     widget = wibox.widget.textbox,
                 },
                 widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/dpi1.lua
+++ b/tests/examples/awful/wallpaper/dpi1.lua
@@ -45,7 +45,7 @@ require("_default_look")
 --DOC_HIDE_END
                text   = "DPI: " .. dpi,
                valign = "center",
-               align  = "center",
+               halign = "center",
                widget = wibox.widget.textbox,
                 }, --DOC_HIDE
                 widget = wibox.layout.stack --DOC_HIDE

--- a/tests/examples/awful/wallpaper/panning_custom.lua
+++ b/tests/examples/awful/wallpaper/panning_custom.lua
@@ -62,9 +62,9 @@ for i=0, 1 do
                 widget = wibox.widget.base.make_widget()
             },
             {
-                text = "Center",
+                text   = "Center",
                 valign = "center",
-                align  = "center",
+                halign = "center",
                 widget = wibox.widget.textbox,
             },
             widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/panning_inner.lua
+++ b/tests/examples/awful/wallpaper/panning_inner.lua
@@ -47,9 +47,9 @@ for i=0, 1 do
                 widget = wibox.widget.base.make_widget()
             },
             {
-                text = "Center",
+                text   = "Center",
                 valign = "center",
-                align  = "center",
+                halign = "center",
                 widget = wibox.widget.textbox,
             },
             widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/panning_inner_horizontal.lua
+++ b/tests/examples/awful/wallpaper/panning_inner_horizontal.lua
@@ -47,9 +47,9 @@ for i=0, 1 do
                 widget = wibox.widget.base.make_widget()
             },
             {
-                text = "Center",
+                text   = "Center",
                 valign = "center",
-                align  = "center",
+                halign = "center",
                 widget = wibox.widget.textbox,
             },
             widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/panning_inner_vertical.lua
+++ b/tests/examples/awful/wallpaper/panning_inner_vertical.lua
@@ -47,9 +47,9 @@ for i=0, 1 do
                 widget = wibox.widget.base.make_widget()
             },
             {
-                text = "Center",
+                text   = "Center",
                 valign = "center",
-                align  = "center",
+                halign = "center",
                 widget = wibox.widget.textbox,
             },
             widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/panning_outer.lua
+++ b/tests/examples/awful/wallpaper/panning_outer.lua
@@ -45,9 +45,9 @@ for i=0, 1 do
                 widget = wibox.widget.base.make_widget()
             },
             {
-                text = "Center",
+                text   = "Center",
                 valign = "center",
-                align  = "center",
+                halign = "center",
                 widget = wibox.widget.textbox,
             },
             widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/remove_screen1.lua
+++ b/tests/examples/awful/wallpaper/remove_screen1.lua
@@ -39,7 +39,7 @@ require("_default_look")
            {
                text   = "Center",
                valign = "center",
-               align  = "center",
+               halign = "center",
                widget = wibox.widget.textbox,
            },
            widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/remove_screen2.lua
+++ b/tests/examples/awful/wallpaper/remove_screen2.lua
@@ -39,7 +39,7 @@ require("_default_look")
            {
                text   = "Center",
                valign = "center",
-               align  = "center",
+               halign = "center",
                widget = wibox.widget.textbox,
            },
            widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/screens1.lua
+++ b/tests/examples/awful/wallpaper/screens1.lua
@@ -43,7 +43,7 @@ require("_default_look")
            {
                text   = "Center",
                valign = "center",
-               align  = "center",
+               halign = "center",
                widget = wibox.widget.textbox,
            },
            widget = wibox.layout.stack

--- a/tests/examples/awful/wallpaper/widget2.lua
+++ b/tests/examples/awful/wallpaper/widget2.lua
@@ -30,7 +30,7 @@ screen[1]._resize {x = 0, y = 0, width = 320, height = 196} --DOC_HIDE
                {
                    markup = "<tt><b>[SYSTEM FAILURE]</b></tt>",
                    valign = "center",
-                   align  = "center",
+                   halign = "center",
                    widget = wibox.widget.textbox
                },
                fg = "#00ff00",

--- a/tests/examples/awful/wallpaper/workarea1.lua
+++ b/tests/examples/awful/wallpaper/workarea1.lua
@@ -39,7 +39,7 @@ require("_default_look")
                 {
                     text   = "honor_workarea = " .. (s.index == 2 and "true" or "false"),
                     valign = "center",
-                    align  = "center",
+                    halign = "center",
                     widget = wibox.widget.textbox,
                 },
                 widget = wibox.layout.stack

--- a/tests/examples/awful/wibar/align.lua
+++ b/tests/examples/awful/wibar/align.lua
@@ -22,7 +22,7 @@ for s, align in ipairs { "left", "centered", "right" } do
         align    = align,
         widget   = {
             text   = align,
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox
         },
     }

--- a/tests/examples/awful/wibar/defaultwibar.lua
+++ b/tests/examples/awful/wibar/defaultwibar.lua
@@ -43,7 +43,7 @@ local function create_info(text, x, y, width, height)
         {
             {
                 text = text,
-                align = "center",
+                halign = "center",
                 ellipsize = "none",
                 wrap = "word",
                 widget = wibox.widget.textbox

--- a/tests/examples/awful/wibar/margins.lua
+++ b/tests/examples/awful/wibar/margins.lua
@@ -40,7 +40,7 @@ for _, c in ipairs {c1, c2} do
         },
         { -- Middle
             { -- Title
-                align  = "center",
+                halign = "center",
                 widget = awful.titlebar.widget.titlewidget(c)
             },
             layout  = wibox.layout.flex.horizontal
@@ -66,7 +66,7 @@ awful.wibar {
     width    = 196,
     margins  = 24,
     widget   = {
-        align  = "center",
+        halign = "center",
         text   = "unform margins",
         widget = wibox.widget.textbox
     }
@@ -84,7 +84,7 @@ awful.wibar {
         bottom = 5
     },
     widget   = {
-        align  = "center",
+        halign = "center",
         text   = "non unform margins",
         widget = wibox.widget.textbox
     }

--- a/tests/examples/awful/wibar/position.lua
+++ b/tests/examples/awful/wibar/position.lua
@@ -22,7 +22,7 @@ screen[1]._resize {width = 480, height = 196}
            widget   = {
                {
                    text   = position,
-                   align  = "center",
+                   halign = "center",
                    widget = wibox.widget.textbox
                },
                direction = (position == "left" or position == "right") and

--- a/tests/examples/awful/wibar/position2.lua
+++ b/tests/examples/awful/wibar/position2.lua
@@ -24,7 +24,7 @@ screen[1]._resize {width = 480, height = 196}
             widget   = {
                 {
                     text   = position,
-                    align  = "center",
+                    halign = "center",
                     widget = wibox.widget.textbox
                 },
                 direction = (position == "left" or position == "right") and

--- a/tests/examples/awful/wibar/stretch.lua
+++ b/tests/examples/awful/wibar/stretch.lua
@@ -16,7 +16,7 @@ awful.wibar {
     width    = 196,
     widget   = {
         text   = "stretched",
-        align  = "center",
+        halign = "center",
         widget = wibox.widget.textbox
     },
 }

--- a/tests/examples/sequences/template.lua
+++ b/tests/examples/sequences/template.lua
@@ -780,7 +780,7 @@ local function wrap_with_arrows(widget)
         },
         {
             markup      = "<span color='#ff000055'>Code for this sequence</span>",
-            align       = "center",
+            halign      = "center",
             foced_width = w,
             widget      = wibox.widget.textbox,
         },

--- a/tests/examples/shims/_default_look.lua
+++ b/tests/examples/shims/_default_look.lua
@@ -67,7 +67,7 @@ for i = 1, screen.count() do
             },
             { -- Middle
                 { -- Title
-                    align  = "center",
+                    halign = "center",
                     widget = awful.titlebar.widget.titlewidget(c)
                 },
                 layout  = wibox.layout.flex.horizontal

--- a/tests/examples/uml/template.lua
+++ b/tests/examples/uml/template.lua
@@ -21,7 +21,7 @@ local function gen_class(name)
             {
                 {
                     valign = "center",
-                    align  = "center",
+                    halign = "center",
                     markup = "<b>"..name.."</b>",
                     widget = wibox.widget.textbox
                 },

--- a/tests/examples/wibox/container/arcchart/bg.lua
+++ b/tests/examples/wibox/container/arcchart/bg.lua
@@ -12,7 +12,7 @@ for _, v in ipairs {"", "#00ff00", "#0000ff"} do
     l:add(wibox.widget {
           {
               text   = v~="" and v or "nil",
-              align  = "center",
+              halign = "center",
               valign = "center",
               widget = wibox.widget.textbox,
           },

--- a/tests/examples/wibox/container/arcchart/border_width.lua
+++ b/tests/examples/wibox/container/arcchart/border_width.lua
@@ -16,7 +16,7 @@ for _, v in ipairs {0,1,3,6.5} do
               {
                   {
                       text   = v,
-                      align  = "center",
+                      halign = "center",
                       valign = "center",
                       widget = wibox.widget.textbox,
                   },

--- a/tests/examples/wibox/container/arcchart/paddings.lua
+++ b/tests/examples/wibox/container/arcchart/paddings.lua
@@ -13,7 +13,7 @@ for _, v in ipairs {0, 2, 4} do
           {
               {
                   text   = v,
-                  align  = "center",
+                  halign = "center",
                   valign = "center",
                   widget = wibox.widget.textbox,
               },
@@ -45,7 +45,7 @@ l:add(wibox.widget {
       {
           {
               text   = 6,
-              align  = "center",
+              halign = "center",
               valign = "center",
               widget = wibox.widget.textbox,
           },

--- a/tests/examples/wibox/container/arcchart/start_angle.lua
+++ b/tests/examples/wibox/container/arcchart/start_angle.lua
@@ -12,7 +12,7 @@ for _, v in ipairs {0, math.pi/2, math.pi} do
     l:add(wibox.widget {
           {
               text   = v,
-              align  = "center",
+              halign = "center",
               valign = "center",
               widget = wibox.widget.textbox,
           },

--- a/tests/examples/wibox/container/arcchart/thickness.lua
+++ b/tests/examples/wibox/container/arcchart/thickness.lua
@@ -12,7 +12,7 @@ for _, v in ipairs {1,3,7,10} do
     l:add(wibox.widget {
           {
               text   = v,
-              align  = "center",
+              halign = "center",
               valign = "center",
               widget = wibox.widget.textbox,
           },

--- a/tests/examples/wibox/container/defaults/arcchart.lua
+++ b/tests/examples/wibox/container/defaults/arcchart.lua
@@ -5,7 +5,7 @@ local beautiful = require("beautiful")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
@@ -13,7 +13,7 @@ return {
     {
         {
             text   = "After",
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/defaults/background.lua
+++ b/tests/examples/wibox/container/defaults/background.lua
@@ -6,14 +6,14 @@ local beautiful = require("beautiful")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
 {
     {
         text   = "After",
-        align  = "center",
+        halign = "center",
         valign = "center",
         widget = wibox.widget.textbox,
     },

--- a/tests/examples/wibox/container/defaults/constraint.lua
+++ b/tests/examples/wibox/container/defaults/constraint.lua
@@ -4,7 +4,7 @@ local wibox = require("wibox")
 
 return {
     text   = "Some long text",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
@@ -13,7 +13,7 @@ return {
         {
             {
                 text   = "Some long text",
-                align  = "center",
+                halign = "center",
                 valign = "center",
                 widget = wibox.widget.textbox,
             },

--- a/tests/examples/wibox/container/defaults/margin.lua
+++ b/tests/examples/wibox/container/defaults/margin.lua
@@ -10,7 +10,7 @@ return {
         {
             {
                 text   = "Before",
-                align  = "center",
+                halign = "center",
                 valign = "center",
                 widget = wibox.widget.textbox,
             },
@@ -33,7 +33,7 @@ return {
             {
                 {
                     text   = "After",
-                    align  = "center",
+                    halign = "center",
                     valign = "center",
                     widget = wibox.widget.textbox,
                 },

--- a/tests/examples/wibox/container/defaults/mirror.lua
+++ b/tests/examples/wibox/container/defaults/mirror.lua
@@ -4,14 +4,14 @@ local wibox     = require("wibox")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
 {
     {
         text   = "After",
-        align  = "center",
+        halign = "center",
         valign = "center",
         widget = wibox.widget.textbox,
     },

--- a/tests/examples/wibox/container/defaults/only_on_screen.lua
+++ b/tests/examples/wibox/container/defaults/only_on_screen.lua
@@ -5,14 +5,14 @@ local awful = { widget = { only_on_screen = require("awful.widget.only_on_screen
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
 {
     {
         text   = "After",
-        align  = "center",
+        halign = "center",
         valign = "center",
         widget = wibox.widget.textbox,
     },

--- a/tests/examples/wibox/container/defaults/place.lua
+++ b/tests/examples/wibox/container/defaults/place.lua
@@ -4,7 +4,7 @@ local wibox     = require("wibox")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
@@ -12,7 +12,7 @@ return {
     {
         {
             text   = "After",
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/defaults/radialprogressbar.lua
+++ b/tests/examples/wibox/container/defaults/radialprogressbar.lua
@@ -4,7 +4,7 @@ local wibox = require("wibox")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
@@ -13,7 +13,7 @@ return {
     {
         {
             text   = "After",
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/defaults/rotate.lua
+++ b/tests/examples/wibox/container/defaults/rotate.lua
@@ -4,14 +4,14 @@ local wibox     = require("wibox")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
 {
     {
         text   = "After",
-        align  = "center",
+        halign = "center",
         valign = "center",
         widget = wibox.widget.textbox,
     },

--- a/tests/examples/wibox/container/defaults/scroll.lua
+++ b/tests/examples/wibox/container/defaults/scroll.lua
@@ -4,14 +4,14 @@ local wibox = require("wibox")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
 {
     {
         text   = "After",
-        align  = "center",
+        halign = "center",
         valign = "center",
         widget = wibox.widget.textbox,
     },

--- a/tests/examples/wibox/container/defaults/tile.lua
+++ b/tests/examples/wibox/container/defaults/tile.lua
@@ -4,7 +4,7 @@ local wibox     = require("wibox")
 
 return {
     text   = "Before",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox,
 },
@@ -12,7 +12,7 @@ return {
     {
         {
             text   = "After",
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/radialprogressbar/border_color.lua
+++ b/tests/examples/wibox/container/radialprogressbar/border_color.lua
@@ -7,7 +7,7 @@ local function gen(val)
     return wibox.widget {
         {
             text   = "Value: "..val,
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/radialprogressbar/border_width.lua
+++ b/tests/examples/wibox/container/radialprogressbar/border_width.lua
@@ -7,7 +7,7 @@ local function gen(val)
     return wibox.widget {
         {
             text   = "Value: "..val,
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/radialprogressbar/color.lua
+++ b/tests/examples/wibox/container/radialprogressbar/color.lua
@@ -7,7 +7,7 @@ local function gen(val)
     return wibox.widget {
         {
             text   = "Value: "..val,
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/radialprogressbar/padding.lua
+++ b/tests/examples/wibox/container/radialprogressbar/padding.lua
@@ -9,7 +9,7 @@ local function gen(val)
         {
             {
                 text   = "Value: "..val,
-                align  = "center",
+                halign = "center",
                 valign = "center",
                 widget = wibox.widget.textbox,
             },

--- a/tests/examples/wibox/container/radialprogressbar/value.lua
+++ b/tests/examples/wibox/container/radialprogressbar/value.lua
@@ -7,7 +7,7 @@ local function gen(val)
     return wibox.widget {
         {
             text   = "Value: "..(val*100).."%",
-            align  = "center",
+            halign = "center",
             valign = "center",
             widget = wibox.widget.textbox,
         },

--- a/tests/examples/wibox/container/rotate/angle.lua
+++ b/tests/examples/wibox/container/rotate/angle.lua
@@ -9,7 +9,7 @@ local function create_arrow(text)                     --DOC_HIDE
         {                                             --DOC_HIDE
             {                                         --DOC_HIDE
                 text   = text,                        --DOC_HIDE
-                align  = "center",                    --DOC_HIDE
+                halign = "center",                    --DOC_HIDE
                 valign = "center",                    --DOC_HIDE
                 widget = wibox.widget.textbox,        --DOC_HIDE
             },                                        --DOC_HIDE

--- a/tests/examples/wibox/layout/template.lua
+++ b/tests/examples/wibox/layout/template.lua
@@ -23,7 +23,7 @@ local function generic_widget(text, col, margins)
             },
             {
                 id     = "text",
-                align  = "center",
+                halign = "center",
                 valign = "center",
                 text   = text or "foobar",
                 widget = wibox.widget.textbox

--- a/tests/examples/wibox/nwidget/default.lua
+++ b/tests/examples/wibox/nwidget/default.lua
@@ -50,7 +50,7 @@ local function create_info(text, x, y, width, height)
         {
             {
                 text = text,
-                align = "center",
+                halign = "center",
                 ellipsize = "none",
                 wrap = "word",
                 widget = wibox.widget.textbox

--- a/tests/examples/wibox/nwidget/rules/widget_template.lua
+++ b/tests/examples/wibox/nwidget/rules/widget_template.lua
@@ -25,11 +25,11 @@ beautiful.notification_bg = beautiful.bg_normal --DOC_HIDE
                                    widget        = wibox.container.place
                                },
                                {
-                                   align  = "center",
+                                   halign = "center",
                                    widget = naughty.widget.title,
                                },
                                {
-                                   align  = "center",
+                                   halign = "center",
                                    widget = naughty.widget.message,
                                },
                                {

--- a/tests/examples/wibox/widget/calendar/month.lua
+++ b/tests/examples/wibox/widget/calendar/month.lua
@@ -20,7 +20,7 @@ local date = os.date("*t") --DOC_HIDE
             {
                 {
                     text = '{day='..date.day..', month='..date.month..',\n year='..date.year..'}',
-                    align = 'center',
+                    halign = 'center',
                     widget = wibox.widget.textbox
                 },
                 border_width = 2,
@@ -35,7 +35,7 @@ local date = os.date("*t") --DOC_HIDE
             {
                 {
                     text = '{month='..date.month..',\n year='..date.year..'}',
-                    align = 'center',
+                    halign = 'center',
                     widget = wibox.widget.textbox
                 },
                 border_width = 2,

--- a/tests/examples/wibox/widget/defaults/textbox.lua
+++ b/tests/examples/wibox/widget/defaults/textbox.lua
@@ -6,7 +6,7 @@ parent:add( --DOC_HIDE
 
 wibox.widget{
     markup = "This <i>is</i> a <b>textbox</b>!!!",
-    align  = "center",
+    halign = "center",
     valign = "center",
     widget = wibox.widget.textbox
 }

--- a/tests/examples/wibox/widget/progressbar/background_color.lua
+++ b/tests/examples/wibox/widget/progressbar/background_color.lua
@@ -20,7 +20,7 @@ for _, color in ipairs { {nil}, {"#ff0000"}, {"#00ff00"}, {"#0000ff44"} } do
         pb,
         {
             text   = color[1] and '"'..color[1]..'"' or "nil",
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/bar_border_color.lua
+++ b/tests/examples/wibox/widget/progressbar/bar_border_color.lua
@@ -21,7 +21,7 @@ for _, color in ipairs { {nil}, {"#ff0000"}, {"#00ff00"}, {"#0000ff44"} } do
         pb,
         {
             text   = color[1] and '"'..color[1]..'"' or "nil",
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/bar_border_width.lua
+++ b/tests/examples/wibox/widget/progressbar/bar_border_width.lua
@@ -21,7 +21,7 @@ for _, width in ipairs { 0, 2, 4, 6 } do
         pb,
         {
             text   = width,
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/border_color.lua
+++ b/tests/examples/wibox/widget/progressbar/border_color.lua
@@ -21,7 +21,7 @@ for _, color in ipairs { {nil}, {"#ff0000"}, {"#00ff00"}, {"#0000ff44"} } do
         pb,
         {
             text   = color[1] and '"'..color[1]..'"' or "nil",
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/border_width.lua
+++ b/tests/examples/wibox/widget/progressbar/border_width.lua
@@ -21,7 +21,7 @@ for _, width in ipairs { 0, 2, 4, 6 } do
         pb,
         {
             text   = width,
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/color.lua
+++ b/tests/examples/wibox/widget/progressbar/color.lua
@@ -20,7 +20,7 @@ for _, color in ipairs { {nil}, {"#ff0000"}, {"#00ff00"}, {"#0000ff44"} } do
         pb,
         {
             text   = color[1] and '"'..color[1]..'"' or "nil",
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/margins1.lua
+++ b/tests/examples/wibox/widget/progressbar/margins1.lua
@@ -20,7 +20,7 @@ for _, margin in ipairs { 0, 2, 4, 6 } do
         pb,
         {
             text   = margin,
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/max_value.lua
+++ b/tests/examples/wibox/widget/progressbar/max_value.lua
@@ -20,7 +20,7 @@ for _, value in ipairs { 0, 10, 42, 999 } do
         pb,
         {
             text   = value.."/42",
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/paddings1.lua
+++ b/tests/examples/wibox/widget/progressbar/paddings1.lua
@@ -20,7 +20,7 @@ for _, padding in ipairs { 0, 2, 4, 6 } do
         pb,
         {
             text   = padding,
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/text.lua
+++ b/tests/examples/wibox/widget/progressbar/text.lua
@@ -19,7 +19,7 @@ parent:add( --DOC_HIDE
         {
             text   = "50%",
             valign = "center",
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         layout = wibox.layout.stack

--- a/tests/examples/wibox/widget/progressbar/ticks.lua
+++ b/tests/examples/wibox/widget/progressbar/ticks.lua
@@ -21,7 +21,7 @@ for _, has_ticks in ipairs { true, false } do
         pb,
         {
             text   = tostring(has_ticks),
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/ticks_gap.lua
+++ b/tests/examples/wibox/widget/progressbar/ticks_gap.lua
@@ -22,7 +22,7 @@ for _, gap in ipairs { 0, 2, 4, 6 } do
         pb,
         {
             text   = gap,
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/ticks_size.lua
+++ b/tests/examples/wibox/widget/progressbar/ticks_size.lua
@@ -22,7 +22,7 @@ l.spacing = 5
            pb,
            {
                text   = size,
-               align  = "center",
+               halign = "center",
                widget = wibox.widget.textbox,
            },
            forced_height = 30,

--- a/tests/examples/wibox/widget/progressbar/ticks_size2.lua
+++ b/tests/examples/wibox/widget/progressbar/ticks_size2.lua
@@ -74,7 +74,7 @@ l3.spacing = 5
            pb,
            {
                text   = size,
-               align  = "center",
+               halign = "center",
                widget = wibox.widget.textbox,
            },
            forced_height = 30,
@@ -85,7 +85,7 @@ l3.spacing = 5
            pb3,
            {
                text   = size,
-               align  = "center",
+               halign = "center",
                widget = wibox.widget.textbox,
            },
            forced_height = 30,
@@ -100,7 +100,7 @@ l3.spacing = 5
                    {
                        {
                            text   = size,
-                           align  = "center",
+                           halign = "center",
                            widget = wibox.widget.textbox,
                        },
                        margins = 4,
@@ -110,7 +110,7 @@ l3.spacing = 5
                    shape = gears.shape.circle,
                    widget = wibox.container.background,
                },
-               align = "center",
+               halign = "center",
                valign = "center",
                widget = wibox.container.place,
            },

--- a/tests/examples/wibox/widget/progressbar/value.lua
+++ b/tests/examples/wibox/widget/progressbar/value.lua
@@ -19,7 +19,7 @@ for _, value in ipairs { 0, 0.2, 0.5, 1 } do
         pb,
         {
             text   = value,
-            align  = "center",
+            halign = "center",
             widget = wibox.widget.textbox,
         },
         forced_height = 30,

--- a/tests/examples/wibox/widget/textbox/align1.lua
+++ b/tests/examples/wibox/widget/textbox/align1.lua
@@ -8,7 +8,7 @@ local ret = wibox.layout.fixed.vertical()
 --DOC_HIDE_END
 for _, align in ipairs {"left", "center", "right"} do
     local w = wibox.widget {
-        align  = align,
+        halign = align,
         text   = "some text",
         widget = wibox.widget.textbox,
     }

--- a/tests/examples/wibox/widget/textbox/ellipsize.lua
+++ b/tests/examples/wibox/widget/textbox/ellipsize.lua
@@ -3,6 +3,7 @@
 --DOC_HIDE_START
 local parent = ...
 local wibox  = require("wibox")
+local beautiful = require("beautiful")
 
 local widget = function(inner)
     return wibox.widget {
@@ -13,6 +14,7 @@ local widget = function(inner)
                 widget = wibox.container.margin,
             },
             border_width = 2,
+            border_color = beautiful.border_color,
             widget = wibox.container.background,
         },
         strategy = "max",

--- a/tests/examples/wibox/widget/textbox/indent.lua
+++ b/tests/examples/wibox/widget/textbox/indent.lua
@@ -1,0 +1,47 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+
+--DOC_HIDE_START
+local parent = ...
+local wibox  = require("wibox")
+local beautiful = require("beautiful")
+
+local widget = function(inner)
+    return wibox.widget {
+        {
+            inner,
+            margins = 5,
+            widget  = wibox.container.margin,
+        },
+        border_width = 1,
+        forced_width = 150,
+        forced_height = 150,
+        border_color = beautiful.border_color,
+        widget = wibox.container.background,
+    }
+end
+
+local l = wibox.layout.grid.horizontal(2)
+l. homogeneous = false
+--DOC_HIDE_END
+
+local lorem_ipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed "..
+    "do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad "..
+    "minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex "..
+    "ea commodo consequat."
+
+for _, indent in ipairs { -10, 0, 10 } do
+    l:add(wibox.widget.textbox("indent = "..indent)) --DOC_HIDE
+    l:add( --DOC_HIDE
+    widget{
+        text   = lorem_ipsum,
+        indent = indent,
+        widget = wibox.widget.textbox,
+    }
+    ) --DOC_HIDE
+end
+--DOC_HIDE_START
+
+parent:add(l)
+
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/textbox/justify.lua
+++ b/tests/examples/wibox/widget/textbox/justify.lua
@@ -1,0 +1,52 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+
+--DOC_HIDE_START
+local parent = ...
+local wibox  = require("wibox")
+local beautiful = require("beautiful")
+
+local widget = function(inner)
+    return wibox.widget {
+        {
+            inner,
+            margins = 5,
+            widget = wibox.container.margin,
+        },
+        border_width = 1,
+        border_color = beautiful.border_color,
+        widget = wibox.container.background,
+    }
+end
+
+local l = wibox.layout.flex.horizontal()
+
+--DOC_HIDE_END
+
+local lorem_ipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed "..
+    "do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad "..
+    "minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex "..
+    "ea commodo consequat."
+--DOC_NEWLINE
+
+l:add( --DOC_HIDE
+widget{
+    text    = lorem_ipsum,
+    justify = false,
+    widget  = wibox.widget.textbox,
+}
+) --DOC_HIDE
+--DOC_NEWLINE
+l:add( --DOC_HIDE
+widget{
+    text    = lorem_ipsum,
+    justify = true,
+    widget  = wibox.widget.textbox,
+}
+) --DOC_HIDE
+--DOC_HIDE_START
+
+parent:add(l)
+
+return 320
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/examples/wibox/widget/textbox/line_spacing.lua
+++ b/tests/examples/wibox/widget/textbox/line_spacing.lua
@@ -1,0 +1,41 @@
+--DOC_GEN_IMAGE --DOC_HIDE
+
+--DOC_HIDE_START
+local parent = ...
+local wibox  = require("wibox")
+local beautiful = require("beautiful")
+
+local widget = function(inner)
+    return wibox.widget {
+        {
+            inner,
+            margins = 5,
+            widget = wibox.container.margin,
+        },
+        border_width = 1,
+        border_color = beautiful.border_color,
+        widget = wibox.container.background,
+    }
+end
+
+local l = wibox.layout.grid.vertical(4)
+--DOC_HIDE_END
+
+for _, spacing in ipairs {0.0, 0.1, 0.5, 0.9, 1, 1.5, 2.0, 2.5} do
+    local text = "This text shas a line\nspacing of "..tostring(spacing).. "\nunits."
+    --DOC_NEWLINE
+    l:add( --DOC_HIDE
+    widget{
+        text                = text,
+        font                = "sans 10",
+        line_spacing_factor = spacing,
+        widget              = wibox.widget.textbox,
+    }
+    ) --DOC_HIDE
+end
+--DOC_HIDE_START
+
+parent:add(l)
+
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-leak-client.lua
+++ b/tests/test-leak-client.lua
@@ -39,7 +39,7 @@ local function create_titlebar(c)
 
     -- The title goes in the middle
     parts.title = awful.titlebar.widget.titlewidget(c)
-    parts.title:set_align("center")
+    parts.title:set_halign("center")
     local middle_layout = wibox.layout.flex.horizontal(parts.title)
     middle_layout.buttons = buttons
 


### PR DESCRIPTION
Fix a consistency bug and implement a feature request from Discord. Last time we did a sync with the Pango API was in 2011. There isn't that many useful new features for us, but there's some. Note that this soft-bump the required Pango version to 1.44. If it's an older version, it will print an error if `line_spacing_factor` is used.