### PR TITLE
fix(timer): return glib.SOURCE_CONTINUE instead true

### DIFF
--- a/lib/gears/timer.lua
+++ b/lib/gears/timer.lua
@@ -101,7 +101,7 @@ function timer:start()
     local timeout_ms = gmath.round(self.data.timeout * 1000)
     self.data.source_id = glib.timeout_add(glib.PRIORITY_DEFAULT, timeout_ms, function()
         protected_call(self.emit_signal, self, "timeout")
-        return true
+        return glib.SOURCE_CONTINUE
     end)
     self:emit_signal("start")
 end


### PR DESCRIPTION
The timer callback must return SOURCE_CONTINUE or SOURCE_REMOVE. Although these are essentially equivalent to true and false, this approach is more rigorous.