### PR TITLE
chore: remove unnecessary array initialization

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -568,7 +568,7 @@ true_config_callback(const char *unused)
 int
 main(int argc, char **argv)
 {
-    string_array_t searchpath;
+    string_array_t searchpath = {};
     int xfd;
     xdgHandle xdg;
     xcb_query_tree_cookie_t tree_c;
@@ -589,7 +589,6 @@ main(int argc, char **argv)
     globalconf.exit_code = EXIT_SUCCESS;
     globalconf.api_level = awesome_default_api_level();
     buffer_init(&globalconf.startup_errors);
-    string_array_init(&searchpath);
 
     /* save argv */
     awesome_argv = argv;

--- a/ewmh.c
+++ b/ewmh.c
@@ -768,10 +768,9 @@ static cairo_surface_array_t
 ewmh_window_icon_from_reply(xcb_get_property_reply_t *r)
 {
     uint32_t *data, *data_end;
-    cairo_surface_array_t result;
+    cairo_surface_array_t result = {};
     cairo_surface_t *s;
 
-    cairo_surface_array_init(&result);
     if(!r || r->type != XCB_ATOM_CARDINAL || r->format != 32)
         return result;
 

--- a/objects/client.c
+++ b/objects/client.c
@@ -3184,8 +3184,7 @@ client_set_icons(client_t *c, cairo_surface_array_t array)
 static void
 client_set_icon(client_t *c, cairo_surface_t *s)
 {
-    cairo_surface_array_t array;
-    cairo_surface_array_init(&array);
+    cairo_surface_array_t array = {};
     if (s && cairo_surface_status(s) == CAIRO_STATUS_SUCCESS)
         cairo_surface_array_push(&array, draw_dup_image_surface(s));
     client_set_icons(c, array);

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1107,12 +1107,11 @@ screen_refresh(gpointer unused)
 
     monitor_unmark();
 
-    screen_array_t new_screens;
-    screen_array_t removed_screens;
+    screen_array_t new_screens = {};
+    screen_array_t removed_screens = {};
     lua_State *L = globalconf_get_lua_State();
     bool list_changed = false;
 
-    screen_array_init(&new_screens);
     if (globalconf.have_randr_15)
         screen_scan_randr_monitors(L, &new_screens);
     else
@@ -1146,7 +1145,6 @@ screen_refresh(gpointer unused)
     }
 
     /* Remove screens which are gone */
-    screen_array_init(&removed_screens);
     for(int i = 0; i < globalconf.screens.len; i++) {
         screen_t *old_screen = globalconf.screens.tab[i];
         bool found = old_screen->xid == FAKE_SCREEN_XID;

--- a/options.c
+++ b/options.c
@@ -102,8 +102,7 @@ options_init_config(xdgHandle *xdg, char *execpath, char *configpath, int *init_
     static char file_buf[READ_BUF_MAX+1     ] = {'\0'};
     size_t pos = 0;
 
-    string_array_t argv;
-    string_array_init(&argv);
+    string_array_t argv = {};
     string_array_append(&argv, a_strdup(execpath));
 
     FILE *fp = NULL;


### PR DESCRIPTION
Structure initialization sets uninitialized fields to zero, just like global variables, so these `array_init` calls are unnecessary.
Reference: https://github.com/lvgl/lvgl/pull/9348