### PR TITLE
Fix rule source order

### DIFF
--- a/lib/gears/matcher.lua
+++ b/lib/gears/matcher.lua
@@ -431,7 +431,7 @@ function matcher:add_matching_function(name, callback, depends_on, precede)
 
     for _, v in ipairs(res) do
         if callbacks[v] then
-            table.insert(self._matching_source, 1, {
+            table.insert(self._matching_source, {
                 callback = callbacks[v],
                 name     = v
             })

--- a/lib/ruled/client.lua
+++ b/lib/ruled/client.lua
@@ -264,7 +264,7 @@ end
 --
 -- @rulesources awful.rules
 
-crules:add_matching_rules("awful.rules", {}, {"awful.spawn"}, {})
+crules:add_matching_rules("awful.rules", {}, {}, {"awful.spawn"})
 
 -- Add startup_id overridden properties
 local function apply_spawn_rules(c, props, callbacks)
@@ -289,7 +289,7 @@ end
 --
 -- @rulesources awful.spawn
 
-module.add_rule_source("awful.spawn", apply_spawn_rules, {}, {"awful.rules"})
+module.add_rule_source("awful.spawn", apply_spawn_rules, {"awful.rules"}, {})
 
 local function apply_singleton_rules(c, props, callbacks)
     local persis_id, info = c.single_instance_id, nil
@@ -331,7 +331,7 @@ end
 --
 -- @rulesources awful.spawn_once
 
-module.add_rule_source("awful.spawn_once", apply_singleton_rules, {"awful.spawn"}, {"awful.rules"})
+module.add_rule_source("awful.spawn_once", apply_singleton_rules, {"awful.rules"}, {"awful.spawn"})
 
 local function add_to_tag(c, t)
     if not t then return end

--- a/objects/client.c
+++ b/objects/client.c
@@ -1415,7 +1415,7 @@ lua_class_t client_class;
  *        -- subprocess or another window for the same process. While it makes sense
  *        -- in some case to apply the same rules, it is not always the case, so
  *        -- better doing nothing rather than something stupid.
- *        if blacklisted_snid[snid] then return end
+ *        if not snid or blacklisted_snid[snid] then return end
  *
  *        c.startup_id = snid
  *
@@ -1423,7 +1423,7 @@ lua_class_t client_class;
  *    end
  *
  *    ruled.client.add_rule_source(
- *        "snid", fix_startup_id, {}, {"awful.spawn", "ruled.client"}
+ *        "snid", fix_startup_id, {}, {"awful.spawn", "awful.rules"}
  *    )
  *
  * @property startup_id


### PR DESCRIPTION
Default rule source order is:

1. `awful.rules`
2. `awful.spawn_once`
3. `awful.spawn`

I wanted to use `fix_startup_id` function as suggested in the documentation, but the function put the `snid` rule source at the end.

1. `awful.rules`
2. `awful.spawn_once`
3. `awful.spawn`
4. `snid`

It should be the first rule because the `precede` parameter is `{"awful.spawn", "awful.rules"}`.

There is a mismatch between the code and the comments for `depends_on` and `precede` parameters in `ruled.client.add_rule_source`/`gears.matcher.add_matching_function` functions.

- `depends_on` -  A list of names of sources this source depends on (**sources that must be executed *before* `name`**).
- `precede` -  A list of names of sources this source has a priority over.

A quick fix would be to swap the parameters (I guess) however that would break the API.
