### PR TITLE
Fix building docs

### DIFF
--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -383,7 +383,7 @@ add_custom_target(check-examples DEPENDS ${EXAMPLE_DOC_TEST_TARGETS})
 
 # Some tests produce multiple files, find them and post-process them.
 add_custom_target(DOC_EXAMPLES_PPOSTPROCESS_CLEANUP
-    COMMAND "${TOP_SOURCE_DIR}/tests/examples/_postprocess_cleanup.lua" ${RAW_IMAGE_DIR} ${IMAGE_DIR} "${TOP_SOURCE_DIR}/tests/examples/_postprocess.lua"
+    COMMAND "${LUA_EXECUTABLE}" "${TOP_SOURCE_DIR}/tests/examples/_postprocess_cleanup.lua" ${RAW_IMAGE_DIR} ${IMAGE_DIR} "${TOP_SOURCE_DIR}/tests/examples/_postprocess.lua"
     VERBATIM
     DEPENDS ${BUILD_DIR}/doc/index.html
 )


### PR DESCRIPTION
One of the new build scripts doesn't use the CMake `LUA_EXECUTABLE` and instead relies on `/usr/bin/env lua`.
On systems where multiple Lua versions are installed, that can lead to inconsistencies.
On systems where 5.4 is the default, for which LGI doesn't have a release, that will lead to

```
lua: ...projects/awesome/tests/examples/_postprocess_cleanup.lua:8: module 'lgi' not found:
        No LuaRocks module found for lgi
        no field package.preload['lgi']
        no file '/home/lucas/.luarocks/share/lua/5.4/lgi.lua'
        no file '/home/lucas/.luarocks/share/lua/5.4/lgi/init.lua'
        no file '/usr/share/lua/5.4/lgi.lua'
        no file '/usr/share/lua/5.4/lgi/init.lua'
        no file './lgi.lua'
        no file './lgi/init.lua'
        no file '/usr/lib/lua/5.4/lgi.lua'
        no file '/usr/lib/lua/5.4/lgi/init.lua'
        no file '/home/lucas/.luarocks/lib/lua/5.4/lgi.so'
        no file '/usr/lib/lua/5.4/lgi.so'
        no file '/usr/local/lib/lua/5.4/lgi.so'
        no file './lgi.so'
        no file '/usr/lib/lua/5.4/loadall.so'
stack traceback:
        [C]: in function 'require'
        ...projects/awesome/tests/examples/_postprocess_cleanup.lua:8: in main chunk
        [C]: in ?
make[3]: *** [CMakeFiles/DOC_EXAMPLES_PPOSTPROCESS_CLEANUP.dir/build.make:70: CMakeFiles/DOC_EXAMPLES_PPOSTPROCESS_CLEANUP] Error 1
make[2]: *** [CMakeFiles/Makefile2:28711: CMakeFiles/DOC_EXAMPLES_PPOSTPROCESS_CLEANUP.dir/all] Error 2
make[1]: *** [Makefile:136: all] Error 2
make: *** [Makefile:15: cmake-build] Error 2
```