### PR TITLE
Fix focus.global_bydirection not moving focus from empty screen

### DIFF
--- a/lib/awful/client/focus.lua
+++ b/lib/awful/client/focus.lua
@@ -208,7 +208,7 @@ function focus.global_bydirection(dir, c, stacked)
 
     -- if focus not changed, we must change screen
     if sel == capi.client.focus then
-        screen.focus_bydirection(dir, scr)
+        screen.focus_bydirection(dir, screen.focused())
         if scr ~= get_screen(screen.focused()) then
             local cltbl = client.visible(screen.focused(), stacked)
             local geomtbl = {}


### PR DESCRIPTION
When having three monitors and only one client on the first monitor, the function does not work when the middle monitor is focused, as it uses the focused clients' screen instead of the currently focused screen as the base.