### PR TITLE
Fix: Make spawn.with_line_callback compatible with both old and new lgi

### DIFF
--- a/lib/awful/spawn.lua
+++ b/lib/awful/spawn.lua
@@ -417,13 +417,20 @@ function spawn.with_line_callback(cmd, callbacks)
             done_callback()
         end
     end
+    -- Determine InputStream compatibly
+    local InputStream
+    pcall(function()
+        InputStream = lgi.GioUnix.InputStream
+    end)
+    if not InputStream then
+        InputStream = lgi.Gio.UnixInputStream
+    end
+
     if have_stdout then
-        spawn.read_lines(Gio.UnixInputStream.new(stdout, true),
-                stdout_callback, step_done, true)
+        spawn.read_lines(InputStream.new(stdout, true), stdout_callback, step_done, true)
     end
     if have_stderr then
-        spawn.read_lines(Gio.UnixInputStream.new(stderr, true),
-                stderr_callback, step_done, true)
+        spawn.read_lines(InputStream.new(stderr, true), stderr_callback, step_done, true)
     end
     assert(stdin == nil)
     return pid


### PR DESCRIPTION
### Problem
Gio.UnixInputStream was removed in newer lgi2, causing spawn output handling to break.

### Solution
Use GioUnix.InputStream when available, fallback to Gio.UnixInputStream for older versions.

### Impact
- Compatible with both old and new lgi.
- No changes to callback logic or existing behavior.

### Testing
- Verified spawn output works for stdout and stderr on Arch Linux with latest lgi.
- Also works on older lgi versions.

### Related Issues
- None reported yet
