### PR TITLE
chore(options): remove unnecessary static modifiers

### DIFF
--- a/options.c
+++ b/options.c
@@ -97,9 +97,9 @@ options_init_config(xdgHandle *xdg, char *execpath, char *configpath, int *init_
         MODELINE_MODE_SHEBANG, /* #! shebang  */
     } mode = MODELINE_MODE_NONE;
 
-    static const unsigned char name[] = "awesome_mode:";
-    static char key_buf [KEY_VALUE_BUF_MAX+1] = {'\0'};
-    static char file_buf[READ_BUF_MAX+1     ] = {'\0'};
+    const unsigned char name[] = "awesome_mode:";
+    char key_buf [KEY_VALUE_BUF_MAX+1] = {'\0'};
+    char file_buf[READ_BUF_MAX+1     ] = {'\0'};
     size_t pos = 0;
 
     string_array_t argv;
@@ -405,7 +405,7 @@ char *
 options_check_args(int argc, char **argv, int *init_flags, string_array_t *paths)
 {
 
-    static struct option long_options[] =
+    const struct option long_options[] =
     {
         { "help"      , NO_ARG, NULL, 'h'  },
         { "version"   , NO_ARG, NULL, 'v'  },


### PR DESCRIPTION
These variables do not need to reside in memory.
Using the static modifier on a local variable causes the modified variable to reside permanently in memory.