### PR TITLE
Fix typo in taglist.lua

### DIFF
--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -522,7 +522,7 @@ end
 -- @see filter
 -- @see awful.widget.taglist.source.for_screen
 
---- A template used to genetate the individual tag widgets.
+--- A template used to generate the individual tag widgets.
 --
 -- @property widget_template
 -- @tparam[opt=nil] template|nil widget_template

--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -522,7 +522,7 @@ end
 -- @see filter
 -- @see awful.widget.taglist.source.for_screen
 
---- A templete used to genetate the individual tag widgets.
+--- A template used to genetate the individual tag widgets.
 --
 -- @property widget_template
 -- @tparam[opt=nil] template|nil widget_template


### PR DESCRIPTION
Just a small typo correction from 'templete' to 'template' in the comments.

EDIT: Also changed 'genetate' to 'generate' in the same sentence. Didn't see it initially. 