### PR TITLE
chore(objects): use luaA_class_add_properties

### DIFF
--- a/objects/button.c
+++ b/objects/button.c
@@ -171,14 +171,22 @@ button_class_setup(lua_State *L)
                      (lua_class_allocator_t) button_new, NULL, NULL,
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      button_methods, button_meta);
-    luaA_class_add_property(&button_class, "button",
-                            (lua_class_propfunc_t) luaA_button_set_button,
-                            (lua_class_propfunc_t) luaA_button_get_button,
-                            (lua_class_propfunc_t) luaA_button_set_button);
-    luaA_class_add_property(&button_class, "modifiers",
-                            (lua_class_propfunc_t) luaA_button_set_modifiers,
-                            (lua_class_propfunc_t) luaA_button_get_modifiers,
-                            (lua_class_propfunc_t) luaA_button_set_modifiers);
+
+    const lua_class_property_t properties[] = {
+        {
+            .name = "button",
+            .new = (lua_class_propfunc_t)luaA_button_set_button,
+            .index = (lua_class_propfunc_t)luaA_button_get_button,
+            .newindex = (lua_class_propfunc_t)luaA_button_set_button,
+        },
+        {
+            .name = "modifiers",
+            .new = (lua_class_propfunc_t)luaA_button_set_modifiers,
+            .index = (lua_class_propfunc_t)luaA_button_get_modifiers,
+            .newindex = (lua_class_propfunc_t)luaA_button_set_modifiers,
+        },
+    };
+    luaA_class_add_properties(&button_class, properties, G_N_ELEMENTS(properties));
 }
 
 /* @DOC_cobject_COMMON@ */

--- a/objects/client.c
+++ b/objects/client.c
@@ -4567,7 +4567,7 @@ client_class_setup(lua_State *L)
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      client_methods, client_meta);
     luaA_class_set_tostring(&client_class, (lua_class_propfunc_t) client_tostring);
