### PR TITLE
chore: place `xdgconfigdirs` inside the for loop.

### DIFF
--- a/awesome.c
+++ b/awesome.c
@@ -606,9 +606,7 @@ main(int argc, char **argv)
         fatal("Function xdgInitHandle() failed, is $HOME unset?");
 
     /* add XDG_CONFIG_DIR as include path */
-    const char * const *xdgconfigdirs = xdgSearchableConfigDirectories(&xdg);
-    for(; *xdgconfigdirs; xdgconfigdirs++)
-    {
+    for (const char* const* xdgconfigdirs = xdgSearchableConfigDirectories(&xdg); *xdgconfigdirs; xdgconfigdirs++) {
         /* Append /awesome to *xdgconfigdirs */
         const char *suffix = "/awesome";
         size_t len = a_strlen(*xdgconfigdirs) + a_strlen(suffix) + 1;


### PR DESCRIPTION
xdgconfigdirs is only used within the for loop, so we should place it directly inside the for loop.