### PR TITLE
Layoutbox rendering is blurry on HiDPI screen

### DIFF
--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -15,7 +15,6 @@ local layout = require("awful.layout")
 local tooltip = require("awful.tooltip")
 local beautiful = require("beautiful")
 local wibox = require("wibox")
-local surface = require("gears.surface")
 local gdebug = require("gears.debug")
 local gtable = require("gears.table")
 

--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -36,7 +36,7 @@ local function update(w, screen)
     if img then
         w.imagebox:set_image(beautiful["layout_" .. name])
     end
-    w.textbox.text   = img and "" or name
+    w.textbox.text = img and "" or name
 end
 
 local function update_from_tag(t)

--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -33,7 +33,9 @@ local function update(w, screen)
     w._layoutbox_tooltip:set_text(name or "[no name]")
 
     local img = surface.load_silently(beautiful["layout_" .. name], false)
-    w.imagebox.image = img
+    if img then
+        w.imagebox:set_image(beautiful["layout_" .. name])
+    end
     w.textbox.text   = img and "" or name
 end
 

--- a/lib/awful/widget/layoutbox.lua
+++ b/lib/awful/widget/layoutbox.lua
@@ -32,11 +32,13 @@ local function update(w, screen)
     local name = layout.getname(layout.get(screen))
     w._layoutbox_tooltip:set_text(name or "[no name]")
 
-    local img = surface.load_silently(beautiful["layout_" .. name], false)
-    if img then
-        w.imagebox:set_image(beautiful["layout_" .. name])
+    local image_name = "layout_" .. name
+    local theme_image = beautiful[image_name]
+    local success = false
+    if theme_image ~= nil then
+        success = w.imagebox:set_image(beautiful[image_name])
     end
-    w.textbox.text = img and "" or name
+    w.textbox.text = success and "" or name
 end
 
 local function update_from_tag(t)


### PR DESCRIPTION
I think, layoutbox should not render icons directly. On HiDPI screens, svg files rendered this way are always in base resoltuion, which looks blurry. Method :set_image() should be called instead.

Few possible modifications:

Silent loading (surface.load_silently) could be dropped and if "layout_" .. name is set, image can be loaded directly. If it's not set, user will see just text representation. If path to image is not valid, i think, it's ok to display error message.

```
local image_name = "layout_" .. name
local theme_image = beautiful[image_name]
local success = false
if theme_image ~= nil then
    success = w.imagebox:set_image(beautiful[image_name])
end
w.textbox.text = success and "" or name
```

Or imagebox could have interface for silent loading.

![layotubox_sharp](https://user-images.githubusercontent.com/33599/227758182-e2251184-2102-4c9b-a622-553422475540.png)
