### PR TITLE
Add Nix flake (draft)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1714076141,
+        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "AwesomeWM";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: {
+    overlay = final: prev: {
+      awesome = (prev.awesome.overrideAttrs (old: {
+        version = "latest";
+        src = ./.;
+
+        patches = [ ];
+
+        cmakeFlags = old.cmakeFlags ++ [
+          "-DGENERATE_MANPAGES=OFF"
+          "-DGENERATE_DOC=OFF"
+        ];
+      }));
+    };
+  } // flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        overlays = [ self.overlay ];
+        inherit system;
+      };
+    in
+    {
+      packages = with pkgs; {
+        default = awesome;
+        inherit awesome;
+      };
+    });
+}
+


### PR DESCRIPTION
I believe Nix is a helpful tool for both development as well as a (at least for some) comfortable package manager. Having an official Nix flake in the repo is nowadays pretty common (e.g. the [Neovim](https://github.com/neovim/neovim) and [Prism Launcher](https://github.com/PrismLauncher/PrismLauncher/) repos do this) and can be beneficial to Nix users and developers alike.

The current revision builds just fine on my Arch Linux install, however it is by no means finished and I am looking for feedback. The flake was heavily inspired by [Neovim's flake](https://github.com/neovim/neovim/blob/master/contrib/flake.nix).