### PR TITLE
Modeline parsing never ends before end of file

### DIFF
--- a/options.c
+++ b/options.c
@@ -267,6 +267,7 @@ options_init_config(xdgHandle *xdg, char *execpath, char *configpath, int *init_
                         state = MODELINE_STATE_KEY_DELIM;
                         break;
                     case '\n': case '\r':
+                        push_arg(&argv, key_buf, &pos);
                         state = MODELINE_STATE_COMPLETE;
                         break;
                     default:
@@ -291,7 +292,7 @@ options_init_config(xdgHandle *xdg, char *execpath, char *configpath, int *init_
             break;
 
         /* Try the next line */
-        if (((i == READ_BUF_MAX || file_buf[i+1] == '\0') && !feof(fp)) || state == MODELINE_STATE_INVALID) {
+        if (((i == READ_BUF_MAX || file_buf[i] == '\0') && !feof(fp)) || state == MODELINE_STATE_INVALID) {
             if (state == MODELINE_STATE_KEY || state == MODELINE_STATE_VALUE)
                 push_arg(&argv, key_buf, &pos);
 


### PR DESCRIPTION
Next line parsing checks if next character is end of buffer, but position i is already incremented with postfix operator. Branch MODELINE_STATE_VALUE never received '\n' character and state MODELINE_STATE_COMPLETE is never used. Next line should check for character on position i instead of i+1, then new line is pssed to MODELINE_STATE_VALUE branch and in this branch, current argument should be pushed to argument list.