### PR TITLE
Possible CI fix - set DEBIAN_FRONTEND environment variable to noninteractive

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       # Used for stable dates in documentation examples. See #2070.
       SOURCE_DATE_EPOCH: "1893456000"
+      DEBIAN_FRONTEND: "noninteractive"
 
     steps:
       # Create a cache invalidation key based on the current year + week.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
       TESTS_SCREEN_SIZE: ${{ matrix.tests_screen_size }}
       TEST_TIMEOUT: "100"
       CI: "true"
+      DEBIAN_FRONTEND: "noninteractive"
 
     steps:
       # Create a cache invalidation key based on the current year + week.


### PR DESCRIPTION
Since the actions are taking a lot to execute (>24h) and finally getting a timeout error, I'm guessing the are waiting for user's input. We can resolve this issue by setting the environment variable `DEBIAN_FRONTEND` to `noninteractive`.

Issue: #3994 