-    lua_class_property_t properties[] = {
+    const lua_class_property_t properties[] = {
         {
             .name = "name",
             .new = (lua_class_propfunc_t) luaA_client_set_name,

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -234,10 +234,14 @@ drawable_class_setup(lua_State *L)
                      (lua_class_collector_t) drawable_wipe, NULL,
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      drawable_methods, drawable_meta);
-    luaA_class_add_property(&drawable_class, "surface",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_drawable_get_surface,
-                            NULL);
+
+    const lua_class_property_t properties[] = {
+        {
+            .name = "surface",
+            .index = (lua_class_propfunc_t)luaA_drawable_get_surface,
+        },
+    };
+    luaA_class_add_properties(&drawable_class, properties, G_N_ELEMENTS(properties));
 }
 
 /* @DOC_cobject_COMMON@ */

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -784,54 +784,80 @@ drawin_class_setup(lua_State *L)
                      NULL,
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      drawin_methods, drawin_meta);
-    luaA_class_add_property(&drawin_class, "drawable",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_drawin_get_drawable,
-                            NULL);
-    luaA_class_add_property(&drawin_class, "visible",
-                            (lua_class_propfunc_t) luaA_drawin_set_visible,
-                            (lua_class_propfunc_t) luaA_drawin_get_visible,
-                            (lua_class_propfunc_t) luaA_drawin_set_visible);
-    luaA_class_add_property(&drawin_class, "ontop",
-                            (lua_class_propfunc_t) luaA_drawin_set_ontop,
-                            (lua_class_propfunc_t) luaA_drawin_get_ontop,
-                            (lua_class_propfunc_t) luaA_drawin_set_ontop);
-    luaA_class_add_property(&drawin_class, "cursor",
-                            (lua_class_propfunc_t) luaA_drawin_set_cursor,
-                            (lua_class_propfunc_t) luaA_drawin_get_cursor,
-                            (lua_class_propfunc_t) luaA_drawin_set_cursor);
-    luaA_class_add_property(&drawin_class, "x",
-                            (lua_class_propfunc_t) luaA_drawin_set_x,
-                            (lua_class_propfunc_t) luaA_drawin_get_x,
-                            (lua_class_propfunc_t) luaA_drawin_set_x);
-    luaA_class_add_property(&drawin_class, "y",
-                            (lua_class_propfunc_t) luaA_drawin_set_y,
-                            (lua_class_propfunc_t) luaA_drawin_get_y,
-                            (lua_class_propfunc_t) luaA_drawin_set_y);
-    luaA_class_add_property(&drawin_class, "width",
-                            (lua_class_propfunc_t) luaA_drawin_set_width,
-                            (lua_class_propfunc_t) luaA_drawin_get_width,
-                            (lua_class_propfunc_t) luaA_drawin_set_width);
-    luaA_class_add_property(&drawin_class, "height",
-                            (lua_class_propfunc_t) luaA_drawin_set_height,
-                            (lua_class_propfunc_t) luaA_drawin_get_height,
-                            (lua_class_propfunc_t) luaA_drawin_set_height);
-    luaA_class_add_property(&drawin_class, "type",
-                            (lua_class_propfunc_t) luaA_window_set_type,
-                            (lua_class_propfunc_t) luaA_window_get_type,
-                            (lua_class_propfunc_t) luaA_window_set_type);
-    luaA_class_add_property(&drawin_class, "shape_bounding",
-                            (lua_class_propfunc_t) luaA_drawin_set_shape_bounding,
-                            (lua_class_propfunc_t) luaA_drawin_get_shape_bounding,
-                            (lua_class_propfunc_t) luaA_drawin_set_shape_bounding);
-    luaA_class_add_property(&drawin_class, "shape_clip",
-                            (lua_class_propfunc_t) luaA_drawin_set_shape_clip,
-                            (lua_class_propfunc_t) luaA_drawin_get_shape_clip,
-                            (lua_class_propfunc_t) luaA_drawin_set_shape_clip);
-    luaA_class_add_property(&drawin_class, "shape_input",
-                            (lua_class_propfunc_t) luaA_drawin_set_shape_input,
-                            (lua_class_propfunc_t) luaA_drawin_get_shape_input,
-                            (lua_class_propfunc_t) luaA_drawin_set_shape_input);
+
+    const lua_class_property_t properties[] = {
+        {
+            .name = "drawable",
+            .index = (lua_class_propfunc_t)luaA_drawin_get_drawable,
+        },
+        {
+            .name = "visible",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_visible,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_visible,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_visible,
+        },
+        {
+            .name = "ontop",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_ontop,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_ontop,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_ontop,
+        },
+        {
+            .name = "cursor",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_cursor,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_cursor,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_cursor,
+        },
+        {
+            .name = "x",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_x,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_x,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_x,
+        },
+        {
+            .name = "y",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_y,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_y,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_y,
+        },
+        {
+            .name = "width",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_width,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_width,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_width,
+        },
+        {
+            .name = "height",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_height,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_height,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_height,
+        },
+        {
+            .name = "type",
+            .new = (lua_class_propfunc_t)luaA_window_set_type,
+            .index = (lua_class_propfunc_t)luaA_window_get_type,
+            .newindex = (lua_class_propfunc_t)luaA_window_set_type,
+        },
+        {
+            .name = "shape_bounding",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_shape_bounding,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_shape_bounding,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_shape_bounding,
+        },
+        {
+            .name = "shape_clip",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_shape_clip,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_shape_clip,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_shape_clip,
+        },
+        {
+            .name = "shape_input",
+            .new = (lua_class_propfunc_t)luaA_drawin_set_shape_input,
+            .index = (lua_class_propfunc_t)luaA_drawin_get_shape_input,
+            .newindex = (lua_class_propfunc_t)luaA_drawin_set_shape_input,
+        },
+    };
+    luaA_class_add_properties(&drawin_class, properties, G_N_ELEMENTS(properties));
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/key.c
+++ b/objects/key.c
@@ -362,18 +362,26 @@ key_class_setup(lua_State *L)
                      (lua_class_allocator_t) key_new, NULL, NULL,
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      key_methods, key_meta);
-    luaA_class_add_property(&key_class, "key",
-                            (lua_class_propfunc_t) luaA_key_set_key,
-                            (lua_class_propfunc_t) luaA_key_get_key,
-                            (lua_class_propfunc_t) luaA_key_set_key);
-    luaA_class_add_property(&key_class, "keysym",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_key_get_keysym,
-                            NULL);
-    luaA_class_add_property(&key_class, "modifiers",
-                            (lua_class_propfunc_t) luaA_key_set_modifiers,
-                            (lua_class_propfunc_t) luaA_key_get_modifiers,
-                            (lua_class_propfunc_t) luaA_key_set_modifiers);
+
+    const lua_class_property_t properties[] = {
+        {
+            .name = "key",
+            .new = (lua_class_propfunc_t)luaA_key_set_key,
+            .index = (lua_class_propfunc_t)luaA_key_get_key,
+            .newindex = (lua_class_propfunc_t)luaA_key_set_key,
+        },
+        {
+            .name = "keysym",
+            .index = (lua_class_propfunc_t)luaA_key_get_keysym,
+        },
+        {
+            .name = "modifiers",
+            .new = (lua_class_propfunc_t)luaA_key_set_modifiers,
+            .index = (lua_class_propfunc_t)luaA_key_get_modifiers,
+            .newindex = (lua_class_propfunc_t)luaA_key_set_modifiers,
+        },
+    };
+    luaA_class_add_properties(&key_class, properties, G_N_ELEMENTS(properties));
 }
 
 /* @DOC_cobject_COMMON@ */

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1880,30 +1880,36 @@ screen_class_setup(lua_State *L)
                      (lua_class_checker_t) screen_checker,
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      screen_methods, screen_meta);
-    luaA_class_add_property(&screen_class, "geometry",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_screen_get_geometry,
-                            NULL);
-    luaA_class_add_property(&screen_class, "index",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_screen_get_index,
-                            NULL);
-    luaA_class_add_property(&screen_class, "_outputs",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_screen_get_outputs,
-                            NULL);
-    luaA_class_add_property(&screen_class, "_managed",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_screen_get_managed,
-                            NULL);
-    luaA_class_add_property(&screen_class, "workarea",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_screen_get_workarea,
-                            NULL);
-    luaA_class_add_property(&screen_class, "name",
-                            (lua_class_propfunc_t) luaA_screen_set_name,
-                            (lua_class_propfunc_t) luaA_screen_get_name,
-                            (lua_class_propfunc_t) luaA_screen_set_name);
+
+    const lua_class_property_t properties[] = {
+        {
+            .name = "geometry",
+            .index = (lua_class_propfunc_t)luaA_screen_get_geometry,
+        },
+        {
+            .name = "index",
+            .index = (lua_class_propfunc_t)luaA_screen_get_index,
+        },
+        {
+            .name = "_outputs",
+            .index = (lua_class_propfunc_t)luaA_screen_get_outputs,
+        },
+        {
+            .name = "_managed",
+            .index = (lua_class_propfunc_t)luaA_screen_get_managed,
+        },
+        {
+            .name = "workarea",
+            .index = (lua_class_propfunc_t)luaA_screen_get_workarea,
+        },
+        {
+            .name = "name",
+            .new = (lua_class_propfunc_t)luaA_screen_set_name,
+            .index = (lua_class_propfunc_t)luaA_screen_get_name,
+            .newindex = (lua_class_propfunc_t)luaA_screen_set_name,
+        },
+    };
+    luaA_class_add_properties(&screen_class, properties, G_N_ELEMENTS(properties));
 }
 
 /* @DOC_cobject_COMMON@ */

