### PR TITLE
ruled.notifications remove mistaken code example line

### DIFF
--- a/tests/examples/wibox/nwidget/rules/widget_template.lua
+++ b/tests/examples/wibox/nwidget/rules/widget_template.lua
@@ -78,7 +78,7 @@ local notif2 =  --DOC_HIDE
    naughty.notification {  --DOC_HIDE
        title     = "Daft Punk",  --DOC_HIDE
        message   = "Harder, Better, Faster, Stronger",  --DOC_HIDE
-       icon      = beautiful.awesome_icon,
+       icon      = beautiful.awesome_icon, --DOC_HIDE
        icon_size = 128,  --DOC_HIDE
        app_name  = "mdp",  --DOC_HIDE
    }  --DOC_HIDE


### PR DESCRIPTION
1. The second code example on [ruled.notifications](https://awesomewm.org/apidoc/declarative_rules/ruled.notifications.html) has what seems to be an extra unneeded line at the end:
```lua
naughty.connect_signal("request::display", function(n)
    naughty.layout.box { notification = n }
end)
    icon      = beautiful.awesome_icon,
```

In the source file it appears to come from a later, separate creation of a notification which doesn't appear in any doc.
I assume it is supposed to be hidden altogether.

2. The `app_name` string  `mdp` appear several times in the file. I couldn't find such app, is it actually meant to be [mpd](https://github.com/MusicPlayerDaemon/MPD) ? Let me know and I will push a commit changing it