### PR TITLE
Deprecate `awesome.load_image`

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -783,6 +783,14 @@ create_type {
     subfield_title = "Parameters",
 }
 
+-- Documentation for objects depecated static methods
+create_type {
+    name           = "deprecatedstaticmtd",
+    title          = "Deprecated static object methods",
+    project_level  = false,
+    subfield_title = "Parameters",
+}
+
 -- Use a custom type for the methods to bypass the faulty ldoc built-in detection.
 -- (yes, the space after Methods *is* on purpose to avoid clashing with ldoc
 --  internal "methods" concept)
@@ -2304,6 +2312,7 @@ local display_return_type = {
     method           = true,
     deprecatedmethod = true,
     staticfct        = true,
+    deprecatedstaticmtd = true,
 }
 
 -- Show return values.
@@ -2316,6 +2325,7 @@ local show_return = {
     method           = true,
     deprecated       = true,
     deprecatedmethod = true,
+    deprecatedstaticmtd = true,
 }
 
 -- The different type of deprecation.
@@ -2324,6 +2334,7 @@ local is_deprecated = {
     deprecatedproperty = true,
     deprecatedmethod   = true,
     deprecatedsignal   = true,
+    deprecatedstaticmtd = true,
 }
 
 custom_display_name_handler = function(item, default_handler)

--- a/luaa.c
+++ b/luaa.c
@@ -326,8 +326,8 @@ luaA_pixbuf_to_surface(lua_State *L)
  * @tparam string name The file name.
  * @treturn gears.surface A cairo surface as light user datum.
  * @treturn nil|string The error message, if any.
- * @staticfct load_image
- * @deprecated awesome.pixbuf_to_surface
+ * @deprecatedstaticmtd awesome.load_image
+ * @see awesome.pixbuf_to_surface
  */
 static int
 luaA_load_image(lua_State *L)

--- a/luaa.c
+++ b/luaa.c
@@ -327,14 +327,12 @@ luaA_pixbuf_to_surface(lua_State *L)
  * @treturn gears.surface A cairo surface as light user datum.
  * @treturn nil|string The error message, if any.
  * @staticfct load_image
+ * @deprecated awesome.pixbuf_to_surface
  */
 static int
 luaA_load_image(lua_State *L)
 {
-    /* TODO: Deprecate this function, Lua can use GdkPixbuf directly plus
-     * awesome.pixbuf_to_surface
-     */
-
+    luaA_deprecate(L, "awesome.pixbuf_to_surface");
     GError *error = NULL;
     const char *filename = luaL_checkstring(L, 1);
     cairo_surface_t *surface = draw_load_image(L, filename, &error);


### PR DESCRIPTION
As it currently stands, both [`luaA_load_image`](<https://github.com/awesomeWM/awesome/blob/0f950cbb625175134b45ea65acdf29b2cbe8c456/luaa.c#L332>) and [`draw_load_image`](<https://github.com/awesomeWM/awesome/blob/0f950cbb625175134b45ea65acdf29b2cbe8c456/draw.c#L181>) are left unused and only serve to pad `luaa.c` and `draw.c` respectively. This PR deprecates the former to allow the eventual removal of both.