### PR TITLE
feat: add the mayused modifier

### DIFF
--- a/common/luaclass.h
+++ b/common/luaclass.h
@@ -23,6 +23,7 @@
 #define AWESOME_COMMON_LUACLASS
 
 #include "common/signal.h"
+#include "common/util.h"
 
 #include <lua.h>
 #include <lauxlib.h>
@@ -132,14 +133,14 @@ luaA_checkudataornil(lua_State *L, int udx, lua_class_t *class)
 }
 
 #define LUA_CLASS_FUNCS(prefix, lua_class) \
-    static inline int                                                          \
+    static inline int maybe_unused                                             \
     luaA_##prefix##_class_add_signal(lua_State *L)                             \
     {                                                                          \
         luaA_deprecate(L, "signal usage without add_signal()");                \
         return 0;                                                              \
     }                                                                          \
                                                                                \
-    static inline int                                                          \
+    static inline int maybe_unused                                             \
     luaA_##prefix##_class_connect_signal(lua_State *L)                         \
     {                                                                          \
         luaA_class_connect_signal_from_stack(L, &(lua_class),                  \
@@ -147,7 +148,7 @@ luaA_checkudataornil(lua_State *L, int udx, lua_class_t *class)
         return 0;                                                              \
     }                                                                          \
                                                                                \
-    static inline int                                                          \
+    static inline int maybe_unused                                             \
     luaA_##prefix##_class_disconnect_signal(lua_State *L)                      \
     {                                                                          \
         luaA_class_disconnect_signal_from_stack(L, &(lua_class),               \
@@ -155,7 +156,7 @@ luaA_checkudataornil(lua_State *L, int udx, lua_class_t *class)
         return 0;                                                              \
     }                                                                          \
                                                                                \
-    static inline int                                                          \
+    static inline int maybe_unused                                             \
     luaA_##prefix##_class_emit_signal(lua_State *L)                            \
     {                                                                          \
         luaA_class_emit_signal(L, &(lua_class), luaL_checkstring(L, 1),        \
@@ -163,20 +164,20 @@ luaA_checkudataornil(lua_State *L, int udx, lua_class_t *class)
         return 0;                                                              \
     }                                                                          \
                                                                                \
-    static inline int                                                          \
+    static inline int maybe_unused                                             \
     luaA_##prefix##_class_instances(lua_State *L)                              \
     {                                                                          \
         lua_pushinteger(L, (lua_class).instances);                             \
         return 1;                                                              \
     }                                                                          \
                                                                                \
-    static inline int                                                          \
+    static inline int maybe_unused                                             \
     luaA_##prefix##_set_index_miss_handler(lua_State *L)                       \
     {                                                                          \
         return luaA_registerfct(L, 1, &(lua_class).index_miss_handler);        \
     }                                                                          \
                                                                                \
-    static inline int                                                          \
+    static inline int maybe_unused                                             \
     luaA_##prefix##_set_newindex_miss_handler(lua_State *L)                    \
     {                                                                          \
         return luaA_registerfct(L, 1, &(lua_class).newindex_miss_handler);     \

--- a/common/util.h
+++ b/common/util.h
@@ -94,6 +94,8 @@
 #define unlikely(expr)  expr
 #endif
 
+#define maybe_unused __attribute__ ((unused))
+
 static inline void * __attribute__ ((malloc)) xmalloc(ssize_t size)
 {
     void *ptr;


### PR DESCRIPTION
Many of our macro-generated functions are never used. This causes the compiler to generate warnings. Functions decorated with the mayused attribute can eliminate these warnings.
I felt the original “attribute unused” was unintuitive, so I renamed it to mayused, meaning “maybe used.”
“attribute unused” always gives the impression that the function is completely unusable.
array.h also needs modification. If this PR gets merged, I'll make the changes then.