### PR TITLE
refactor(awesome): use arrays instead of pointer

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -610,8 +610,8 @@ main(int argc, char **argv)
     for(; *xdgconfigdirs; xdgconfigdirs++)
     {
         /* Append /awesome to *xdgconfigdirs */
-        const char *suffix = "/awesome";
-        size_t len = a_strlen(*xdgconfigdirs) + a_strlen(suffix) + 1;
+        const char suffix[] = "/awesome";
+        size_t len = a_strlen(*xdgconfigdirs) + sizeof(suffix);
         char *entry = p_new(char, len);
         a_strcat(entry, len, *xdgconfigdirs);
         a_strcat(entry, len, suffix);


### PR DESCRIPTION
This saves one strlen call.
Since sizeof returns the length including the terminator, I didn't add one.