### PR TITLE
Fix: CI "Run require test" is broken

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,7 @@ jobs:
         run: cd "${{ github.workspace }}/build" && make check-examples
 
       - name: Run requires tests
-        if: matrix.coverage
+        if: matrix.check_qa
         run: cd "${{ github.workspace }}/build" && make check-requires
 
       - name: Run themes tests

--- a/build-utils/check_for_invalid_requires.lua
+++ b/build-utils/check_for_invalid_requires.lua
@@ -8,10 +8,10 @@
 local have_depgraph, depgraph = pcall(require, "depgraph")
 
 if not have_depgraph then
-    print("depgraph not found")
-    print(depgraph)
-    print("(this error is non-fatal; we just skip its use)")
-    os.exit(0)
+    io.stderr:write("depgraph not found\n")
+    io.stderr:write(tostring(depgraph) .. "\n")
+    io.stderr:write("depgraph is required for check-requires\n")
+    os.exit(1)
 end
 
 local allowed_deps = {

--- a/docs/10-building-and-testing.md
+++ b/docs/10-building-and-testing.md
@@ -43,6 +43,8 @@ Additionally, the following optional dependencies exist:
   documentation
 - [busted](https://olivinelabs.com/busted/) for running unit tests
 - [luacheck](https://github.com/mpeterv/luacheck) for static code analysis
+- [depgraph](https://github.com/starius/lua-depgraph) for validating
+  `require()` dependencies in `make check-requires`
 - [LuaCov](https://keplerproject.github.io/luacov/) for collecting code coverage
   information
 - libexecinfo on systems where libc does not provide `backtrace_symbols()` to
@@ -137,6 +139,6 @@ Individual test categories can be run as well:
 * `make check-integration`: Run integration tests within a Xephyr session.
 * `make check-qa`: Run `luacheck` against the Lua library
 * `make check-unit`: Run unit tests with `busted` against the Lua library. You can also run `busted <options> ./spec` if you want to specify options for `busted`.
-* `make check-requires`: Check for invalid `require()` calls.
+* `make check-requires`: Check for invalid `require()` calls. This test requires `depgraph`.
 * `make check-examples`: Run integration tests within the examples in `./tests/examples`.
 * `make check-themes`: Test themes.


### PR DESCRIPTION
The matrix gate used for the `Run requires tests` step was incorrect. `depgraph` is only installed for `matrix.check_qa`. And it makes more sense to gate the actual `make check-requires` with this rather than `matrix.coverage`.

The initial implementation for `check_for_invalid_requires.lua` from https://github.com/awesomeWM/awesome/pull/1531 allowed the script to quietly skip if `depgraph` is not installed. IMO this is a bad idea since it was silently skipped in our CI since the GitHub Actions migrations (it seems), and we had no alert for that.

`depgraph` is unmaintained since 8 years, and its dependencies are explicitly constrained with `lua >= 5.1, < 5.4`. So with an up-to-date system, you can't install it. The CI will be ok since the `check_qa` matrix is only used by `fixed-lgi-lua5.2`, but it's kind of a dealbreaker for a developer, since `make check-requires` and `make check` are most likely to fail now. **This needs to be sorted out before merge, suggestions welcomed!**

Fix: #4111 