### PR TITLE
Support for Lua 5.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - test_name: "lua5.5"
+            lua_version: "5.5"
+            lua_name: "lua5.5"
+
           - test_name: "lua5.4"
             lua_version: "5.4"
             lua_name: "lua5.4"
@@ -190,21 +194,25 @@ jobs:
 
       # Only LGI git master supports Lua 5.4. We need to build it from source.
       - name: Build and Install LGI
-        if: matrix.lua_version == '5.4'
+        if: matrix.lua_version == '5.4' || matrix.lua_version == '5.5'
         run: |
           wget -O /tmp/lgi.zip https://github.com/pavouk/lgi/archive/refs/heads/master.zip
           unzip /tmp/lgi.zip -d /tmp
           cd /tmp/lgi-master
-          sed -i 's/5.1/5.4/' lgi/Makefile
+          sed -i 's/5.1/${{ matrix.lua_version }}/' lgi/Makefile
           make all CFLAGS="-I$LUAINCLUDE"
           sudo make install
 
       - name: Install rocks
         run: |
-          if [ "${{ matrix.lua_name }}" != "lua5.4" ]; then
+          if [[ "${{ matrix.lua_name }}" != "lua5.4" && "${{ matrix.lua_name }}" != "lua5.5" ]]; then
             luarocks install lgi ${{ matrix.lgi_version }}
           fi
-          luarocks install ldoc
+          if [ "${{ matrix.lua_name }}" == "lua5.5" ]; then
+            luarocks install https://raw.githubusercontent.com/lunarmodules/ldoc/refs/heads/master/ldoc-dev-1.rockspec
+          else
+            luarocks install ldoc
+          fi
           luarocks install busted
 
       - name: Install QA check rocks

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - label!=no-mergify
       - '#approved-reviews-by>=2'
+      - check-success=lua5.5
       - check-success=lua5.4
       - check-success=codecov-lua5.3
       - check-success=lua5.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ if(NOT EXISTS ${SOURCE_DIR}/awesomeConfig.cmake)
     message(FATAL_ERROR "Please provide awesomeConfig.cmake")
 endif()
 
+# Add vendored CMake modules to the search path.
+# This is necessary to use an updated version of FindLua.cmake, which is
+# required to find Lua 5.5.
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # Define many variables
 
 include(awesomeConfig.cmake)

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -73,9 +73,9 @@ if (NOT LUA_FOUND)
 endif()
 
 set(LUA_FULL_VERSION "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_PATCH}")