--- a/objects/selection_watcher.c
+++ b/objects/selection_watcher.c
@@ -190,10 +190,16 @@ selection_watcher_class_setup(lua_State *L)
             (lua_class_allocator_t) selection_watcher_new, NULL, NULL,
             luaA_class_index_miss_property, luaA_class_newindex_miss_property,
             selection_watcher_methods, selection_watcher_meta);
-    luaA_class_add_property(&selection_watcher_class, "active",
-            (lua_class_propfunc_t) luaA_selection_watcher_set_active,
-            (lua_class_propfunc_t) luaA_selection_watcher_get_active,
-            (lua_class_propfunc_t) luaA_selection_watcher_set_active);
+
+    const lua_class_property_t properties[] = {
+        {
+            .name = "active",
+            .new = (lua_class_propfunc_t)luaA_selection_watcher_set_active,
+            .index = (lua_class_propfunc_t)luaA_selection_watcher_get_active,
+            .newindex = (lua_class_propfunc_t)luaA_selection_watcher_set_active,
+        },
+    };
+    luaA_class_add_properties(&selection_watcher_class, properties, G_N_ELEMENTS(properties));
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -615,18 +615,28 @@ tag_class_setup(lua_State *L)
                      NULL,
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      tag_methods, tag_meta);
-    luaA_class_add_property(&tag_class, "name",
-                            (lua_class_propfunc_t) luaA_tag_set_name,
-                            (lua_class_propfunc_t) luaA_tag_get_name,
-                            (lua_class_propfunc_t) luaA_tag_set_name);
-    luaA_class_add_property(&tag_class, "selected",
-                            (lua_class_propfunc_t) luaA_tag_set_selected,
-                            (lua_class_propfunc_t) luaA_tag_get_selected,
-                            (lua_class_propfunc_t) luaA_tag_set_selected);
-    luaA_class_add_property(&tag_class, "activated",
-                            (lua_class_propfunc_t) luaA_tag_set_activated,
-                            (lua_class_propfunc_t) luaA_tag_get_activated,
-                            (lua_class_propfunc_t) luaA_tag_set_activated);
+
+    const lua_class_property_t properties[] = {
+        {
+            .name = "name",
+            .new = (lua_class_propfunc_t)luaA_tag_set_name,
+            .index = (lua_class_propfunc_t)luaA_tag_get_name,
+            .newindex = (lua_class_propfunc_t)luaA_tag_set_name,
+        },
+        {
+            .name = "selected",
+            .new = (lua_class_propfunc_t)luaA_tag_set_selected,
+            .index = (lua_class_propfunc_t)luaA_tag_get_selected,
+            .newindex = (lua_class_propfunc_t)luaA_tag_set_selected,
+        },
+        {
+            .name = "activated",
+            .new = (lua_class_propfunc_t)luaA_tag_set_activated,
+            .index = (lua_class_propfunc_t)luaA_tag_get_activated,
+            .newindex = (lua_class_propfunc_t)luaA_tag_set_activated,
+        },
+    };
+    luaA_class_add_properties(&tag_class, properties, G_N_ELEMENTS(properties));
 }
 
 /* @DOC_cobject_COMMON@ */

