### PR TITLE
fix missing dep on Debian 13

### DIFF
--- a/docs/01-readme.md
+++ b/docs/01-readme.md
@@ -49,6 +49,7 @@ makepkg -fsri
 
 ```sh
 sudo apt build-dep awesome
+sudo apt install libxcb-xfixes0-dev 
 git clone https://github.com/awesomewm/awesome
 cd awesome
 make package


### PR DESCRIPTION
Added installation of libxcb-xfixes0-dev for Debian-based systems.