### PR TITLE
Draft: awful.hotkeys_popup rework

### DIFF
--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -676,6 +676,10 @@ function widget.new(args)
             -- for _, w in pairs(keys_layout.children) do
             --   w:adjust_ratio(2, keys_ratio, 1 - keys_ratio, 0)
             -- end
+
+            -- Remove the header if overlaps
+            if ik_add_new_column and overlap_leftovers ~= nil then ret:remove(1) end
+
             current_column.layout:add {
                 widget = wibox.container.background,
                 bg = self.group_bg,
@@ -686,6 +690,8 @@ function widget.new(args)
                         bottom = self.group_margin,
                         left = self.group_margin,
                         right = self.group_margin,
+                        top = (ik_add_new_column and overlap_leftovers ~= nil)
+                            and self.group_margin or 0
                     },
                     ret,
                 },
@@ -727,14 +733,12 @@ function widget.new(args)
                 self._additional_hotkeys[group]
             )
             if #keys > 0 then
-                -- - 2 * self.group_margin for actual usable space
-                self:_create_group_columns(column_layouts, group, keys, s, wibox_height - 2 * self.group_margin)
+                self:_create_group_columns(column_layouts, group, keys, s, wibox_height)
             end
         end
 
         -- arrange columns into pages
-        -- - 2 * self.group_margin for actual usable space
-        local available_width_px = wibox_width - 2 * self.group_margin
+        local available_width_px = wibox_width
         local pages = {}
         local columns = wibox.layout.fixed.horizontal()
         local previous_page_last_layout

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -268,14 +268,6 @@ widget.labels = {
 -- @beautiful beautiful.hotkeys_modifiers_fg
 -- @tparam color hotkeys_modifiers_fg
 
---- Background color used for miscellaneous labels of hotkeys widget.
--- @beautiful beautiful.hotkeys_label_bg
--- @tparam color hotkeys_label_bg
-
---- Foreground color used for hotkey groups and other labels.
--- @beautiful beautiful.hotkeys_label_fg
--- @tparam color hotkeys_label_fg
-
 --- Main hotkeys widget font.
 -- @beautiful beautiful.hotkeys_font
 -- @tparam string|lgi.Pango.FontDescription hotkeys_font
@@ -305,9 +297,6 @@ widget.labels = {
 -- @tparam[opt] string|lgi.Pango.FontDescription args.description_font Font used for hotkeys' descriptions.
 -- @tparam[opt] color args.modifiers_fg Foreground color used for hotkey
 -- modifiers (Ctrl, Alt, Super, etc).
--- @tparam[opt] color args.label_bg Background color used for miscellaneous labels.
--- @tparam[opt] color args.label_fg Foreground color used for group and other
--- labels.
 -- @tparam[opt] int args.group_margin Margin between hotkeys groups.
 -- @tparam[opt] table args.labels Labels used for displaying human-readable keynames.
 -- @tparam[opt] table args.group_rules Rules for showing 3rd-party hotkeys. @see `awful.hotkeys_popup.keys.vim`.
@@ -319,8 +308,6 @@ widget.labels = {
 -- @usebeautiful beautiful.hotkeys_border_color
 -- @usebeautiful beautiful.hotkeys_shape
 -- @usebeautiful beautiful.hotkeys_modifiers_fg
--- @usebeautiful beautiful.hotkeys_label_bg
--- @usebeautiful beautiful.hotkeys_label_fg
 -- @usebeautiful beautiful.hotkeys_font
 -- @usebeautiful beautiful.hotkeys_description_font
 -- @usebeautiful beautiful.hotkeys_group_margin
@@ -374,25 +361,26 @@ function widget.new(args)
         self.border_width = args.border_width or beautiful.hotkeys_border_width or beautiful.border_width
         self.border_color = args.border_color or beautiful.hotkeys_border_color or self.fg
         self.shape = args.shape or beautiful.hotkeys_shape
+        self.opacity = args.opacity or beautiful.hotkeys_opacity or 1
+        self.font = args.font or beautiful.hotkeys_font or "Monospace Bold 9"
+
+        -- Keys and their descriptions.
         self.modifiers_fg = args.modifiers_fg or beautiful.hotkeys_modifiers_fg or beautiful.bg_minimize or "#555555"
         self.modifiers_bg = args.modifiers_bg or beautiful.hotkeys_modifiers_bg or beautiful.bg_minimize
         self.modifiers_separator = args.modifiers_separator or "+"
         self.key_bg = args.key_bg or self.modifiers_bg
         self.keys_spacing = args.keys_spacing or 0
-        self.label_bg = args.label_bg or beautiful.hotkeys_label_bg or self.fg
-        self.label_fg = args.label_fg or beautiful.hotkeys_label_fg or self.bg
-        self.opacity = args.opacity or beautiful.hotkeys_opacity or 1
-        self.font = args.font or beautiful.hotkeys_font or "Monospace Bold 9"
         self.align_description = args.align_description == nil and true or args.align_description
         self.description_font = args.description_font or beautiful.hotkeys_description_font or "Monospace 8"
-        self.group_margin = args.group_margin or beautiful.hotkeys_group_margin or dpi(6)
-        self.label_colors = beautiful.xresources.get_current_theme()
 
+        -- Groups and their labels/titles
+        self.label_colors = beautiful.xresources.get_current_theme()
         self.group_bg = args.group_bg or beautiful.hotkeys_group_bg or beautiful.bg_normal
         self.group_icon_font = args.group_icon_font or self.font
         self.group_width = args.group_width or dpi(600)
         self.group_shape = args.group_shape or beautiful.hotkeys_group_shape
         self.group_spacing = args.group_spacing or dpi(12)
+        self.group_margin = args.group_margin or beautiful.hotkeys_group_margin or dpi(6)
 
         self._widget_settings_loaded = true
     end

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -69,25 +69,25 @@ local capi = {
     screen = screen,
     client = client,
 }
-local awful = require "awful"
-local gtable = require "gears.table"
-local gstring = require "gears.string"
-local wibox = require "wibox"
-local beautiful = require "beautiful"
+local awful = require("awful")
+local gtable = require("gears.table")
+local gstring = require("gears.string")
+local wibox = require("wibox")
+local beautiful = require("beautiful")
 local rgba = require("gears.color").to_rgba_string
 local dpi = beautiful.xresources.apply_dpi
 
-local matcher = require "gears.matcher"()
+local matcher = require("gears.matcher")()
 
 -- Stripped copy of this module https://github.com/copycat-killer/lain/blob/master/util/markup.lua:
 local markup = {}
 -- Set the font.
 function markup.font(font, text)
-    return '<span font="' .. tostring(font) .. '">' .. tostring(text) .. "</span>"
+    return '<span font="'       .. tostring(font)                   .. '">' .. tostring(text) .. '</span>'
 end
 -- Set the foreground.
 function markup.fg(color, text)
-    return '<span foreground="' .. rgba(color, beautiful.fg_normal) .. '">' .. tostring(text) .. "</span>"
+    return '<span foreground="' .. rgba(color, beautiful.fg_normal) .. '">' .. tostring(text) .. '</span>'
 end
 -- Set the background.
 function markup.bg(color, text)
@@ -95,24 +95,20 @@ function markup.bg(color, text)
 end
 -- Enable bold.
 function markup.bold(text)
-    return "<b>" .. text .. "</b>"
+    return '<b>'                .. text                             .. '</b>'
 end
 
 local function join_plus_sort(modifiers)
-    if #modifiers < 1 then
-        return "none"
-    end
+    if #modifiers < 1 then return "none" end
     table.sort(modifiers)
-    return table.concat(modifiers, "+")
+    return table.concat(modifiers, '+')
 end
 
 local function join_modifiers_and_style_with_sep(modifiers, bg, fg, sep)
-    if #modifiers < 1 then
-        return "none"
-    end
+    if #modifiers < 1 then return "none" end
     local ret = ""
     for i, modifier in ipairs(modifiers) do
-        ret = ret .. markup.fg(fg, markup.bg(bg, " " .. modifier .. " ")) .. (i == #modifiers and "" or sep)
+        ret = ret .. markup.fg(fg, markup.bg(bg, ' ' .. modifier .. ' ')) .. (i == #modifiers and '' or sep)
     end
     return ret
 end
@@ -193,47 +189,47 @@ widget.group_icons = {}
 -- @tfield[opt="⏭"] string XF86AudioNext
 -- @tfield[opt="⏹"] string XF86AudioStop
 widget.labels = {
-    Control = "Ctrl",
-    Mod1 = "Alt",
+    Control          = "Ctrl",
+    Mod1             = "Alt",
     ISO_Level3_Shift = "Alt Gr",
-    Mod4 = "Super",
-    Insert = "Ins",
-    Delete = "Del",
-    Next = "PgDn",
-    Prior = "PgUp",
-    Left = "←",
-    Up = "↑",
-    Right = "→",
-    Down = "↓",
-    KP_End = "Num1",
-    KP_Down = "Num2",
-    KP_Next = "Num3",
-    KP_Left = "Num4",
-    KP_Begin = "Num5",
-    KP_Right = "Num6",
-    KP_Home = "Num7",
-    KP_Up = "Num8",
-    KP_Prior = "Num9",
-    KP_Insert = "Num0",
-    KP_Delete = "Num.",
-    KP_Divide = "Num/",
-    KP_Multiply = "Num*",
-    KP_Subtract = "Num-",
-    KP_Add = "Num+",
-    KP_Enter = "NumEnter",
+    Mod4             = "Super",
+    Insert           = "Ins",
+    Delete           = "Del",
+    Next             = "PgDn",
+    Prior            = "PgUp",
+    Left             = "←",
+    Up               = "↑",
+    Right            = "→",
+    Down             = "↓",
+    KP_End           = "Num1",
+    KP_Down          = "Num2",
+    KP_Next          = "Num3",
+    KP_Left          = "Num4",
+    KP_Begin         = "Num5",
+    KP_Right         = "Num6",
+    KP_Home          = "Num7",
+    KP_Up            = "Num8",
+    KP_Prior         = "Num9",
+    KP_Insert        = "Num0",
+    KP_Delete        = "Num.",
+    KP_Divide        = "Num/",
+    KP_Multiply      = "Num*",
+    KP_Subtract      = "Num-",
+    KP_Add           = "Num+",
+    KP_Enter         = "NumEnter",
     -- Some "obvious" entries are necessary for the Escape sequence
     -- and whitespace characters:
-    Escape = "Esc",
-    Tab = "Tab",
-    space = "Space",
-    Return = "Enter",
+    Escape           = "Esc",
+    Tab              = "Tab",
+    space            = "Space",
+    Return           = "Enter",
     -- Dead keys aren't distinct from non-dead keys because no sane
     -- layout should have both of the same kind:
-    dead_acute = "´",
-    dead_circumflex = "^",
-    dead_grave = "`",
+    dead_acute       = "´",
+    dead_circumflex  = "^",
+    dead_grave       = "`",
     -- Basic multimedia keys:
-    XF86MonBrightnessUp = "🔆+",
+    XF86MonBrightnessUp   = "🔆+",
     XF86MonBrightnessDown = "🔅-",
     XF86AudioRaiseVolume = "🕩+",
     XF86AudioLowerVolume = "🕩-",
@@ -384,10 +380,12 @@ widget.labels = {
 function widget.new(args)
     args = args or {}
     local widget_instance = {
-        hide_without_description = (args.hide_without_description == nil)
-                and widget.hide_without_description
-            or args.hide_without_description,
-        merge_duplicates = (args.merge_duplicates == nil) and widget.merge_duplicates or args.merge_duplicates,
+        hide_without_description = (
+            args.hide_without_description == nil
+        ) and widget.hide_without_description or args.hide_without_description,
+        merge_duplicates = (
+            args.merge_duplicates == nil
+        ) and widget.merge_duplicates or args.merge_duplicates,
         group_rules = args.group_rules or gtable.clone(widget.group_rules),
         group_icons = args.group_icons or widget.group_icons,
         -- For every key in every `awful.key` binding, the first non-nil result
@@ -411,7 +409,8 @@ function widget.new(args)
         widget_instance._keygroups[k] = {}
         for k2, v2 in pairs(v) do
             local keysym, keyprint = awful.keyboard.get_key_name(v2[1])
-            widget_instance._keygroups[k][k2] = widget_instance.labels[keysym] or keyprint or keysym or v2[1]
+            widget_instance._keygroups[k][k2] =
+                widget_instance.labels[keysym] or keyprint or keysym or v2[1]
         end
     end
 
@@ -422,31 +421,50 @@ function widget.new(args)
 
         self.width = args.width or dpi(1200)
         self.height = args.height or dpi(800)
-        self.bg = args.bg or beautiful.hotkeys_bg or beautiful.bg_normal
-        self.fg = args.fg or beautiful.hotkeys_fg or beautiful.fg_normal
-        self.border_width = args.border_width or beautiful.hotkeys_border_width or beautiful.border_width
-        self.border_color = args.border_color or beautiful.hotkeys_border_color or self.fg
-        self.shape = args.shape or beautiful.hotkeys_shape
-        self.opacity = args.opacity or beautiful.hotkeys_opacity or 1
-        self.font = args.font or beautiful.hotkeys_font or "Monospace Bold 9"
+        self.bg = args.bg or
+            beautiful.hotkeys_bg or beautiful.bg_normal
+        self.fg = args.fg or
+            beautiful.hotkeys_fg or beautiful.fg_normal
+        self.border_width = args.border_width or
+            beautiful.hotkeys_border_width or beautiful.border_width
+        self.border_color = args.border_color or
+            beautiful.hotkeys_border_color or self.fg
+        self.shape = args.shape or
+            beautiful.hotkeys_shape
+        self.opacity = args.opacity or
+            beautiful.hotkeys_opacity or 1
+        self.font = args.font or
+            beautiful.hotkeys_font or "Monospace Bold 9"
 
         -- Keys and their descriptions.
-        self.modifiers_bg = args.modifiers_bg or beautiful.hotkeys_modifiers_bg or beautiful.fg_minimize
-        self.modifiers_fg = args.modifiers_fg or beautiful.hotkeys_modifiers_fg or beautiful.bg_minimize or "#555555"
+        self.modifiers_bg = args.modifiers_bg or
+            beautiful.hotkeys_modifiers_bg or beautiful.fg_minimize
+        self.modifiers_fg = args.modifiers_fg or
+            beautiful.hotkeys_modifiers_fg or beautiful.bg_minimize or "#555555"
         self.modifiers_separator = args.modifiers_separator or "+"
-        self.keys_fg = args.keys_fg or beautiful.hotkeys_keys_fg or self.fg
-        self.keys_bg = args.keys_bg or beautiful.hotkeys_keys_bg or self.modifiers_bg
-        self.keys_spacing = args.keys_spacing or beautiful.hotkeys_keys_spacing or 0
-        self.align_description = args.align_description == nil and true or args.align_description
-        self.description_font = args.description_font or beautiful.hotkeys_description_font or "Monospace 8"
+        self.keys_fg = args.keys_fg or
+            beautiful.hotkeys_keys_fg or self.fg
+        self.keys_bg = args.keys_bg or
+            beautiful.hotkeys_keys_bg or self.modifiers_bg
+        self.keys_spacing = args.keys_spacing or
+            beautiful.hotkeys_keys_spacing or 0
+        self.align_description = (
+            args.align_description == nil
+        ) and true or args.align_description
+        self.description_font = args.description_font or
+            beautiful.hotkeys_description_font or "Monospace 8"
 
         -- Groups and their labels/titles
         self.group_bg = args.group_bg or beautiful.hotkeys_group_bg or beautiful.bg_normal
         self.group_width = args.group_width or dpi(600)
-        self.group_shape = args.group_shape or beautiful.hotkeys_group_shape or nil
-        self.group_margin = args.group_margin or beautiful.hotkeys_group_margin or dpi(6)
-        self.group_spacing = args.group_spacing or beautiful.hotkeys_group_spacing or dpi(12)
-        self.group_icon_font = args.group_icon_font or beautiful.hotkeys_group_icon_font or self.font
+        self.group_shape = args.group_shape or
+            beautiful.hotkeys_group_shape or nil
+        self.group_margin = args.group_margin or
+            beautiful.hotkeys_group_margin or dpi(6)
+        self.group_spacing = args.group_spacing or
+            beautiful.hotkeys_group_spacing or dpi(12)
+        self.group_icon_font = args.group_icon_font or
+            beautiful.hotkeys_group_icon_font or self.font
         self.label_colors = beautiful.xresources.get_current_theme()
 
         self._widget_settings_loaded = true
@@ -463,9 +481,7 @@ function widget.new(args)
     end
 
     function widget_instance:_add_hotkey(key, data, target)
-        if self.hide_without_description and not data.description then
-            return
-        end
+        if self.hide_without_description and not data.description then return end
 
         local readable_mods = {}
         for _, mod in ipairs(data.mod) do
@@ -475,16 +491,14 @@ function widget.new(args)
 
         local group = data.group or "none"
         self._group_list[group] = true
-        if not target[group] then
-            target[group] = {}
-        end
+        if not target[group] then target[group] = {} end
         local keysym, keyprint = awful.keyboard.get_key_name(key)
         local keylabel = self.labels[keysym] or keyprint or keysym or key
         local new_key = {
             key = keylabel,
-            keylist = { keylabel },
+            keylist = {keylabel},
             mod = joined_mods,
-            description = data.description,
+            description = data.description
         }
         local index = data.description or "none" -- or use its hash?
         if not target[group][index] then
@@ -509,10 +523,12 @@ function widget.new(args)
                 for _, key in pairs(target[group]) do
                     table.insert(sorted_table, key)
                 end
-                table.sort(sorted_table, function(a, b)
-                    local k1, k2 = a.key or a.keys[1][1], b.key or b.keys[1][1]
-                    return (a.mod or "") .. k1 < (b.mod or "") .. k2
-                end)
+                table.sort(
+                    sorted_table,
+                    function(a, b)
+                        local k1, k2 = a.key or a.keys[1][1], b.key or b.keys[1][1]
+                        return (a.mod or "") .. k1 < (b.mod or "") .. k2 end
+                )
                 target[group] = sorted_table
             end
         end
@@ -545,12 +561,8 @@ function widget.new(args)
                         local i = gtable.hasitem(self._keygroups[keygroup], k)
                         if i and not tally[i] then
                             tally[i] = k
-                            if (not first) or (i < first) then
-                                first = i
-                            end
-                            if (not last) or (i > last) then
-                                last = i
-                            end
+                            if (not first) or (i < first) then first = i end
+                            if (not last) or (i > last) then last = i end
                             count = count + 1
                         elseif not i then
                             count = 0
@@ -615,14 +627,15 @@ function widget.new(args)
     end
 
     function widget_instance:_create_group_columns(column_layouts, group, keys, s, wibox_height)
-        local line_height =
-            math.max(beautiful.get_font_height(self.font), beautiful.get_font_height(self.description_font))
+        local line_height = math.max(
+            beautiful.get_font_height(self.font),
+            beautiful.get_font_height(self.description_font)
+        )
         local group_label_height = line_height + 2 * self.group_margin
         -- -1 for possible pagination:
         local max_height_px = wibox_height - group_label_height
 
-        -- TODO: Calculate description height with using using something else,
-        -- idk?
+        -- TODO: Calculate description height with using using something else idk?
         local joined_descriptions = ""
         for i, key in ipairs(keys) do
             joined_descriptions = joined_descriptions .. key.description .. (i ~= #keys and "\n" or "")
@@ -637,9 +650,8 @@ function widget.new(args)
         local available_height_px = max_height_px
         local add_new_column = true
         for i, column in ipairs(column_layouts) do
-            if
-                ((column.height_px + items_height) < max_height_px)
-                or (i == #column_layouts and column.height_px < max_height_px / 2)
+            if ((column.height_px + items_height) < max_height_px) or
+                (i == #column_layouts and column.height_px < max_height_px / 2)
             then
                 current_column = column
                 add_new_column = false
@@ -652,15 +664,15 @@ function widget.new(args)
             local new_keys = {}
             overlap_leftovers = {}
             -- +1 for group title and +1 for possible hyphen (v):
-            local available_height_items = (available_height_px - group_label_height * 2) / line_height
-            for i = 1, #keys do
-                table.insert(((i < available_height_items) and new_keys or overlap_leftovers), keys[i])
+            local available_height_items = (available_height_px - group_label_height*2) / line_height
+            for i=1,#keys do
+                table.insert(((i<available_height_items) and new_keys or overlap_leftovers), keys[i])
             end
             keys = new_keys
-            table.insert(keys, { key = "▽", description = "" })
+            table.insert(keys, {key="▽", description=""})
         end
         if not current_column then
-            current_column = { layout = wibox.layout.fixed.vertical() }
+            current_column = {layout=wibox.layout.fixed.vertical()}
             current_column.layout.spacing = self.group_spacing
         end
 
@@ -735,7 +747,7 @@ function widget.new(args)
             -- Remove the header if overlaps
             if ik_add_new_column and overlap_leftovers ~= nil then ret:remove(1) end
 
-            current_column.layout:add {
+            current_column.layout:add({
                 widget = wibox.container.background,
                 bg = self.group_bg,
                 shape = self.group_shape,
@@ -750,7 +762,7 @@ function widget.new(args)
                     },
                     ret,
                 },
-            }
+            })
             local max_width = self.group_width or 0
             if not current_column.max_width or (max_width > current_column.max_width) then
                 current_column.max_width = max_width
@@ -769,7 +781,8 @@ function widget.new(args)
 
         insert_keys(keys, add_new_column)
         if overlap_leftovers then
-            current_column = { layout = wibox.layout.fixed.vertical() }
+            current_column = {layout=wibox.layout.fixed.vertical()}
+            current_column.layout.spacing = self.keys_spacing
             insert_keys(overlap_leftovers, true)
         end
     end
@@ -777,8 +790,10 @@ function widget.new(args)
     function widget_instance:_create_wibox(s, available_groups, show_awesome_keys)
         s = get_screen(s)
         local wa = s.workarea
-        local wibox_height = (self.height < wa.height) and self.height or (wa.height - self.border_width * 2)
-        local wibox_width = (self.width < wa.width) and self.width or (wa.width - self.border_width * 2)
+        local wibox_height = (self.height < wa.height) and self.height or
+            (wa.height - self.border_width * 2)
+        local wibox_width = (self.width < wa.width) and self.width or
+            (wa.width - self.border_width * 2)
 
         -- arrange hotkey groups into columns
         local column_layouts = {}
@@ -797,8 +812,8 @@ function widget.new(args)
         local pages = {}
         local columns = wibox.layout.fixed.horizontal()
         local previous_page_last_layout
-        for _, column in ipairs(column_layouts) do
-            if column.max_width > available_width_px then
+        for _, item in ipairs(column_layouts) do
+            if item.max_width > available_width_px then
                 previous_page_last_layout:add(wibox.widget {
                     widget = wibox.container.background,
                     bg = self.group_bg,
@@ -811,10 +826,9 @@ function widget.new(args)
                 })
                 table.insert(pages, columns)
                 columns = wibox.layout.fixed.horizontal()
-                available_width_px = wibox_width - column.max_width
-                column.layout:insert(
-                    1,
-                    wibox.widget {
+                available_width_px = wibox_width - item.max_width
+                item.layout:insert(
+                    1, wibox.widget {
                         widget = wibox.container.background,
                         bg = self.group_bg,
                         shape = self.group_shape,
@@ -826,13 +840,13 @@ function widget.new(args)
                     }
                 )
             else
-                available_width_px = available_width_px - column.max_width
+                available_width_px = available_width_px - item.max_width
             end
             local column_margin = wibox.container.margin()
-            column_margin:set_widget(column.layout)
+            column_margin:set_widget(item.layout)
             column_margin:set_margins(self.group_spacing)
             columns:add(column_margin)
-            previous_page_last_layout = column.layout
+            previous_page_last_layout = item.layout
         end
         table.insert(pages, columns)
 
@@ -868,25 +882,17 @@ function widget.new(args)
         -- Any keybinding except what the keygrabber wants wil hide the popup
         -- too
         mypopup.buttons = {
-            awful.button({}, 1, function()
-                widget_obj:hide()
-            end),
-            awful.button({}, 3, function()
-                widget_obj:hide()
-            end),
+            awful.button({ }, 1, function () widget_obj:hide() end),
+            awful.button({ }, 3, function () widget_obj:hide() end)
         }
 
         function widget_obj.page_next(w_self)
-            if w_self.current_page == #pages then
-                return
-            end
+            if w_self.current_page == #pages then return end
             w_self.current_page = w_self.current_page + 1
             w_self.popup:set_widget(pages[w_self.current_page])
         end
         function widget_obj.page_prev(w_self)
-            if w_self.current_page == 1 then
-                return
-            end
+            if w_self.current_page == 1 then return end
             w_self.current_page = w_self.current_page - 1
             w_self.popup:set_widget(pages[w_self.current_page])
         end
@@ -957,9 +963,7 @@ function widget.new(args)
         help_wibox:show()
 
         help_wibox.keygrabber = awful.keygrabber.run(function(_, key, event)
-            if event == "release" then
-                return
-            end
+            if event == "release" then return end
             if key then
                 if key == "Next" then
                     help_wibox:page_next()
@@ -985,10 +989,11 @@ function widget.new(args)
                 local keys = binding.keys
                 for key, description in pairs(keys) do
                     self:_add_hotkey(key, {
-                        mod = modifiers,
-                        description = description,
-                        group = group,
-                    }, self._additional_hotkeys)
+                        mod=modifiers,
+                        description=description,
+                        group=group},
+                    self._additional_hotkeys
+                )
                 end
             end
         end

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -69,43 +69,47 @@ local capi = {
     screen = screen,
     client = client,
 }
-local awful = require("awful")
-local gtable = require("gears.table")
-local gstring = require("gears.string")
-local wibox = require("wibox")
-local beautiful = require("beautiful")
+local awful = require "awful"
+local gtable = require "gears.table"
+local gstring = require "gears.string"
+local wibox = require "wibox"
+local beautiful = require "beautiful"
 local rgba = require("gears.color").to_rgba_string
 local dpi = beautiful.xresources.apply_dpi
 
-local matcher = require ("gears.matcher")()
+local matcher = require "gears.matcher"()
 
 -- Stripped copy of this module https://github.com/copycat-killer/lain/blob/master/util/markup.lua:
 local markup = {}
 -- Set the font.
 function markup.font(font, text)
-    return '<span font="'       .. tostring(font)                   .. '">' .. tostring(text) .. '</span>'
+    return '<span font="' .. tostring(font) .. '">' .. tostring(text) .. "</span>"
 end
 -- Set the foreground.
 function markup.fg(color, text)
-    return '<span foreground="' .. rgba(color, beautiful.fg_normal) .. '">' .. tostring(text) .. '</span>'
+    return '<span foreground="' .. rgba(color, beautiful.fg_normal) .. '">' .. tostring(text) .. "</span>"
 end
 -- Set the background.
 function markup.bg(color, text)
-    return '<span background="' .. rgba(color, beautiful.bg_normal) .. '">' .. tostring(text) .. '</span>'
+    return '<span background="' .. rgba(color, beautiful.bg_normal) .. '">' .. tostring(text) .. "</span>"
 end
 -- Enable bold.
 function markup.bold(text)
-    return '<b>'                .. text                             .. '</b>'
+    return "<b>" .. text .. "</b>"
 end
 
 local function join_plus_sort(modifiers)
-    if #modifiers < 1 then return "none" end
+    if #modifiers < 1 then
+        return "none"
+    end
     table.sort(modifiers)
-    return table.concat(modifiers, '+')
+    return table.concat(modifiers, "+")
 end
 
 local function join_modifiers_and_style_with_sep(modifiers, bg, fg, sep)
-    if #modifiers < 1 then return "none" end
+    if #modifiers < 1 then
+        return "none"
+    end
     local ret = ""
     for i, modifier in ipairs(modifiers) do
         ret = ret .. markup.fg(fg, markup.bg(bg, " " .. modifier .. " ")) .. (i == #modifiers and "" or sep)
@@ -116,7 +120,6 @@ end
 local function get_screen(s)
     return s and capi.screen[s]
 end
-
 
 local widget = {
     group_rules = {},
@@ -190,47 +193,47 @@ widget.group_icons = {}
 -- @tfield[opt="⏭"] string XF86AudioNext
 -- @tfield[opt="⏹"] string XF86AudioStop
 widget.labels = {
-    Control          = "Ctrl",
-    Mod1             = "Alt",
+    Control = "Ctrl",
+    Mod1 = "Alt",
     ISO_Level3_Shift = "Alt Gr",
-    Mod4             = "Super",
-    Insert           = "Ins",
-    Delete           = "Del",
-    Next             = "PgDn",
-    Prior            = "PgUp",
-    Left             = "←",
-    Up               = "↑",
-    Right            = "→",
-    Down             = "↓",
-    KP_End           = "Num1",
-    KP_Down          = "Num2",
-    KP_Next          = "Num3",
-    KP_Left          = "Num4",
-    KP_Begin         = "Num5",
-    KP_Right         = "Num6",
-    KP_Home          = "Num7",
-    KP_Up            = "Num8",
-    KP_Prior         = "Num9",
-    KP_Insert        = "Num0",
-    KP_Delete        = "Num.",
-    KP_Divide        = "Num/",
-    KP_Multiply      = "Num*",
-    KP_Subtract      = "Num-",
-    KP_Add           = "Num+",
-    KP_Enter         = "NumEnter",
+    Mod4 = "Super",
+    Insert = "Ins",
+    Delete = "Del",
+    Next = "PgDn",
+    Prior = "PgUp",
+    Left = "←",
+    Up = "↑",
+    Right = "→",
+    Down = "↓",
+    KP_End = "Num1",
+    KP_Down = "Num2",
+    KP_Next = "Num3",
+    KP_Left = "Num4",
+    KP_Begin = "Num5",
+    KP_Right = "Num6",
+    KP_Home = "Num7",
+    KP_Up = "Num8",
+    KP_Prior = "Num9",
+    KP_Insert = "Num0",
+    KP_Delete = "Num.",
+    KP_Divide = "Num/",
+    KP_Multiply = "Num*",
+    KP_Subtract = "Num-",
+    KP_Add = "Num+",
+    KP_Enter = "NumEnter",
     -- Some "obvious" entries are necessary for the Escape sequence
     -- and whitespace characters:
-    Escape           = "Esc",
-    Tab              = "Tab",
-    space            = "Space",
-    Return           = "Enter",
+    Escape = "Esc",
+    Tab = "Tab",
+    space = "Space",
+    Return = "Enter",
     -- Dead keys aren't distinct from non-dead keys because no sane
     -- layout should have both of the same kind:
-    dead_acute       = "´",
-    dead_circumflex  = "^",
-    dead_grave       = "`",
+    dead_acute = "´",
+    dead_circumflex = "^",
+    dead_grave = "`",
     -- Basic multimedia keys:
-    XF86MonBrightnessUp   = "🔆+",
+    XF86MonBrightnessUp = "🔆+",
     XF86MonBrightnessDown = "🔅-",
     XF86AudioRaiseVolume = "🕩+",
     XF86AudioLowerVolume = "🕩-",
@@ -285,7 +288,6 @@ widget.labels = {
 -- @beautiful beautiful.hotkeys_group_margin
 -- @tparam int hotkeys_group_margin
 
-
 --- Create an instance of widget with hotkeys help.
 -- @tparam[opt] table args Configuration options for the widget.
 -- @tparam[opt] boolean args.hide_without_description Don't show hotkeys without descriptions.
@@ -329,12 +331,10 @@ widget.labels = {
 function widget.new(args)
     args = args or {}
     local widget_instance = {
-        hide_without_description = (
-            args.hide_without_description == nil
-        ) and widget.hide_without_description or args.hide_without_description,
-        merge_duplicates = (
-            args.merge_duplicates == nil
-        ) and widget.merge_duplicates or args.merge_duplicates,
+        hide_without_description = (args.hide_without_description == nil)
+                and widget.hide_without_description
+            or args.hide_without_description,
+        merge_duplicates = (args.merge_duplicates == nil) and widget.merge_duplicates or args.merge_duplicates,
         group_rules = args.group_rules or gtable.clone(widget.group_rules),
         group_icons = args.group_icons or widget.group_icons,
         -- For every key in every `awful.key` binding, the first non-nil result
@@ -358,45 +358,33 @@ function widget.new(args)
         widget_instance._keygroups[k] = {}
         for k2, v2 in pairs(v) do
             local keysym, keyprint = awful.keyboard.get_key_name(v2[1])
-            widget_instance._keygroups[k][k2] =
-                widget_instance.labels[keysym] or keyprint or keysym or v2[1]
+            widget_instance._keygroups[k][k2] = widget_instance.labels[keysym] or keyprint or keysym or v2[1]
         end
     end
 
-
     function widget_instance:_load_widget_settings()
-        if self._widget_settings_loaded then return end
+        if self._widget_settings_loaded then
+            return
+        end
 
         self.width = args.width or dpi(1200)
         self.height = args.height or dpi(800)
-        self.bg = args.bg or
-            beautiful.hotkeys_bg or beautiful.bg_normal
-        self.fg = args.fg or
-            beautiful.hotkeys_fg or beautiful.fg_normal
-        self.border_width = args.border_width or
-            beautiful.hotkeys_border_width or beautiful.border_width
-        self.border_color = args.border_color or
-            beautiful.hotkeys_border_color or self.fg
+        self.bg = args.bg or beautiful.hotkeys_bg or beautiful.bg_normal
+        self.fg = args.fg or beautiful.hotkeys_fg or beautiful.fg_normal
+        self.border_width = args.border_width or beautiful.hotkeys_border_width or beautiful.border_width
+        self.border_color = args.border_color or beautiful.hotkeys_border_color or self.fg
         self.shape = args.shape or beautiful.hotkeys_shape
-        self.modifiers_fg = args.modifiers_fg or
-            beautiful.hotkeys_modifiers_fg or beautiful.bg_minimize or "#555555"
-        self.modifiers_bg = args.modifiers_bg or
-            beautiful.hotkeys_modifiers_bg or beautiful.bg_minimize
+        self.modifiers_fg = args.modifiers_fg or beautiful.hotkeys_modifiers_fg or beautiful.bg_minimize or "#555555"
+        self.modifiers_bg = args.modifiers_bg or beautiful.hotkeys_modifiers_bg or beautiful.bg_minimize
         self.modifiers_separator = args.modifiers_separator or "+"
         self.key_bg = args.key_bg or self.modifiers_bg
         self.keys_spacing = args.keys_spacing or 0
-        self.label_bg = args.label_bg or
-            beautiful.hotkeys_label_bg or self.fg
-        self.label_fg = args.label_fg or
-            beautiful.hotkeys_label_fg or self.bg
-        self.opacity = args.opacity or
-            beautiful.hotkeys_opacity or 1
-        self.font = args.font or
-            beautiful.hotkeys_font or "Monospace Bold 9"
-        self.description_font = args.description_font or
-            beautiful.hotkeys_description_font or "Monospace 8"
-        self.group_margin = args.group_margin or
-            beautiful.hotkeys_group_margin or dpi(6)
+        self.label_bg = args.label_bg or beautiful.hotkeys_label_bg or self.fg
+        self.label_fg = args.label_fg or beautiful.hotkeys_label_fg or self.bg
+        self.opacity = args.opacity or beautiful.hotkeys_opacity or 1
+        self.font = args.font or beautiful.hotkeys_font or "Monospace Bold 9"
+        self.description_font = args.description_font or beautiful.hotkeys_description_font or "Monospace 8"
+        self.group_margin = args.group_margin or beautiful.hotkeys_group_margin or dpi(6)
         self.label_colors = beautiful.xresources.get_current_theme()
 
         self.group_bg = args.group_bg or beautiful.hotkeys_group_bg or beautiful.bg_normal
@@ -408,7 +396,6 @@ function widget.new(args)
         self._widget_settings_loaded = true
     end
 
-
     function widget_instance:_get_next_color(id)
         id = id or "default"
         if self._colors_counter[id] then
@@ -419,9 +406,10 @@ function widget.new(args)
         return self.label_colors["color" .. tostring(self._colors_counter[id], 15)]
     end
 
-
     function widget_instance:_add_hotkey(key, data, target)
-        if self.hide_without_description and not data.description then return end
+        if self.hide_without_description and not data.description then
+            return
+        end
 
         local readable_mods = {}
         for _, mod in ipairs(data.mod) do
@@ -431,14 +419,16 @@ function widget.new(args)
 
         local group = data.group or "none"
         self._group_list[group] = true
-        if not target[group] then target[group] = {} end
+        if not target[group] then
+            target[group] = {}
+        end
         local keysym, keyprint = awful.keyboard.get_key_name(key)
         local keylabel = self.labels[keysym] or keyprint or keysym or key
         local new_key = {
             key = keylabel,
-            keylist = {keylabel},
+            keylist = { keylabel },
             mod = joined_mods,
-            description = data.description
+            description = data.description,
         }
         local index = data.description or "none" -- or use its hash?
         if not target[group][index] then
@@ -456,7 +446,6 @@ function widget.new(args)
         end
     end
 
-
     function widget_instance:_sort_hotkeys(target)
         for group, _ in pairs(self._group_list) do
             if target[group] then
@@ -464,17 +453,14 @@ function widget.new(args)
                 for _, key in pairs(target[group]) do
                     table.insert(sorted_table, key)
                 end
-                table.sort(
-                    sorted_table,
-                    function(a, b)
-                        local k1, k2 = a.key or a.keys[1][1], b.key or b.keys[1][1]
-                        return (a.mod or '')..k1<(b.mod or '')..k2 end
-                )
+                table.sort(sorted_table, function(a, b)
+                    local k1, k2 = a.key or a.keys[1][1], b.key or b.keys[1][1]
+                    return (a.mod or "") .. k1 < (b.mod or "") .. k2
+                end)
                 target[group] = sorted_table
             end
         end
     end
-
 
     function widget_instance:_abbreviate_awful_keys()
         -- This method is intended to abbreviate the keys of a merged entry (not
@@ -503,8 +489,12 @@ function widget.new(args)
                         local i = gtable.hasitem(self._keygroups[keygroup], k)
                         if i and not tally[i] then
                             tally[i] = k
-                            if (not first) or (i < first) then first = i end
-                            if (not last) or (i > last) then last = i end
+                            if (not first) or (i < first) then
+                                first = i
+                            end
+                            if (not last) or (i > last) then
+                                last = i
+                            end
                             count = count + 1
                         elseif not i then
                             count = 0
@@ -521,7 +511,6 @@ function widget.new(args)
             end
         end
     end
-
 
     function widget_instance:_import_awful_keys()
         if next(self._cached_awful_keys) then
@@ -540,8 +529,7 @@ function widget.new(args)
 
     function widget_instance:_group_label(group, color)
         local group_icon = self.group_icons[group]
-        local fallback_color =
-            self.group_rules[group] and self.group_rules[group].color
+        local fallback_color = self.group_rules[group] and self.group_rules[group].color
             or self:_get_next_color "group_title"
         local ret = wibox.widget {
             widget = wibox.container.margin,
@@ -550,14 +538,13 @@ function widget.new(args)
                 layout = wibox.layout.fixed.horizontal,
                 spacing = dpi(6),
                 forced_width = self.group_width,
-                (group_icon ~= nil and group_icon ~= "") and {
-                    widget = wibox.widget.textbox,
-                    markup = markup.fg(
-                        color or fallback_color,
-                        markup.font(self.group_icon_font, group_icon)
-                    ),
-                    halign = "left",
-                } or nil,
+                (group_icon ~= nil and group_icon ~= "")
+                        and {
+                            widget = wibox.widget.textbox,
+                            markup = markup.fg(color or fallback_color, markup.font(self.group_icon_font, group_icon)),
+                            halign = "left",
+                        }
+                    or nil,
                 {
                     widget = wibox.widget.textbox,
                     markup = markup.fg(
@@ -572,10 +559,8 @@ function widget.new(args)
     end
 
     function widget_instance:_create_group_columns(column_layouts, group, keys, s, wibox_height)
-        local line_height = math.max(
-            beautiful.get_font_height(self.font),
-            beautiful.get_font_height(self.description_font)
-        )
+        local line_height =
+            math.max(beautiful.get_font_height(self.font), beautiful.get_font_height(self.description_font))
         local group_label_height = line_height + 2 * self.group_margin
         -- -1 for possible pagination:
         local max_height_px = wibox_height - group_label_height
@@ -588,17 +573,17 @@ function widget.new(args)
         end
         -- +1 for group label:
         local joined_descriptions_count = gstring.linecount(joined_descriptions)
-        local items_height =
-            joined_descriptions_count * line_height -- account each line
-            + (joined_descriptions_count - 1 ) * self.keys_spacing -- and their spacing
+        local items_height = joined_descriptions_count * line_height -- account each line
+            + (joined_descriptions_count - 1) * self.keys_spacing -- and their spacing
             + group_label_height
             + self.group_margin -- for keys' paddings
         local current_column
         local available_height_px = max_height_px
         local add_new_column = true
         for i, column in ipairs(column_layouts) do
-            if ((column.height_px + items_height) < max_height_px) or
-                (i == #column_layouts and column.height_px < max_height_px / 2)
+            if
+                ((column.height_px + items_height) < max_height_px)
+                or (i == #column_layouts and column.height_px < max_height_px / 2)
             then
                 current_column = column
                 add_new_column = false
@@ -611,15 +596,15 @@ function widget.new(args)
             local new_keys = {}
             overlap_leftovers = {}
             -- +1 for group title and +1 for possible hyphen (v):
-            local available_height_items = (available_height_px - group_label_height*2) / line_height
-            for i=1,#keys do
-                table.insert(((i<available_height_items) and new_keys or overlap_leftovers), keys[i])
+            local available_height_items = (available_height_px - group_label_height * 2) / line_height
+            for i = 1, #keys do
+                table.insert(((i < available_height_items) and new_keys or overlap_leftovers), keys[i])
             end
             keys = new_keys
-            table.insert(keys, {key="▽", description=""})
+            table.insert(keys, { key = "▽", description = "" })
         end
         if not current_column then
-            current_column = {layout = wibox.layout.fixed.vertical()}
+            current_column = { layout = wibox.layout.fixed.vertical() }
             current_column.layout.spacing = self.group_spacing
         end
 
@@ -645,14 +630,19 @@ function widget.new(args)
                 else
                     -- The already existing modifiers are just to cache keys and stuff, we will style them now
                     local mods_table = gstring.split(modifiers, "+")
-                    modifiers = join_modifiers_and_style_with_sep(mods_table, self.modifiers_bg, self.modifiers_fg, self.modifiers_separator)
+                    modifiers = join_modifiers_and_style_with_sep(
+                        mods_table,
+                        self.modifiers_bg,
+                        self.modifiers_fg,
+                        self.modifiers_separator
+                    )
                 end
                 local key_label = ""
                 if key.keylist and #key.keylist > 1 then
                     for each_key_idx, each_key in ipairs(key.keylist) do
                         key_label = key_label .. gstring.xml_escape(each_key)
                         if each_key_idx ~= #key.keylist then
-                            key_label = key_label .. markup.fg(self.modifiers_fg, '/')
+                            key_label = key_label .. markup.fg(self.modifiers_fg, "/")
                         end
                     end
                     modifiers = modifiers .. " "
@@ -725,10 +715,8 @@ function widget.new(args)
     function widget_instance:_create_wibox(s, available_groups, show_awesome_keys)
         s = get_screen(s)
         local wa = s.workarea
-        local wibox_height = (self.height < wa.height) and self.height or
-            (wa.height - self.border_width * 2)
-        local wibox_width = (self.width < wa.width) and self.width or
-            (wa.width - self.border_width * 2)
+        local wibox_height = (self.height < wa.height) and self.height or (wa.height - self.border_width * 2)
+        local wibox_width = (self.width < wa.width) and self.width or (wa.width - self.border_width * 2)
 
         -- arrange hotkey groups into columns
         local column_layouts = {}
@@ -751,12 +739,29 @@ function widget.new(args)
         local previous_page_last_layout
         for _, item in ipairs(column_layouts) do
             if item.max_width > available_width_px then
-                previous_page_last_layout:add(self:_group_label("Page Down - Next Page", self.modifiers_fg))
+                previous_page_last_layout:add(wibox.widget {
+                    widget = wibox.container.background,
+                    bg = self.group_bg,
+                    {
+                        widget = wibox.container.margin,
+                        margins = { left = self.group_margin, right = self.group_margin },
+                        self:_group_label("Page Down - Next Page", self.modifiers_fg),
+                    },
+                })
                 table.insert(pages, columns)
                 columns = wibox.layout.fixed.horizontal()
                 available_width_px = wibox_width - item.max_width
                 item.layout:insert(
-                    1, self:_group_label("Page Down - Next Page", self.modifiers_fg)
+                    1,
+                    wibox.widget {
+                        widget = wibox.container.background,
+                        bg = self.group_bg,
+                        {
+                            widget = wibox.container.margin,
+                            margins = { left = self.group_margin, right = self.group_margin },
+                            self:_group_label("Page Up - Previous Page", self.modifiers_fg),
+                        },
+                    }
                 )
             else
                 available_width_px = available_width_px - item.max_width
@@ -801,8 +806,12 @@ function widget.new(args)
         -- Any keybinding except what the keygrabber wants wil hide the popup
         -- too
         mypopup.buttons = {
-            awful.button({ }, 1, function() widget_obj:hide() end),
-            awful.button({ }, 3, function() widget_obj:hide() end),
+            awful.button({}, 1, function()
+                widget_obj:hide()
+            end),
+            awful.button({}, 3, function()
+                widget_obj:hide()
+            end),
         }
 
         function widget_obj.page_next(w_self)
@@ -813,7 +822,9 @@ function widget.new(args)
             w_self.popup:set_widget(pages[w_self.current_page])
         end
         function widget_obj.page_prev(w_self)
-            if w_self.current_page == 1 then return end
+            if w_self.current_page == 1 then
+                return
+            end
             w_self.current_page = w_self.current_page - 1
             w_self.popup:set_widget(pages[w_self.current_page])
         end
@@ -853,21 +864,24 @@ function widget.new(args)
         for group, _ in pairs(self._group_list) do
             local need_match
             for group_name, data in pairs(self.group_rules) do
-                if group_name == group and (
-                    data.rule or data.rule_any or data.except or data.except_any
-                ) then
-                    if not c or not matcher:matches_rule(c, {
-                        rule = data.rule,
-                        rule_any = data.rule_any,
-                        except = data.except,
-                        except_any=data.except_any
-                    }) then
+                if group_name == group and (data.rule or data.rule_any or data.except or data.except_any) then
+                    if
+                        not c
+                        or not matcher:matches_rule(c, {
+                            rule = data.rule,
+                            rule_any = data.rule_any,
+                            except = data.except,
+                            except_any = data.except_any,
+                        })
+                    then
                         need_match = true
                         break
                     end
                 end
             end
-            if not need_match then table.insert(available_groups, group) end
+            if not need_match then
+                table.insert(available_groups, group)
+            end
         end
 
         local joined_groups = join_plus_sort(available_groups) .. tostring(show_awesome_keys)
@@ -881,7 +895,9 @@ function widget.new(args)
         help_wibox:show()
 
         help_wibox.keygrabber = awful.keygrabber.run(function(_, key, event)
-            if event == "release" then return end
+            if event == "release" then
+                return
+            end
             if key then
                 if key == "Next" then
                     help_wibox:page_next()
@@ -907,11 +923,10 @@ function widget.new(args)
                 local keys = binding.keys
                 for key, description in pairs(keys) do
                     self:_add_hotkey(key, {
-                        mod=modifiers,
-                        description=description,
-                        group=group},
-                    self._additional_hotkeys
-                    )
+                        mod = modifiers,
+                        description = description,
+                        group = group,
+                    }, self._additional_hotkeys)
                 end
             end
         end

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -540,6 +540,9 @@ function widget.new(args)
 
     function widget_instance:_group_label(group, color)
         local group_icon = self.group_icons[group]
+        local fallback_color =
+            self.group_rules[group] and self.group_rules[group].color
+            or self:_get_next_color "group_title"
         local ret = wibox.widget {
             widget = wibox.container.margin,
             margins = { top = self.group_margin, bottom = self.group_margin },
@@ -550,18 +553,17 @@ function widget.new(args)
                 (group_icon ~= nil and group_icon ~= "") and {
                     widget = wibox.widget.textbox,
                     markup = markup.fg(
-                        color
-                            or (
-                                self.group_rules[group] and self.group_rules[group].color
-                                or self:_get_next_color "group_title"
-                            ),
+                        color or fallback_color,
                         markup.font(self.group_icon_font, group_icon)
                     ),
                     halign = "left",
                 } or nil,
                 {
                     widget = wibox.widget.textbox,
-                    markup = markup.fg(self.fg, markup.font(self.font, "<b>" .. group .. "</b>")),
+                    markup = markup.fg(
+                        (group_icon == nil or group_icon == "") and (color or fallback_color) or self.fg,
+                        markup.font(self.font, "<b>" .. group .. "</b>")
+                    ),
                     halign = "left",
                 },
             },

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -105,7 +105,7 @@ local function join_plus_sort(modifiers)
 end
 
 local function join_modifiers_and_style_with_sep(modifiers, bg, fg, sep)
-    if #modifiers < 1 then return "none" end
+    if #modifiers<1 then return "none" end
     local ret = ""
     for i, modifier in ipairs(modifiers) do
         ret = ret .. markup.fg(fg, markup.bg(bg, ' ' .. modifier .. ' ')) .. (i == #modifiers and '' or sep)
@@ -116,6 +116,7 @@ end
 local function get_screen(s)
     return s and capi.screen[s]
 end
+
 
 local widget = {
     group_rules = {},
@@ -415,9 +416,7 @@ function widget.new(args)
     end
 
     function widget_instance:_load_widget_settings()
-        if self._widget_settings_loaded then
-            return
-        end
+        if self._widget_settings_loaded then return end
 
         self.width = args.width or dpi(1200)
         self.height = args.height or dpi(800)
@@ -470,6 +469,7 @@ function widget.new(args)
         self._widget_settings_loaded = true
     end
 
+
     function widget_instance:_get_next_color(id)
         id = id or "default"
         if self._colors_counter[id] then
@@ -477,8 +477,9 @@ function widget.new(args)
         else
             self._colors_counter[id] = 1
         end
-        return self.label_colors["color" .. tostring(self._colors_counter[id], 15)]
+        return self.label_colors["color"..tostring(self._colors_counter[id], 15)]
     end
+
 
     function widget_instance:_add_hotkey(key, data, target)
         if self.hide_without_description and not data.description then return end
@@ -500,7 +501,7 @@ function widget.new(args)
             mod = joined_mods,
             description = data.description
         }
-        local index = data.description or "none" -- or use its hash?
+        local index = data.description or "none"  -- or use its hash?
         if not target[group][index] then
             target[group][index] = new_key
         else
@@ -525,9 +526,9 @@ function widget.new(args)
                 end
                 table.sort(
                     sorted_table,
-                    function(a, b)
+                    function(a,b)
                         local k1, k2 = a.key or a.keys[1][1], b.key or b.keys[1][1]
-                        return (a.mod or "") .. k1 < (b.mod or "") .. k2 end
+                        return (a.mod or "")..k1 < (b.mod or "")..k2 end
                 )
                 target[group] = sorted_table
             end
@@ -638,7 +639,7 @@ function widget.new(args)
         -- TODO: Calculate description height with using using something else idk?
         local joined_descriptions = ""
         for i, key in ipairs(keys) do
-            joined_descriptions = joined_descriptions .. key.description .. (i ~= #keys and "\n" or "")
+            joined_descriptions = joined_descriptions .. key.description .. (i~=#keys and "\n" or "")
         end
         -- +1 for group label:
         local joined_descriptions_count = gstring.linecount(joined_descriptions)
@@ -710,7 +711,7 @@ function widget.new(args)
                     for each_key_idx, each_key in ipairs(key.keylist) do
                         key_label = key_label .. gstring.xml_escape(each_key)
                         if each_key_idx ~= #key.keylist then
-                            key_label = key_label .. markup.fg(self.modifiers_fg, "/")
+                            key_label = key_label .. markup.fg(self.modifiers_fg, '/')
                         end
                     end
                     modifiers = modifiers .. " "
@@ -936,10 +937,10 @@ function widget.new(args)
                     data.rule or data.rule_any or data.except or data.except_any)
                 then
                     if not c or not matcher:matches_rule(c, {
-                            rule = data.rule,
-                            rule_any = data.rule_any,
-                            except = data.except,
-                            except_any = data.except_any,
+                            rule=data.rule,
+                            rule_any=data.rule_any,
+                            except=data.except,
+                            except_any=data.except_any
                     }) then
                         need_match = true
                         break

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -747,6 +747,7 @@ function widget.new(args)
                 previous_page_last_layout:add(wibox.widget {
                     widget = wibox.container.background,
                     bg = self.group_bg,
+                    shape = self.group_shape,
                     {
                         widget = wibox.container.margin,
                         margins = { left = self.group_margin, right = self.group_margin },
@@ -761,6 +762,7 @@ function widget.new(args)
                     wibox.widget {
                         widget = wibox.container.background,
                         bg = self.group_bg,
+                        shape = self.group_shape,
                         {
                             widget = wibox.container.margin,
                             margins = { left = self.group_margin, right = self.group_margin },
@@ -798,7 +800,7 @@ function widget.new(args)
             shape = self.shape,
             placement = place_func,
             minimum_height = wibox_height,
-            maximum_width = wibox_width,
+            minimum_width = wibox_width,
             screen = s,
         }
 

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -934,13 +934,13 @@ function widget.new(args)
             local need_match
             for group_name, data in pairs(self.group_rules) do
                 if group_name==group and (
-                    data.rule or data.rule_any or data.except or data.except_any)
-                then
+                    data.rule or data.rule_any or data.except or data.except_any
+                ) then
                     if not c or not matcher:matches_rule(c, {
-                            rule=data.rule,
-                            rule_any=data.rule_any,
-                            except=data.except,
-                            except_any=data.except_any
+                        rule=data.rule,
+                        rule_any=data.rule_any,
+                        except=data.except,
+                        except_any=data.except_any
                     }) then
                         need_match = true
                         break

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -264,21 +264,53 @@ widget.labels = {
 -- @tparam[opt] gears.shape hotkeys_shape
 -- @see gears.shape
 
+--- Main hotkeys widget font.
+-- @beautiful beautiful.hotkeys_font
+-- @tparam string|lgi.Pango.FontDescription hotkeys_font
+
 --- Foreground color used for hotkey modifiers (Ctrl, Alt, Super, etc).
 -- @beautiful beautiful.hotkeys_modifiers_fg
 -- @tparam color hotkeys_modifiers_fg
 
---- Main hotkeys widget font.
--- @beautiful beautiful.hotkeys_font
--- @tparam string|lgi.Pango.FontDescription hotkeys_font
+--- Background color used for hotkey modifiers (Ctrl, Alt, Super, etc).
+-- @beautiful beautiful.hotkeys_modifiers_bg
+-- @tparam color hotkeys_modifiers_bg
+
+--- Background color used for hotkeys (except modifiers)
+-- @beautiful beautiful.hotkeys_keys_bg
+-- @tparam color hotkeys_keys_bg
+
+--- Foreground color used for hotkeys (except modifiers)
+-- @beautiful beautiful.hotkeys_keys_fg
+-- @tparam color hotkeys_keys_fg
+
+--- Vertical spacing between hotkeys
+-- @beautiful beautiful.hotkeys_keys_spacing
+-- @tparam int hotkeys_keys_spacing
 
 --- Font used for hotkeys' descriptions.
 -- @beautiful beautiful.hotkeys_description_font
 -- @tparam string|lgi.Pango.FontDescription hotkeys_description_font
 
---- Margin between hotkeys groups.
+--- Background color used for hotkeys groups
+-- @beautiful beautiful.hotkeys_group_bg
+-- @tparam color hotkeys_group_bg
+
+--- Shape for hotkeys group
+-- @beautiful beautiful.hotkeys_group_shape
+-- @tparam shape hotkeys_group_shape
+
+--- Margins (or paddings) inside a hotkey group
 -- @beautiful beautiful.hotkeys_group_margin
 -- @tparam int hotkeys_group_margin
+
+--- Margins (or spacing) between hotkey groups
+-- @beautiful beautiful.hotkeys_group_spacing
+-- @tparam int hotkeys_group_spacing
+
+--- Font used for hotkeys' group icons.
+-- @beautiful beautiful.hotkeys_group_icon_font
+-- @tparam string|lgi.Pango.FontDescription hotkeys_group_icon_font
 
 --- Create an instance of widget with hotkeys help.
 -- @tparam[opt] table args Configuration options for the widget.
@@ -293,11 +325,32 @@ widget.labels = {
 -- @tparam[opt] int args.border_width Border width.
 -- @tparam[opt] color args.border_color Border color.
 -- @tparam[opt] gears.shape args.shape Widget shape.
+-- @tparam[opt] number args.opacity Widget opacity.
 -- @tparam[opt] string|lgi.Pango.FontDescription args.font Main widget font.
--- @tparam[opt] string|lgi.Pango.FontDescription args.description_font Font used for hotkeys' descriptions.
+-- @tparam[opt] color args.modifiers_bg Background color used for hotkey
+-- modifiers (Ctrl, Alt, Super, etc).
 -- @tparam[opt] color args.modifiers_fg Foreground color used for hotkey
 -- modifiers (Ctrl, Alt, Super, etc).
--- @tparam[opt] int args.group_margin Margin between hotkeys groups.
+-- @tparam[opt] string args.modifiers_separator String inserted between each
+-- modifier (Ctrl, Alt, Super, etc).
+-- @tparam[opt] color args.keys_bg Background color used for hotkey
+-- keys (except modifiers).
+-- @tparam[opt] color args.keys_fg Foreground color used for hotkey
+-- keys (except modifiers).
+-- @tparam[opt] int args.keys_spacing Vertical spacing between hotkeys.
+-- @tparam[opt] boolean args.align_description Whether to align all hotkeys'
+-- descriptions
+-- @tparam[opt] string|lgi.Pango.FontDescription args.description_font Font used for hotkeys' descriptions.
+-- ---
+-- @tparam[opt] color args.group_bg Background color used for hotkeys groups
+-- @tparam[opt] color args.group_fg Foreground color used for hotkeys groups
+-- @tparam[opt] gears.shape args.group_shape Shape for hotkeys groups
+-- @tparam[opt] int args.group_margin Margins (or paddings) inside a hotkeys
+-- group
+-- @tparam[opt] int args.group_spacing Margins (or spacing) between hotkey
+-- groups
+-- @tparam[opt] string|lgi.Pango.FontDescription args.group_icon_font Font used for hotkeys group icons.
+-- ---
 -- @tparam[opt] table args.labels Labels used for displaying human-readable keynames.
 -- @tparam[opt] table args.group_rules Rules for showing 3rd-party hotkeys. @see `awful.hotkeys_popup.keys.vim`.
 -- @return Widget instance.
@@ -307,10 +360,19 @@ widget.labels = {
 -- @usebeautiful beautiful.hotkeys_border_width
 -- @usebeautiful beautiful.hotkeys_border_color
 -- @usebeautiful beautiful.hotkeys_shape
--- @usebeautiful beautiful.hotkeys_modifiers_fg
 -- @usebeautiful beautiful.hotkeys_font
+-- @usebeautiful beautiful.hotkeys_modifiers_bg
+-- @usebeautiful beautiful.hotkeys_modifiers_fg
+-- @usebeautiful beautiful.hotkeys_keys_bg
+-- @usebeautiful beautiful.hotkeys_keys_fg
+-- @usebeautiful beautiful.hotkeys_keys_spacing
 -- @usebeautiful beautiful.hotkeys_description_font
+-- @usebeautiful beautiful.hotkeys_group_bg
+-- @usebeautiful beautiful.hotkeys_group_fg
+-- @usebeautiful beautiful.hotkeys_group_shape
 -- @usebeautiful beautiful.hotkeys_group_margin
+-- @usebeautiful beautiful.hotkeys_group_spacing
+-- @usebeautiful beautiful.hotkeys_group_icon_font
 -- @usebeautiful beautiful.bg_normal Fallback.
 -- @usebeautiful beautiful.fg_normal Fallback.
 -- @usebeautiful beautiful.fg_minimize Fallback.
@@ -365,22 +427,23 @@ function widget.new(args)
         self.font = args.font or beautiful.hotkeys_font or "Monospace Bold 9"
 
         -- Keys and their descriptions.
+        self.modifiers_bg = args.modifiers_bg or beautiful.hotkeys_modifiers_bg or beautiful.fg_minimize
         self.modifiers_fg = args.modifiers_fg or beautiful.hotkeys_modifiers_fg or beautiful.bg_minimize or "#555555"
-        self.modifiers_bg = args.modifiers_bg or beautiful.hotkeys_modifiers_bg or beautiful.bg_minimize
         self.modifiers_separator = args.modifiers_separator or "+"
-        self.key_bg = args.key_bg or self.modifiers_bg
-        self.keys_spacing = args.keys_spacing or 0
+        self.keys_fg = args.keys_fg or beautiful.hotkeys_keys_fg or self.fg
+        self.keys_bg = args.keys_bg or beautiful.hotkeys_keys_bg or self.modifiers_bg
+        self.keys_spacing = args.keys_spacing or beautiful.hotkeys_keys_spacing or 0
         self.align_description = args.align_description == nil and true or args.align_description
         self.description_font = args.description_font or beautiful.hotkeys_description_font or "Monospace 8"
 
         -- Groups and their labels/titles
-        self.label_colors = beautiful.xresources.get_current_theme()
         self.group_bg = args.group_bg or beautiful.hotkeys_group_bg or beautiful.bg_normal
-        self.group_icon_font = args.group_icon_font or self.font
         self.group_width = args.group_width or dpi(600)
-        self.group_shape = args.group_shape or beautiful.hotkeys_group_shape
-        self.group_spacing = args.group_spacing or dpi(12)
+        self.group_shape = args.group_shape or beautiful.hotkeys_group_shape or nil
         self.group_margin = args.group_margin or beautiful.hotkeys_group_margin or dpi(6)
+        self.group_spacing = args.group_spacing or beautiful.hotkeys_group_spacing or dpi(12)
+        self.group_icon_font = args.group_icon_font or beautiful.hotkeys_group_icon_font or self.font
+        self.label_colors = beautiful.xresources.get_current_theme()
 
         self._widget_settings_loaded = true
     end
@@ -639,7 +702,7 @@ function widget.new(args)
                 elseif key.key then
                     key_label = " " .. gstring.xml_escape(key.key) .. " "
                 end
-                key_label = markup.bg(self.key_bg, key_label)
+                key_label = markup.bg(self.keys_bg, key_label)
                 local keys_markup = markup.font(self.font, modifiers .. key_label)
                 local keys_width = wibox.widget.textbox.get_markup_geometry(keys_markup, s, self.font).width
                 if keys_width > max_keys_width then

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -83,7 +83,7 @@ local matcher = require("gears.matcher")()
 local markup = {}
 -- Set the font.
 function markup.font(font, text)
-    return '<span font="'       .. tostring(font)                   .. '">' .. tostring(text) .. '</span>'
+    return '<span font="'    .. tostring(font)    .. '">' .. tostring(text) ..'</span>'
 end
 -- Set the foreground.
 function markup.fg(color, text)
@@ -91,7 +91,7 @@ function markup.fg(color, text)
 end
 -- Set the background.
 function markup.bg(color, text)
-    return '<span background="' .. rgba(color, beautiful.bg_normal) .. '">' .. tostring(text) .. "</span>"
+    return '<span background="' .. rgba(color, beautiful.bg_normal) .. '">' .. tostring(text) .. '</span>'
 end
 -- Enable bold.
 function markup.bold(text)
@@ -854,22 +854,22 @@ function widget.new(args)
         -- workarea. This will be called in the placement field of the
         -- awful.popup constructor.
         local place_func = function(c)
-            awful.placement.centered(c, { honor_workarea = true })
+            awful.placement.centered(c, {honor_workarea = true})
         end
 
         -- Construct the popup with the widget
         local mypopup = awful.popup {
             widget = pages[1],
             ontop = true,
-            bg = self.bg,
-            fg = self.fg,
+            bg=self.bg,
+            fg=self.fg,
             opacity = self.opacity,
             border_width = self.border_width,
             border_color = self.border_color,
             shape = self.shape,
             placement = place_func,
-            minimum_height = wibox_height,
             minimum_width = wibox_width,
+            minimum_height = wibox_height,
             screen = s,
         }
 
@@ -932,27 +932,24 @@ function widget.new(args)
         for group, _ in pairs(self._group_list) do
             local need_match
             for group_name, data in pairs(self.group_rules) do
-                if group_name == group and (data.rule or data.rule_any or data.except or data.except_any) then
-                    if
-                        not c
-                        or not matcher:matches_rule(c, {
+                if group_name==group and (
+                    data.rule or data.rule_any or data.except or data.except_any)
+                then
+                    if not c or not matcher:matches_rule(c, {
                             rule = data.rule,
                             rule_any = data.rule_any,
                             except = data.except,
                             except_any = data.except_any,
-                        })
-                    then
+                    }) then
                         need_match = true
                         break
                     end
                 end
             end
-            if not need_match then
-                table.insert(available_groups, group)
-            end
+            if not need_match then table.insert(available_groups, group) end
         end
 
-        local joined_groups = join_plus_sort(available_groups) .. tostring(show_awesome_keys)
+        local joined_groups = join_plus_sort(available_groups)..tostring(show_awesome_keys)
         if not self._cached_wiboxes[s] then
             self._cached_wiboxes[s] = {}
         end

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -737,8 +737,8 @@ function widget.new(args)
         local pages = {}
         local columns = wibox.layout.fixed.horizontal()
         local previous_page_last_layout
-        for _, item in ipairs(column_layouts) do
-            if item.max_width > available_width_px then
+        for _, column in ipairs(column_layouts) do
+            if column.max_width > available_width_px then
                 previous_page_last_layout:add(wibox.widget {
                     widget = wibox.container.background,
                     bg = self.group_bg,
@@ -750,8 +750,8 @@ function widget.new(args)
                 })
                 table.insert(pages, columns)
                 columns = wibox.layout.fixed.horizontal()
-                available_width_px = wibox_width - item.max_width
-                item.layout:insert(
+                available_width_px = wibox_width - column.max_width
+                column.layout:insert(
                     1,
                     wibox.widget {
                         widget = wibox.container.background,
@@ -764,13 +764,13 @@ function widget.new(args)
                     }
                 )
             else
-                available_width_px = available_width_px - item.max_width
+                available_width_px = available_width_px - column.max_width
             end
             local column_margin = wibox.container.margin()
-            column_margin:set_widget(item.layout)
+            column_margin:set_widget(column.layout)
             column_margin:set_margins(self.group_spacing)
             columns:add(column_margin)
-            previous_page_last_layout = item.layout
+            previous_page_last_layout = column.layout
         end
         table.insert(pages, columns)
 

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -383,6 +383,7 @@ function widget.new(args)
         self.label_fg = args.label_fg or beautiful.hotkeys_label_fg or self.bg
         self.opacity = args.opacity or beautiful.hotkeys_opacity or 1
         self.font = args.font or beautiful.hotkeys_font or "Monospace Bold 9"
+        self.align_description = args.align_description == nil and true or args.align_description
         self.description_font = args.description_font or beautiful.hotkeys_description_font or "Monospace 8"
         self.group_margin = args.group_margin or beautiful.hotkeys_group_margin or dpi(6)
         self.label_colors = beautiful.xresources.get_current_theme()
@@ -657,7 +658,7 @@ function widget.new(args)
                     max_keys_width = keys_width
                 end
                 local final_layout = wibox.widget {
-                    layout = wibox.layout.ratio.horizontal,
+                    layout = wibox.layout[self.align_description and "ratio" or "fixed"].horizontal,
                     {
                         widget = wibox.widget.textbox,
                         halign = "right",

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -296,6 +296,10 @@ widget.labels = {
 -- @beautiful beautiful.hotkeys_group_bg
 -- @tparam color hotkeys_group_bg
 
+--- Foreground color used for hotkeys groups
+-- @beautiful beautiful.hotkeys_group_fg
+-- @tparam color hotkeys_group_fg
+
 --- Shape for hotkeys group
 -- @beautiful beautiful.hotkeys_group_shape
 -- @tparam shape hotkeys_group_shape


### PR DESCRIPTION
This pull request aims to rework `awful.hotkeys_popup`, to be more modern and more customizable with the following main changes:
- Reworked the keys layout, instead of having multiple strings joined to eachother, use a wibox.layout.fixed.vertical with multiple wibox.layout.(ratio/fixed).horizontal to hold the keys and their descriptions. This allows for options like keys_spacing.
- Added many options for styling
- Added widget.group_icons for whoever wants that

TODO:

- [ ] Check for edge cases? (weird width, etc)
- [ ] Sometimes the Next/Previous page buttons look weird, maybe investigate that?
- [x] Documentation for new options  