### PR TITLE
Default to only use ARGB visual for ARGB client windows

### DIFF
--- a/color.c
+++ b/color.c
@@ -159,7 +159,7 @@ color_init_unchecked(color_t *color, const char *colstr, ssize_t len, xcb_visual
         return req;
     }
     req.cookie_hexa = xcb_alloc_color_unchecked(globalconf.connection,
-                                                globalconf.default_cmap,
+                                                globalconf.screen_cmap,
                                                 RGB_8TO16(red),
                                                 RGB_8TO16(green),
                                                 RGB_8TO16(blue));

--- a/draw.c
+++ b/draw.c
@@ -242,10 +242,10 @@ uint8_t draw_visual_depth(const xcb_screen_t *s, xcb_visualid_t vis)
 void draw_test_cairo_xcb(void)
 {
     xcb_pixmap_t pixmap = xcb_generate_id(globalconf.connection);
-    xcb_create_pixmap(globalconf.connection, globalconf.default_depth, pixmap,
+    xcb_create_pixmap(globalconf.connection, globalconf.screen_depth, pixmap,
                       globalconf.screen->root, 1, 1);
     cairo_surface_t *surface = cairo_xcb_surface_create(globalconf.connection,
-                                          pixmap, globalconf.visual, 1, 1);
+                                          pixmap, globalconf.screen_visual, 1, 1);
     if(cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
         fatal("Could not set up display: got cairo surface with status %s",
                 cairo_status_to_string(cairo_surface_status(surface)));

--- a/globalconf.h
+++ b/globalconf.h
@@ -77,6 +77,15 @@ ARRAY_TYPE(xproperty_t, xproperty)
 DO_ARRAY(sequence_pair_t, sequence_pair, DO_NOTHING)
 DO_ARRAY(xcb_window_t, window, DO_NOTHING)
 
+enum argb_mode {
+    /** No window will be created with an ARGB visual */
+    ARGB_MODE_DISABLED = 0,
+    /** Client window with an ARGB visual will be reparented an ARGB window */
+    ARGB_MODE_ENABLED,
+    /** All windows will be created with an ARGB visual */
+    ARGB_MODE_FULL
+};
+
 /** Main configuration structure */
 typedef struct
 {
@@ -185,20 +194,24 @@ typedef struct
     } systray;
     /** The monitor of startup notifications */
     SnMonitorContext *snmonitor;
-    /** The visual, used to draw */
-    xcb_visualtype_t *visual;
     /** The screen's default visual */
-    xcb_visualtype_t *default_visual;
+    xcb_visualtype_t *screen_visual;
+    /** An ARGB visual */
+    xcb_visualtype_t *argb_visual;
     /** The screen's information */
     xcb_screen_t *screen;
     /** A graphic context. */
     xcb_gcontext_t gc;
-    /** Our default depth */
-    uint8_t default_depth;
-    /** Our default color map */
-    xcb_colormap_t default_cmap;
+    /** The screen's depth */
+    uint8_t screen_depth;
+    /** The screen's default color map */
+    xcb_colormap_t screen_cmap;
+    /** ARGB color map */
+    xcb_colormap_t argb_cmap;
     /** Do we have to reban clients? */
     bool need_lazy_banning;
+    /** Should we use ARGB visual for all windows? */
+    enum argb_mode argb_mode;
     /** Tag list */
     tag_array_t tags;
     /** List of registered xproperties */

--- a/objects/client.h
+++ b/objects/client.h
@@ -173,7 +173,7 @@ struct client_t
     /** Size hints */
     xcb_size_hints_t size_hints;
     /** The visualtype that c->window uses */
-    xcb_visualtype_t *visualtype;
+    xcb_visualtype_t *client_visualtype;
     /** Do we honor the client's size hints? */
     bool size_hints_honor;
     /** Machine the client is running on. */

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -105,7 +105,7 @@ static lua_class_t drawable_class;
 LUA_OBJECT_FUNCS(drawable_class, drawable_t, drawable)
 
 drawable_t *
-drawable_allocator(lua_State *L, drawable_refresh_callback *callback, void *data)
+drawable_allocator(lua_State *L, uint8_t depth, xcb_visualtype_t *visual, drawable_refresh_callback *callback, void *data)
 {
     drawable_t *d = drawable_new(L);
     d->refresh_callback = callback;
@@ -113,6 +113,8 @@ drawable_allocator(lua_State *L, drawable_refresh_callback *callback, void *data
     d->refreshed = false;
     d->surface = NULL;
     d->pixmap = XCB_NONE;
+    d->depth = depth;
+    d->visual = visual;
     return d;
 }
 
@@ -147,10 +149,10 @@ drawable_set_geometry(lua_State *L, int didx, area_t geom)
     if (area_changed && geom.width > 0 && geom.height > 0)
     {
         d->pixmap = xcb_generate_id(globalconf.connection);
-        xcb_create_pixmap(globalconf.connection, globalconf.default_depth, d->pixmap,
+        xcb_create_pixmap(globalconf.connection, d->depth, d->pixmap,
                           globalconf.screen->root, geom.width, geom.height);
         d->surface = cairo_xcb_surface_create(globalconf.connection,
-                                              d->pixmap, globalconf.visual,
+                                              d->pixmap, d->visual,
                                               geom.width, geom.height);
         luaA_object_emit_signal(L, didx, "property::surface", 0);
     }

--- a/objects/drawable.h
+++ b/objects/drawable.h
@@ -44,10 +44,14 @@ struct drawable_t
     drawable_refresh_callback *refresh_callback;
     /** Data for refresh callback. */
     void *refresh_data;
+    /** Drawable depth */
+    uint8_t depth;
+    /** Drawable visual */
+    xcb_visualtype_t *visual;
 };
 typedef struct drawable_t drawable_t;
 
-drawable_t *drawable_allocator(lua_State *, drawable_refresh_callback *, void *);
+drawable_t *drawable_allocator(lua_State *, uint8_t depth, xcb_visualtype_t *visual, drawable_refresh_callback *, void *);
 void drawable_set_geometry(lua_State *, int, area_t);
 void drawable_class_setup(lua_State *);
 

--- a/objects/window.c
+++ b/objects/window.c
@@ -195,7 +195,7 @@ luaA_window_set_border_color(lua_State *L, window_t *window)
     const char *color_name = luaL_checklstring(L, -1, &len);
 
     if(color_name &&
-       color_init_reply(color_init_unchecked(&window->border_color, color_name, len, globalconf.visual)))
+       color_init_reply(color_init_unchecked(&window->border_color, color_name, len, window->visualtype)))
     {
         window->border_need_update = true;
         luaA_object_emit_signal(L, -3, "property::border_color", 0);

--- a/objects/window.h
+++ b/objects/window.h
@@ -69,6 +69,8 @@ typedef enum
     color_t border_color; \
     /** Border width */ \
     uint16_t border_width; \
+    /** The visual type */ \
+    xcb_visualtype_t *visualtype; \
     /** The window type */ \
     window_type_t type; \
     /** The border width callback */ \

--- a/options.c
+++ b/options.c
@@ -418,6 +418,7 @@ options_check_args(int argc, char **argv, int *init_flags, string_array_t *paths
         { "screen"    , ARG   , NULL, 'm'  },
         { "api-level" , ARG   , NULL, 'l'  },
         { "reap"      , ARG   , NULL, '\1' },
+        { "full-argb" , NO_ARG, NULL, 'A'  },
         { NULL        , NO_ARG, NULL, 0    }
     };
 
@@ -466,6 +467,9 @@ options_check_args(int argc, char **argv, int *init_flags, string_array_t *paths
           case 'a':
             globalconf.had_overriden_depth = true;
             (*init_flags) &= ~INIT_FLAG_ARGB;
+            break;
+          case 'A':
+            (*init_flags) |= INIT_FLAG_FULL_ARGB | INIT_FLAG_ARGB;
             break;
           case 'r':
             (*init_flags) |= INIT_FLAG_REPLACE_WM;

--- a/options.h
+++ b/options.h
@@ -32,6 +32,7 @@ typedef enum {
     INIT_FLAG_AUTO_SCREEN    = 0x1 << 3,
     INIT_FLAG_ALLOW_FALLBACK = 0x1 << 4,
     INIT_FLAG_FORCE_CMD_ARGS = 0x1 << 5,
+    INIT_FLAG_FULL_ARGB      = 0x1 << 6,
 } awesome_init_config_t;
 
 char *options_detect_shebang(int argc, char **argv);

--- a/root.c
+++ b/root.c
@@ -193,13 +193,13 @@ root_update_wallpaper(void)
     }
 
     /* Only the default visual makes sense, so just the default depth */
-    if (geom_r->depth != draw_visual_depth(globalconf.screen, globalconf.default_visual->visual_id))
+    if (geom_r->depth != draw_visual_depth(globalconf.screen, globalconf.screen_visual->visual_id))
         warn("Got a pixmap with depth %d, but the default depth is %d, continuing anyway",
-                geom_r->depth, draw_visual_depth(globalconf.screen, globalconf.default_visual->visual_id));
+                geom_r->depth, draw_visual_depth(globalconf.screen, globalconf.screen_visual->visual_id));
 
     globalconf.wallpaper = cairo_xcb_surface_create(globalconf.connection,
                                                     *rootpix,
-                                                    globalconf.default_visual,
+                                                    globalconf.screen_visual,
                                                     geom_r->width,
                                                     geom_r->height);
 
@@ -530,7 +530,7 @@ luaA_root_get_content(lua_State *L)
 
     surface = cairo_xcb_surface_create(globalconf.connection,
                                        globalconf.screen->root,
-                                       globalconf.default_visual,
+                                       globalconf.screen_visual,
                                        globalconf.screen->width_in_pixels,
                                        globalconf.screen->height_in_pixels);
 

--- a/systray.c
+++ b/systray.c
@@ -372,7 +372,7 @@ luaA_systray(lua_State *L)
         color_t bg_color;
         bool force_redraw = false;
 
-        if(color_init_reply(color_init_unchecked(&bg_color, bg, bg_len, globalconf.default_visual))
+        if(color_init_reply(color_init_unchecked(&bg_color, bg, bg_len, globalconf.screen_visual))
                 && globalconf.systray.background_pixel != bg_color.pixel)
         {
             uint32_t config_back[] = { bg_color.pixel };


### PR DESCRIPTION
Don't use the same visual for all windows.

And add a `--full-argb` option to force ARGB visual for all windows, which is the current default behavior.

Fixes #2408