### PR TITLE
Fix error in docs

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -340,7 +340,7 @@ lua_class_t client_class;
  *        end
  *    end)
  *
- * @signal request::urgent
+ * @signal property::urgent
  * @tparam client c The client whose property changed.
  * @classsignal
  */


### PR DESCRIPTION
Isn't that supposed to be `property::urgent` and not `request::urgent`.