### PR TITLE
Arrange layout when client gets untagged

### DIFF
--- a/lib/awful/layout/init.lua
+++ b/lib/awful/layout/init.lua
@@ -372,6 +372,7 @@ capi.tag.connect_signal("property::activated", arrange_tag)
 capi.tag.connect_signal("property::useless_gap", arrange_tag)
 capi.tag.connect_signal("property::master_fill_policy", arrange_tag)
 capi.tag.connect_signal("tagged", arrange_tag)
+capi.tag.connect_signal("untagged", arrange_tag)
 
 capi.screen.connect_signal("property::workarea", layout.arrange)
 capi.screen.connect_signal("padding", layout.arrange)


### PR DESCRIPTION
This fixes the following bug.

When client gets untagged with current tag then the tag layout is not arranged. This can leave empty space in some layouts. To fix this, the user must manually ensure layout arrange using other action (e.g. resize any client, unselect and select again current tag, ...).

**Steps to reproduce:**

1. Initial state (`awful.layout.suit.tile` layout)

        tag 1 (selected)  tag 2
        +───+─────────+   +─────────────+
        |   |    2    |   |             |
        |   +─────────+   |             |
        | 1 |    3    |   |    empty    |
        |   +─────────+   |             |
        |   |    4    |   |             |
        +───+─────────+   +─────────────+

2. Toggle tag 2 on client 4 (`c4:toggle_tag(t2)`)

        tag 1 (selected)  tag 2
        +───+─────────+   +─────────────+
        |   |    2    |   |             |
        |   +─────────+   |             |
        | 1 |    3    |   |      4      |
        |   +─────────+   |             |
        |   |    4    |   |             |
        +───+─────────+   +─────────────+

3. Toggle tag 1 on client 4 (`c4:toggle_tag(t1)`)

    **Actual result:**

        tag 1 (selected)  tag 2
        +───+─────────+   +─────────────+
        |   |    2    |   |             |
        |   +─────────+   |             |
        | 1 |    3    |   |      4      |
        |   +─────────+   |             |
        |   |  empty  |   |             |
        +───+─────────+   +─────────────+

    **Expected result:**

        tag 1 (selected)  tag 2
        +───+─────────+   +─────────────+
        |   |    2    |   |             |
        | 1 +─────────+   |      4      |
        |   |    3    |   |             |
        +───+─────────+   +─────────────+


**Awesome version:**
awesome v4.3-1583-ge281fa3a3