### PR TITLE
fix(awful.key.keygroups): can't use 0 . key

### DIFF
--- a/lib/awful/key.lua
+++ b/lib/awful/key.lua
@@ -397,7 +397,7 @@ key.keygroups = {
 -- Technically, this isn't very popular, but we have been doing this for 12
 -- years and nobody complained too loudly.
 for i = 1, 10 do
-    table.insert(key.keygroups.numrow, {"#" .. i + 9, i == 10 and 0 or i})
+    table.insert(key.keygroups.numrow, {"#" .. i + 9, i})
 end
 for i = 1, 35 do
     table.insert(key.keygroups.fkeys, {"F" .. i, "F" .. i})


### PR DESCRIPTION
I can't use 0. key to view the 10th tag
```
    awful.key({
        modifiers = { keys.super },
        keygroup = awful.key.keygroup.NUMROW,
        description = "Only view tag",
        group = "tag",
        on_press = function(index)
            local screen = awful.screen.focused()
            local tag = screen.tags[index]
            if tag then
                tag:view_only()
            end
        end,
    }),
```
Because the value assigned with 0. key (`#19`) is 0 and not 10