### PR TITLE
fix(naughty): honor beautiful.notification_border_width (fixes #3786)

### DIFF
--- a/lib/naughty/core.lua
+++ b/lib/naughty/core.lua
@@ -92,6 +92,10 @@ gtable.crush(naughty, require("naughty.constants"))
 
 --- Defaults for `naughty.notify`.
 --
+-- These values apply only when neither the notification itself (constructor
+-- arguments or `ruled.notification` rules), its preset, nor the theme
+-- (`beautiful.notification_*`) provides a value.
+--
 -- @table naughty.config.defaults
 -- @tfield[opt=5] integer timeout
 -- @tfield[opt=""] string text
@@ -272,8 +276,11 @@ local function update_index(n)
     local s = get_screen(n.screen
         or (n.preset and n.preset.screen)
         or screen.focused())
+    local pos = n.position
+
     naughty.notifications[s] = naughty.notifications[s] or {}
-    table.insert(naughty.notifications[s][n.position], n)
+    table.insert(naughty.notifications[s][pos], n)
+    n._private.index_position = pos
 end
 
 --- Notification state.
@@ -490,11 +497,16 @@ local function cleanup(self, reason)
     end
     local scr = self.screen
 
-    assert(naughty.notifications[scr][self.position][self.idx] == self)
+    -- Use the position the notification was indexed under rather than its
+    -- current one. `position` can fall back to `beautiful.notification_position`,
+    -- and the theme changing emits no `property::position` to re-index with.
+    local pos = self._private.index_position or self.position
+
+    assert(naughty.notifications[scr][pos][self.idx] == self)
     remove_from_index(self)
 
     -- Update all indices
-    for k, n in ipairs(naughty.notifications[scr][self.position]) do
+    for k, n in ipairs(naughty.notifications[scr][pos]) do
         n.idx = k
     end
 
@@ -700,10 +712,14 @@ local function register(notification, args)
     end
 
     -- insert the notification to the table
+    local pos = notification.position
+
     table.insert(naughty._active, notification)
-    table.insert(naughty.notifications[s][notification.position], notification)
-    notification.idx    = #naughty.notifications[s][notification.position]
+    table.insert(naughty.notifications[s][pos], notification)
+    notification.idx    = #naughty.notifications[s][pos]
     notification.screen = s
+
+    notification._private.index_position = pos
 
     notification._private.registered = true
 

--- a/lib/naughty/layout/box.lua
+++ b/lib/naughty/layout/box.lua
@@ -117,18 +117,21 @@ end
 
 local function finish(self)
     self.visible = false
-    assert(init_screen(self.screen)[self.position])
 
-    for k, v in ipairs(init_screen(self.screen)[self.position]) do
+    local position = self._private.index_position or self.position
+
+    assert(init_screen(self.screen)[position])
+
+    for k, v in ipairs(init_screen(self.screen)[position]) do
         if v == self then
-            table.remove(init_screen(self.screen)[self.position], k)
+            table.remove(init_screen(self.screen)[position], k)
             break
         end
     end
 
     local preset = (self._private.notification[1] or {}).preset
 
-    update_position(self.position, preset)
+    update_position(position, preset)
 
     disconnect(self)
 
@@ -277,6 +280,11 @@ local function init(self, notification)
     self:_apply_size_now()
 
     table.insert(init_screen(s)[position], self)
+
+    -- Record the position the box was indexed under. `self.position` reads it
+    -- back from the notification, whose value can fall back to
+    -- `beautiful.notification_position` and thus change while displayed.
+    self._private.index_position = position
 
     self._private.update = function() update_position(position, preset) end
     self._private.hide = function(_, value)

--- a/lib/naughty/list/notifications.lua
+++ b/lib/naughty/list/notifications.lua
@@ -116,20 +116,37 @@ local function update_style(self)
     end
 end
 
+-- The notification property getters fall back to `beautiful.notification_<prop>`.
+-- This widget has its own, more specific, `_normal`/`_selected` variables, so a
+-- value which only reached the notification through the global theme must not
+-- override them. `_private` holds the value set on the notification itself;
+-- preset values count as such because `select_legacy_preset` copies the preset
+-- into `_private` (and `ruled.notification` applies presets through setters).
+local function pick(notification, style, prop, style_prop)
+    return notification._private[prop]
+        or style[style_prop or prop]
+        or notification[prop]
+end
+
 local function wb_label(notification, self)
     -- Get the title
     local title = notification.title
 
     local style = self._private.style_cache[notification.selected and "selected" or "normal"]
 
-    if notification.fg or style.fg then
-        title = "<span color='" .. (notification.fg or style.fg) .. "'>" .. title .. "</span>"
+    local fg = pick(notification, style, "fg")
+
+    if fg then
+        title = "<span color='" .. fg .. "'>" .. title .. "</span>"
     end
 
-    return title, notification.bg or style.bg, style.bg_image, notification.icon, {
-        shape              = notification.shape         or style.shape,
+    return title, pick(notification, style, "bg"), style.bg_image, notification.icon, {
+        -- `border_width` deliberately keeps the old order. `notification.border_width`
+        -- has always been non-nil (`naughty.config.defaults.border_width`), so
+        -- `shape_border_width` was already unreachable here before this change.
+        shape              = pick(notification, style, "shape"),
         shape_border_width =  notification.border_width or style.shape_border_width,
-        shape_border_color =  notification.border_color or style.shape_border_color,
+        shape_border_color = pick(notification, style, "border_color", "shape_border_color"),
         icon_size          =  style.icon_size,
     }
 end

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -23,6 +23,7 @@ local gfs      = require("gears.filesystem")
 local cst      = require("naughty.constants")
 local naughty  = require("naughty.core")
 local gdebug   = require("gears.debug")
+local beautiful = require("beautiful")
 local pcommon = require("awful.permissions._common")
 
 local notification = {}
@@ -321,7 +322,7 @@ local notification = {}
 
 --- Border width.
 -- @property border_width
--- @tparam[opt=beautiful.notification_border_width or 0] number|nil border_width
+-- @tparam[opt=beautiful.notification_border_width or naughty.config.defaults.border_width] number|nil border_width
 -- @negativeallowed false
 -- @propertyunit pixel
 -- @propbeautiful
@@ -667,6 +668,19 @@ function notification:get_text()
     return self:get_message()
 end
 
+-- Properties which fall back to the `beautiful.notification_<name>` theme
+-- variables, as documented in the property definitions above. The theme value
+-- ranks below values set on the notification (directly, using the constructor
+-- arguments or by `ruled.notification`) and below the preset, but above the
+-- built-in `naughty.config.defaults`.
+local beautiful_fallback = {
+    bg           = true, border_color = true, border_width = true,
+    fg           = true, font         = true, height       = true,
+    icon_size    = true, margin       = true, max_width    = true,
+    opacity      = true, position     = true, shape        = true,
+    width        = true,
+}
+
 local properties = {
     "message"  , "title"   , "timeout" , "hover_timeout"     ,
     "app_name" , "position", "ontop"   , "border_width"      ,
@@ -680,6 +694,9 @@ local properties = {
 }
 
 for _, prop in ipairs(properties) do
+    -- Resolved once per property rather than on every getter call.
+    local beautiful_key = beautiful_fallback[prop] and "notification_"..prop
+
     notification["get_"..prop] = notification["get_"..prop] or function(self)
         -- It's possible this could be called from the `request::preset` handler.
         -- `rawget()` is necessary to avoid a stack overflow.
@@ -687,6 +704,7 @@ for _, prop in ipairs(properties) do
 
         return self._private[prop]
             or (preset and preset[prop])
+            or (beautiful_key and beautiful[beautiful_key])
             or cst.config.defaults[prop]
     end
 
@@ -936,9 +954,13 @@ local function select_legacy_preset(n, args)
         end
     end
 
-    -- gather variables together
+    -- gather variables together.
+    --
+    -- `naughty.config.defaults` is intentionally *not* joined into the
+    -- preset. It is the final fallback of the property getters, below the
+    -- `beautiful.notification_*` theme variables. Joining it here would rank
+    -- it above the theme and shadow it.
     rawset(n, "preset", gtable.join(
-        cst.config.defaults or {},
         args.preset or cst.config.presets.normal or {},
         rawget(n, "preset") or {}
     ))
@@ -951,8 +973,15 @@ local function select_legacy_preset(n, args)
         end
     end
 
-    if n.preset.screen then
-        n._private.weak_screen[1] = capi.screen[n.preset.screen]
+    -- `screen` is not a generated property, so it has no getter to fall back
+    -- to `naughty.config.defaults`. It has to be resolved here, where the
+    -- defaults used to arrive through the preset. Note that this, like the
+    -- rest of this function, only covers the legacy path; `ruled.notification`
+    -- has never applied `naughty.config.defaults.screen`.
+    local scr = n.preset.screen or cst.config.defaults.screen
+
+    if scr then
+        n._private.weak_screen[1] = capi.screen[scr]
     end
 end
 

--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -1126,6 +1126,26 @@ table.insert(steps, function()
     return true
 end)
 
+-- The theme border width must reach the popup built by the legacy handler
+-- (#3786). The property level is covered by `test-naughty-theme-fallback.lua`;
+-- this is about the wibox that only this code path creates.
+table.insert(steps, function()
+    beautiful.notification_border_width = 7
+
+    local n = naughty.notification {
+        title   = "foo",
+        message = "bar",
+        timeout = 25000,
+    }
+
+    assert(n.box.border_width == 7)
+
+    n:destroy()
+    beautiful.notification_border_width = nil
+
+    return true
+end)
+
 -- Add a "new API" handler.
 local current_template, had_error, handler_called = nil
 

--- a/tests/test-naughty-theme-fallback.lua
+++ b/tests/test-naughty-theme-fallback.lua
@@ -1,0 +1,331 @@
+--- Test that the `beautiful.notification_*` theme variables are honored.
+-- Regression test for #3786: keys present in `naughty.config.defaults` used to
+-- shadow the theme because the property getter never consulted `beautiful`.
+
+local naughty      = require("naughty")
+local notification = require("naughty.notification")
+local background   = require("naughty.container.background")
+local beautiful    = require("beautiful")
+local gshape       = require("gears.shape")
+local gcolor       = require("gears.color")
+local wibox        = require("wibox")
+
+require("ruled.notification"):_clear()
+
+-- Every property documented with a `beautiful.notification_*` fallback, along
+-- with a value to set the theme variable to. Keep in sync with the
+-- `beautiful_fallback` table of `naughty.notification`.
+local themed = {
+    { "border_width", 7             },
+    { "margin"      , 11            },
+    { "position"    , "bottom_left" },
+    { "width"       , 321           },
+    { "height"      , 123           },
+    { "max_width"   , 345           },
+    { "icon_size"   , 27            },
+    { "opacity"     , 0.5           },
+    { "font"        , "sans 11"     },
+    { "fg"          , "#123456"     },
+    { "bg"          , "#654321"     },
+    { "border_color", "#abcdef"     },
+    { "shape"       , gshape.octogon},
+}
+
+local function set_theme(value)
+    for _, prop in ipairs(themed) do
+        beautiful["notification_"..prop[1]] = value and prop[2] or nil
+    end
+end
+
+local steps = {}
+
+-- Run every scenario on both the legacy preset path and the ruled path.
+for _, has_handler in ipairs {false, true} do
+    -- Every theme variable must win over the built-in defaults.
+    table.insert(steps, function()
+        function naughty.get__has_preset_handler()
+            return has_handler
+        end
+
+        set_theme(true)
+
+        local n = notification { title = "t", message = "m", timeout = 0 }
+
+        for _, prop in ipairs(themed) do
+            assert(n[prop[1]] == prop[2], "theme " .. prop[1]
+                .. " not applied: " .. tostring(n[prop[1]]))
+        end
+
+        -- The rendered widget must see it too.
+        assert(background { notification = n }.border_width == 7)
+
+        n:destroy()
+        set_theme(false)
+
+        return true
+    end)
+
+    -- An explicit value takes precedence over the theme.
+    table.insert(steps, function()
+        beautiful.notification_border_width = 7
+
+        local n = notification {
+            title = "t", message = "m", border_width = 3, timeout = 0
+        }
+
+        assert(n.border_width == 3,
+            "explicit border_width ignored: " .. tostring(n.border_width))
+
+        n:destroy()
+        beautiful.notification_border_width = nil
+
+        return true
+    end)
+
+    -- A preset also takes precedence over the theme.
+    table.insert(steps, function()
+        beautiful.notification_border_width = 7
+
+        local n = notification {
+            title = "t", message = "m", timeout = 0,
+            preset = { border_width = 4 },
+        }
+
+        assert(n.border_width == 4,
+            "preset border_width ignored: " .. tostring(n.border_width))
+
+        n:destroy()
+        beautiful.notification_border_width = nil
+
+        return true
+    end)
+
+    -- The theme takes precedence over `naughty.config.defaults`. This pins the
+    -- documented fallback order (see the `border_width` property doc).
+    table.insert(steps, function()
+        local old = naughty.config.defaults.border_width
+        naughty.config.defaults.border_width = 9
+        beautiful.notification_border_width  = 7
+
+        local n = notification { title = "t", message = "m", timeout = 0 }
+
+        assert(n.border_width == 7,
+            "theme border_width shadowed by config.defaults: "
+                .. tostring(n.border_width))
+
+        n:destroy()
+        beautiful.notification_border_width = nil
+
+        n = notification { title = "t", message = "m", timeout = 0 }
+
+        assert(n.border_width == 9,
+            "config.defaults border_width not applied: "
+                .. tostring(n.border_width))
+
+        n:destroy()
+        naughty.config.defaults.border_width = old
+
+        return true
+    end)
+
+    -- With neither a theme nor an explicit value, the defaults are preserved.
+    table.insert(steps, function()
+        local n = notification { title = "t", message = "m", timeout = 0 }
+
+        assert(n.border_width == naughty.config.defaults.border_width,
+            "default border_width not preserved: " .. tostring(n.border_width))
+        assert(n.margin == naughty.config.defaults.margin,
+            "default margin not preserved: " .. tostring(n.margin))
+        assert(n.position == "top_right",
+            "default position not preserved: " .. tostring(n.position))
+
+        n:destroy()
+
+        return true
+    end)
+end
+
+-- Changing the theme while a notification is on screen must not corrupt the
+-- position index. `position` now falls back to the theme, and `beautiful`
+-- changing emits no `property::position` for `naughty.core` to re-index with.
+table.insert(steps, function()
+    beautiful.notification_position = "top_right"
+
+    local n = notification { title = "t", message = "m", timeout = 0 }
+
+    beautiful.notification_position = "bottom_right"
+
+    n:destroy()
+    beautiful.notification_position = nil
+
+    return true
+end)
+
+-- `naughty.config.defaults.screen` has no property getter to fall back to, so
+-- it has to keep working on its own.
+table.insert(steps, function()
+    function naughty.get__has_preset_handler()
+        return false
+    end
+
+    -- A second screen is needed, otherwise the default is indistinguishable
+    -- from the focused screen the notification would have picked anyway.
+    if screen.count() == 1 then
+        screen[1]:split()
+    end
+
+    assert(screen.count() > 1)
+
+    -- Pick the screen the notification would *not* have landed on by itself.
+    local target = mouse.screen == screen[1] and 2 or 1
+
+    naughty.config.defaults.screen = target
+
+    local n = notification { title = "t", message = "m", timeout = 0 }
+
+    assert(n.screen == screen[target],
+        "config.defaults.screen ignored: " .. tostring(n.screen))
+
+    n:destroy()
+    naughty.config.defaults.screen = nil
+
+    return true
+end)
+
+-- `naughty.list.notifications` has its own, more specific, `_normal`/`_selected`
+-- theme variables. Now that the property getters fall back to the global
+-- `beautiful.notification_*`, that global value must not silently override them.
+local list_layout, current
+
+local function new_list()
+    list_layout = wibox.layout.fixed.vertical()
+    naughty.list.notifications { base_layout = list_layout }
+end
+
+-- The bg the list actually painted, as set by `awful.widget.common.list_update`.
+local function list_bg()
+    local kids = list_layout:get_children()
+
+    if #kids == 0 then return nil end
+
+    local bgb = kids[1]:get_children_by_id("background_role")[1]
+
+    return bgb and bgb.bg
+end
+
+-- The list needs its entries registered, and the assertions need a main loop
+-- turn after the notification is created, hence the step pairs below.
+--
+-- `rc.lua` already connected a `request::display` handler, and its boxes are
+-- only weakly referenced, so their garbage collection would make the position
+-- of the boxes created here unpredictable. Replace it instead of adding a
+-- second box per notification.
+local last_box
+
+naughty._reset_display_handlers()
+
+naughty.connect_signal("request::display", function(n)
+    last_box = naughty.layout.box { notification = n }
+end)
+
+-- The list-specific variable wins over the global one.
+table.insert(steps, function()
+    beautiful.notification_bg        = "#111111"
+    beautiful.notification_bg_normal = "#222222"
+
+    new_list()
+    current = notification { title = "t", message = "m", timeout = 0 }
+
+    return true
+end)
+
+table.insert(steps, function()
+    assert(list_bg() == gcolor("#222222"),
+        "notification_bg_normal was overridden by the global notification_bg")
+
+    current:destroy()
+
+    return true
+end)
+
+-- A value set on the notification itself still wins over both.
+table.insert(steps, function()
+    new_list()
+    current = notification {
+        title = "t", message = "m", timeout = 0, bg = "#333333"
+    }
+
+    return true
+end)
+
+table.insert(steps, function()
+    assert(list_bg() == gcolor("#333333"),
+        "explicit bg ignored by the notification list")
+
+    current:destroy()
+    beautiful.notification_bg_normal = nil
+
+    return true
+end)
+
+-- With no list-specific variable, the global theme still reaches the list.
+table.insert(steps, function()
+    new_list()
+    current = notification { title = "t", message = "m", timeout = 0 }
+
+    return true
+end)
+
+table.insert(steps, function()
+    assert(list_bg() == gcolor("#111111"),
+        "global notification_bg did not reach the list")
+
+    current:destroy()
+    beautiful.notification_bg = nil
+
+    return true
+end)
+
+-- A theme position change while a notification is displayed must not leave its
+-- box behind in `naughty.layout.box`'s position index. A leftover would anchor
+-- the next box at the old position below it instead of at the screen edge.
+local stale_box
+
+table.insert(steps, function()
+    beautiful.notification_position = "top_right"
+    current = notification { title = "t", message = "m", timeout = 0 }
+
+    return true
+end)
+
+table.insert(steps, function()
+    stale_box = last_box
+
+    beautiful.notification_position = "bottom_right"
+    current:destroy()
+    beautiful.notification_position = nil
+
+    return true
+end)
+
+table.insert(steps, function()
+    current = notification { title = "t", message = "m", timeout = 0 }
+
+    return true
+end)
+
+table.insert(steps, function()
+    assert(last_box ~= stale_box)
+    assert(last_box.y == stale_box.y,
+        "box left in the old position index after a theme position change: y="
+        .. last_box.y .. ", expected " .. stale_box.y)
+
+    current:destroy()
+    stale_box = nil
+
+    return true
+end)
+
+require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Fixes #3786 

The theme variables are shadowed by a built-in default because the property lookup finds a built-in default first:

  - `n.border_width` resolves: `_private` -> `preset` -> `config.defaults`.
  - `config.defaults.border_width` is `dpi(1)`, so the chain always stops there.
  - `beautiful.notification_border_width` is never read. Same for margin, position, and every other themed key with a built-in default.
  - Legacy path is worse IMO: it merges `config.defaults` into the preset, then copies the preset into `_private`, so the chain stops at step 1.

  The fix puts the theme into the chain, above the built-in defaults:

  - Getter resolves: `_private` -> `preset` -> `beautiful.notification_<prop>`  -> `config.defaults`.
  - Legacy path no longer merges the defaults into the preset.