### PR TITLE
doc: Remove references to unmerged commits in `awful.keygrabber`.

### DIFF
--- a/tests/examples/text/awful/keygrabber/alttab.lua
+++ b/tests/examples/text/awful/keygrabber/alttab.lua
@@ -7,8 +7,6 @@ local awful = { keygrabber = require("awful.keygrabber"), --DOC_HIDE
     client={focus={history={--DOC_HIDE
         disable_tracking = function() was_called[1] = true end, --DOC_HIDE
         enable_tracking  = function() was_called[2] = true end, --DOC_HIDE
-        select_next      = function() was_called[3] = true end, --DOC_HIDE
-        select_previous  = function() was_called[4] = true end, --DOC_HIDE
 }}}}--DOC_HIDE
 
     awful.keygrabber {


### PR DESCRIPTION
Fixes #2636