### PR TITLE
chore(workflows): upgrade actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     env:
       # Used for stable dates in documentation examples. See #2070.
@@ -56,10 +56,13 @@ jobs:
             gir1.2-gtk-3.0 \
             gir1.2-pango-1.0 \
             git \
+            imagemagick \
             libdbus-1-dev \
+            libgdk-pixbuf-2.0-dev \
             libgirepository1.0-dev \
             libnotify-bin \
             libpango1.0-dev \
+            librsvg2-dev \
             libstartup-notification0-dev \
             libx11-xcb-dev \
             libxcb-cursor-dev \

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Cache apt packages
         id: cache-apt
-        uses: actions/cache@v2
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /var/cache/apt/archives
           # The trailing number serves as a version flag that can be incremented
@@ -87,7 +87,7 @@ jobs:
 
       - name: Cache luarocks
         id: cache-luarocks
-        uses: actions/cache@v2
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /tmp/luarocks
           key: ${{ github.workflow }}-${{ runner.os }}-luarocks-3.5.0
@@ -114,7 +114,7 @@ jobs:
           sudo -H luarocks install lgi
           sudo -H luarocks install ldoc
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build Awesome version string
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,15 @@ jobs:
         id: get-date
         run: echo "date=$(/bin/date -u "+%Y%W")" >> $GITHUB_OUTPUT
 
+      # Varibales doesn't work in matrix definition. The gh-actions-lua Actions
+      # install Lua in the workspace directory, so we refer to it with a relative
+      # path.
+      # This step corrects LUAINCLUDE and LUALIBRARY to absolute paths.
+      - name: Correct Lua variables paths
+        run: |
+          [[ $LUAINCLUDE != /* ]] && echo LUAINCLUDE="${{ github.workspace }}/$LUAINCLUDE" >> $GITHUB_ENV || true
+          [[ $LUALIBRARY != /* ]] && echo LUALIBRARY="${{ github.workspace }}/$LUALIBRARY" >> $GITHUB_ENV || true
+
       - name: Cache apt packages
         id: cache-apt
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Cache apt packages
         id: cache-apt
-        uses: actions/cache@v2
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /var/cache/apt/archives
           # The trailing number serves as a version flag that can be incremented
@@ -166,7 +166,7 @@ jobs:
 
       - name: Cache luarocks
         id: cache-luarocks
-        uses: actions/cache@v2
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /tmp/luarocks
           # The build input for luarocks changes per test, so we need separate caches
@@ -191,7 +191,7 @@ jobs:
 
       - name: Cache xcb-errors
         id: cache-xcb-errors
-        uses: actions/cache@v2
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /tmp/xcb-errors
           key: ${{ github.workflow }}-${{ runner.os }}-xcb-errors-1.0.1
@@ -244,7 +244,7 @@ jobs:
 
       # Check out repository to ${{ github.workspace }}
       # Automatically picks the current branch/PR
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Create Build Environment
         run: cmake -E make_directory -B "${{ github.workspace }}/build"
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload Lua code coverage report
         if: matrix.coverage == 'codecov'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           files: "${{ github.workspace }}/build/luacov.report.out"
         env:
@@ -350,7 +350,7 @@ jobs:
 
       - name: Upload C code coverage report
         if: matrix.coverage == 'codecov'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           files: "${{ github.workspace }}/build/*/*.gcov"
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,8 @@ jobs:
           - test_name: "luajit"
             lua_version: "5.1"
             lua_name: "luajit"
-            lua_library: "/usr/lib/x86_64-linux-gnu/libluajit-5.1.so"
-            lua_include: "/usr/include/luajit-2.1"
-            luarocks_args: "--lua-suffix=jit-2.1.0-beta3"
+            lua_library: ".lua/lib/libluajit-5.1.a"
+            lua_include: ".lua/include/luajit-2.0"
 
           # Lua 5.2 with fixed lgi version and screen size not divisible by 2.
           - test_name: "fixed-lgi-lua5.2"
@@ -151,10 +150,17 @@ jobs:
       - name: Install Lua packages
         if: matrix.lua_version != '5.4'
         run: |
-          if [ "${{ matrix.lua_name }}" = "luajit" ]; then
-            sudo apt-get install libluajit-5.1-dev luajit
-          fi
           sudo apt-get install liblua${{ matrix.lua_version }}-dev lua${{ matrix.lua_version }}
+          
+      # Check out repository to ${{ github.workspace }}
+      # Automatically picks the current branch/PR
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install LuaJIT
+        if: matrix.lua_name == 'luajit'
+        uses: luarocks/gh-actions-lua@989f8e6ffba55ce1817e236478c98558e598776c #v11
+        with:
+          luaVersion: luajit-master
 
       # Ubuntu 20.04 hasn't a package for Lua 5.4, we need to build it from source.
       - name: Build and Install Lua 5.4
@@ -244,10 +250,6 @@ jobs:
       - name: Install cluacov rock
         if: matrix.coverage
         run: sudo -H luarocks install cluacov
-
-      # Check out repository to ${{ github.workspace }}
-      # Automatically picks the current branch/PR
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Create Build Environment
         run: cmake -E make_directory -B "${{ github.workspace }}/build"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   main:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: ${{ matrix.test_name }}
 
     strategy:
@@ -140,7 +140,10 @@ jobs:
             fonts-noto-core \
             fonts-dejavu-core \
             fonts-roboto-unhinted \
-            fonts-open-sans
+            fonts-open-sans \
+            imagemagick \
+            libgdk-pixbuf-2.0-dev \
+            librsvg2-dev
 
       - name: Install downloaded packages
         run: sudo dpkg -i /var/cache/apt/archives/*.deb

--- a/lib/awful/layout/suit/tile.lua
+++ b/lib/awful/layout/suit/tile.lua
@@ -218,10 +218,12 @@ local function tile_group(gs, cls, wa, orientation, fact, group, useless_gap)
         geom[y] = coord
         gs[cls[c]] = geom
         hints.width, hints.height = apply_size_hints(cls[c], geom.width, geom.height, useless_gap)
-        coord = coord + hints[height]
-        unused = unused - hints[height]
+
+        local space_to_use = math.min(hints[height], unused)
+        coord = coord + space_to_use
+        unused = unused - space_to_use
         total_fact = total_fact - fact[i]
-        used_size = math.max(used_size, hints[width])
+        used_size = math.max(used_size, math.min(hints[width], available))
     end
 
     return used_size


### PR DESCRIPTION
actions/cache@v2 is being deprecated, and older versions are removed: https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes

Only updating the version seems to be enough to unblock the CI (running workflows on my fork was a success https://github.com/Aire-One/awesome/pull/3)