### PR TITLE
Fix typo in example wibox.widget.textbox file

### DIFF
--- a/tests/examples/wibox/widget/textbox/line_spacing.lua
+++ b/tests/examples/wibox/widget/textbox/line_spacing.lua
@@ -22,7 +22,7 @@ local l = wibox.layout.grid.vertical(4)
 --DOC_HIDE_END
 
 for _, spacing in ipairs {0.0, 0.1, 0.5, 0.9, 1, 1.5, 2.0, 2.5} do
-    local text = "This text shas a line\nspacing of "..tostring(spacing).. "\nunits."
+    local text = "This text has a line\nspacing of "..tostring(spacing).. "\nunits."
     --DOC_NEWLINE
     l:add( --DOC_HIDE
     widget{


### PR DESCRIPTION
In tests/examples/wibox/widget/textbox/line_spacing.lua, there is a typo in the line 25.
It's supposed to be "has", but it's "shas", this is obviously not a grammar issue, so it's a typo.