### PR TITLE
mousegrabber: add nil as a possible cursor value to not change the cursor

### DIFF
--- a/docs/89-NEWS.md
+++ b/docs/89-NEWS.md
@@ -14,6 +14,7 @@ This document was last updated at commit v4.3-197-g9085ed631.
 
 ## New features
 
+* `mousegrabber` can now take `nil` as a cursor to not change the cursor at all.
 * `awful.screen` now has a `request::wallpaper` and a
   `request::desktop_decoration` signal. They make some workflow implementation
   cleaner.


### PR DESCRIPTION
I've changed the mousegrabber so it can take a nil as an argument to simply not change the cursor.
(This time without nuking my repo and this rp)

The function will now first check if the value if nil, if its not nil its going to check if the string is valid, if not the user will get a warning if its valid its going to get the cursor and attach it (if its nil its going to attach XCB_NULL). 