### PR TITLE
Revert "fix(ldoc): set `format` to "markdown" (#3500)" (#3703)

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -74,6 +74,7 @@ jobs:
             libxkbcommon-dev \
             libxkbcommon-x11-dev \
             xutils-dev \
+            lua-discount \
             liblua5.3-dev \
             lua5.3
 

--- a/docs/config.ld
+++ b/docs/config.ld
@@ -9,6 +9,7 @@ project='awesome' -- luacheck: globals project
 title='awesome API documentation'  -- luacheck: globals title
 description='API documentation for awesome, a highly configurable X window manager (version @AWESOME_VERSION@).'  -- luacheck: globals description
 
+format='discount'  -- luacheck: globals format
 dir='../doc'  -- luacheck: globals dir
 
 -- Make the docs prettier


### PR DESCRIPTION
This reverts commit 8d5c74fae39061efe5403d4b98419c0440a8121e.

I was sure to have generated and checked the doc locally. I think it's safer to revert the commit, and I'll work again on this topic latter.

Sorry for the annoyance.

Fix: #3703