### PR TITLE
fix(awesome): memory leak

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -608,8 +608,8 @@ main(int argc, char **argv)
         fatal("Function xdgInitHandle() failed, is $HOME unset?");
 
     /* add XDG_CONFIG_DIR as include path */
-    const char * const *xdgconfigdirs = xdgSearchableConfigDirectories(&xdg);
-    for(; *xdgconfigdirs; xdgconfigdirs++)
+    for(const char * const *xdgconfigdirs = xdgSearchableConfigDirectories(&xdg);
+            *xdgconfigdirs; xdgconfigdirs++)
     {
         /* Append /awesome to *xdgconfigdirs */
         const char *suffix = "/awesome";


### PR DESCRIPTION
The variable `entry` was not freed.
Since the length wouldn't be too large, I directly used a variable-length array instead. Variable-length arrays offer better performance and eliminate the need to worry about memory release.