### PR TITLE
Fix the documentation warnings

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -1739,6 +1739,13 @@ local summarize = {
     readonly      = {index = 8, title = "read only"       , count = false},
 }
 
+local no_prefix = {
+    property           = true,
+    signal             = true,
+    clientruleproperty = true,
+    deprecatedproperty = true,
+}
+
 local delimiter_for_tag = {
     usebeautiful  = { "table class='widget_list' border=1", "table", "tr", "tr", {"Theme variable", "Usage"}},
     propbeautiful = { "table class='widget_list' border=1", "table", "tr", "tr", {"Theme variable", "Usage"}},
@@ -2126,7 +2133,11 @@ local function global_init(_ldoc)
                 -- Decorate the item with our customizations.
                 init_custom_types(item)
 
-                -- print(item.description)
+                -- Remove the "namespace" from the signals and properties
+                if no_prefix[item.type] then
+                    local name = item.name:match("%.([^.]+)$")
+                    item.name = name ~= "" and name or item.name
+                end
 
                 if item.summary and not detect_markdown_footguns(item.summary) then
                     print(
@@ -2247,13 +2258,6 @@ local function compare_module_name(input, module)
     return false
 end
 
-local no_prefix = {
-    property           = true,
-    signal             = true,
-    clientruleproperty = true,
-    deprecatedproperty = true,
-}
-
 -- These modules merge the doc of their `awful` siblings.
 local coreclassmap = {
     tag    = "tag<span class='listplusign'> and awful.tag</span>",
@@ -2364,12 +2368,6 @@ custom_display_name_handler = function(item, default_handler)
     if show_return[item.type] and item.tags["return"] then
         item.ret = item.tags["return"]
         item:build_return_groups()
-    end
-
-    -- Remove the "namespace" from the signals and properties
-    if no_prefix[item.type] then
-        local name = item.name:match("%.([^.]+)$")
-        return name ~= "" and name or item.name
     end
 
     -- Handle the left sidebar modules.

--- a/lib/awful/screenshot.lua
+++ b/lib/awful/screenshot.lua
@@ -440,15 +440,15 @@ end
 -- @tparam[opt=nil] screen|nil screen
 -- @propemits true false
 -- @see mouse.screen
--- @see awful.screen.focused
+-- @see screen.focused
 -- @see screen.primary
 
 --- Get screenshot client.
 --
 -- @property client
--- @tparam[opt=nil] client|nil client
+-- @tparam[opt=nil] client|nil client The client.
 -- @propemits true false
--- @see mouse.client
+-- @see mouse.current_client
 -- @see client.focus
 
 --- Get screenshot geometry.
@@ -891,6 +891,7 @@ end
 -- @method reject
 -- @tparam[opt=nil] string||nil reason The reason why it was rejected. This is
 --  passed to the `"snipping::cancelled"` signal.
+-- @noreturn
 -- @emits snipping::cancelled
 
 function module:reject(reason)

--- a/lib/gears/shape.lua
+++ b/lib/gears/shape.lua
@@ -778,6 +778,7 @@ end
 -- @tparam number height The shape height
 -- @tparam[opt=5] number x_offset The shadow area horizontal offset.
 -- @tparam[opt=5] number y_offset The shadow area vertical offset.
+-- @noreturn
 function module.solid_rectangle_shadow(cr, w, h, x_offset, y_offset)
     x_offset, y_offset = x_offset or 5, y_offset or 5
     w, h = w - math.abs(x_offset), h - math.abs(y_offset)

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -58,6 +58,7 @@ ${TOP_SOURCE_DIR}/lib/?/init.lua\\;\
 ${TOP_SOURCE_DIR}/lib/?\\;\
 ${TOP_SOURCE_DIR}/themes/?.lua\\;\
 ${TOP_SOURCE_DIR}/themes/?\\;\
+${TOP_SOURCE_DIR}/tests/examples/?.lua\\;\
 ${LUA_PATH_}")
 
 # Add the C API shims.

--- a/tests/examples/sequences/client/jump_to_urgent1.lua
+++ b/tests/examples/sequences/client/jump_to_urgent1.lua
@@ -6,7 +6,6 @@ local beautiful = require("beautiful")
 require("awful.ewmh")
 screen[1]._resize {x = 0, width = 160, height = 90}
 awful.tag({ "one", "two", "three" }, screen[1], awful.layout.suit.tile)
-beautiful.bg_urgent = "#ff0000"
 
 function awful.spawn(name, properties)
     client.gen_fake{class = name, name = name, x = 10, y=10, width = 60, height =50, tags = properties.tags}

--- a/tests/examples/shims/beautiful.lua
+++ b/tests/examples/shims/beautiful.lua
@@ -40,6 +40,8 @@ local module = {
     bg_normal    = "#6181FF7D",
     bg_focus     = "#AA00FF7D",
     bg_highlight = "#AA00FF7D",
+    bg_urgent    = "#FF00377D",
+    fg_urgent    = "#FFFFFFFF",
     border_color = "#6181FF"  ,
     border_width = 1.5        ,
 


### PR DESCRIPTION
They were added because the PRs which added those APIs predated the warnings, but were merged later.

And also fix some rendering bugs caused by the shims not behaving correctly.