### PR TITLE
chore: remove unnecessary static modifiers

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -1088,7 +1088,7 @@ void
 luaA_init(xdgHandle* xdg, string_array_t *searchpath)
 {
     lua_State *L;
-    static const struct luaL_Reg awesome_lib[] =
+    const struct luaL_Reg awesome_lib[] =
     {
         { "quit", luaA_quit },
         { "exec", luaA_exec },

--- a/objects/button.c
+++ b/objects/button.c
@@ -153,14 +153,14 @@ luaA_button_set_button(lua_State *L, button_t *b)
 void
 button_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg button_methods[] =
+    const struct luaL_Reg button_methods[] =
     {
         LUA_CLASS_METHODS(button)
         { "__call", luaA_button_new },
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg button_meta[] =
+    const struct luaL_Reg button_meta[] =
     {
         LUA_OBJECT_META(button)
         LUA_CLASS_META

--- a/objects/client.c
+++ b/objects/client.c
@@ -4485,7 +4485,7 @@ client_checker(client_t *c)
 void
 client_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg client_methods[] =
+    const struct luaL_Reg client_methods[] =
     {
         LUA_CLASS_METHODS(client)
         { "get", luaA_client_get },
@@ -4494,7 +4494,7 @@ client_class_setup(lua_State *L)
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg client_meta[] =
+    const struct luaL_Reg client_meta[] =
     {
         LUA_OBJECT_META(client)
         LUA_CLASS_META

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -214,13 +214,13 @@ luaA_drawable_geometry(lua_State *L)
 void
 drawable_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg drawable_methods[] =
+    const struct luaL_Reg drawable_methods[] =
     {
         LUA_CLASS_METHODS(drawable)
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg drawable_meta[] =
+    const struct luaL_Reg drawable_meta[] =
     {
         LUA_OBJECT_META(drawable)
         LUA_CLASS_META

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -762,7 +762,7 @@ luaA_drawin_set_shape_input(lua_State *L, drawin_t *drawin)
 void
 drawin_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg drawin_methods[] =
+    const struct luaL_Reg drawin_methods[] =
     {
         LUA_CLASS_METHODS(drawin)
         { "get", luaA_drawin_get },
@@ -770,7 +770,7 @@ drawin_class_setup(lua_State *L)
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg drawin_meta[] =
+    const struct luaL_Reg drawin_meta[] =
     {
         LUA_OBJECT_META(drawin)
         LUA_CLASS_META

--- a/objects/key.c
+++ b/objects/key.c
@@ -344,14 +344,14 @@ luaA_key_set_key(lua_State *L, keyb_t *k)
 void
 key_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg key_methods[] =
+    const struct luaL_Reg key_methods[] =
     {
         LUA_CLASS_METHODS(key)
         { "__call", luaA_key_new },
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg key_meta[] =
+    const struct luaL_Reg key_meta[] =
     {
         LUA_OBJECT_META(key)
         LUA_CLASS_META

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1853,7 +1853,7 @@ luaA_screen_swap(lua_State *L)
 void
 screen_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg screen_methods[] =
+    const struct luaL_Reg screen_methods[] =
     {
         LUA_CLASS_METHODS(screen)
         { "count", luaA_screen_count },
@@ -1866,7 +1866,7 @@ screen_class_setup(lua_State *L)
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg screen_meta[] =
+    const struct luaL_Reg screen_meta[] =
     {
         LUA_OBJECT_META(screen)
         LUA_CLASS_META

--- a/objects/selection_acquire.c
+++ b/objects/selection_acquire.c
@@ -214,13 +214,13 @@ selection_acquire_checker(selection_acquire_t *selection)
 void
 selection_acquire_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg selection_acquire_methods[] =
+    const struct luaL_Reg selection_acquire_methods[] =
     {
         { "__call", luaA_selection_acquire_new },
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg selection_acquire_meta[] =
+    const struct luaL_Reg selection_acquire_meta[] =
     {
         LUA_OBJECT_META(selection_acquire)
         LUA_CLASS_META

--- a/objects/selection_getter.c
+++ b/objects/selection_getter.c
@@ -253,13 +253,13 @@ event_handle_selectionnotify(xcb_selection_notify_event_t *ev)
 void
 selection_getter_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg selection_getter_methods[] =
+    const struct luaL_Reg selection_getter_methods[] =
     {
         { "__call", luaA_selection_getter_new },
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg selection_getter_metha[] = {
+    const struct luaL_Reg selection_getter_metha[] = {
         LUA_OBJECT_META(selection_getter)
         LUA_CLASS_META
         { NULL, NULL }

--- a/objects/selection_transfer.c
+++ b/objects/selection_transfer.c
@@ -358,12 +358,12 @@ selection_transfer_checker(selection_transfer_t *transfer)
 void
 selection_transfer_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg selection_transfer_methods[] =
+    const struct luaL_Reg selection_transfer_methods[] =
     {
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg selection_transfer_meta[] =
+    const struct luaL_Reg selection_transfer_meta[] =
     {
         LUA_OBJECT_META(selection_transfer)
         LUA_CLASS_META

--- a/objects/selection_watcher.c
+++ b/objects/selection_watcher.c
@@ -166,14 +166,14 @@ luaA_selection_watcher_get_active(lua_State *L, selection_watcher_t *selection)
 void
 selection_watcher_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg selection_watcher_methods[] =
+    const struct luaL_Reg selection_watcher_methods[] =
     {
         LUA_CLASS_METHODS(selection_watcher)
         { "__call", luaA_selection_watcher_new },
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg selection_watcher_meta[] = {
+    const struct luaL_Reg selection_watcher_meta[] = {
         LUA_OBJECT_META(selection_watcher)
         LUA_CLASS_META
         { NULL, NULL }

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -594,14 +594,14 @@ luaA_tag_set_activated(lua_State *L, tag_t *tag)
 void
 tag_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg tag_methods[] =
+    const struct luaL_Reg tag_methods[] =
     {
         LUA_CLASS_METHODS(tag)
         { "__call", luaA_tag_new },
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg tag_meta[] =
+    const struct luaL_Reg tag_meta[] =
     {
         LUA_OBJECT_META(tag)
         LUA_CLASS_META

--- a/objects/window.c
+++ b/objects/window.c
@@ -508,12 +508,12 @@ LUA_OBJECT_EXPORT_PROPERTY(window, window_t, border_width, lua_pushinteger)
 void
 window_class_setup(lua_State *L)
 {
-    static const struct luaL_Reg window_methods[] =
+    const struct luaL_Reg window_methods[] =
     {
         { NULL, NULL }
     };
 
-    static const struct luaL_Reg window_meta[] =
+    const struct luaL_Reg window_meta[] =
     {
         { "struts", luaA_window_struts },
         { "_buttons", luaA_window_buttons },


### PR DESCRIPTION
Like #4048, these variables can be destroyed after use and do not need to remain resident in memory.