### PR TITLE
fix(ci): force examples sequential run for luacov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,8 +319,15 @@ jobs:
       - name: Run unit tests
         run: cd "${{ github.workspace }}/build" && make check-unit
 
-      - name: Run examples tests
+      - name: Run examples tests (non-coverage)
+        if: matrix.coverage != 'codecov'
         run: cd "${{ github.workspace }}/build" && make check-examples -j24
+
+      # Parallel tests interfere with coverage collection. All processes write
+      # to the same luacov.stats.out file, corrupting it.
+      - name: Run examples tests (with coverage)
+        if: matrix.coverage == 'codecov'
+        run: cd "${{ github.workspace }}/build" && make check-examples
 
       - name: Run requires tests
         if: matrix.coverage


### PR DESCRIPTION
For some times now, the coverage numbers are crazy. I found one reason with the way we run the examples tests in the CI: we have a `-j24` to make them run faster. This is causing trouble with how the `luacov.stats.out` is written.

```sh
make distclean
mkdir build
cd build
cmake .. -DDO_COVERAGE=codecov
make check-examples -j24 
luacov
grep "tests/examples" luacov.report.out | wc -l # 38
make check-examples
luacov
grep "tests/examples" luacov.report.out | wc -l # 1164
```

This PR adds a new step for coverage where we run check-examples sequentially while preserving a faster step with the `-j` flag, so other jobs provides faster feedbacks.