### PR TITLE
refactor: use variable-length arrays instead of p_alloca

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -123,7 +123,7 @@ awesome_atexit(bool restart)
     }
 
     /* Save the client order.  This is useful also for "hard" restarts. */
-    xcb_window_t *wins = p_alloca(xcb_window_t, globalconf.clients.len);
+    xcb_window_t wins[globalconf.clients.len];
     int n = 0;
     foreach(client, globalconf.clients)
         wins[n++] = (*client)->window;

--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -302,7 +302,7 @@ luaA_class_connect_signal_from_stack(lua_State *L, lua_class_t *lua_class,
     /* Duplicate the function in the stack */
     lua_pushvalue(L, ud);
 
-    char *buf = p_alloca(char, a_strlen(name) + a_strlen(CONNECTED_SUFFIX) + 1);
+    char buf[a_strlen(name) + a_strlen(CONNECTED_SUFFIX) + 1];
 
     /* Create a new signal to notify there is a global connection. */
     sprintf(buf, "%s%s", name, CONNECTED_SUFFIX);

--- a/common/util.h
+++ b/common/util.h
@@ -32,10 +32,6 @@
 #include <assert.h>
 #include <stdio.h>
 
-#if !(defined (__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined (__DragonFly__))
-#include <alloca.h>
-#endif
-
 /** \brief replace \c NULL strings with empty strings */
 #define NONULL(x)       (x ? x : "")
 
@@ -58,10 +54,6 @@
 #define countof(foo)            (ssizeof(foo) / ssizeof(foo[0]))
 #define fieldsizeof(type_t, m)  sizeof(((type_t *)0)->m)
 #define fieldtypeof(type_t, m)  typeof(((type_t *)0)->m)
-
-#define p_alloca(type, count)                                \
-        ((type *)memset(alloca(sizeof(type) * (count)),      \
-                        0, sizeof(type) * (count)))
 
 #define p_alloc_nr(x)           (((x) + 16) * 3 / 2)
 #define p_new(type, count)      ((type *)xmalloc(sizeof(type) * (count)))

--- a/ewmh.c
+++ b/ewmh.c
@@ -94,7 +94,7 @@ ewmh_update_net_active_window(lua_State *L)
 static int
 ewmh_update_net_client_list(lua_State *L)
 {
-    xcb_window_t *wins = p_alloca(xcb_window_t, globalconf.clients.len);
+    xcb_window_t wins[globalconf.clients.len];
 
     int n = 0;
     foreach(client, globalconf.clients)
@@ -271,7 +271,7 @@ void
 ewmh_update_net_client_list_stacking(void)
 {
     int n = 0;
-    xcb_window_t *wins = p_alloca(xcb_window_t, globalconf.stack.len);
+    xcb_window_t wins[globalconf.stack.len];
 
     foreach(client, globalconf.stack)
         wins[n++] = (*client)->window;


### PR DESCRIPTION
Removing p_alloca is primarily for readability and maintainability.
Since p_alloca also performs an extra memset to zero the allocated memory, this change will also yield performance improvements.
Since variable-length arrays are already used in the scan function of the awesome.c file, my modification will not cause compatibility issues.