### PR TITLE
Find in the hotkeys popup

### DIFF
--- a/lib/awful/hotkeys_popup/init.lua
+++ b/lib/awful/hotkeys_popup/init.lua
@@ -22,6 +22,7 @@ local hotkeys_popup = {
 -- see `awful.hotkeys_popup.widget.show_help` for more information
 -- @tparam[opt] client c The hostkeys for the client "c".
 -- @tparam[opt] screen s The screen.
+-- @tparam[opt=true] boolean show_args.enable_find Enable find.
 -- @tparam[opt=true] boolean show_args.show_awesome_keys Show AwesomeWM hotkeys.
 -- When set to `false` only app-specific hotkeys will be shown.
 -- @staticfct awful.hotkeys_popup.show_help

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -393,6 +393,8 @@ function widget.new(args)
             beautiful.hotkeys_find_ul_cursor
         self.find_font = args.find_font or
             beautiful.hotkeys_find_font or self.font
+        self.find_margin = args.find_margin or
+            beautiful.hotkeys_find_margin or self.group_margin
         self.label_colors = beautiful.xresources.get_current_theme()
         self._widget_settings_loaded = true
     end
@@ -771,8 +773,8 @@ function widget.new(args)
     end
 
     function widget_instance:_create_find_data()
-        local margin = self.group_margin
-        local textbox = wibox.widget.textbox("", true)
+        local margin = self.find_margin
+        local textbox = wibox.widget.textbox()
         local container = wibox.container.margin(textbox, margin, margin, margin, margin)
         local height = beautiful.get_font_height(self.find_font) + 2 * margin
         return {

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -699,7 +699,7 @@ function widget.new(args)
             end
             local textbox = wibox.widget.textbox(joined_labels)
             current_column.layout:add(textbox)
-            table.insert(find_data.rows, {
+            table.insert(find_data.groups, {
                 textbox = textbox,
                 labels = labels,
             })
@@ -779,7 +779,7 @@ function widget.new(args)
             textbox = textbox,
             container = container,
             height = height,
-            rows = {},
+            groups = {},
             last_query = "",
         }
     end
@@ -894,7 +894,7 @@ function widget.new(args)
             end
             w_self.find_data.last_query = query
 
-            for _, row in ipairs(w_self.find_data.rows) do
+            for _, row in ipairs(w_self.find_data.groups) do
                 local rendered_hotkeys = {}
                 for _, label in ipairs(row.labels) do
                     table.insert(rendered_hotkeys, self:_render_hotkey(label, keywords))

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -428,9 +428,9 @@ function widget.new(args)
         self.group_margin = args.group_margin or
             beautiful.hotkeys_group_margin or dpi(6)
         self.highlight_bg = args.highlight_bg or
-            beautiful.hotkeys_highlight_bg or "#ffff00"
+            beautiful.hotkeys_highlight_bg or beautiful.bg_urgent
         self.highlight_fg = args.highlight_fg or
-            beautiful.hotkeys_highlight_fg or "#000000"
+            beautiful.hotkeys_highlight_fg or beautiful.fg_urgent
         self.find_prompt = args.find_prompt or
             beautiful.hotkeys_find_prompt or "<b>Find: </b>"
         self.find_fg_cursor = args.find_fg_cursor or

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -274,6 +274,38 @@ widget.labels = {
 -- @beautiful beautiful.hotkeys_group_margin
 -- @tparam int hotkeys_group_margin
 
+--- The highlighted text background color.
+-- @beautiful beautiful.hotkeys_highlight_bg
+-- @tparam color hotkeys_highlight_bg
+
+--- The highlighted text foreground color.
+-- @beautiful beautiful.hotkeys_highlight_fg
+-- @tparam color hotkeys_highlight_fg
+
+--- The find prompt cursor foreground color.
+-- @beautiful beautiful.hotkeys_find_fg_cursor
+-- @tparam color hotkeys_find_fg_cursor
+
+--- The find prompt cursor background color.
+-- @beautiful beautiful.hotkeys_find_bg_cursor
+-- @tparam color hotkeys_find_bg_cursor
+
+--- The find prompt cursor underline style.
+-- @beautiful beautiful.hotkeys_find_ul_cursor
+-- @tparam string hotkeys_find_ul_cursor
+
+--- The find prompt text.
+-- @beautiful beautiful.hotkeys_find_prompt
+-- @tparam string hotkeys_find_prompt
+
+--- The find prompt text font.
+-- @beautiful beautiful.hotkeys_find_font
+-- @tparam string|lgi.Pango.FontDescription hotkeys_find_font
+
+--- Margin around the find prompt.
+-- @beautiful beautiful.hotkeys_find_margin
+-- @tparam int hotkeys_find_margin
+
 
 --- Create an instance of widget with hotkeys help.
 -- @tparam[opt] table args Configuration options for the widget.
@@ -296,6 +328,14 @@ widget.labels = {
 -- @tparam[opt] color args.label_fg Foreground color used for group and other
 -- labels.
 -- @tparam[opt] int args.group_margin Margin between hotkeys groups.
+-- @tparam[opt] color args.highlight_bg The highlighted text background color.
+-- @tparam[opt] color args.highlight_fg The highlighted text foreground color.
+-- @tparam[opt] color args.find_fg_cursor The find prompt cursor foreground color.
+-- @tparam[opt] color args.find_bg_cursor The find prompt cursor background color.
+-- @tparam[opt] string args.find_ul_cursor The find prompt cursor underline style.
+-- @tparam[opt] string args.find_prompt The find prompt text.
+-- @tparam[opt] string|lgi.Pango.FontDescription args.find_font The find prompt text font.
+-- @tparam[opt] int args.find_margin Margin around the find prompt.
 -- @tparam[opt] table args.labels Labels used for displaying human-readable keynames.
 -- @tparam[opt] table args.group_rules Rules for showing 3rd-party hotkeys. @see `awful.hotkeys_popup.keys.vim`.
 -- @return Widget instance.
@@ -311,6 +351,14 @@ widget.labels = {
 -- @usebeautiful beautiful.hotkeys_font
 -- @usebeautiful beautiful.hotkeys_description_font
 -- @usebeautiful beautiful.hotkeys_group_margin
+-- @usebeautiful beautiful.hotkeys_highlight_bg
+-- @usebeautiful beautiful.hotkeys_highlight_fg
+-- @usebeautiful beautiful.hotkeys_find_fg_cursor
+-- @usebeautiful beautiful.hotkeys_find_bg_cursor
+-- @usebeautiful beautiful.hotkeys_find_ul_cursor
+-- @usebeautiful beautiful.hotkeys_find_prompt
+-- @usebeautiful beautiful.hotkeys_find_font
+-- @usebeautiful beautiful.hotkeys_find_margin
 -- @usebeautiful beautiful.bg_normal Fallback.
 -- @usebeautiful beautiful.fg_normal Fallback.
 -- @usebeautiful beautiful.fg_minimize Fallback.
@@ -828,8 +876,6 @@ function widget.new(args)
         }
 
         -- Set up the mouse buttons to hide the popup
-        -- Any keybinding except what the keygrabber wants wil hide the popup
-        -- too
         mypopup.buttons = {
             awful.button({ }, 1, function () widget_obj:hide() end),
             awful.button({ }, 3, function () widget_obj:hide() end)
@@ -915,8 +961,7 @@ function widget.new(args)
     -- @tparam[opt={}] table show_args Additional arguments.
     -- @tparam[opt=true] boolean show_args.show_awesome_keys Show AwesomeWM hotkeys.
     -- When set to `false` only app-specific hotkeys will be shown.
-    -- @treturn awful.keygrabber The keybrabber used to detect when the key is
-    --  released.
+    -- @noreturn
     -- @method show_help
     function widget_instance:show_help(c, s, show_args)
         show_args = show_args or {}
@@ -1009,11 +1054,10 @@ end
 -- @tparam[opt] table args Additional arguments.
 -- @tparam[opt=true] boolean args.show_awesome_keys Show AwesomeWM hotkeys.
 -- When set to `false` only app-specific hotkeys will be shown.
--- @treturn awful.keygrabber The keybrabber used to detect when the key is
---  released.
+-- @noreturn
 -- @staticfct awful.hotkeys_popup.widget.show_help
 function widget.show_help(...)
-    return get_default_widget():show_help(...)
+    get_default_widget():show_help(...)
 end
 
 --- Add hotkey descriptions for third-party applications

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -606,7 +606,7 @@ function widget.new(args)
                 end
 
                 rendered_text = table.concat(gtable.map(function(part)
-                    local capture = string.sub(text, part.from, part.to)
+                    local capture = string.sub(rendered_text, part.from, part.to)
                     if part.highlight then
                         return markup.bg(self.highlight_bg, markup.fg(self.highlight_fg, capture))
                     else

--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -403,7 +403,7 @@ function widget.new(args)
     function widget_instance:_load_widget_settings()
         if self._widget_settings_loaded then return end
         self.width = args.width or dpi(1200)
-        self.height = args.height or dpi(300)
+        self.height = args.height or dpi(800)
         self.bg = args.bg or
             beautiful.hotkeys_bg or beautiful.bg_normal
         self.fg = args.fg or

--- a/tests/test-awesomerc.lua
+++ b/tests/test-awesomerc.lua
@@ -282,12 +282,12 @@ local steps = {
         if count == 2 then
             assert(hotkeys_popup ~= nil)
             assert(hotkeys_popup.visible)
-            -- Should disappear on anykey
-            root.fake_input("key_press", "Super_L")
+            -- Should disappear on escape (awful.prompt)
+            root.fake_input("key_press", "Escape")
 
         elseif count == 3 then
             assert(not hotkeys_popup.visible)
-            root.fake_input("key_release", "Super_L")
+            root.fake_input("key_release", "Escape")
             test_context.hotkeys01_clients_before = #client.get()
             -- imitate fake client with name "vim"
             -- so hotkeys widget will offer vim hotkeys:
@@ -314,11 +314,11 @@ local steps = {
                 assert(visible_hotkeys_widget ~= nil)
                 assert(visible_hotkeys_widget.current_page == 2)
                 root.fake_input("key_release", "Next")
-                -- Should disappear on anykey
-                root.fake_input("key_press", "Super_L")
+                -- Should disappear on escape (awful.prompt)
+                root.fake_input("key_press", "Escape")
             elseif (count - test_context.hotkeys01_count_vim) == 3 then
                 assert(not visible_hotkeys_widget)
-                root.fake_input("key_release", "Super_L")
+                root.fake_input("key_release", "Escape")
                 return true
             end
         end


### PR DESCRIPTION
Implements #3963

- find in description only
- no fuzzy or other sophisticated searching
- uses `awful.prompt.run`
- `show_help()` does not return `awful.keygrabber` (breaking change?)

## Theme variables

| Theme | Default value | Description |
|-------|---------------|-------------|
| `highlight_bg` | `"#ffff00"` | The highlighted text background color. |
| `highlight_fg` | `"#000000"` | The highlighted text foreground color. |
| `find_fg_cursor` | - | The find prompt cursor foreground color. |
| `find_bg_cursor` | - | The find prompt cursor background color. |
| `find_ul_cursor` | - | The find prompt cursor underline style. |
| `find_prompt` | `"<b>Find: </b>"` | The find prompt text. |
| `find_font` | `font` | The find prompt text font. |
| `find_margin` | `group_margin` | Margin around the find prompt. |

![hotkeys_popup_find](https://github.com/user-attachments/assets/54edee44-4aa7-42c4-a6ca-83c956990ea5)
