### PR TITLE
Failsafe exit setting for awful.popup in doc example

### DIFF
--- a/tests/examples/awful/widget/layoutlist/default.lua
+++ b/tests/examples/awful/widget/layoutlist/default.lua
@@ -15,6 +15,7 @@ local wibox = require("wibox") --DOC_HIDE
         maximum_height = #awful.layout.layouts * 24,
         minimum_height = #awful.layout.layouts * 24,
         placement      = awful.placement.centered,
+        hide_on_right_click = true,
     }
 
 --DOC_HIDE vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The first `awful.widget.layoutlist` [[popup example](https://awesomewm.org/apidoc/widgets/awful.widget.layoutlist.html)] does not show how to bind the popup to a widget or a button press.
Nevertheless when the popup is shown it is never actually removed from display, even after selecting a layout,
and not even after awesome restart, so I think adding this option which lets the unaware user click right mouse button 
to make the popup disappear is a good default. 
I would also consider adding ontop so it is not covered by clients/more visible when active since it is usually an immediate type of action.
