### PR TITLE
fix(naughty): add missing break in cleanup() active list removal

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -503,6 +503,7 @@ local function cleanup(self, reason)
          if n == self then
             table.remove(naughty._active, k)
             naughty.emit_signal("property::active")
+            break  -- each notification appears only once
          end
     end
 

--- a/tests/test-naughty-destroy.lua
+++ b/tests/test-naughty-destroy.lua
@@ -1,0 +1,37 @@
+-- Test that destroying multiple notifications correctly removes all of them
+-- from naughty.active (regression test for missing break in cleanup()).
+
+local naughty = require("naughty")
+local notification = require("naughty.notification")
+
+local steps = {}
+
+table.insert(steps, function()
+    -- Create 3 persistent notifications.
+    for i = 1, 3 do
+        notification {
+            title   = "test" .. i,
+            timeout = 0,
+        }
+    end
+
+    assert(#naughty.active == 3, "expected 3 active, got " .. #naughty.active)
+
+    return true
+end)
+
+table.insert(steps, function()
+    -- Destroy them all.  Copy the list first because :destroy() removes
+    -- from naughty._active, and ipairs over a shrinking table skips entries.
+    local copy = {}
+    for _, n in ipairs(naughty.active) do copy[#copy+1] = n end
+    for _, n in ipairs(copy) do
+        n:destroy()
+    end
+
+    assert(#naughty.active == 0, "expected 0 active, got " .. #naughty.active)
+
+    return true
+end)
+
+require("_runner").run_steps(steps)


### PR DESCRIPTION
Add `break` after `table.remove` in `cleanup()`'s active-list removal loop. Without it, `ipairs` skips the next entry after removal so destroying multiple notifications in quick succession can leave stale entries in `naughty.active`.

Present since commit 97417121. Found while working on SomeWM, fixed there first in trip-zip/somewm#274, contributing the fix back upstream.

Includes a regression test (`tests/test-naughty-destroy.lua`).