### PR TITLE
Rewrite the xcursor caching code

### DIFF
--- a/common/xcursor.h
+++ b/common/xcursor.h
@@ -24,10 +24,12 @@
 
 #include <xcb/xcb.h>
 #include <xcb/xcb_cursor.h>
+#include "common/array.h"
 
-uint16_t xcursor_font_fromstr(const char *);
-const char * xcursor_font_tostr(uint16_t);
-xcb_cursor_t xcursor_new(xcb_cursor_context_t *, uint16_t);
+typedef struct cursor_cache_entry_t cursor_cache_entry_t;
+ARRAY_TYPE(cursor_cache_entry_t, cursors)
+
+xcb_cursor_t xcursor_new(cursors_array_t *, xcb_cursor_context_t *, const char *);
 
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/globalconf.h
+++ b/globalconf.h
@@ -40,6 +40,7 @@
 
 #include "objects/key.h"
 #include "common/xembed.h"
+#include "common/xcursor.h"
 #include "common/buffer.h"
 
 #define ROOT_WINDOW_EVENT_MASK \
@@ -88,6 +89,8 @@ typedef struct
     int default_screen;
     /** xcb-cursor context */
     xcb_cursor_context_t *cursor_ctx;
+    /** cache of already loaded cursors */
+    cursors_array_t cursor_cache;
 #ifdef WITH_XCB_ERRORS
     /** xcb-errors context */
     xcb_errors_context_t *errors_ctx;

--- a/mousegrabber.c
+++ b/mousegrabber.c
@@ -103,14 +103,12 @@ luaA_mousegrabber_run(lua_State *L)
 
     if(!lua_isnil(L, 2))
     {
-        uint16_t cfont = xcursor_font_fromstr(luaL_checkstring(L, 2));
-        if(!cfont)
+        cursor = xcursor_new(&globalconf.cursor_cache, globalconf.cursor_ctx, luaL_checkstring(L, 2));
+        if (!cursor)
         {
             luaA_warn(L, "invalid cursor");
             return 0;
         }
-
-        cursor = xcursor_new(globalconf.cursor_ctx, cfont);
     }
 
     luaA_registerfct(L, 1, &globalconf.mousegrabber);

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -449,7 +449,7 @@ drawin_allocator(lua_State *L)
                           | XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_EXPOSURE
                           | XCB_EVENT_MASK_PROPERTY_CHANGE,
                           globalconf.default_cmap,
-                          xcursor_new(globalconf.cursor_ctx, xcursor_font_fromstr(w->cursor))
+                          xcursor_new(&globalconf.cursor_cache, globalconf.cursor_ctx, w->cursor)
                       });
     xwindow_set_class_instance(w->window);
     xwindow_set_name_static(w->window, "Awesome drawin");
@@ -608,10 +608,9 @@ luaA_drawin_set_cursor(lua_State *L, drawin_t *drawin)
     const char *buf = luaL_checkstring(L, -1);
     if(buf)
     {
-        uint16_t cursor_font = xcursor_font_fromstr(buf);
-        if(cursor_font)
+        xcb_cursor_t cursor = xcursor_new(&globalconf.cursor_cache, globalconf.cursor_ctx, buf);
+        if(cursor)
         {
-            xcb_cursor_t cursor = xcursor_new(globalconf.cursor_ctx, cursor_font);
             p_delete(&drawin->cursor);
             drawin->cursor = a_strdup(buf);
             xwindow_set_cursor(drawin->window, cursor);

--- a/root.c
+++ b/root.c
@@ -447,11 +447,11 @@ static int
 luaA_root_cursor(lua_State *L)
 {
     const char *cursor_name = luaL_checkstring(L, 1);
-    uint16_t cursor_font = xcursor_font_fromstr(cursor_name);
+    xcb_cursor_t cursor = xcursor_new(&globalconf.cursor_cache, globalconf.cursor_ctx, cursor_name);
 
-    if(cursor_font)
+    if(cursor)
     {
-        uint32_t change_win_vals[] = { xcursor_new(globalconf.cursor_ctx, cursor_font) };
+        uint32_t change_win_vals[] = { cursor };
 
         xcb_change_window_attributes(globalconf.connection,
                                      globalconf.screen->root,


### PR DESCRIPTION
Previously, the cache for xcursors consisted of a static array. We had a hardcoded list of supported cursor names and each one got assigned a position in this array. This hardcoded list means that one cannot simply use whatever cursor a cursor theme happens to provide, since the name needs to be in our list.

In this commit, the code is rewritten. Instead of a hardcoded list, a sorted array is now used as the cache, as provided by the BARRAY code from common/util.h. The array is sorted by the name of the cursor.

This change implies an API change for the xcursor code. Previously, one had to first translate a cursor name into a cache index (xcursor_font_fromstr()) and could then use this to actually get the cursor (xcursor_new()). With this commit, xcursor_new() is the only function provided by the cursor code and it directly gets a string as argument.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

This PR is related to #3737. I am 80% sure that this PR implements (half of) that feature request by making it possible to use arbitrary cursors, as long as xcb-util-cursor can load a cursor by that name.

@akinokonomi Are you in a position to test this? (=Can you build awesome from a git branch and verify whether this does what you want?)

Personally, I only started awesome via `tests/run.sh /dev/null` and started xterm from the menu. The "waiting for startup" cursor briefly appeared. Nothing more was tested.