### PR TITLE
chore: optimize luaA_class_add_properties

### DIFF
--- a/common/array.h
+++ b/common/array.h
@@ -142,7 +142,7 @@
         pfx##_array_splice(arr, r, 0, &e, 1);                               \
     }                                                                       \
     static inline void                                                      \
-    pfx##_array_inserts(pfx##_array_t *arr, type_t items[], int count)      \
+    pfx##_array_inserts(pfx##_array_t *arr, const type_t items[], int count)\
     {                                                                       \
         pfx##_array_growx(arr, arr->len + count);                           \
         memcpy(arr->tab + arr->len, items, count * sizeof(*items));         \

--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -155,8 +155,8 @@ luaA_class_add_property(lua_class_t *lua_class,
 
 void
 luaA_class_add_properties(lua_class_t* lua_class,
-                          lua_class_property_t properties[],
-                          size_t count)
+                          const lua_class_property_t properties[],
+                          int count)
 {
     lua_class_property_array_inserts(&lua_class->properties, properties, count);
 }

--- a/common/luaclass.h
+++ b/common/luaclass.h
@@ -108,7 +108,7 @@ void luaA_class_setup(lua_State *, lua_class_t *, const char *, lua_class_t *,
 
 void luaA_class_add_property(lua_class_t *, const char *,
                              lua_class_propfunc_t, lua_class_propfunc_t, lua_class_propfunc_t);
-void luaA_class_add_properties(lua_class_t *, lua_class_property_t[] , size_t);
+void luaA_class_add_properties(lua_class_t *, const lua_class_property_t[] , int);
 
 int luaA_usemetatable(lua_State *, int, int);
 int luaA_class_index(lua_State *);


### PR DESCRIPTION
We definitely won't modify the incoming properties, so I added the `const` modifier.
As for `count`, since the convention is to use `int`, I changed it.