### PR TITLE
Menu items can be disabled (+ menu separator)

### DIFF
--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -241,7 +241,7 @@ local function check_access_key(self, key)
    end
 end
 
-local function select_next(self, current, direction)
+function menu:select_next(direction, current)
     local count = #self.items
     if count < 1 then
         return
@@ -249,7 +249,7 @@ local function select_next(self, current, direction)
 
     local index = current or self.sel or 0
     for _ = 1, count do
-        index = index + direction
+        index = index + (direction or 1)
         if index < 1 then
             index = count
         elseif index > count then
@@ -269,9 +269,9 @@ local function grabber(self, _, key, event)
 
     local sel = self.sel or 0
     if gtable.hasitem(menu.menu_keys.up, key) then
-        select_next(self, sel, -1)
+        self:select_next(-1, sel)
     elseif gtable.hasitem(menu.menu_keys.down, key) then
-        select_next(self, sel, 1)
+        self:select_next(1, sel)
     elseif sel > 0 and gtable.hasitem(menu.menu_keys.enter, key) then
         self:exec(sel)
     elseif sel > 0 and gtable.hasitem(menu.menu_keys.exec, key) then
@@ -764,6 +764,7 @@ function menu.new(args, parent)
     args = args or {}
     args.layout = args.layout or wibox.layout.flex.vertical
     local _menu = table_update(object(), {
+        select_next = menu.select_next,
         item_enter = menu.item_enter,
         item_leave = menu.item_leave,
         get_root = menu.get_root,


### PR DESCRIPTION
This PR allow menu items to be disabled.

I would like to add menu separators (as regular items with custom style) but I need them to be disabled. So that the separators don't change style on hover and are skipped when navigating with a keyboard.

Usage:

```lua
awful.menu {
    { "foo" },
    { "bar", enabled = false },
    { "baz" },
}
```

### Edit:

I think a menu separator is a basic feature and should be in Awesome library. The new "enabled" property together with existing `new` function allows easy implementation of the separator.

```lua
awful.menu {
    { "foo" },
    { new = awful.menu.separator },
    { "baz" },
}

function awful.menu.separator(parent, args)
    args = args or {}
    return {
        enabled = false,
        height = args.theme.height * 0.5,
        widget = wibox.widget.separator {
            span_ratio = args.span_ratio or 1,
            thickness = args.thickness or args.theme.border_width or 1,
            color = args.color or args.theme.border,
        }
    }
end
```


Maybe it could be defined directly as an item with the `new` property:
```lua
awful.menu {
    { "foo" },
    awful.menu.separator,
    { "baz" },
}
```


