### PR TITLE
Fixing warnings in the documentation build.

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -1994,7 +1994,7 @@ local function detect_markdown_footguns(string)
 
             -- Detect unquoted code with 2 underscores. They will render as italic,
             -- which is definitively not wanted. Add "`" to fix.
-            for part in line:gmatch("[^`]*") do
+            for part in line:gmatch("[^`]*`?") do
                 if not is_tick then
                     local count = 0
 


### PR DESCRIPTION
There are warnings like:
```
WARNING: awful.hotkeys_popup.show_help from awful.hotkeys_popup seems to have ambiguous markdown in its summary, probably underscores. Please either use '`' or HTML.
```

during `ldoc` execution. This fix correctly checks when the underscores are within the '`'.