### PR TITLE
Release all grabs when unmanaging windows

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -3010,6 +3010,8 @@ client_unmanage(client_t *c, client_unmanage_t reason)
 
     if(reason != CLIENT_UNMANAGE_DESTROYED)
     {
+        xwindow_buttons_grab(c->window, &(button_array_t){ .len = 0 });
+        xwindow_grabkeys(c->window, &(key_array_t){ .len = 0 });
         area_t geometry = client_get_undecorated_geometry(c);
         xcb_unmap_window(globalconf.connection, c->window);
         xcb_reparent_window(globalconf.connection, c->window, globalconf.screen->root,


### PR DESCRIPTION
When a top-level window is unmapped, awesome stops tracking it, possibly leaving behind stale passive grabs.  If the window is later reparented and mapped again, these grabs can become activated, locking the pointer.  awesome does not release grabs on windows it’s not managing, even though it technically could.  The only remedy is destroying the poisoned window.

This was discovered while using [tabbed](https://tools.suckless.org/tabbed/).