### PR TITLE
awful.menu: map KP_Enter similar to Return

### DIFF
--- a/lib/awful/menu.lua
+++ b/lib/awful/menu.lua
@@ -107,8 +107,8 @@ end
 menu.menu_keys = { up = { "Up", "k" },
               down = { "Down", "j" },
               back = { "Left", "h" },
-              exec = { "Return" },
-              enter = { "Right", "l", "KP_Enter" },
+              exec = { "Return" , "KP_Enter" },
+              enter = { "Right", "l" },
               close = { "Escape" } }
 
 


### PR DESCRIPTION
In Awesome's menu system, the KP_Enter key is currently used the same as the Right key (to descend into a child menu). This is unexpected, since in general, users expect KP_Enter to work similar to the Return key (to run the highlighted action/command). This commit corrects that behavior.

Related: https://github.com/awesomeWM/awesome/issues/3867