### PR TITLE
Imagebox: add proper svg resizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0.0)
-project(awesome C)
+project(awesome_crylia C)
 
 # Require an out-of-source build. We generate an awesomerc.lua in the build dir
 # from the one in the source dir and this does not work otherwise.

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -1,4 +1,4 @@
-set(PROJECT_AWE_NAME awesome)
+set(PROJECT_AWE_NAME awesome_crylia)
 
 # If ${SOURCE_DIR} is a git repository VERSION is set to
 # `git describe` later.

--- a/lib/wibox/widget/imagebox.lua
+++ b/lib/wibox/widget/imagebox.lua
@@ -182,6 +182,9 @@ function imagebox:draw(ctx, cr, width, height)
 
     local w, h = self._private.default.width, self._private.default.height
 
+    local RsvgRect = Rsvg.Rectangle {x = 0, y = 0, width = w, height = h}
+    local svg_surf = cairo.ImageSurface(cairo.Format.ARGB32, w, h)
+
     if self._private.resize then
         -- That's for the "fit" policy.
         local aspects = {
@@ -233,7 +236,12 @@ function imagebox:draw(ctx, cr, width, height)
             cr:clip(self._private.clip_shape(cr, w*aspects.w, h*aspects.h, unpack(self._private.clip_args)))
         end
 
-        cr:scale(aspects.w, aspects.h)
+        if self._private.handle then
+            RsvgRect = Rsvg.Rectangle {x = 0, y = 0, width = w*aspects.w, height = h*aspects.h }
+            svg_surf = cairo.ImageSurface(cairo.Format.ARGB32, w*aspects.w, h*aspects.h)
+        else
+            cr:scale(aspects.w, aspects.h)
+        end
     else
         if self._private.halign == "center" then
             translate.x = math.floor((width - w)/2)
@@ -256,7 +264,8 @@ function imagebox:draw(ctx, cr, width, height)
     end
 
     if self._private.handle then
-        self._private.handle:render_cairo(cr)
+        cr:set_source_surface(svg_surf, 0, 0)
+        self._private.handle:render_document(cr, RsvgRect)
     else
         cr:set_source_surface(self._private.image, 0, 0)
 

--- a/lib/wibox/widget/imagebox.lua
+++ b/lib/wibox/widget/imagebox.lua
@@ -182,8 +182,7 @@ function imagebox:draw(ctx, cr, width, height)
 
     local w, h = self._private.default.width, self._private.default.height
 
-    local RsvgRect = Rsvg.Rectangle {x = 0, y = 0, width = w, height = h}
-    local svg_surf = cairo.ImageSurface(cairo.Format.ARGB32, w, h)
+    local svg_surf
 
     if self._private.resize then
         -- That's for the "fit" policy.
@@ -237,8 +236,8 @@ function imagebox:draw(ctx, cr, width, height)
         end
 
         if self._private.handle then
-            RsvgRect = Rsvg.Rectangle {x = 0, y = 0, width = w*aspects.w, height = h*aspects.h }
             svg_surf = cairo.ImageSurface(cairo.Format.ARGB32, w*aspects.w, h*aspects.h)
+            self._private.handle:render_document(cr, Rsvg.Rectangle {x = 0, y = 0, width = w*aspects.w, height = h*aspects.h})
         else
             cr:scale(aspects.w, aspects.h)
         end
@@ -261,11 +260,16 @@ function imagebox:draw(ctx, cr, width, height)
         if self._private.clip_shape then
             cr:clip(self._private.clip_shape(cr, w, h, unpack(self._private.clip_args)))
         end
+
+        if self._private.handle then
+            -- Translation is not needed in the new surface
+            svg_surf = cairo.ImageSurface(cairo.Format.ARGB32, 0, 0)
+            self._private.handle:render_document(cr, Rsvg.Rectangle {x = 0, y = 0, width = w, height = h})
+        end
     end
 
     if self._private.handle then
         cr:set_source_surface(svg_surf, 0, 0)
-        self._private.handle:render_document(cr, RsvgRect)
     else
         cr:set_source_surface(self._private.image, 0, 0)
 


### PR DESCRIPTION
This is part one of a small fix for imagebox. This PR is so imagebox correctly resized SVG's, previously it was just rendered by cairo (which worked fine) but for the svg to be properly recolored and rendered the Rsvg object needs to know about its future size, thats why I had to switch to render_document (its what the docs recommend to use anyway) which now takes an extra RsvgRect argument which is a simple stuct with its w/h and x/y(not needed) information

I also added seperate logic to scale the cairo surface. This was needed because the original scale would also automatically scale the SVG *again*, instead It now scales the rect, and the temporary surface (I needed a new one with the new size, else the original wouldn't fit the resized SVG anymore)