### PR TITLE
Restore minimized sticky clients

### DIFF
--- a/lib/awful/client.lua
+++ b/lib/awful/client.lua
@@ -1132,8 +1132,12 @@ function client.restore(s)
     local cls = capi.client.get(s)
     local tags = s.selected_tags
     for _, c in pairs(cls) do
-        local ctags = c:tags()
         if c.minimized then
+            if c.sticky then
+                c.minimized = false
+                return c
+            end
+            local ctags = c:tags()
             for _, t in ipairs(tags) do
                 if gtable.hasitem(ctags, t) then
                     c.minimized = false


### PR DESCRIPTION
If a sticky client is minimized on a tag not assigned to it, one has to switch to the tag to be able to restore the minimized client.
A minimized sticky client should be able to be restored with `awful.client.restore()`.