### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -17,8 +17,12 @@ defaults:
     # to improve debugging some of the longer scripts.
     shell: /bin/bash -o errexit -o pipefail -o xtrace {0}
 
+permissions: {}
 jobs:
   main:
+    permissions:
+      contents: write # for git push
+
     runs-on: ubuntu-20.04
 
     env:

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -17,12 +17,11 @@ defaults:
     # to improve debugging some of the longer scripts.
     shell: /bin/bash -o errexit -o pipefail -o xtrace {0}
 
-permissions: {}
+permissions:
+  contents: read
+
 jobs:
   main:
-    permissions:
-      contents: write # for git push
-
     runs-on: ubuntu-20.04
 
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,9 @@ defaults:
     # to improve debugging some of the longer scripts.
     shell: /bin/bash -o errexit -o pipefail -o xtrace {0}
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   main:
     # The type of runner that the job will run on


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.