### PR TITLE
fix(awesome-client): ensure there are CLI arguments before reexec'ing with rlwrap

### DIFF
--- a/utils/awesome-client
+++ b/utils/awesome-client
@@ -5,7 +5,7 @@
 # when used with "|tail".
 set -o pipefail
 
-if [ -t 0 ]  # is a tty.
+if [ -t 0 -a $# = 0 ]  # is a tty.
 then
     # rlwrap provides readline functionality for "read", which is more enhanced
     # than bash's "read" itself.


### PR DESCRIPTION
in my `.zshrc`, i'm hooking `cd` with `chpwd(){...}`, to execute lua functions through awesome-client whenever i switch directories in my terminal.
i installed rlwrap lately and noticed `ls` wouldn't be executed anymore if i typed really fast a command such as
`sleep 1`
`cd`
`ls`
because `cd` (which calls rlwrap now) reads from stdin, so my shell can't read `ls` anymore.

currently, awesome-client won't execute rlwrap if the stdin is not a tty (e.g. when piping through awesome-client).
however, it should also check that awesome-client is not called with arguments (since there'd be no point in reading the stdin). 