### PR TITLE
Compute maximized geometry after applying titlebar (fixes #3778)

### DIFF
--- a/lib/awful/permissions/init.lua
+++ b/lib/awful/permissions/init.lua
@@ -365,6 +365,11 @@ local context_mapper = {
 function permissions.geometry(c, context, hints)
     if not pcommon.check(c, "client", "geometry", context) then return end
 
+    -- Don't update geometry if rules haven't been applied yet (e.g. when processing
+    -- EWMH client hints during client initialization), since a titlebar may perturb
+    -- the intended geometry later
+    if not c._border_geometry_rules_applied then return end
+
     local layout = c.screen.selected_tag and c.screen.selected_tag.layout or nil
 
     context = context or ""

--- a/lib/ruled/client.lua
+++ b/lib/ruled/client.lua
@@ -535,7 +535,6 @@ end
 --  rules.
 
 crules._execute = function(_, c, props, callbacks)
-
     -- Set the default buttons and keys
     local btns = amouse._get_client_mousebindings()
     local keys = akeyboard._get_client_keybindings()
@@ -553,6 +552,18 @@ crules._execute = function(_, c, props, callbacks)
             or props.titlebars_enabled(c,props)) then
         c:emit_signal("request::titlebars", "rules", {properties=props})
         c._request_titlebars_called = true
+    end
+
+    -- Handle deferred maximized geometry from EWMH client hints
+    if not c._border_geometry_rules_applied then
+        c._border_geometry_rules_applied = true
+        if c.maximized then
+            c:emit_signal("request::geometry", "maximized")
+        elseif c.maximized_horizontal then
+            c:emit_signal("request::geometry", "maximized_horizontal")
+        elseif c.maximized_vertical then
+            c:emit_signal("request::geometry", "maximized_vertical")
+        end
     end
 
     -- Size hints will be re-applied when setting width/height unless it is


### PR DESCRIPTION
The issue in #3778 is essentially just that EWMH client hints are processed before the rule engine runs, which means the maximized client geometry is computed without accounting for titlebars (or borders). This can be partially solved by writing a rule that applies a maximizing geometry after the fact, like so:
```lua
{
  rule = { maximized = true },
  properties = { placement = awful.placement.maximize }
}
```
However, I have found that there are situations where this is insufficient, particularly when clients have the `maximized` property set by another rule.

This PR fixes this by deferring the `request::geometry` signal normally sent by `client_set_maximized_common` until after titlebars and borders are applied. This is done by emitting the signal during the first run of rule processing in `ruled.client` and disabling the geometry signal handler in `awful.permissions` until that happens.

I note that it's not possible to defer the entire EWMH hint check, since we want the `maximized` flag to be set before the rule engine runs. Otherwise, rules matching on `maximized` won't be processed correctly for new clients.