### PR TITLE
fix build for CMake 4+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,10 @@ if(LUACHECK_EXECUTABLE)
     list(APPEND CHECK_QA_TARGETS luacheck)
 endif()
 add_custom_target(check-qa DEPENDS ${CHECK_QA_TARGETS})
-add_dependencies(check check-qa check-examples)
+add_dependencies(check check-qa)
+if (TARGET check-examples)
+    add_dependencies(check check-examples)
+endif()
 # }}}
 
 INCLUDE(${CMAKE_SOURCE_DIR}/Packaging.cmake)


### PR DESCRIPTION
From CMake 4.0, a target can only depend on a target. Hence, check if the dependencies is a target before adding dependency on it.