### PR TITLE
doc(naughty.notification): use message instead of text

### DIFF
--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -958,7 +958,7 @@ end
 --- Create a notification.
 --
 -- @tparam[opt={}] table args The argument table containing any of the arguments below.
--- @tparam[opt=""] string args.text Text of the notification.
+-- @tparam[opt=""] string args.message Text of the notification.
 -- @tparam[opt] string args.title Title of the notification.
 -- @tparam[opt=5] integer args.timeout Time in seconds after which popup expires.
 --   Set 0 for no timeout.


### PR DESCRIPTION
The text has been deprecated; we need to correct it in the document.