### PR TITLE
fix xrandr 1.5 virtual monitors. issue 3132

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -664,9 +664,6 @@ screen_scan_randr_monitors(lua_State *L, screen_array_t *screens)
     {
         screen_t *new_screen;
 
-        if(!xcb_randr_monitor_info_outputs_length(monitor_iter.data))
-            continue;
-
         screen_output_t output = screen_get_randr_output(L, &monitor_iter);
 
         viewport_t *viewport = viewport_add(L,


### PR DESCRIPTION
This is the fix mentioned in https://github.com/awesomeWM/awesome/issues/3132 . The issue is that virtual monitors that xrandr 1.5 create don't always have an output device. I have removed the check that doesn't allow monitors with no output devices attached. This solution works for me.