-# 5.1 <= LUA_VERSION < 5.5
-if(NOT ((LUA_FULL_VERSION VERSION_EQUAL 5.1.0 OR LUA_FULL_VERSION VERSION_GREATER 5.1.0) AND LUA_FULL_VERSION VERSION_LESS 5.5.0))
-    message(FATAL_ERROR "Awesome only supports Lua versions 5.1-5.4, please refer to"
+# 5.1 <= LUA_VERSION < 5.6
+if(NOT ((LUA_FULL_VERSION VERSION_EQUAL 5.1.0 OR LUA_FULL_VERSION VERSION_GREATER 5.1.0) AND LUA_FULL_VERSION VERSION_LESS 5.6.0))
+    message(FATAL_ERROR "Awesome only supports Lua versions 5.1-5.5, please refer to"
                         "https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building")
 endif()
 

--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -1,0 +1,355 @@
+# TODO: REMOVE THIS FILE WHEN WE CAN USE CMAKE 4.3.0 OR LATER
+#
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file LICENSE.rst or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindLua
+-------
+
+Finds the Lua library:
+
+.. code-block:: cmake
+
+  find_package(Lua [<version>] [...])
+
+Lua is a embeddable scripting language.
+
+.. versionadded:: 3.18
+  Support for Lua 5.4.
+
+.. versionadded:: 4.3
+  Support for Lua 5.5.
+
+When working with Lua, its library headers are intended to be included in
+project source code as:
+
+.. code-block:: c
+
+  #include <lua.h>
+
+and not:
+
+.. code-block:: c
+
+  #include <lua/lua.h>
+
+This is because, the location of Lua headers may differ across platforms and may
+exist in locations other than ``lua/``.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``Lua_FOUND``
+  .. versionadded:: 3.3
+
+  Boolean indicating whether (the requested version of) Lua was found.
+
+``Lua_VERSION``
+  .. versionadded:: 4.2
+
+  The version of Lua found.
+
+``Lua_VERSION_MAJOR``
+  .. versionadded:: 4.2
+
+  The major version of Lua found.
+
+``Lua_VERSION_MINOR``
+  .. versionadded:: 4.2
+
+  The minor version of Lua found.
+
+``Lua_VERSION_PATCH``
+  .. versionadded:: 4.2
+
+  The patch version of Lua found.
+
+``LUA_LIBRARIES``
+  Libraries needed to link against to use Lua.  This list includes both ``lua``
+  and ``lualib`` libraries.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``LUA_INCLUDE_DIR``
+  The directory containing the Lua header files, such as ``lua.h``,
+  ``lualib.h``, and ``lauxlib.h``, needed to use Lua.
+
+Deprecated Variables
+^^^^^^^^^^^^^^^^^^^^
+
+The following variables are provided for backward compatibility:
+
+``LUA_FOUND``
+  .. deprecated:: 4.2
+    Use ``Lua_FOUND``, which has the same value.
+
+  Boolean indicating whether (the requested version of) Lua was found.
+
+``LUA_VERSION_STRING``
+  .. deprecated:: 4.2
+    Superseded by the ``Lua_VERSION``.
+
+  The version of Lua found.
+
+``LUA_VERSION_MAJOR``
+  .. deprecated:: 4.2
+    Superseded by the ``Lua_VERSION_MAJOR``.
+
+  The major version of Lua found.
+
+``LUA_VERSION_MINOR``
+  .. deprecated:: 4.2
+    Superseded by the ``Lua_VERSION_MINOR``.
+
+  The minor version of Lua found.
+
+``LUA_VERSION_PATCH``
+  .. deprecated:: 4.2
+    Superseded by the ``Lua_VERSION_PATCH``.
+
+  The patch version of Lua found.
+
+Examples
+^^^^^^^^
+
+Finding the Lua library and creating an interface :ref:`imported target
+<Imported Targets>` that encapsulates its usage requirements for linking to a
+project target:
+
+.. code-block:: cmake
+
+  find_package(Lua)
+
+  if(Lua_FOUND AND NOT TARGET Lua::Lua)
+    add_library(Lua::Lua INTERFACE IMPORTED)
+    set_target_properties(
+      Lua::Lua
+      PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${LUA_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES "${LUA_LIBRARIES}"
+    )
+  endif()
+
+  target_link_libraries(project_target PRIVATE Lua::Lua)
+#]=======================================================================]
+
+cmake_policy(PUSH)  # Policies apply to functions at definition-time
+cmake_policy(SET CMP0140 NEW)
+
+# Aire-One edit:
+# This policy was introduced in CMake 3.29, Ubuntu 24.04 (latest for GitHub
+# Actions) currently comes with 3.28.3, and our minimum required version is 3.5.
+if(POLICY CMP0159)
+  cmake_policy(SET CMP0159 NEW)  # file(STRINGS) with REGEX updates CMAKE_MATCH_<n>
+endif()
+
+unset(_lua_include_subdirs)
+unset(_lua_library_names)
+unset(_lua_append_versions)
+
+# this is a function only to have all the variables inside go away automatically
+function(_lua_get_versions)
+    set(LUA_VERSIONS5 5.5 5.4 5.3 5.2 5.1 5.0)
+
+    if (Lua_FIND_VERSION_EXACT)
+        if (Lua_FIND_VERSION_COUNT GREATER 1)
+            set(_lua_append_versions ${Lua_FIND_VERSION_MAJOR}.${Lua_FIND_VERSION_MINOR})
+        endif ()
+    elseif (Lua_FIND_VERSION)
+        # once there is a different major version supported this should become a loop
+        if (NOT Lua_FIND_VERSION_MAJOR GREATER 5)
+            if (Lua_FIND_VERSION_COUNT EQUAL 1)
+                set(_lua_append_versions ${LUA_VERSIONS5})
+            else ()
+                foreach (subver IN LISTS LUA_VERSIONS5)
+                    if (NOT subver VERSION_LESS ${Lua_FIND_VERSION})
+                        list(APPEND _lua_append_versions ${subver})
+                    endif ()
+                endforeach ()
+                # New version -> Search for it (heuristic only! Defines in include might have changed)
+                if (NOT _lua_append_versions)
+                    set(_lua_append_versions ${Lua_FIND_VERSION_MAJOR}.${Lua_FIND_VERSION_MINOR})
+                endif()
+            endif ()
+        endif ()
+    else ()
+        # once there is a different major version supported this should become a loop
+        set(_lua_append_versions ${LUA_VERSIONS5})
+    endif ()
+
+    if (LUA_Debug)
+        message(STATUS "Considering following Lua versions: ${_lua_append_versions}")
+    endif()
+
+    set(_lua_append_versions "${_lua_append_versions}" PARENT_SCOPE)
+endfunction()
+
+function(_lua_set_version_vars)
+  set(_lua_include_subdirs_raw "lua")
+
+  foreach (ver IN LISTS _lua_append_versions)
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)$" _ver "${ver}")
+    list(APPEND _lua_include_subdirs_raw
+        lua${CMAKE_MATCH_1}${CMAKE_MATCH_2}
+        lua${CMAKE_MATCH_1}.${CMAKE_MATCH_2}
+        lua-${CMAKE_MATCH_1}.${CMAKE_MATCH_2}
+        )
+  endforeach ()
+
+  # Prepend "include/" to each path directly after the path
+  set(_lua_include_subdirs "include")
+  foreach (dir IN LISTS _lua_include_subdirs_raw)
+    list(APPEND _lua_include_subdirs "${dir}" "include/${dir}")
+  endforeach ()
+
+  set(_lua_include_subdirs "${_lua_include_subdirs}" PARENT_SCOPE)
+endfunction()
+
+function(_lua_get_header_version)
+  unset(Lua_VERSION PARENT_SCOPE)
+  set(_hdr_file "${LUA_INCLUDE_DIR}/lua.h")
+
+  if (NOT EXISTS "${_hdr_file}")
+    return()
+  endif ()
+
+  # At least 5.[012] have different ways to express the version
+  # so all of them need to be tested. Lua 5.2 defines LUA_VERSION
+  # and LUA_RELEASE as joined by the C preprocessor, so avoid those.
+  file(STRINGS "${_hdr_file}" lua_version_strings
+       REGEX "^#define[ \t]+LUA_(RELEASE[ \t]+\"Lua [0-9]|VERSION([ \t]+\"Lua [0-9]|_[MR])).*")
+
+  string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MAJOR(_N)?[ \t]+\"?([0-9])\"?[ \t]*;.*" "\\2" Lua_VERSION_MAJOR ";${lua_version_strings};")
+
+  if (Lua_VERSION_MAJOR MATCHES "^[0-9]+$")
+    string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_MINOR(_N)?[ \t]+\"?([0-9])\"?[ \t]*;.*" "\\2" Lua_VERSION_MINOR ";${lua_version_strings};")
+    string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION_RELEASE(_N)?[ \t]+\"?([0-9])\"?[ \t]*;.*" "\\2" Lua_VERSION_PATCH ";${lua_version_strings};")
+    set(Lua_VERSION "${Lua_VERSION_MAJOR}.${Lua_VERSION_MINOR}.${Lua_VERSION_PATCH}")
+  else ()
+    string(REGEX REPLACE ".*;#define[ \t]+LUA_RELEASE[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" Lua_VERSION ";${lua_version_strings};")
+    if (NOT Lua_VERSION MATCHES "^[0-9.]+$")
+      string(REGEX REPLACE ".*;#define[ \t]+LUA_VERSION[ \t]+\"Lua ([0-9.]+)\"[ \t]*;.*" "\\1" Lua_VERSION ";${lua_version_strings};")
+    endif ()
+    string(REGEX REPLACE "^([0-9]+)\\.[0-9.]*$" "\\1" Lua_VERSION_MAJOR "${Lua_VERSION}")
+    string(REGEX REPLACE "^[0-9]+\\.([0-9]+)[0-9.]*$" "\\1" Lua_VERSION_MINOR "${Lua_VERSION}")
+    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]).*" "\\1" Lua_VERSION_PATCH "${Lua_VERSION}")
+  endif ()
+  foreach (ver IN LISTS _lua_append_versions)
+    if (ver STREQUAL "${Lua_VERSION_MAJOR}.${Lua_VERSION_MINOR}")
+      set(LUA_VERSION_STRING "${Lua_VERSION}")
+      set(LUA_VERSION_MAJOR "${Lua_VERSION_MAJOR}")
+      set(LUA_VERSION_MINOR "${Lua_VERSION_MINOR}")
+      set(LUA_VERSION_PATCH "${Lua_VERSION_PATCH}")
+
+      return(
+        PROPAGATE
+          Lua_VERSION
+          Lua_VERSION_MAJOR
+          Lua_VERSION_MINOR
+          Lua_VERSION_PATCH
+          LUA_VERSION_STRING
+          LUA_VERSION_MAJOR
+          LUA_VERSION_MINOR
+          LUA_VERSION_PATCH
+      )
+    endif ()
+  endforeach ()
+endfunction()
+
+function(_lua_find_header)
+  _lua_set_version_vars()
+
+  # Initialize as local variable
+  set(CMAKE_IGNORE_PATH ${CMAKE_IGNORE_PATH})
+  while (TRUE)
+    # Find the next header to test. Check each possible subdir in order
+    # This prefers e.g. higher versions as they are earlier in the list
+    # It is also consistent with previous versions of FindLua
+    foreach (subdir IN LISTS _lua_include_subdirs)
+      find_path(LUA_INCLUDE_DIR lua.h
+        HINTS ENV LUA_DIR
+        PATH_SUFFIXES ${subdir}
+        )
+      if (LUA_INCLUDE_DIR)
+        break()
+      endif()
+    endforeach()
+    # Did not found header -> Fail
+    if (NOT LUA_INCLUDE_DIR)
+      return()
+    endif()
+    _lua_get_header_version()
+    # Found accepted version -> Ok
+    if (Lua_VERSION)
+      if (LUA_Debug)
+        message(STATUS "Found suitable version ${Lua_VERSION} in ${LUA_INCLUDE_DIR}/lua.h")
+      endif()
+      return()
+    endif()
+    # Found wrong version -> Ignore this path and retry
+    if (LUA_Debug)
+      message(STATUS "Ignoring unsuitable version in ${LUA_INCLUDE_DIR}")
+    endif()
+    list(APPEND CMAKE_IGNORE_PATH "${LUA_INCLUDE_DIR}")
+    unset(LUA_INCLUDE_DIR CACHE)
+    unset(LUA_INCLUDE_DIR)
+    unset(LUA_INCLUDE_DIR PARENT_SCOPE)
+  endwhile ()
+endfunction()
+
+_lua_get_versions()
+_lua_find_header()
+_lua_get_header_version()
+unset(_lua_append_versions)
+
+if (Lua_VERSION)
+  set(_lua_library_names
+    lua${Lua_VERSION_MAJOR}${Lua_VERSION_MINOR}
+    lua${Lua_VERSION_MAJOR}.${Lua_VERSION_MINOR}
+    lua-${Lua_VERSION_MAJOR}.${Lua_VERSION_MINOR}
+    lua.${Lua_VERSION_MAJOR}.${Lua_VERSION_MINOR}
+    )
+endif ()
+
+find_library(LUA_LIBRARY
+  NAMES ${_lua_library_names} lua
+  NAMES_PER_DIR
+  HINTS
+    ENV LUA_DIR
+  PATH_SUFFIXES lib
+)
+unset(_lua_library_names)
+
+if (LUA_LIBRARY)
+  # include the math library for Unix
+  if (UNIX AND NOT APPLE AND NOT BEOS)
+    find_library(LUA_MATH_LIBRARY m)
+    mark_as_advanced(LUA_MATH_LIBRARY)
+    set(LUA_LIBRARIES "${LUA_LIBRARY};${LUA_MATH_LIBRARY}")
+
+    # include dl library for statically-linked Lua library
+    get_filename_component(LUA_LIB_EXT ${LUA_LIBRARY} EXT)
+    if(LUA_LIB_EXT STREQUAL CMAKE_STATIC_LIBRARY_SUFFIX)
+      list(APPEND LUA_LIBRARIES ${CMAKE_DL_LIBS})
+    endif()
+
+  # For Windows and Mac, don't need to explicitly include the math library
+  else ()
+    set(LUA_LIBRARIES "${LUA_LIBRARY}")
+  endif ()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Lua
+                                  REQUIRED_VARS LUA_LIBRARIES LUA_INCLUDE_DIR
+                                  VERSION_VAR Lua_VERSION)
+
+mark_as_advanced(LUA_INCLUDE_DIR LUA_LIBRARY)
+
+cmake_policy(POP)

