### PR TITLE
Connect signal and disconnect signal leaks memory

### DIFF
--- a/common/signal.h
+++ b/common/signal.h
@@ -98,8 +98,12 @@ signal_disconnect(signal_array_t *arr, const char *name, const void *ref)
             if(ref == *func)
             {
                 cptr_array_remove(&sigfound->sigfuncs, func);
-                if(sigfound->sigfuncs.len == 0)
+                if(sigfound->sigfuncs.len == 0) {
+                    if(sigfound->sigfuncs.tab) {
+                        p_delete(&sigfound->sigfuncs.tab);
+                    }
                     signal_array_remove(arr, sigfound);
+                }
                 return true;
             }
     }

--- a/common/signal.h
+++ b/common/signal.h
@@ -100,7 +100,7 @@ signal_disconnect(signal_array_t *arr, const char *name, const void *ref)
                 cptr_array_remove(&sigfound->sigfuncs, func);
                 if(sigfound->sigfuncs.len == 0) {
                     if(sigfound->sigfuncs.tab) {
-                        p_delete(&sigfound->sigfuncs.tab);
+                        cptr_array_wipe(&sigfound->sigfuncs);
                     }
                     signal_array_remove(arr, sigfound);
                 }


### PR DESCRIPTION
Function signal_disconnect don't deallocate signal array after last signal removed. For example this is my rc.lua:

```lua
local a = function()
end

for s in screen do
	for i=0, 10000000 do
		s:connect_signal("property::geometry" , a)
		s:disconnect_signal("property::geometry" , a)
	end
end

awesome.quit();
```
And this is memusage:
![mem](https://user-images.githubusercontent.com/33599/222075407-f30dece9-7a4b-4ec2-ae0a-29038ce7c33f.png)

This is memusage after patch:
![mem](https://user-images.githubusercontent.com/33599/222076055-8b98e3b6-9449-4801-a309-bf24fdabdb10.png)


