### PR TITLE
feat: add luaA_newlib

### DIFF
--- a/common/luaclass.c
+++ b/common/luaclass.c
@@ -207,11 +207,12 @@ luaA_class_gc(lua_State *L)
      * this object. This is needed since other __gc methods can still use this.
      * We also make sure that `item.valid == false`.
      */
-    lua_newtable(L);
-    lua_pushcfunction(L, luaA_class_index_invalid);
-    lua_setfield(L, -2, "__index");
-    lua_pushcfunction(L, luaA_class_newindex_invalid);
-    lua_setfield(L, -2, "__newindex");
+    const luaL_Reg meta[] = {
+        {"__index", luaA_class_index_invalid},
+        {"__newindex", luaA_class_newindex_invalid},
+        {}
+    };
+    luaA_newlib(L, meta);
     lua_setmetatable(L, 1);
     return 0;
 }

--- a/luaa.h
+++ b/luaa.h
@@ -153,6 +153,15 @@ luaA_setfuncs(lua_State *L, const luaL_Reg *l)
 #endif
 }
 
+#if LUA_VERSION_NUM >= 502
+    #define luaA_newlibtable(L, l) luaL_newlibtable(L, l)
+    #define luaA_newlib(L, l) luaL_newlib(L, l)
+#else
+    #define luaA_newlibtable(L, l) \
+        lua_createtable(L, 0, sizeof(l) / sizeof(l[0]) - 1)
+    #define luaA_newlib(L, l)   (luaA_newlibtable(L, l), luaA_setfuncs(L, l))
+#endif
+
 static inline bool
 luaA_checkboolean(lua_State *L, int n)
 {


### PR DESCRIPTION
luaA_newlib is modeled after luaL_newlib from Lua 5.2.
It can only be used for arrays, but it outperforms luaA_registerlib because it allows for pre-allocating the table.