--- a/docs/ldoc.ltp
+++ b/docs/ldoc.ltp
@@ -613,9 +613,9 @@
   <p>$(M(ldoc.full_description,nil))</p>
 # end
 
-# for kind, mods in ldoc.kinds() do
-<h2>$(kind)</h2>
-# kind = kind:lower()
+# for k, mods in ldoc.kinds() do
+<h2>$(k)</h2>
+# kind = k:lower()
 <table class="module_list">
 # for m in mods() do
   <tr>

--- a/lib/awful/layout/suit/fair.lua
+++ b/lib/awful/layout/suit/fair.lua
@@ -41,8 +41,8 @@ local function do_fair(p, orientation)
             cols = math.ceil(#cls / rows)
         end
 
-        for k, c in ipairs(cls) do
-            k = k - 1
+        for i, c in ipairs(cls) do
+            local k = i - 1
             local g = {}
 
             local row, col

--- a/lib/naughty/dbus.lua
+++ b/lib/naughty/dbus.lua
@@ -322,8 +322,9 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
             end
 
             for k, v in pairs(args) do
-                if k == "destroy" then k = "destroy_cb" end
-                notification[k] = v
+                notification[
+                    (k == "destroy") and "destroy_cb" or k
+                ] = v
             end
 
             -- Update the icon if necessary.

--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -889,7 +889,8 @@ local function convert_actions(actions)
     local new_actions = {}
 
     -- Does not attempt to handle when there is a mix of strings and objects
-    for idx, name in pairs(actions) do
+    for action_idx, action_name in pairs(actions) do
+        local idx, name = action_idx, action_name
         local cb, old_idx = nil, idx
 
         if type(name) == "function" then

--- a/luaa.h
+++ b/luaa.h
@@ -31,8 +31,8 @@
 #include "common/lualib.h"
 #include "common/luaclass.h"
 
-#if !(501 <= LUA_VERSION_NUM && LUA_VERSION_NUM < 505)
-#error "Awesome only supports Lua versions 5.1-5.4 and LuaJIT2, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building"
+#if !(501 <= LUA_VERSION_NUM && LUA_VERSION_NUM < 506)
+#error "Awesome only supports Lua versions 5.1-5.5 and LuaJIT2, please refer to https://awesomewm.org/apidoc/documentation/10-building-and-testing.md.html#Building"
 #endif
 
 #define luaA_deprecate(L, repl) \

--- a/tests/examples/wibox/widget/graph/subpixel.lua
+++ b/tests/examples/wibox/widget/graph/subpixel.lua
@@ -13,10 +13,6 @@ local l = wibox.layout { --DOC_HIDE
     layout        = wibox.layout.flex.vertical --DOC_HIDE
 } --DOC_HIDE
 
-for _, small_step in ipairs {1, 1/2, 1/3} do
-    _ = small_step --DOC_HIDE silence luacheck unused var warning
-end --DOC_HIDE actually use truncated numbers, hopefully helps with reproducibility
-
 for _, small_step in ipairs {1, 0.5, 21845/65536} do --DOC_HIDE
     local w = --DOC_HIDE
     wibox.widget {


### PR DESCRIPTION
These commits were sleeping on my fork for some time now. The ecosystem is slowly progressing on its update to Lua 5.5. It's time we merge the support.

As for our used dependencies, we have two groups of still-non-lua-55-deps:

- Ldoc is still missing a proper release, but the Git version is ready, I used the rockspec from GitHub to install it in the CI for now.
- Luacheck and Depgraph still don't support Lua 5.5, but we only use them for `check_qa` and  `coverage` which are limited respectively to `fixed-lgi-lua5.2` and `codecov-lua5.3` matrices.

The fact Luacheck doesn't support Lua 5.5 is not a big issue for us. It means we cannot use the new language features since it would trigger linter issue. We would not even use them anyway since our code is supposed to work with Lua 5.1. Only the for-loop immutability of the control variable breaking change can bite our back. If someone introduce a new instance of this, it would be caught by the "build with Lua 5.5" job, so I guess that's ok.

I had to fully copy the updated version of `FindLua.cmake` to allow `cmake` to work properly with Lua 5.5. The alternative would have been to require a newer version of cmake to build Awesome, which is far more aggressive since most Linux distributions still doesn't ship it (including the one GitHub Actions provide, so we would have had to manually build cmake or trust an Actions that provides it).