### PR TITLE
fix: call ret:emit_signal("timeout") instead of args.callback

### DIFF
--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -205,12 +205,11 @@ function timer.new(args)
     end
 
     if args.callback then
-        if args.call_now then
-            args.callback()
-        end
         ret:connect_signal("timeout", args.callback)
     end
-
+    if args.call_now then
+        ret:emit_signal("timeout")
+    end
     if args.single_shot then
         ret:connect_signal("timeout", function() ret:stop() end)
     end


### PR DESCRIPTION
This ensures that the timer gets passed on the first call of callback.
fixes: #3904
