### PR TITLE
Fix typo in menu.lua documentation

### DIFF
--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -707,7 +707,7 @@ end
 -- -- Bound to a key, it can be used to select from dozens of terminals open on
 -- -- several tags.
 -- -- When using @{ruled.client.match_any} instead of @{ruled.client.match},
--- -- a menu of clients with different classes could be build.
+-- -- a menu of clients with different classes could be built.
 --
 -- function terminal_menu ()
 --   terms = {}


### PR DESCRIPTION
A usage example in `menu.lua` has the following text:

> When using rules.match_any instead of rules.match, a menu of clients with different classes could be build.

It should instead say:

> When using rules.match_any instead of rules.match, a menu of clients with different classes could be _built_.