### PR TITLE
Avoid loading duplicate .desktop files in menubar

### DIFF
--- a/lib/menubar/menu_gen.lua
+++ b/lib/menubar/menu_gen.lua
@@ -13,6 +13,7 @@ local utils = require("menubar.utils")
 local pairs = pairs
 local ipairs = ipairs
 local table = table
+local gdebug = require("gears.debug")
 
 local menu_gen = {}
 
@@ -21,6 +22,7 @@ local menu_gen = {}
 --- Get the path to the directories where XDG menu applications are installed.
 local function get_xdg_menu_dirs()
     local dirs = gfilesystem.get_xdg_data_dirs()
+    gdebug.dump(gfilesystem.get_xdg_data_home(), "xdg_data_home")
     table.insert(dirs, 1, gfilesystem.get_xdg_data_home())
     return gtable.map(function(dir) return dir .. 'applications/' end, dirs)
 end
@@ -95,7 +97,7 @@ function menu_gen.generate(callback)
             for _, entry in ipairs(entries) do
                 -- Check whether to include program in the menu
                 if entry.show and entry.Name and entry.cmdline then
-                    local unique_key = entry.Name .. '\0' .. entry.cmdline
+                    local unique_key = entry.desktop_file_id
                     if not unique_entries[unique_key] then
                         local target_category = nil
                         -- Check if the program falls into at least one of the
@@ -120,6 +122,8 @@ function menu_gen.generate(callback)
                                      icon = icon,
                                      category = target_category })
                         unique_entries[unique_key] = true
+                    else
+                        gdebug.dump(entry, "entry not included")
                     end
                 end
             end

--- a/lib/menubar/menu_gen.lua
+++ b/lib/menubar/menu_gen.lua
@@ -13,7 +13,6 @@ local utils = require("menubar.utils")
 local pairs = pairs
 local ipairs = ipairs
 local table = table
-local gdebug = require("gears.debug")
 local lgi = require("lgi")
 local gio = lgi.Gio
 local protected_call = require("gears.protected_call")
@@ -146,8 +145,6 @@ function menu_gen.generate(callback)
                                 { name = name, cmdline = cmdline, icon = icon, category = target_category }
                             )
                             unique_entries[unique_key] = true
-                        else
-                            gdebug.dump(entry, "entry not included")
                         end
                     end
                 end

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -406,7 +406,13 @@ function utils.parse_dir(dir_path, callback)
 
     gio.Async.start(do_protected_call)(function()
         local result = {}
-        parser(gio.File.new_for_path(dir_path), result)
+        local f = gio.File.new_for_path(dir_path)
+        parser(f, result)
+        for i, entry in ipairs(result) do
+            local target = gio.File.new_for_path(entry.file)
+            entry.desktop_file_id = f:get_relative_path(target)
+            result[i] = entry
+        end
         call_callback(callback, result)
     end)
 end

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -382,11 +382,11 @@ function utils.parse_dir(dir_path, callback)
     end
 
     local result = {}
-    local f = gio.File.new_for_path(dir_path)
-    parser(f, result)
+    local dir = gio.File.new_for_path(dir_path)
+    parser(dir, result)
     for i, entry in ipairs(result) do
-        local target = gio.File.new_for_path(entry.file)
-        local relative_path = f:get_relative_path(target)
+        local desktop_file = gio.File.new_for_path(entry.file)
+        local relative_path = dir:get_relative_path(desktop_file)
         entry.desktop_file_id = string.gsub(relative_path, "/", "-")
         result[i] = entry
     end

--- a/lib/menubar/utils.lua
+++ b/lib/menubar/utils.lua
@@ -410,7 +410,8 @@ function utils.parse_dir(dir_path, callback)
         parser(f, result)
         for i, entry in ipairs(result) do
             local target = gio.File.new_for_path(entry.file)
-            entry.desktop_file_id = f:get_relative_path(target)
+            local relative_path = f:get_relative_path(target)
+            entry.desktop_file_id = string.gsub(relative_path, "/", "-")
             result[i] = entry
         end
         call_callback(callback, result)


### PR DESCRIPTION
Currently, if a user copies a .desktop file into some other directory, they will get duplicate entries in menubar. This PR changes that so that only one entry is kept.

The [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) says that entries have an id derived from their path.

>  To determine the ID of a desktop file, make its full path relative to the $XDG_DATA_DIRS component in which the desktop file is installed, remove the "applications/" prefix, and turn '/' into '-'. 

Only the first file found with a given id, following the order of directories in `$XDG_DATA_DIRS`, should be used. This PR changes the logic used by menubar to do exactly this. This allows users to e.g. override a system defined .desktop file by putting a changed one in `~/.local/share/applications/`. Changing '/' into '-' allows overriding a file stored inside a directory hierarchy of the system without creating directories in .local.

To do this, the GIO Async context was hoisted above the iteration through directories as otherwise following directory precedence would be more complex.

There is one divergence from the spec in this implementation. The spec says:
>  If the desktop file is not installed in an applications subdirectory of one of the $XDG_DATA_DIRS components, it does not have an ID. 

In this implementation, we scan through `menu_bar.all_menu_dirs`, and all these directories are treated the same, regardless of whether they are "an applications subdirectory of one of the $XDG_DATA_DIRS components". Some users set this, though it's pretty uncommon. I think this is unlikely to cause the few people who use this to add more directories any problems with accidentally-ignored .desktop files.

Fixes #1816.