### PR TITLE
fix(stack): Decouple fullscreen stacking layer from focus

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -132,8 +132,12 @@ client_layer_translator(client_t *c)
     /* first deal with user set attributes */
     if(c->ontop)
         return WINDOW_LAYER_ONTOP;
-    /* Fullscreen windows only get their own layer when they have the focus */
-    else if(c->fullscreen && globalconf.focus.client == c)
+    /* Fullscreen windows only get their own layer when they are the most
+     * recently raised client.  Using the stack position (instead of focus)
+     * ensures that focus changes alone (e.g. sloppy / mouse-enter focus)
+     * do not alter the stacking order of fullscreen windows. */
+    else if(c->fullscreen && globalconf.stack.len
+            && globalconf.stack.tab[globalconf.stack.len-1] == c)
         return WINDOW_LAYER_FULLSCREEN;
     else if(c->above)
         return WINDOW_LAYER_ABOVE;


### PR DESCRIPTION
Fixes https://github.com/awesomeWM/awesome/issues/4075

Fullscreen clients are assigned a special stacking layer via `client_layer_translator()`. Previously, this was conditioned on the client having focus. When switching focus away from a fullscreen client (e.g. via `awful.client.focus.byidx`), the fullscreen client could intermittently remain visually on top despite losing focus, because the layer reassignment depended on a restack that was not always triggered by the focus change.

This is fixed by conditioning the fullscreen layer on the client being at the top of the internal stack (i.e. the most recently raised client) rather than on focus. Since keyboard focus changes go through `raise()`, the fullscreen layer is correctly updated when switching away. Sloppy mouse-enter focus (which does not call `raise`) is unaffected, as it does not alter the internal stack order.

I'm wondering whether this has a potential of causing issues when the client is set as fullscreen _without_ raising (when could this happen? Could a client be spawned as fullscreen, but not raised? Should it even be given its own layer in that case?). One might switch to a client without raising it — but, once again, should the client be given its own layer in that case?

Admittedly, I'm not very familiar with Awesome's internals and don't _really_ know what I'm doing, but, hopefully, this is at least close to a proper fix.

I'm not sure how to properly auto-test for this... Let me know in case a test is required, and I'll try to figure it out.