### PR TITLE
Customize sorting of modifiers in the hotkeys popup

### DIFF
--- a/lib/awful/hotkeys_popup/widget.lua
+++ b/lib/awful/hotkeys_popup/widget.lua
@@ -142,8 +142,6 @@ widget.modifier_sort_order = {
 -- @param boolean
 widget.hide_without_description = true
 
-
-
 local function modifier_join_plus_sort(modifiers)
     if #modifiers<1 then return "none" end
     table.sort(modifiers, function(a,b)
@@ -364,7 +362,6 @@ function widget.new(args)
         -- be presented to the user as-is. (This is useful for cheatsheets for
         -- external programs.)
         labels = args.labels or widget.labels,
-        modifier_order = args.modifier_order or widget.modifier_order,
         _additional_hotkeys = {},
         _cached_wiboxes = {},
         _cached_awful_keys = {},


### PR DESCRIPTION
Add the ability to customize the sorting order of the modifiers in the hotkeys popup.
Normally, the modifier keys in hotkeys get sorted before being shown in the hotkeys popup, which I didn't like, so I wanted to add a way for customizing it.
I added a new function that's only used for that, a default order and a variable that needs to be set to `true` for new sorting to be used. A custom order can be specified by in the `rc.lua` file of the user.