### PR TITLE
Fix nil reference in clienticon

### DIFF
--- a/lib/awful/widget/clienticon.lua
+++ b/lib/awful/widget/clienticon.lua
@@ -119,7 +119,7 @@ end
 
 client.connect_signal("property::icon", function(c)
     for obj in pairs(instances) do
-        if obj._private.client.valid and obj._private.client == c then
+        if obj._private.client == c and obj._private.client.valid then
             obj:emit_signal("widget::layout_changed")
             obj:emit_signal("widget::redraw_needed")
         end


### PR DESCRIPTION
When a `clienticon` widget is created without specifying a client (for example when the widget is created declaratively), then the `client` attribute is set to `nil`. But the `property::icon` signal is called anyways, leading to an error because a `nil` value is referenced in the first condition of the `if`-clause.
I fixed this by swapping both conditions. Since the signal is only called for existing clients, `c` is never `nil` and so the check `obj._private.client == c` doubles to ensure that `obj._private.client` exists and that `obj._private.client.valid` can be referenced.