### PR TITLE
Fix `widget.wibox.slider` example

### DIFF
--- a/tests/examples/wibox/widget/defaults/slider.lua
+++ b/tests/examples/wibox/widget/defaults/slider.lua
@@ -27,7 +27,7 @@ widget:connect_signal("property::value", function(_, new_value)
         error(string.format("unexpected value %s", new_value))
     end
     --DOC_HIDE_END
-    naughty.notify { title = "Slider changed", message = new_value }
+    naughty.notify { title = "Slider changed", message = tostring(new_value) }
 end)
 
 --DOC_HIDE_START


### PR DESCRIPTION
The [provided example](https://awesomewm.org/apidoc/widgets/wibox.widget.slider.html) for `widget.wibox.slider` does not work due to `naughty.notify` requiring the message to be a string.

```lua
local widget = wibox.widget {
    bar_shape           = gears.shape.rounded_rect,
    bar_height          = 3,
    bar_color           = beautiful.border_color,
    handle_color        = beautiful.bg_normal,
    handle_shape        = gears.shape.circle,
    handle_border_color = beautiful.border_color,
    handle_border_width = 1,
    value               = 25,
    widget              = wibox.widget.slider,
}

-- Connect to `property::value` to use the value on change
widget:connect_signal("property::value", function(_, new_value)
    naughty.notify { title = "Slider changed", message = new_value }
end)
```

`new_value` returns a number in this case.  Running this code will throw an error in `lib/naughty/widget/_markup.lua`:

https://github.com/awesomeWM/awesome/blob/8b1f8958b46b3e75618bc822d512bb4d449a89aa/lib/naughty/widget/_markup.lua#L25

