### PR TITLE
Fix minimum slider value 

### DIFF
--- a/lib/wibox/widget/slider.lua
+++ b/lib/wibox/widget/slider.lua
@@ -520,8 +520,8 @@ end
 
 -- Move the handle to the correct location
 local function move_handle(self, width, x, _)
-    local _, _, interval = get_extremums(self)
-    self:set_value(math.floor((x*interval)/width))
+    local min, _, interval = get_extremums(self)
+    self:set_value(min+math.floor((x*interval)/width))
 end
 
 local function mouse_press(self, x, y, button_id, _, geo)


### PR DESCRIPTION
The slider does not respect the minimum value when dragging (see cursor):

![slider](https://github.com/awesomeWM/awesome/assets/13920314/e7a4eec1-739f-473f-98ad-5c7ee00a9646)

```lua
{
    widget = wibox.widget.slider,
    value = 50,
    minimum = 25,
    maximum = 100,
},
```