--- a/objects/window.c
+++ b/objects/window.c
@@ -527,22 +527,31 @@ window_class_setup(lua_State *L)
                      luaA_class_index_miss_property, luaA_class_newindex_miss_property,
                      window_methods, window_meta);
 
-    luaA_class_add_property(&window_class, "window",
-                            NULL,
-                            (lua_class_propfunc_t) luaA_window_get_window,
-                            NULL);
-    luaA_class_add_property(&window_class, "_opacity",
-                            (lua_class_propfunc_t) luaA_window_set_opacity,
-                            (lua_class_propfunc_t) luaA_window_get_opacity,
-                            (lua_class_propfunc_t) luaA_window_set_opacity);
-    luaA_class_add_property(&window_class, "_border_color",
-                            (lua_class_propfunc_t) luaA_window_set_border_color,
-                            (lua_class_propfunc_t) luaA_window_get_border_color,
-                            (lua_class_propfunc_t) luaA_window_set_border_color);
-    luaA_class_add_property(&window_class, "_border_width",
-                            (lua_class_propfunc_t) luaA_window_set_border_width,
-                            (lua_class_propfunc_t) luaA_window_get_border_width,
-                            (lua_class_propfunc_t) luaA_window_set_border_width);
+    const lua_class_property_t properties[] = {
+        {
+            .name = "window",
+            .index = (lua_class_propfunc_t)luaA_window_get_window,
+        },
+        {
+            .name = "_opacity",
+            .new = (lua_class_propfunc_t)luaA_window_set_opacity,
+            .index = (lua_class_propfunc_t)luaA_window_get_opacity,
+            .newindex = (lua_class_propfunc_t)luaA_window_set_opacity,
+        },
+        {
+            .name = "_border_color",
+            .new = (lua_class_propfunc_t)luaA_window_set_border_color,
+            .index = (lua_class_propfunc_t)luaA_window_get_border_color,
+            .newindex = (lua_class_propfunc_t)luaA_window_set_border_color,
+        },
+        {
+            .name = "_border_width",
+            .new = (lua_class_propfunc_t)luaA_window_set_border_width,
+            .index = (lua_class_propfunc_t)luaA_window_get_border_width,
+            .newindex = (lua_class_propfunc_t)luaA_window_set_border_width,
+        },
+    };
+    luaA_class_add_properties(&window_class, properties, G_N_ELEMENTS(properties));
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Dependency #4059

Using `luaA_class_add_properties` to add properties is more memory-efficient and faster for batch property additions.
Only dynamic, individual property additions require `add_property`. But we have no such need whatsoever.
In fact, we have no requirement for dynamic property additions at all. Properties can be defined statically without needing to dynamically allocate any memory. There's simply no need for `add_properties` or `add_property`.