### PR TITLE
chore(codecov): add threshold for patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 0.5%
+    patch:
+      default:
+        target: auto
+        threshold: 0.5%


### PR DESCRIPTION
Lowers the codecov/patch check by allowing a 0.5% threshold. This should help to merge PR like https://github.com/awesomeWM/awesome/pull/3998 and https://github.com/awesomeWM/awesome/pull/4010 that are blocked by a `0.00% of diff hit`.