### PR TITLE
fix(taglist): for property filter

### DIFF
--- a/lib/awful/widget/taglist.lua
+++ b/lib/awful/widget/taglist.lua
@@ -652,6 +652,7 @@ function taglist.new(args, filter, buttons, style, update_function, base_widget)
     })
 
     gtable.crush(w, taglist, true)
+    rawset(w, "filter", nil)
 
     gtable.crush(w._private, {
         style           = args.style or {},

--- a/tests/test-taglist.lua
+++ b/tests/test-taglist.lua
@@ -1,0 +1,20 @@
+-- Test the taglist
+
+local awful = require "awful"
+local runner = require "_runner"
+
+local taglist = awful.widget.taglist {
+    screen = screen[1],
+    filter = awful.widget.taglist.filter.all
+}
+
+
+runner.run_steps {
+    function()
+        return type(taglist.filter) == "function"
+    end,
+    function()
+        taglist.filter = awful.widget.taglist.filter.selected
+        return taglist.filter == awful.widget.taglist.filter.selected
+    end,
+}


### PR DESCRIPTION
`table filter` interfere with `property filter`, so we need to remove `table filter` from the instance.

In practical terms, this means we cannot modify the filter property of a taglist instance.