### PR TITLE
Use GITHUB_OUTPUT envvar instead of set-output command as the latter is deprecated

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -3,10 +3,10 @@ name: Update API docs
 on:
   # Trigger on push to branches `master` and `3.5`.
   push:
-    branches: [ master, 3.5 ]
+    branches: [master, 3.5]
   # Trigger on pull request events for PRs that have `master` as their target branch
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
   # Allow running the workflow manually
   workflow_dispatch:
@@ -33,7 +33,7 @@ jobs:
       # This way, packages will be checked for updates once every week.
       - name: Get Date
         id: get-date
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
+        run: echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
 
       - name: Cache apt packages
         id: cache-apt
@@ -156,5 +156,4 @@ jobs:
           APIDOC_TOKEN: ${{ secrets.AWESOME_ROBOT_TOKEN || github.token }}
           GITHUB_COMPARE: ${{ github.event.compare }}
         run: .github/scripts/apidoc.sh
-
 # vim: filetype=yaml:expandtab:shiftwidth=2:tabstop=2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: Build & Test
 on:
   # Trigger on push to branches `master` and `3.5`.
   push:
-    branches: [ master, 3.5 ]
+    branches: [master, 3.5]
   # Trigger on pull request events for PRs that have `master` as their target branch
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
   # Allow running the workflow manually
   workflow_dispatch:
@@ -75,15 +75,15 @@ jobs:
       LUAINCLUDE: ${{ matrix.lua_include || format('/usr/include/lua{0}', matrix.lua_version) }}
       LUALIBRARY: ${{ matrix.lua_library || format('/usr/lib/x86_64-linux-gnu/liblua{0}.so', matrix.lua_version) }}
       TESTS_SCREEN_SIZE: ${{ matrix.tests_screen_size }}
-      TEST_TIMEOUT: '100'
-      CI: 'true'
+      TEST_TIMEOUT: "100"
+      CI: "true"
 
     steps:
       # Create a cache invalidation key based on the current year + week.
       # This way, packages will be checked for updates once every week.
       - name: Get Date
         id: get-date
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%W")"
+        run: echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
 
       - name: Cache apt packages
         id: cache-apt


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
